### PR TITLE
Feature/111 privacy policy

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,8 +1,7 @@
 const footerNavigation = {
   events: [
-    { name: "Meetups", href: "/#upcoming-events" },
-    { name: "Hackathons", href: "/#upcoming-events" },
-    { name: "Codecamp", href: "#" },
+    { name: "Upcoming", href: "/#upcoming-events" },
+    { name: "Calendar", href: "/events" },
   ],
   volunteering: [
     {
@@ -15,7 +14,6 @@ const footerNavigation = {
   Sponsoring: [{ name: "Info for sponsors", href: "/sponsors" }],
   About: [
     { name: "Contact", href: "/#about" },
-    // { name: "Code of Conduct", href: "/codeofconduct" },
     { name: "LinkedIn", href: "https://www.linkedin.com/company/mlai-aus-inc" },
   ],
   social: [
@@ -69,106 +67,102 @@ export default function Events() {
       <h2 id="footer-heading" className="sr-only">
         Footer
       </h2>
-      <div className="mx-auto max-w-7xl px-6 pb-8 pt-6 sm:pt-24 lg:px-8 lg:pt-8">
-        <div className="xl:grid xl:grid-cols-3 xl:gap-8">
-          <div className="grid grid-cols-2 gap-8 xl:col-span-2">
-            <div className="md:grid md:grid-cols-2 md:gap-8">
-              <div>
-                <h3 className="text-sm font-semibold leading-6 text-white">
-                  Events
-                </h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {footerNavigation.events.map((item) => (
-                    <li key={item.name}>
-                      <a
-                        href={item.href}
-                        className="text-sm leading-6 text-gray-300 hover:text-white"
-                      >
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="mt-10 md:mt-0">
-                <h3 className="text-sm font-semibold leading-6 text-white">
-                  Volunteering
-                </h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {footerNavigation.volunteering.map((item) => (
-                    <li key={item.name}>
-                      <a
-                        href={item.href}
-                        className="text-sm leading-6 text-gray-300 hover:text-white"
-                        target={item.target}
-                        rel={item.rel}
-                      >
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-            <div className="md:grid md:grid-cols-2 md:gap-8">
-              <div>
-                <h3 className="text-sm font-semibold leading-6 text-white">
-                  Sponsoring
-                </h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {footerNavigation.Sponsoring.map((item) => (
-                    <li key={item.name}>
-                      <a
-                        href={item.href}
-                        className="text-sm leading-6 text-gray-300 hover:text-white"
-                      >
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="mt-10 md:mt-0">
-                <h3 className="text-sm font-semibold leading-6 text-white">
-                  About
-                </h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {footerNavigation.About.map((item) => (
-                    <li key={item.name}>
-                      <a
-                        href={item.href}
-                        className="text-sm leading-6 text-gray-300 hover:text-white"
-                      >
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
+      <div className="mx-auto max-w-7xl px-6 pb-8 sm:pt-24 lg:px-8 lg:pt-8">
+        <div className="grid grid-cols-2 md:grid-cols-[1fr_1fr_1fr_1fr] gap-12 md:gap-6 justify-items-start md:justify-items-center px-6 md:px-12 xl:px-24">
+          <div className="md:items-center md:justify-center md:mx-auto">
+            <h3 className="text-sm font-semibold leading-6 text-white">
+              Events
+            </h3>
+            <ul role="list" className="mt-6 space-y-4">
+              {footerNavigation.events.map((item) => (
+                <li key={item.name}>
+                  <a
+                    href={item.href}
+                    className="text-sm leading-6 text-gray-300 hover:text-white"
+                  >
+                    {item.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
           </div>
-          <div className="flex justify-center items-center p-4 pt-8">
-            <img
-              className="h-10 w-auto"
-              src="/text_logo.png"
-              alt="MLAI text logo"
-            />
+          <div className="md:items-center md:justify-center md:mx-auto">
+            <h3 className="text-sm font-semibold leading-6 text-white">
+              About
+            </h3>
+            <ul role="list" className="mt-6 space-y-4">
+              {footerNavigation.About.map((item) => (
+                <li key={item.name}>
+                  <a
+                    href={item.href}
+                    className="text-sm leading-6 text-gray-300 hover:text-white"
+                  >
+                    {item.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="md:items-center md:justify-center md:mx-auto">
+            <h3 className="text-sm font-semibold leading-6 text-white">
+              Sponsoring
+            </h3>
+            <ul role="list" className="mt-6 space-y-4">
+              {footerNavigation.Sponsoring.map((item) => (
+                <li key={item.name}>
+                  <a
+                    href={item.href}
+                    className="text-sm leading-6 text-gray-300 hover:text-white"
+                  >
+                    {item.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="md:items-center md:justify-center md:mx-auto">
+            <h3 className="text-sm font-semibold leading-6 text-white">
+              Volunteering
+            </h3>
+            <ul role="list" className="mt-6 space-y-4">
+              {footerNavigation.volunteering.map((item) => (
+                <li key={item.name}>
+                  <a
+                    href={item.href}
+                    className="text-sm leading-6 text-gray-300 hover:text-white"
+                    target={item.target}
+                    rel={item.rel}
+                  >
+                    {item.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
-        <div className="mt-8 border-t border-gray-400 pt-8 sm:mt-10 md:flex md:items-center md:justify-between lg:mt-12">
-          <div className="flex space-x-6 md:order-2">
-            {footerNavigation.social.map((item) => (
-              <a
-                key={item.name}
-                href={item.href}
-                className="text-gray-300 hover:text-gray-400"
-              >
-                <span className="sr-only">{item.name}</span>
-                <item.icon className="h-6 w-6" aria-hidden="true" />
-              </a>
-            ))}
+        <div className="mt-8 border-t border-gray-400 pt-8 sm:mt-10 lg:mt-12">
+          <div className="flex flex-row justify-between">
+            <div className="flex space-x-6 md:order-2">
+              {footerNavigation.social.map((item) => (
+                <a
+                  key={item.name}
+                  href={item.href}
+                  className="text-gray-300 hover:text-gray-400"
+                >
+                  <span className="sr-only">{item.name}</span>
+                  <item.icon className="h-6 w-6" aria-hidden="true" />
+                </a>
+              ))}
+            </div>
+            <div className="flex justify-center items-center ">
+              <img
+                className="h-auto w-24"
+                src="/text_logo.png"
+                alt="MLAI text logo"
+              />
+            </div>
           </div>
-          <p className="mt-8 text-xs leading-5 text-gray-300 md:order-1 md:mt-0">
+          <p className="flex justify-center mt-8 text-xs leading-5 text-gray-300 md:mt-0">
             &copy; 2025 MLAI Aus Inc. All rights reserved.{" "}
               <a href="https://mlaiau.notion.site/privacy-policy" className="underline">Privacy Policy</a>
           </p>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -169,7 +169,8 @@ export default function Events() {
             ))}
           </div>
           <p className="mt-8 text-xs leading-5 text-gray-300 md:order-1 md:mt-0">
-            &copy; 2025 MLAI Aus Inc. All rights reserved.
+            &copy; 2025 MLAI Aus Inc. All rights reserved.{" "}
+              <a href="https://mlaiau.notion.site/privacy-policy" className="underline">Privacy Policy</a>
           </p>
         </div>
       </div>

--- a/app/components/team.tsx
+++ b/app/components/team.tsx
@@ -12,6 +12,11 @@ const people = [
     imageUrl: "team-photos/Michael.png",
   },
   {
+    name: "Pegah Khaleghi",
+    role: "Treasurer",
+    imageUrl: "team-photos/Pegah.jpeg",
+  },
+  {
     name: "Lukas Wesemann",
     role: "Secretary",
     imageUrl: "photos/lukas.png",
@@ -32,21 +37,15 @@ const people = [
     imageUrl: "team-photos/Tom.png",
   },
   {
-    name: "Ethan Lee",
-    role: "Co-Head of Community",
-    imageUrl: "team-photos/Ethan.png",
-  },
-  {
     name: "Jasmine Raj",
     role: "Co-Head of Community",
     imageUrl: "team-photos/Jasmine.png",
   },
   {
-    name: "Pegah Khaleghi",
-    role: "Treasurer",
-    imageUrl: "team-photos/Pegah.jpeg",
+    name: "Ethan Lee",
+    role: "Co-Head of Community",
+    imageUrl: "team-photos/Ethan.png",
   },
-
   // More people...
 ];
 

--- a/app/components/testimonials.tsx
+++ b/app/components/testimonials.tsx
@@ -5,7 +5,7 @@ const featuredTestimonial = {
   body: "As excitement about AI builds and the impacts spread into all our daily lives, a strong and diverse community of participants is vital to support positive outcomes for all. It's great to see the MLAI Aus crew working hard to build this community across Australia. Get off the couch and get involved!",
   author: {
     name: "Kendra Vant",
-    handle: "Director Europalabs",
+    handle: "Director - Europalabs",
     imageUrl: "photos/kendra.png",
     logoUrl: "",
   },
@@ -17,7 +17,7 @@ const testimonials: any = [
         body: "It was an absolute pleasure to work with the MLAI team on the Ecosystem Drinks: Talent meets Startups. It was amazing to see so many engaging members of the MLAI community join in for the startup speed dating. ",
         author: {
           name: "Eike Zeller",
-          handle: "Ecosystems Director @ Stone & Chalk",
+          handle: "Ecosystems Director - Stone & Chalk",
           imageUrl: "photos/eikezeller.jpg",
         },
       },
@@ -28,7 +28,7 @@ const testimonials: any = [
         body: "MLAI has been a fantastic community for connecting with like-minded, talented people. Everyone has been warm, welcoming, and eager to talk nitty-gritty tech details.",
         author: {
           name: "Xavier Andueza",
-          handle: "Founder Everdawn.ai",
+          handle: "Founding AI Engineer - Userdoc",
           imageUrl: "photos/xavierandueza.jpg",
         },
       },

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -4,8 +4,8 @@ const stats = [];
 
 export default function Contact() {
   return (
-    <div className="bg-white pt-12 sm:pt-16">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+    <div className="bg-white pt-12 sm:pt-16 min-h-screen flex flex-col">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 flex-grow">
         <div className="flex justify-center">
           <div className="max-w-2xl">
             <div className="text-base leading-7 text-gray-700">


### PR DESCRIPTION
# Summary
This PR introduces the following changes to resolve #111 :
1. Adds the Privacy Policy to the footer using the Notion page published as a viewable link:
    1. Public Link: https://mlaiau.notion.site/privacy-policy
    2. https://www.notion.so/mlaiau/Privacy-Policy-24d9c67419c880c8a9f2d5f7a323bddf 
2. I updated testimonials so that we use a consistent formatting (and updated my title too)
3. Moved Pegah up to the top of the Committee blocks - didn't look great with 3 pasty white dudes being the first thing you see
4. Made the footer styling better - didn't like at all and thought I'd fix up
5. Fixed an issue where the contact screen, on large screens, wouldn't actually fit the screen, so you'd have: content->footer->whitespace and it looked shit. 

# Images
## 1. Privacy Policy AND 4. Footer Styling
BEFORE:
Desktop:
<img width="1340" height="360" alt="image" src="https://github.com/user-attachments/assets/380a3442-d446-4c14-8bd2-3f6769d23802" />

Mobile:
<img width="444" height="447" alt="image" src="https://github.com/user-attachments/assets/4abba887-775a-4bdf-8621-d2a2e393fd92" />

AFTER:
Desktop:
<img width="1296" height="359" alt="image" src="https://github.com/user-attachments/assets/3d7b0eea-0e92-4721-a8a9-1058539189d2" />

Mobile:
<img width="402" height="441" alt="image" src="https://github.com/user-attachments/assets/6f1f1a09-445a-4f2f-866b-04b512902672" />

## 2. Testimonials
BEFORE
<img width="1373" height="717" alt="image" src="https://github.com/user-attachments/assets/a18a924a-881f-49cd-8b23-dbc337e0ffa4" />

AFTER
<img width="1287" height="711" alt="image" src="https://github.com/user-attachments/assets/52e6dfc8-f1e5-4372-b5ee-93433c56811e" />

## 3. Committee Block Rearrange
BEFORE
<img width="1418" height="476" alt="image" src="https://github.com/user-attachments/assets/42d83133-dacd-44b7-95db-51a9e134f4f0" />

AFTER
<img width="1343" height="532" alt="image" src="https://github.com/user-attachments/assets/73f5f820-e598-467c-a687-d9c01680e0af" />

## 5. Contact Screen
BEFORE:
<img width="2433" height="1380" alt="image" src="https://github.com/user-attachments/assets/a6344d5e-6d31-4565-87a1-f9069e26bd6f" />

AFTER:
<img width="2505" height="1371" alt="image" src="https://github.com/user-attachments/assets/46eb206e-10b6-4ce8-a5a4-c8d1f82e0d63" />
