### PR TITLE
Fix class_stats crash when backend returns object instead of array

### DIFF
--- a/app/components/hospital/ClassAccuracyBars.tsx
+++ b/app/components/hospital/ClassAccuracyBars.tsx
@@ -1,4 +1,5 @@
 import type { Feedback } from '~/types/submission';
+import { normalizeClassStats } from '~/types/submission';
 
 const CLASS_COLORS: Record<string, string> = {
     Normal: '#22c55e',
@@ -11,7 +12,8 @@ interface ClassAccuracyBarsProps {
     classStats: Feedback['class_stats'] | undefined;
 }
 
-export default function ClassAccuracyBars({ classStats }: ClassAccuracyBarsProps) {
+export default function ClassAccuracyBars({ classStats: rawClassStats }: ClassAccuracyBarsProps) {
+    const classStats = normalizeClassStats(rawClassStats);
     if (!classStats) return null;
 
     return (

--- a/app/components/hospital/NewestSubmissionCard.tsx
+++ b/app/components/hospital/NewestSubmissionCard.tsx
@@ -1,5 +1,6 @@
 import { timeAgo } from '~/lib/timeAgo';
 import type { HospitalSubmission } from '~/types/submission';
+import { normalizeClassStats } from '~/types/submission';
 
 interface NewestSubmissionCardProps {
     submission: HospitalSubmission | null;
@@ -20,8 +21,9 @@ export default function NewestSubmissionCard({ submission }: NewestSubmissionCar
     const accuracy = submission.accuracy != null
         ? `${(submission.accuracy * 100).toFixed(1)}%`
         : 'N/A';
-    const totalRows = feedback != null
-        ? feedback.class_stats.reduce((sum, s) => sum + s.total, 0)
+    const classStats = feedback != null ? normalizeClassStats(feedback.class_stats) : undefined;
+    const totalRows = classStats
+        ? classStats.reduce((sum, s) => sum + s.total, 0)
         : null;
     const submittedBy = submission.user_name || submission.participant_name || 'Team member';
 

--- a/app/types/submission.ts
+++ b/app/types/submission.ts
@@ -51,10 +51,19 @@ export interface PublicRow {
 
 export interface Feedback {
     confusion_matrix: ConfusionMatrix;
-    class_stats: ClassStat[];
+    class_stats: ClassStat[] | Record<string, Omit<ClassStat, 'name'>>;
     missed_crises: MissedCrisis[];
     missed_crises_total: number;
     first_100_public: PublicRow[];
+}
+
+/** Normalize class_stats from either array or object form into a ClassStat[] */
+export function normalizeClassStats(
+    raw: Feedback['class_stats'] | undefined
+): ClassStat[] | undefined {
+    if (!raw) return undefined;
+    if (Array.isArray(raw)) return raw;
+    return Object.entries(raw).map(([name, stat]) => ({ name, ...stat }));
 }
 
 export interface SubmissionSummary {


### PR DESCRIPTION
The API returns class_stats as a keyed object rather than an array. Add normalizeClassStats helper to handle both shapes, and use it in NewestSubmissionCard and ClassAccuracyBars.