### PR TITLE
Fix Google Search Console redirect issues

### DIFF
--- a/workers/app.ts
+++ b/workers/app.ts
@@ -14,8 +14,44 @@ const requestHandler = createRequestHandler(
   import.meta.env.MODE
 );
 
+/** Query parameters that are tracking-only and should be stripped for SEO */
+const TRACKING_PARAMS = ["trk", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
+
+/** Legacy paths that should 301-redirect to a new location */
+const LEGACY_REDIRECTS: Record<string, string> = {
+  "/hackathon": "/",
+};
+
 export default {
   async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    // 1. Redirect www → non-www (301)
+    if (url.hostname === "www.mlai.au") {
+      url.hostname = "mlai.au";
+      return Response.redirect(url.toString(), 301);
+    }
+
+    // 2. Redirect legacy paths (301)
+    const legacyTarget = LEGACY_REDIRECTS[url.pathname];
+    if (legacyTarget) {
+      url.pathname = legacyTarget;
+      url.search = "";
+      return Response.redirect(url.toString(), 301);
+    }
+
+    // 3. Strip tracking query parameters (301)
+    let hasTrackingParams = false;
+    for (const param of TRACKING_PARAMS) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.delete(param);
+        hasTrackingParams = true;
+      }
+    }
+    if (hasTrackingParams) {
+      return Response.redirect(url.toString(), 301);
+    }
+
     return requestHandler(request, {
       cloudflare: { env, ctx },
     });


### PR DESCRIPTION
## Summary
- Add 301 redirect from `www.mlai.au` → `mlai.au` in the Cloudflare Worker to consolidate www/non-www
- Add 301 redirect for legacy `/hackathon` path → `/` (only used as component on esafety subdomain)
- Strip tracking query params (`trk`, `utm_*`) via 301 redirect to prevent Google indexing parameterized duplicates

Resolves all "Page with redirect" validation errors reported by Google Search Console.

## Test plan
- [ ] Verify `https://www.mlai.au` 301-redirects to `https://mlai.au`
- [ ] Verify `https://mlai.au/?trk=foo` 301-redirects to `https://mlai.au/`
- [ ] Verify `https://mlai.au/hackathon` 301-redirects to `https://mlai.au/`
- [ ] Verify normal pages like `/events`, `/articles` still load correctly
- [ ] Re-validate in Google Search Console after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)