### PR TITLE
Fix hospital leaderboard loader to use server-side axios

### DIFF
--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -258,3 +258,9 @@ export async function getHospitalAllSubmissions() {
     const response = await axiosInstance.get("/api/v1/hackathons/hospital/submissions/");
     return response.data;
 }
+
+export async function getHospitalLeaderboard(env: Env, request: Request) {
+    const client = getAxios(env, request);
+    const response = await client.get("/api/v1/hackathons/hospital/leaderboard/");
+    return response.data;
+}

--- a/app/routes/hospital.app.leaderboard.tsx
+++ b/app/routes/hospital.app.leaderboard.tsx
@@ -1,22 +1,15 @@
 import type { Route } from "./+types/hospital.app.leaderboard";
-import { useLoaderData, redirect } from "react-router";
-import { axiosInstance } from "~/lib/api";
-import { getCurrentUser } from "~/lib/auth";
+import { useLoaderData } from "react-router";
+import { getCurrentUser, getHospitalLeaderboard } from "~/lib/auth";
 import { getEnv } from "~/lib/env.server";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
     const user = await getCurrentUser(env, request);
 
-    let leaderboard = [];
+    let leaderboard: any[] = [];
     try {
-        const cookieHeader = request.headers.get("Cookie");
-        const headers: Record<string, string> = {};
-        if (cookieHeader) {
-            headers["Cookie"] = cookieHeader;
-        }
-        const response = await axiosInstance.get("/api/v1/hackathons/hospital/leaderboard/", { headers });
-        leaderboard = response.data;
+        leaderboard = await getHospitalLeaderboard(env, request);
     } catch (error) {
         console.error("Failed to fetch leaderboard:", error);
     }


### PR DESCRIPTION
The loader was using the client-side axiosInstance which has the wrong base URL server-side, so the leaderboard API call silently failed. Switch to getAxios(env, request) via a new getHospitalLeaderboard helper.