### PR TITLE
Update submission feedback to new backend contract

### DIFF
--- a/app/components/hospital/ClassAccuracyBars.tsx
+++ b/app/components/hospital/ClassAccuracyBars.tsx
@@ -1,0 +1,54 @@
+import type { Feedback } from '~/types/submission';
+
+const CLASS_COLORS: Record<string, string> = {
+    Normal: '#22c55e',
+    Warning: '#f59e0b',
+    Crisis: '#ef4444',
+    Other: '#9ca3af',
+};
+
+interface ClassAccuracyBarsProps {
+    classStats: Feedback['class_stats'] | undefined;
+}
+
+export default function ClassAccuracyBars({ classStats }: ClassAccuracyBarsProps) {
+    if (!classStats) return null;
+
+    return (
+        <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl p-5 space-y-4">
+            <h3 className="text-sm font-semibold text-white/70 uppercase tracking-wider">
+                Per-Class Accuracy
+            </h3>
+            <div className="space-y-3">
+                {classStats.map((stat) => {
+                    const color = CLASS_COLORS[stat.name] || '#9ca3af';
+                    const pct = Math.round(stat.accuracy * 100);
+                    const lowAccuracy = pct < 80;
+
+                    return (
+                        <div
+                            key={stat.name}
+                            className={`rounded-lg p-3 ${lowAccuracy ? 'ring-1 ring-red-400/50' : ''}`}
+                        >
+                            <div className="flex items-center justify-between mb-1.5">
+                                <span className="text-sm font-medium text-white">{stat.name}</span>
+                                <span className="text-xs text-white/60">
+                                    {stat.correct}/{stat.total} &middot; {pct}%
+                                </span>
+                            </div>
+                            <div className="h-2 rounded-full bg-white/10 overflow-hidden">
+                                <div
+                                    className="h-full rounded-full transition-all"
+                                    style={{
+                                        width: `${pct}%`,
+                                        backgroundColor: color,
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/app/components/hospital/ConfusionMatrixHeatmap.tsx
+++ b/app/components/hospital/ConfusionMatrixHeatmap.tsx
@@ -1,0 +1,82 @@
+import type { Feedback } from '~/types/submission';
+
+const CLASS_ORDER = ['0', '1', '2', '3'];
+const CLASS_NAMES: Record<string, string> = {
+    '0': 'Normal',
+    '1': 'Warning',
+    '2': 'Crisis',
+    '3': 'Other',
+};
+
+interface ConfusionMatrixHeatmapProps {
+    confusionMatrix: Feedback['confusion_matrix'] | undefined;
+}
+
+export default function ConfusionMatrixHeatmap({ confusionMatrix }: ConfusionMatrixHeatmapProps) {
+    if (!confusionMatrix) return null;
+
+    // Compute row max for opacity scaling
+    const rowMaxes: Record<string, number> = {};
+    for (const actual of CLASS_ORDER) {
+        const row = confusionMatrix[actual];
+        if (!row) {
+            rowMaxes[actual] = 1;
+            continue;
+        }
+        let max = 0;
+        for (const pred of CLASS_ORDER) {
+            const val = row[pred] ?? 0;
+            if (val > max) max = val;
+        }
+        rowMaxes[actual] = max || 1;
+    }
+
+    return (
+        <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl p-5 space-y-4">
+            <h3 className="text-sm font-semibold text-white/70 uppercase tracking-wider">
+                Confusion Matrix
+            </h3>
+            <div className="overflow-x-auto">
+                <table className="w-full border-collapse">
+                    <thead>
+                        <tr>
+                            <th className="p-2 text-xs text-white/40" />
+                            {CLASS_ORDER.map((pred) => (
+                                <th key={pred} className="p-2 text-xs text-white/60 text-center">
+                                    Pred: {CLASS_NAMES[pred]}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {CLASS_ORDER.map((actual) => (
+                            <tr key={actual}>
+                                <td className="p-2 text-xs text-white/60 whitespace-nowrap">
+                                    Actual: {CLASS_NAMES[actual]}
+                                </td>
+                                {CLASS_ORDER.map((pred) => {
+                                    const value = confusionMatrix[actual]?.[pred] ?? 0;
+                                    const isDiagonal = actual === pred;
+                                    const opacity = value / rowMaxes[actual];
+                                    const bgColor = isDiagonal
+                                        ? `rgba(34, 197, 94, ${0.15 + opacity * 0.6})`
+                                        : `rgba(239, 68, 68, ${opacity * 0.5})`;
+
+                                    return (
+                                        <td
+                                            key={pred}
+                                            className="p-2 text-center text-sm font-semibold text-white border border-white/5"
+                                            style={{ backgroundColor: bgColor }}
+                                        >
+                                            {value}
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/app/components/hospital/First100RowsTable.tsx
+++ b/app/components/hospital/First100RowsTable.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import type { PublicRow } from '~/types/submission';
+
+type Filter = 'all' | 'correct' | 'incorrect' | 'crises';
+
+interface First100RowsTableProps {
+    rows: PublicRow[] | undefined;
+}
+
+const FILTERS: { key: Filter; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'correct', label: 'Correct' },
+    { key: 'incorrect', label: 'Incorrect' },
+    { key: 'crises', label: 'Crises' },
+];
+
+export default function First100RowsTable({ rows }: First100RowsTableProps) {
+    const [filter, setFilter] = useState<Filter>('all');
+
+    if (!rows || rows.length === 0) return null;
+
+    const filtered = rows.filter((r) => {
+        switch (filter) {
+            case 'correct':
+                return r.correct;
+            case 'incorrect':
+                return !r.correct;
+            case 'crises':
+                return r.actual === 2;
+            default:
+                return true;
+        }
+    });
+
+    return (
+        <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl">
+            <div className="px-4 py-5 sm:px-6">
+                <h3 className="text-sm font-semibold text-white/70 uppercase tracking-wider">
+                    First 100 Rows Breakdown
+                </h3>
+                <div className="flex gap-2 mt-3">
+                    {FILTERS.map((f) => (
+                        <button
+                            key={f.key}
+                            onClick={() => setFilter(f.key)}
+                            className={`px-3 py-1 text-xs rounded-lg transition-colors ${
+                                filter === f.key
+                                    ? 'bg-[#783f8e] text-white'
+                                    : 'bg-white/10 text-white/60 hover:bg-white/20'
+                            }`}
+                        >
+                            {f.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            <div className="px-4 pb-5 sm:px-6">
+                <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                    <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                        <table className="min-w-full divide-y divide-[#e2a9f1]/10">
+                            <thead>
+                                <tr>
+                                    <th className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white sm:pl-0">
+                                        Row
+                                    </th>
+                                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                        Actual
+                                    </th>
+                                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                        Predicted
+                                    </th>
+                                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                        Result
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-[#e2a9f1]/10">
+                                {filtered.map((row) => (
+                                    <tr key={row.row}>
+                                        <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm text-white/80 sm:pl-0">
+                                            {row.row}
+                                        </td>
+                                        <td className="whitespace-nowrap px-3 py-3 text-sm text-white/80">
+                                            {row.actual_name}
+                                        </td>
+                                        <td className="whitespace-nowrap px-3 py-3 text-sm text-white/80">
+                                            {row.predicted_name}
+                                        </td>
+                                        <td className="whitespace-nowrap px-3 py-3 text-sm">
+                                            {row.correct ? (
+                                                <span className="text-green-400">&#10003;</span>
+                                            ) : (
+                                                <span className="text-red-400">&#10007;</span>
+                                            )}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                        {filtered.length === 0 && (
+                            <p className="text-center text-sm text-white/40 py-4">
+                                No rows match this filter.
+                            </p>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/components/hospital/MissedCrisesAlert.tsx
+++ b/app/components/hospital/MissedCrisesAlert.tsx
@@ -1,0 +1,55 @@
+import type { MissedCrisis } from '~/types/submission';
+
+interface MissedCrisesAlertProps {
+    missedCrisesTotal: number;
+    missedCrises: MissedCrisis[];
+}
+
+const MAX_SHOWN = 10;
+
+export default function MissedCrisesAlert({ missedCrisesTotal, missedCrises }: MissedCrisesAlertProps) {
+    if (missedCrisesTotal === 0) {
+        return (
+            <div className="bg-green-500/10 border border-green-500/30 rounded-2xl p-4 flex items-start gap-3">
+                <svg className="h-5 w-5 text-green-400 flex-shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
+                </svg>
+                <div>
+                    <p className="text-sm font-semibold text-green-300">No missed crises</p>
+                    <p className="text-xs text-green-200/70 mt-1">Your model correctly identified all crisis states.</p>
+                </div>
+            </div>
+        );
+    }
+
+    const shown = missedCrises.slice(0, MAX_SHOWN);
+    const remaining = missedCrisesTotal - shown.length;
+
+    return (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-2xl p-4 space-y-3">
+            <div className="flex items-start gap-3">
+                <svg className="h-5 w-5 text-red-400 flex-shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                </svg>
+                <div>
+                    <p className="text-sm font-semibold text-red-300">
+                        {missedCrisesTotal} missed crisis{missedCrisesTotal !== 1 ? 'es' : ''}
+                    </p>
+                    <p className="text-xs text-red-200/70 mt-1">
+                        Each missed crisis incurs a -10 point penalty. These are patients in a crisis state that your model failed to identify.
+                    </p>
+                </div>
+            </div>
+            <div className="space-y-1 pl-8">
+                {shown.map((mc) => (
+                    <p key={mc.row} className="text-xs text-red-200/80">
+                        Row {mc.row}: predicted <span className="font-medium text-red-300">{mc.predicted_name}</span>
+                    </p>
+                ))}
+                {remaining > 0 && (
+                    <p className="text-xs text-red-200/50 italic">and {remaining} more...</p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/app/components/hospital/NewestSubmissionCard.tsx
+++ b/app/components/hospital/NewestSubmissionCard.tsx
@@ -1,0 +1,76 @@
+import { timeAgo } from '~/lib/timeAgo';
+import type { HospitalSubmission } from '~/types/submission';
+
+interface NewestSubmissionCardProps {
+    submission: HospitalSubmission | null;
+}
+
+export default function NewestSubmissionCard({ submission }: NewestSubmissionCardProps) {
+    if (!submission) {
+        return (
+            <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl p-6">
+                <h2 className="text-lg font-semibold text-white">Latest Submission</h2>
+                <p className="text-white/50 mt-2 text-sm">No submissions yet.</p>
+            </div>
+        );
+    }
+
+    const feedback = submission.feedback;
+    const missedCrises = feedback != null ? feedback.missed_crises_total : null;
+    const accuracy = submission.accuracy != null
+        ? `${(submission.accuracy * 100).toFixed(1)}%`
+        : 'N/A';
+    const totalRows = feedback != null
+        ? feedback.class_stats.reduce((sum, s) => sum + s.total, 0)
+        : null;
+    const submittedBy = submission.user_name || submission.participant_name || 'Team member';
+
+    return (
+        <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl overflow-hidden">
+            <div className="flex flex-col sm:flex-row">
+                {/* Left: Score display */}
+                <div className="bg-gradient-to-br from-[#783f8e] to-[#5a2d6a] p-6 flex flex-col items-center justify-center sm:w-2/5">
+                    <p className="text-white/70 text-xs uppercase tracking-wider mb-2">Score</p>
+                    <div className="w-24 h-24 rounded-full border-4 border-white/30 flex items-center justify-center">
+                        <span className="text-3xl font-bold text-white">
+                            {typeof submission.score === 'number' ? submission.score.toFixed(1) : 'N/A'}
+                        </span>
+                    </div>
+                    <p className="text-white/80 text-sm mt-3 font-medium">
+                        {submission.team?.team_name || 'Your Team'}
+                    </p>
+                    <p className="text-white/50 text-xs mt-1">{timeAgo(submission.submitted_at)}</p>
+                </div>
+
+                {/* Right: Stats */}
+                <div className="flex-1 p-4 space-y-3">
+                    <h3 className="text-sm font-semibold text-white/70 uppercase tracking-wider">
+                        Submission Details
+                    </h3>
+                    <div className="space-y-2">
+                        <div className="flex items-center justify-between rounded-lg bg-red-500/10 px-3 py-2">
+                            <span className="text-sm text-red-300">Missed Crises</span>
+                            <span className="text-sm font-semibold text-red-400">
+                                {missedCrises != null ? missedCrises : 'N/A'}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between rounded-lg bg-yellow-500/10 px-3 py-2">
+                            <span className="text-sm text-yellow-300">Accuracy</span>
+                            <span className="text-sm font-semibold text-yellow-400">{accuracy}</span>
+                        </div>
+                        <div className="flex items-center justify-between rounded-lg bg-green-500/10 px-3 py-2">
+                            <span className="text-sm text-green-300">Total Rows</span>
+                            <span className="text-sm font-semibold text-green-400">
+                                {totalRows != null ? totalRows : 'N/A'}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between rounded-lg bg-blue-500/10 px-3 py-2">
+                            <span className="text-sm text-blue-300">Submitted By</span>
+                            <span className="text-sm font-semibold text-blue-400">{submittedBy}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/components/hospital/RecentSubmissions.tsx
+++ b/app/components/hospital/RecentSubmissions.tsx
@@ -2,7 +2,9 @@ import { timeAgo } from '~/lib/timeAgo';
 
 interface SubmissionEntry {
     id?: string;
+    submission_id?: number;
     user_name?: string;
+    participant_name?: string;
     score: number;
     accuracy?: number;
     submitted_at: string;
@@ -10,9 +12,10 @@ interface SubmissionEntry {
 
 interface RecentSubmissionsProps {
     submissions: SubmissionEntry[];
+    onRowClick?: (submissionId: number) => void;
 }
 
-export default function RecentSubmissions({ submissions }: RecentSubmissionsProps) {
+export default function RecentSubmissions({ submissions, onRowClick }: RecentSubmissionsProps) {
     if (submissions.length === 0) {
         return (
             <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl p-6">
@@ -51,9 +54,17 @@ export default function RecentSubmissions({ submissions }: RecentSubmissionsProp
                                 </thead>
                                 <tbody className="divide-y divide-[#e2a9f1]/10">
                                     {submissions.map((sub, index) => (
-                                        <tr key={sub.id || index}>
+                                        <tr
+                                            key={sub.id || index}
+                                            className={onRowClick && sub.submission_id != null ? 'cursor-pointer hover:bg-white/5 transition-colors' : ''}
+                                            onClick={() => {
+                                                if (onRowClick && sub.submission_id != null) {
+                                                    onRowClick(sub.submission_id);
+                                                }
+                                            }}
+                                        >
                                             <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-white/80 sm:pl-0">
-                                                {sub.user_name || 'Team member'}
+                                                {sub.user_name || sub.participant_name || 'Team member'}
                                             </td>
                                             <td className="whitespace-nowrap px-3 py-4 text-sm font-semibold text-white">
                                                 {typeof sub.score === 'number' ? sub.score.toFixed(2) : 'N/A'}

--- a/app/components/hospital/SubmissionHistory.tsx
+++ b/app/components/hospital/SubmissionHistory.tsx
@@ -1,0 +1,81 @@
+import { timeAgo } from '~/lib/timeAgo';
+import type { SubmissionSummary } from '~/types/submission';
+
+interface SubmissionHistoryProps {
+    submissions: SubmissionSummary[];
+    selectedId: number | null;
+    bestScore: number | null;
+    onSelect: (id: number) => void;
+}
+
+export default function SubmissionHistory({ submissions, selectedId, bestScore, onSelect }: SubmissionHistoryProps) {
+    if (submissions.length === 0) {
+        return (
+            <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl p-6">
+                <h2 className="text-lg font-semibold text-white">Submission History</h2>
+                <p className="text-white/50 mt-2 text-sm">No submissions yet.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="bg-[#1a0e2e]/80 border border-[#e2a9f1]/20 rounded-2xl">
+            <div className="px-4 py-5 sm:px-6">
+                <h2 className="text-lg font-semibold text-white">Submission History</h2>
+                <p className="mt-1 text-sm text-white/50">All your submissions. Click a row to view details.</p>
+            </div>
+            <div className="px-4 pb-5 sm:px-6">
+                <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                    <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                        <table className="min-w-full divide-y divide-[#e2a9f1]/10">
+                            <thead>
+                                <tr>
+                                    <th className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white sm:pl-0">
+                                        Score
+                                    </th>
+                                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                        Accuracy
+                                    </th>
+                                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-white">
+                                        Submitted
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-[#e2a9f1]/10">
+                                {submissions.map((sub) => {
+                                    const isBest = bestScore != null && sub.score === bestScore;
+                                    const isSelected = sub.submission_id === selectedId;
+
+                                    return (
+                                        <tr
+                                            key={sub.submission_id}
+                                            onClick={() => onSelect(sub.submission_id)}
+                                            className={`cursor-pointer transition-colors hover:bg-white/5 ${
+                                                isBest ? 'bg-[#e2a9f1]/10 border-l-2 border-[#e2a9f1]' : ''
+                                            } ${isSelected ? 'bg-white/5' : ''}`}
+                                        >
+                                            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-semibold text-white sm:pl-0">
+                                                {typeof sub.score === 'number' ? sub.score.toFixed(2) : 'N/A'}
+                                                {isBest && (
+                                                    <span className="ml-2 text-xs text-[#e2a9f1]">Best</span>
+                                                )}
+                                            </td>
+                                            <td className="whitespace-nowrap px-3 py-4 text-sm text-white/50">
+                                                {typeof sub.accuracy === 'number'
+                                                    ? `${(sub.accuracy * 100).toFixed(2)}%`
+                                                    : 'N/A'}
+                                            </td>
+                                            <td className="whitespace-nowrap px-3 py-4 text-sm text-white/50">
+                                                {timeAgo(sub.submitted_at)}
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -105,7 +105,8 @@ export async function getHospitalTeams(env: Env, request: Request) {
     }
 }
 
-export async function getHospitalTeam(env: Env, request: Request, userId: number) {
+export async function getHospitalTeam(env: Env, request: Request, userId: number | undefined) {
+    if (userId == null || !Number.isFinite(userId)) return null;
     try {
         const client = getAxios(env, request);
         const response = await client.get(`/api/v1/hackathons/hospital/teams/?member_id=${userId}`);
@@ -243,5 +244,17 @@ export async function getHospitalRecentSubmissions(env?: Env, request?: Request)
 
 export async function getHospitalLatestSubmission() {
     const response = await axiosInstance.get("/api/v1/hackathons/hospital/get_submission/");
+    return response.data;
+}
+
+export async function getHospitalSubmissionById(submissionId: number) {
+    const response = await axiosInstance.get(
+        `/api/v1/hackathons/hospital/get_submission/${submissionId}/`
+    );
+    return response.data;
+}
+
+export async function getHospitalAllSubmissions() {
+    const response = await axiosInstance.get("/api/v1/hackathons/hospital/submissions/");
     return response.data;
 }

--- a/app/types/submission.ts
+++ b/app/types/submission.ts
@@ -20,3 +20,59 @@ export interface Submission {
     submitted_at: string;
     file_url?: string;
 }
+
+// ─── Feedback types (hospital hackathon) ──────────────────────────────────────
+
+export interface ConfusionMatrix {
+    [actual: string]: { [predicted: string]: number };
+}
+
+export interface ClassStat {
+    name: string;
+    total: number;
+    correct: number;
+    accuracy: number;
+}
+
+export interface MissedCrisis {
+    row: number;
+    predicted: number;
+    predicted_name: string;
+}
+
+export interface PublicRow {
+    row: number;
+    actual: number;
+    actual_name: string;
+    predicted: number;
+    predicted_name: string;
+    correct: boolean;
+}
+
+export interface Feedback {
+    confusion_matrix: ConfusionMatrix;
+    class_stats: ClassStat[];
+    missed_crises: MissedCrisis[];
+    missed_crises_total: number;
+    first_100_public: PublicRow[];
+}
+
+export interface SubmissionSummary {
+    submission_id: number;
+    participant_name?: string;
+    score: number;
+    accuracy?: number;
+    submitted_at: string;
+    team?: Team;
+}
+
+export interface HospitalSubmission {
+    submission_id: number;
+    participant_name?: string;
+    user_name?: string;
+    team?: Team;
+    score: number;
+    accuracy?: number;
+    submitted_at: string;
+    feedback?: Feedback | null;
+}


### PR DESCRIPTION
## Summary
- Replace per-row `predictions[]` with structured `feedback` object (confusion matrix, per-class stats, missed crises, first-100-rows breakdown)
- Update `getHospitalSubmissionById` endpoint from query param (`?id=`) to path param (`/{id}/`)
- Add `getHospitalAllSubmissions` API function and new feedback visualization components: `ClassAccuracyBars`, `ConfusionMatrixHeatmap`, `MissedCrisesAlert`, `First100RowsTable`, `SubmissionHistory`
- Rewrite `NewestSubmissionCard` to derive stats from feedback, add `participant_name` fallback to `RecentSubmissions`

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run build` succeeds
- [ ] Navigate to `/hospital/app/submit` with a team — score card, feedback visualizations, and submission history render correctly
- [ ] Click a submission row to load its detailed feedback
- [ ] Old submissions with null feedback show graceful fallback message
- [ ] New submission refreshes all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)