### PR TITLE
Update ticket links to Luma, add avatar fallbacks, and always show te…

### DIFF
--- a/app/components/medhack/MedhackHero.tsx
+++ b/app/components/medhack/MedhackHero.tsx
@@ -1,5 +1,5 @@
-const EVENTBRITE_URL =
-  "https://www.eventbrite.com.au/o/mlai-machine-learning-ai-61498883493";
+const HACKATHON_TICKETS_URL = "https://luma.com/uxf4awhv";
+const PITCH_NIGHT_TICKETS_URL = "https://luma.com/zi6w8y0x";
 
 const MEDHACK_LOGO_URL =
   "https://firebasestorage.googleapis.com/v0/b/medhack-ai.firebasestorage.app/o/Team%20Formation%20Night%20Slides%20(2).png?alt=media&token=5a1b7fb7-6dd4-4699-9d88-d8db97ff68db";
@@ -32,7 +32,7 @@ export default function MedhackHero() {
 
           <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:flex-wrap sm:justify-center lg:justify-start">
             <a
-              href={EVENTBRITE_URL}
+              href={HACKATHON_TICKETS_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-sm font-bold text-[#783f8e] shadow-lg transition hover:bg-white/90 hover:shadow-xl"
@@ -40,7 +40,7 @@ export default function MedhackHero() {
               Grab Your Spot
             </a>
             <a
-              href={EVENTBRITE_URL}
+              href={HACKATHON_TICKETS_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center rounded-lg border-2 border-white/80 px-6 py-3 text-sm font-bold text-white transition hover:bg-white/10"
@@ -48,7 +48,7 @@ export default function MedhackHero() {
               Hackathon Tickets
             </a>
             <a
-              href={EVENTBRITE_URL}
+              href={PITCH_NIGHT_TICKETS_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center rounded-lg border-2 border-white/80 px-6 py-3 text-sm font-bold text-white transition hover:bg-white/10"

--- a/app/routes/hospital.app.dashboard.tsx
+++ b/app/routes/hospital.app.dashboard.tsx
@@ -101,7 +101,7 @@ export default function HospitalAppDashboard() {
                             </p>
                             <div className="flex flex-wrap gap-2 sm:gap-3 pt-2">
                                 <a
-                                    href="https://www.eventbrite.com.au/o/mlai-machine-learning-ai-61498883493"
+                                    href="https://luma.com/uxf4awhv"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="inline-flex items-center rounded-md border-2 border-white/80 bg-transparent px-3 sm:px-5 py-2 text-[10px] sm:text-xs font-bold uppercase tracking-wider text-white transition-all hover:bg-white hover:text-[#783f8e]"
@@ -109,7 +109,7 @@ export default function HospitalAppDashboard() {
                                     Hackathon Tickets
                                 </a>
                                 <a
-                                    href="https://www.eventbrite.com.au/o/mlai-machine-learning-ai-61498883493"
+                                    href="https://luma.com/zi6w8y0x"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="inline-flex items-center rounded-md border-2 border-white/80 bg-transparent px-3 sm:px-5 py-2 text-[10px] sm:text-xs font-bold uppercase tracking-wider text-white transition-all hover:bg-white hover:text-[#783f8e]"

--- a/app/routes/hospital.app.team.tsx
+++ b/app/routes/hospital.app.team.tsx
@@ -298,16 +298,17 @@ export default function HospitalAppTeam() {
                 <div className="mx-auto mt-8 grid max-w-3xl grid-cols-1 gap-6 px-4 sm:px-6 lg:max-w-7xl lg:grid-flow-col-dense lg:grid-cols-3 lg:px-8">
                     <div className="space-y-6 lg:col-span-2 lg:col-start-1">
 
-                        {/* Team Create / Join — only shown when user has no team */}
-                        {!teamName && (
+                        {/* Team Create / Join */}
                             <section aria-labelledby="team-management-title">
                                 <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl">
                                     <div className="px-4 py-5 sm:px-6">
                                         <h2 id="team-management-title" className="text-lg font-medium leading-6 text-white">
-                                            Create or Join a Team
+                                            {teamName ? 'Change Team' : 'Create or Join a Team'}
                                         </h2>
                                         <p className="mt-1 max-w-2xl text-sm text-white/50">
-                                            You need a team to participate in the hackathon.
+                                            {teamName
+                                                ? 'Create a new team or switch to an existing one.'
+                                                : 'You need a team to participate in the hackathon.'}
                                         </p>
                                     </div>
                                     <div className="border-t border-[#e2a9f1]/10 px-4 py-5 sm:px-6">
@@ -432,7 +433,6 @@ export default function HospitalAppTeam() {
                                     </div>
                                 </div>
                             </section>
-                        )}
 
                         {/* Profile editing form */}
                         <section aria-labelledby="applicant-information-title">


### PR DESCRIPTION
…am management

- Switch hackathon/pitch night ticket links from Eventbrite to Luma
- Add initials-based fallback avatars and hardcoded Roo bot avatar in Slack chat
- Show create/join team section regardless of current team membership