### PR TITLE
chore: Simplify React Router future config by standardizing `unstable…

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,8 +3,6 @@ import type { Config } from "@react-router/dev/config";
 export default {
   ssr: true,
   future: {
-    ...(process.env.CI
-      ? { v8_viteEnvironmentApi: true }
-      : { unstable_viteEnvironmentApi: true }),
+    unstable_viteEnvironmentApi: true,
   },
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         target: 'http://localhost',
         changeOrigin: true,
         secure: false,
-        ws: true, // Handle websockets
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
…_viteEnvironmentApi` and remove redundant comment from Vite proxy.