### PR TITLE
Add side navigation for sponsors page

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   UserGroupIcon,
   XMarkIcon,
   InformationCircleIcon,
+  HeartIcon,
 } from "@heroicons/react/24/outline";
 import { useState } from "react";
 
@@ -17,6 +18,7 @@ const navigation = [
   { name: "Home", href: "/", icon: HomeIcon },
   { name: "About", href: "/#about", icon: InformationCircleIcon },
   { name: "Events", href: "/events", icon: CalendarIcon },
+  { name: "Sponsors", href: "/sponsors", icon: HeartIcon },
   {
     name: "Post a Bounty Job",
     href: "https://mlaiau.notion.site/2619c67419c880ad8654df2ec0998a74?pvs=105",

--- a/app/components/sponsors-sidenav.tsx
+++ b/app/components/sponsors-sidenav.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from "react";
+import {
+  InformationCircleIcon,
+  UserGroupIcon,
+  PhoneIcon,
+} from "@heroicons/react/24/outline";
+
+const sponsorNavigation = [
+  {
+    name: "Why Sponsor MLAI?",
+    href: "#why-sponsor",
+    icon: InformationCircleIcon,
+  },
+  {
+    name: "Current Sponsors",
+    href: "#current-sponsors",
+    icon: UserGroupIcon,
+  },
+  {
+    name: "Get in Touch",
+    href: "#contact-sponsorship",
+    icon: PhoneIcon,
+  },
+];
+
+export default function SponsorsSideNav() {
+  const [activeSection, setActiveSection] = useState("");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const sections = sponsorNavigation.map((item) =>
+        item.href.replace("#", "")
+      );
+      const scrollPosition = window.scrollY + 100; // offset for header
+
+      for (const section of sections) {
+        const element = document.getElementById(section);
+        if (element) {
+          const { offsetTop, offsetHeight } = element;
+          if (
+            scrollPosition >= offsetTop &&
+            scrollPosition < offsetTop + offsetHeight
+          ) {
+            setActiveSection(`#${section}`);
+            break;
+          }
+        }
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // Call once to set initial active section
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const handleSmoothScroll = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    href: string
+  ) => {
+    e.preventDefault();
+    const element = document.getElementById(href.replace("#", ""));
+    if (element) {
+      element.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  return (
+    <nav className="hidden xl:flex xl:w-64 xl:fixed xl:right-8 xl:top-32 xl:flex-col xl:space-y-2">
+      <div className="bg-white/80 backdrop-blur-sm rounded-lg p-4 shadow-lg border border-gray-200">
+        <h3 className="text-sm font-semibold text-gray-900 mb-3">
+          Page Navigation
+        </h3>
+        <ul className="space-y-1">
+          {sponsorNavigation.map((item) => (
+            <li key={item.name}>
+              <a
+                href={item.href}
+                onClick={(e) => handleSmoothScroll(e, item.href)}
+                className={`group flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition-colors ${
+                  activeSection === item.href
+                    ? "bg-teal-50 text-teal-600"
+                    : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                }`}
+              >
+                <item.icon
+                  className={`mr-2 h-4 w-4 flex-shrink-0 ${
+                    activeSection === item.href
+                      ? "text-teal-500"
+                      : "text-gray-400 group-hover:text-gray-500"
+                  }`}
+                  aria-hidden="true"
+                />
+                {item.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/app/routes/sponsors.tsx
+++ b/app/routes/sponsors.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "~/components/ui/Button";
 import { Body, H1, H2 } from "~/components/ui/Typography";
+import SponsorsSideNav from "~/components/sponsors-sidenav";
 
 const sponsorshipTiers = [
   {
@@ -59,7 +60,8 @@ const currentSponsors = [
 
 export default function SponsorPage() {
   return (
-    <main className="bg-white">
+    <main className="bg-white relative">
+      <SponsorsSideNav />
       {/* Hero Section */}
       <div className="relative isolate bg-gray-900 py-24">
         <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80">
@@ -83,7 +85,7 @@ export default function SponsorPage() {
         </div>
       </div>
       {/* Why Sponsor Section */}
-      <div className="py-24 sm:py-32">
+      <div id="why-sponsor" className="py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl lg:text-center">
             <H2>Why Sponsor MLAI Aus?</H2>
@@ -263,7 +265,7 @@ export default function SponsorPage() {
         </div>
       </div> */}
       {/* Current Sponsors */}
-      <div className="py-24 sm:py-32">
+      <div id="current-sponsors" className="py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-2xl lg:text-center">
             <H2>Our Current Sponsors</H2>
@@ -291,7 +293,7 @@ export default function SponsorPage() {
         </div>
       </div>
       {/* CTA Section */}
-      <div className="bg-teal-500">
+      <div id="contact-sponsorship" className="bg-teal-500">
         <div className="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
             <H2 className="text-white">


### PR DESCRIPTION
**Needs testing please!!!**

---

Fixes #131

Adds side navigation for the sponsorships page to improve user navigation and page accessibility.

## Changes

- Added "Sponsors" link to main sidebar navigation with heart icon
- Created dedicated sponsors side navigation component for quick section jumping
- Added proper section IDs to sponsors page for navigation anchors
- Implemented smooth scrolling and active section highlighting
- Responsive design that only shows on large screens

## Features

- Smooth scrolling between page sections
- Automatic scroll tracking with active section highlighting
- Clean, modern design with backdrop blur effect
- Fully responsive and accessible

Generated with [Claude Code](https://claude.ai/code)