### PR TITLE
Fix 500 from undefined member_id in team queries

### DIFF
--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -105,7 +105,8 @@ export async function getHospitalTeams(env: Env, request: Request) {
     }
 }
 
-export async function getHospitalTeam(env: Env, request: Request, userId: number) {
+export async function getHospitalTeam(env: Env, request: Request, userId: number | undefined) {
+    if (userId == null || !Number.isFinite(userId)) return null;
     try {
         const client = getAxios(env, request);
         const response = await client.get(`/api/v1/hackathons/hospital/teams/?member_id=${userId}`);

--- a/app/routes/esafety.team.tsx
+++ b/app/routes/esafety.team.tsx
@@ -11,20 +11,23 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
     // Fetch user's team for this hackathon
     let myTeam = null;
-    try {
-        const cookieHeader = request.headers.get("Cookie");
-        const headers: Record<string, string> = {};
-        if (cookieHeader) {
-            headers["Cookie"] = cookieHeader;
-        }
-        const response = await axiosInstance.get("/api/v1/hackathons/esafety/teams/?member_id=" + (user as any).id, { headers });
-        const teams = response.data;
+    const memberId = (user as any).id;
+    if (memberId != null && Number.isFinite(memberId)) {
+        try {
+            const cookieHeader = request.headers.get("Cookie");
+            const headers: Record<string, string> = {};
+            if (cookieHeader) {
+                headers["Cookie"] = cookieHeader;
+            }
+            const response = await axiosInstance.get(`/api/v1/hackathons/esafety/teams/?member_id=${memberId}`, { headers });
+            const teams = response.data;
 
-        if (Array.isArray(teams) && teams.length > 0) {
-            myTeam = teams[0]; // Assuming user can only be in one team per hackathon
+            if (Array.isArray(teams) && teams.length > 0) {
+                myTeam = teams[0]; // Assuming user can only be in one team per hackathon
+            }
+        } catch (error) {
+            console.error("Failed to fetch teams:", error);
         }
-    } catch (error) {
-        console.error("Failed to fetch teams:", error);
     }
 
     return { user, myTeam };


### PR DESCRIPTION
## Summary
- Guards `getHospitalTeam` in `auth.ts` against `undefined`/non-numeric `userId` — returns `null` instead of sending `?member_id=undefined` to the backend
- Wraps the esafety team loader's fetch with the same guard to prevent the identical bug there
- Fixes Django `ValueError: Field 'id' expected a number but got 'undefined'` (500 on `/api/v1/hackathons/hospital/teams/`)

## Root cause
`/api/v1/auth/me/` doesn't always return a numeric `id` field. `(user as any).id` evaluates to JS `undefined`, which template-interpolates to the **string** `"undefined"` in the query param.

## Test plan
- [ ] Log in as `hi@mlai.au` and visit `/hospital/app/team` — no more 500 in backend logs
- [ ] Visit `/esafety/team` — no 500 from undefined member_id
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)