### PR TITLE
Restore team avatar upload functionality

### DIFF
--- a/app/routes/hospital.app.team.tsx
+++ b/app/routes/hospital.app.team.tsx
@@ -170,6 +170,10 @@ export default function HospitalAppTeam() {
     const [avatarFile, setAvatarFile] = useState<File | null>(null);
     const [previewAvatarUrl, setPreviewAvatarUrl] = useState<string | null>(null);
 
+    const [teamAvatarFile, setTeamAvatarFile] = useState<File | null>(null);
+    const [previewTeamAvatarUrl, setPreviewTeamAvatarUrl] = useState<string | null>(null);
+    const [isTeamAvatarModalOpen, setIsTeamAvatarModalOpen] = useState(false);
+
     // Join team autocomplete
     const [joinSearch, setJoinSearch] = useState('');
     const [isJoinDropdownOpen, setIsJoinDropdownOpen] = useState(false);
@@ -210,6 +214,13 @@ export default function HospitalAppTeam() {
         setIsAvatarModalOpen(false);
     };
 
+    const handleTeamAvatarSave = async (file: File) => {
+        setTeamAvatarFile(file);
+        const objectUrl = URL.createObjectURL(file);
+        setPreviewTeamAvatarUrl(objectUrl);
+        setIsTeamAvatarModalOpen(false);
+    };
+
     useEffect(() => {
         if (initialUser) {
             setFirstName(initialUser.first_name || '');
@@ -242,6 +253,9 @@ export default function HospitalAppTeam() {
         if (avatarFile) {
             formData.append('avatar', avatarFile);
         }
+        if (teamAvatarFile) {
+            formData.append('team_avatar', teamAvatarFile);
+        }
 
         fetcher.submit(formData, {
             method: "post",
@@ -254,6 +268,7 @@ export default function HospitalAppTeam() {
             if (fetcher.data.success && fetcher.data.profileUpdated) {
                 setMessage('Profile updated successfully.');
                 setAvatarFile(null);
+                setTeamAvatarFile(null);
             } else if (fetcher.data.error) {
                 setError(fetcher.data.error);
             }
@@ -262,6 +277,7 @@ export default function HospitalAppTeam() {
 
     const isSaving = fetcher.state !== "idle";
     const avatarUrl = previewAvatarUrl || initialUser.avatar_url || generateAvatarUrl(getInitials(initialUser.full_name || ''));
+    const teamAvatarUrl = previewTeamAvatarUrl || teamData?.avatar_url || generateAvatarUrl(getInitials(teamName || 'Team'));
 
     return (
         <div className="min-h-screen bg-[#110822]">
@@ -534,6 +550,32 @@ export default function HospitalAppTeam() {
                                                 </div>
                                             </div>
 
+                                            {teamName && (
+                                                <div className="sm:col-span-6">
+                                                    <label className="block text-sm font-medium leading-6 text-white mb-2">
+                                                        Team Avatar
+                                                    </label>
+                                                    <div className="flex items-center gap-x-4">
+                                                        <div className="relative size-16 shrink-0">
+                                                            <img
+                                                                alt=""
+                                                                src={teamAvatarUrl}
+                                                                className="size-16 rounded-lg object-cover ring-1 ring-[#e2a9f1]/20"
+                                                            />
+                                                            <span aria-hidden="true" className="absolute inset-0 rounded-lg shadow-inner" />
+                                                            <button
+                                                                type="button"
+                                                                className="absolute inset-0 flex items-center justify-center rounded-lg bg-black bg-opacity-50 opacity-0 hover:opacity-100 transition-opacity cursor-pointer"
+                                                                onClick={() => setIsTeamAvatarModalOpen(true)}
+                                                            >
+                                                                <PencilIcon className="h-6 w-6 text-white" aria-hidden="true" />
+                                                            </button>
+                                                        </div>
+                                                        <p className="text-sm text-white/50">Click the image to change your team avatar.</p>
+                                                    </div>
+                                                </div>
+                                            )}
+
                                             <div className="sm:col-span-6">
                                                 <div className="flex items-center gap-2 mb-2">
                                                     <label className="block text-sm font-medium leading-6 text-white">
@@ -639,6 +681,11 @@ export default function HospitalAppTeam() {
 
                                     <div className="px-4 py-5 sm:px-6">
                                         <div className="flex flex-col items-center pb-6 border-b border-[#e2a9f1]/10">
+                                            <img
+                                                className="h-24 w-24 rounded-lg object-cover mb-4 ring-1 ring-[#e2a9f1]/20"
+                                                src={teamAvatarUrl}
+                                                alt={teamName || 'Team'}
+                                            />
                                             <h2 id="timeline-title" className="text-xl font-bold text-white text-center">
                                                 {teamName}
                                             </h2>
@@ -717,6 +764,13 @@ export default function HospitalAppTeam() {
                 onClose={() => setIsAvatarModalOpen(false)}
                 onSave={handleAvatarSave}
                 initialImage={avatarUrl}
+            />
+            <AvatarModal
+                isOpen={isTeamAvatarModalOpen}
+                onClose={() => setIsTeamAvatarModalOpen(false)}
+                onSave={handleTeamAvatarSave}
+                initialImage={teamAvatarUrl}
+                title="Update Team Logo"
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- Re-adds the team avatar upload UI to the hospital hackathon team page
- Adds team avatar preview in the sidebar and an editable avatar in the profile form
- Includes a second AvatarModal for updating the team logo
- Sends `team_avatar` file with the profile update form submission

## Test plan
- [ ] Navigate to /hospital/app/team while in a team
- [ ] Verify team avatar appears in the sidebar and in the profile form
- [ ] Click the team avatar to open the crop/upload modal
- [ ] Upload a new team avatar and verify preview updates
- [ ] Save profile and verify team avatar is submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)