### PR TITLE
Use email-draft flow for Vibe Raising Gmail drafting

### DIFF
--- a/app/components/DraftFromEmailWizard.tsx
+++ b/app/components/DraftFromEmailWizard.tsx
@@ -2,7 +2,6 @@ import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { clsx } from "clsx";
 import {
-  EnvelopeIcon,
   SparklesIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
@@ -28,7 +27,7 @@ interface DraftFromEmailWizardProps {
 }
 
 type WizardStep = "provider" | "drafting";
-type Provider = "gmail" | "outlook";
+type Provider = "gmail";
 
 const DEFAULT_DRAFTING_MESSAGE =
   "AI is scanning your recent emails and drafting your investor update.";
@@ -78,7 +77,7 @@ function ProviderStep({
         We&apos;ll scan your recent emails to draft your investor update.
       </p>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 gap-4">
         <button
           type="button"
           onClick={onConnectGmail}
@@ -114,19 +113,7 @@ function ProviderStep({
             </svg>
           )}
           <span className="font-bold text-gray-900">
-            {gmailBusy ? "Redirecting..." : "Gmail"}
-          </span>
-        </button>
-
-        <button
-          type="button"
-          disabled
-          className="relative flex cursor-not-allowed flex-col items-center gap-4 rounded-xl border-2 border-gray-200 bg-gray-50 p-6 opacity-70"
-        >
-          <EnvelopeIcon className="h-12 w-12 text-blue-600" />
-          <span className="font-bold text-gray-900">Outlook</span>
-          <span className="text-xs font-medium uppercase tracking-[0.24em] text-gray-400">
-            Coming soon
+            {gmailBusy ? "Connecting..." : "Continue with Gmail"}
           </span>
         </button>
       </div>
@@ -201,14 +188,16 @@ export default function DraftFromEmailWizard({
 
   const handleStatus = useCallback(
     (statusResponse: VibeRaisingStartupUpdateStatusResponse) => {
-      if (statusResponse.state === "ready" && statusResponse.draft) {
+      if (statusResponse.state === "completed" && statusResponse.draft) {
         onDraftComplete(statusResponse.draft);
         return false;
       }
 
-      if (statusResponse.state === "processing") {
+      if (statusResponse.state === "queued" || statusResponse.state === "running") {
         setStep("drafting");
-        setStatusMessage(formatRunStep(statusResponse.run?.currentStep));
+        setStatusMessage(
+          formatRunStep(statusResponse.currentStep ?? statusResponse.run?.currentStep),
+        );
         return true;
       }
 
@@ -217,7 +206,7 @@ export default function DraftFromEmailWizard({
         statusResponse.error ??
           (statusResponse.state === "needs_domain"
             ? "Add a company domain before connecting Gmail."
-            : statusResponse.state === "needs_google_auth"
+            : statusResponse.state === "auth_required"
               ? "Reconnect Gmail to continue drafting from email."
               : "We couldn't draft your update from Gmail. Please try again."),
       );

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -78,9 +78,13 @@ export function createApiClient(env: any, request?: Request) {
                 }
                 config.headers.set('X-CSRFToken', csrfToken);
             }
+            const headerObject =
+                config.headers && typeof config.headers.toJSON === "function"
+                    ? config.headers.toJSON()
+                    : config.headers;
             console.log(`[API] Request ${config.method?.toUpperCase()} ${config.url}`, {
                 baseURL: config.baseURL,
-                headers: config.headers,
+                headers: sanitizeHeaders(headerObject),
                 dataIsFormData: config.data instanceof FormData
             });
             return config;
@@ -124,6 +128,22 @@ const getCSRFToken = () => {
     return cookieValue;
 };
 
+function sanitizeHeaders(
+    headers: Record<string, unknown> | AxiosHeaders | undefined,
+): Record<string, unknown> | undefined {
+    if (!headers || typeof headers !== "object") {
+        return headers as Record<string, unknown> | undefined;
+    }
+
+    const clone: Record<string, unknown> = { ...(headers as Record<string, unknown>) };
+    for (const key of Object.keys(clone)) {
+        if (key.toLowerCase() === "cookie") {
+            clone[key] = "[redacted]";
+        }
+    }
+    return clone;
+}
+
 axiosInstance.interceptors.request.use(
     (config: InternalAxiosRequestConfig) => {
         const csrfToken = getCSRFToken();
@@ -135,8 +155,12 @@ axiosInstance.interceptors.request.use(
             // Set the CSRF token
             config.headers.set('X-CSRFToken', csrfToken);
         }
+        const headerObject =
+            config.headers && typeof config.headers.toJSON === "function"
+                ? config.headers.toJSON()
+                : config.headers;
         console.log(`[API] Request ${config.method?.toUpperCase()} ${config.url}`, {
-            headers: config.headers,
+            headers: sanitizeHeaders(headerObject),
             dataIsFormData: config.data instanceof FormData
         });
         return config;

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -6,10 +6,12 @@ import type {
   VibeRaisingAppUser,
   VibeRaisingCompany,
   VibeRaisingDraftedContent,
+  VibeRaisingEmailDraftMonth,
   VibeRaisingProfile,
   VibeRaisingRole,
   VibeRaisingStartupUpdateBootstrapResponse,
   VibeRaisingStartupUpdateRunSummary,
+  VibeRaisingStartupUpdateStepState,
   VibeRaisingStartupUpdateState,
   VibeRaisingStartupUpdateStatusResponse,
 } from "~/types/vibe-raising";
@@ -18,8 +20,8 @@ const PROFILE_PATH = "/api/v1/vibe-raising/profile/";
 const COMPANIES_PATH = "/api/v1/vibe-raising/companies/";
 const ACTIVE_COMPANY_PATH = "/api/v1/vibe-raising/active-company/";
 const STARTUP_UPDATE_BOOTSTRAP_PATH = "/api/v1/vibe-raising/startup-update/bootstrap/";
-const STARTUP_UPDATE_RUN_PATH = "/api/v1/vibe-raising/startup-update/run/";
-const STARTUP_UPDATE_STATUS_PATH = "/api/v1/vibe-raising/startup-update/status/";
+const EMAIL_DRAFT_START_PATH = "/api/v1/vibe-raising/email-draft/start/";
+const EMAIL_DRAFT_STATUS_PATH = "/api/v1/vibe-raising/email-draft/status/";
 
 type OptionalContext = {
   authUser: User | null;
@@ -216,6 +218,73 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
   };
 }
 
+function normalizeStepStates(raw: unknown): Record<string, VibeRaisingStartupUpdateStepState> {
+  if (!raw || typeof raw !== "object") return {};
+
+  const normalized: Record<string, VibeRaisingStartupUpdateStepState> = {};
+  for (const [stepKey, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object") continue;
+    const payload = value as Record<string, unknown>;
+    normalized[stepKey] = {
+      name: asNullableString(payload.name) ?? stepKey,
+      required: Boolean(payload.required),
+      status: asNullableString(payload.status) ?? "",
+      attempts:
+        typeof payload.attempts === "number" && Number.isFinite(payload.attempts)
+          ? payload.attempts
+          : Number(payload.attempts ?? 0) || 0,
+      message: asNullableString(payload.message),
+      startedAt:
+        asNullableString(payload.startedAt) ??
+        asNullableString(payload.started_at),
+      completedAt:
+        asNullableString(payload.completedAt) ??
+        asNullableString(payload.completed_at),
+      error: asNullableString(payload.error),
+      artifacts: Array.isArray(payload.artifacts) ? payload.artifacts : [],
+    };
+  }
+
+  return normalized;
+}
+
+function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const payload = unwrapPayload(raw) as Record<string, unknown>;
+  const month = asNullableString(payload.month);
+  if (!month) return null;
+
+  const rawDraftId = payload.draftId ?? payload.draft_id;
+  const draftId =
+    typeof rawDraftId === "number" && Number.isFinite(rawDraftId)
+      ? rawDraftId
+      : typeof rawDraftId === "string" && rawDraftId.trim()
+        ? Number(rawDraftId)
+        : undefined;
+  const rawYear = payload.year;
+  const year =
+    typeof rawYear === "number" && Number.isFinite(rawYear)
+      ? rawYear
+      : typeof rawYear === "string" && rawYear.trim()
+        ? Number(rawYear)
+        : undefined;
+
+  return {
+    draftId: typeof draftId === "number" && Number.isFinite(draftId) ? draftId : undefined,
+    isoMonth:
+      asNullableString(payload.isoMonth) ??
+      asNullableString(payload.iso_month) ??
+      undefined,
+    month,
+    year: typeof year === "number" && Number.isFinite(year) ? year : undefined,
+    highlights: asNullableString(payload.highlights) ?? "",
+    challenges: asNullableString(payload.challenges) ?? "",
+    asks: asNullableString(payload.asks) ?? "",
+    metrics: normalizeMetrics(payload.metrics),
+  };
+}
+
 function normalizeStartupUpdateRun(raw: unknown): VibeRaisingStartupUpdateRunSummary | null {
   if (!raw || typeof raw !== "object") return null;
 
@@ -248,17 +317,30 @@ function normalizeStartupUpdateRun(raw: unknown): VibeRaisingStartupUpdateRunSum
       asNullableString(payload.updatedAt) ??
       asNullableString(payload.updated_at) ??
       undefined,
+    stepStates: normalizeStepStates(
+      payload.stepStates ??
+        payload.step_states,
+    ),
   };
 }
 
 function normalizeStartupUpdateState(value: unknown): VibeRaisingStartupUpdateState {
   switch (value) {
     case "needs_domain":
+      return "needs_domain";
+    case "auth_required":
     case "needs_google_auth":
+      return "auth_required";
+    case "queued":
+      return "queued";
+    case "running":
     case "processing":
+      return "running";
+    case "completed":
     case "ready":
+      return "completed";
     case "failed":
-      return value;
+      return "failed";
     default:
       return "failed";
   }
@@ -332,14 +414,60 @@ function normalizeStartupUpdateStatus(
   raw: unknown,
 ): VibeRaisingStartupUpdateStatusResponse {
   const payload = unwrapPayload(raw) as Record<string, unknown>;
+  const currentMonth =
+    normalizeEmailDraftMonth(payload.currentMonth) ??
+    normalizeEmailDraftMonth(payload.current_month);
+  const rawPastMonths = payload.pastMonths ?? payload.past_months;
+  const pastMonths = Array.isArray(rawPastMonths)
+    ? rawPastMonths
+        .map(normalizeEmailDraftMonth)
+        .filter((value): value is VibeRaisingEmailDraftMonth => value !== null)
+    : [];
+  const run = normalizeStartupUpdateRun(payload.run ?? payload);
+  const draft =
+    normalizeDraftedContent(payload.draft) ??
+    normalizeDraftedContent({
+      ...(currentMonth ?? {}),
+      pastMonths,
+    });
+  const topLevelStepStates = normalizeStepStates(
+    payload.stepStates ??
+      payload.step_states,
+  );
   return {
     state: normalizeStartupUpdateState(payload.state),
-    googleConnected: Boolean(
-      payload.googleConnected ?? payload.google_connected,
+    gmailConnected: Boolean(
+      payload.gmailConnected ??
+        payload.gmail_connected ??
+        payload.googleConnected ??
+        payload.google_connected,
     ),
+    authUrl:
+      asNullableString(payload.authUrl) ??
+      asNullableString(payload.auth_url),
     company: payload.company ? normalizeCompany(payload.company) : null,
-    run: normalizeStartupUpdateRun(payload.run),
-    draft: normalizeDraftedContent(payload.draft),
+    run,
+    draft,
+    runId:
+      asNullableString(payload.runId) ??
+      asNullableString(payload.run_id) ??
+      run?.runId ??
+      null,
+    status:
+      asNullableString(payload.status) ??
+      run?.status ??
+      null,
+    currentStep:
+      asNullableString(payload.currentStep) ??
+      asNullableString(payload.current_step) ??
+      run?.currentStep ??
+      null,
+    stepStates:
+      Object.keys(topLevelStepStates).length > 0
+        ? topLevelStepStates
+        : (run?.stepStates ?? {}),
+    currentMonth,
+    pastMonths,
     error:
       asNullableString(payload.error) ??
       asNullableString(payload.detail),
@@ -581,7 +709,10 @@ export async function bootstrapVibeRaisingStartupUpdate(
             ),
           }
         : null,
-    oauthUrl: asNullableString(response.oauthUrl) ?? "",
+    oauthUrl:
+      asNullableString(response.oauthUrl) ??
+      asNullableString(response.oauth_url) ??
+      "",
   };
 }
 
@@ -590,7 +721,7 @@ export async function runVibeRaisingStartupUpdate(
 ): Promise<VibeRaisingStartupUpdateStatusResponse> {
   const response = await requestBrowserJson<Record<string, unknown>>(
     backendBaseUrl,
-    STARTUP_UPDATE_RUN_PATH,
+    EMAIL_DRAFT_START_PATH,
     { method: "POST" },
   );
   return normalizeStartupUpdateStatus(response);
@@ -601,7 +732,7 @@ export async function getVibeRaisingStartupUpdateStatus(
 ): Promise<VibeRaisingStartupUpdateStatusResponse> {
   const response = await requestBrowserJson<Record<string, unknown>>(
     backendBaseUrl,
-    STARTUP_UPDATE_STATUS_PATH,
+    EMAIL_DRAFT_STATUS_PATH,
     { method: "GET" },
   );
   return normalizeStartupUpdateStatus(response);

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -40,7 +40,9 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     // Check for edit mode
     const url = new URL(request.url);
     const editId = url.searchParams.get("edit");
-    const resumeEmailDrafting = url.searchParams.get("draft_from_email") === "1";
+    const resumeEmailDrafting =
+        url.searchParams.get("email_draft") === "1" ||
+        url.searchParams.get("draft_from_email") === "1";
 
     let existingData = null;
     if (editId) {
@@ -633,6 +635,7 @@ export default function CreateUpdate() {
         if (initial.size === 0) initial.add("revenue");
         return initial;
     });
+    const canGenerateDraftFromEmail = Boolean((user.domain || "").trim());
 
     const handleDraftComplete = (data: any) => {
         if (data.month) setSelectedMonth(data.month);
@@ -661,7 +664,7 @@ export default function CreateUpdate() {
         const params = new URLSearchParams(location.search);
         let changed = false;
 
-        ["gmail_connected", "draft_from_email"].forEach((key) => {
+        ["gmail_connected", "draft_from_email", "email_draft"].forEach((key) => {
             if (params.has(key)) {
                 params.delete(key);
                 changed = true;
@@ -1399,23 +1402,45 @@ export default function CreateUpdate() {
                 {/* ─── Draft from Email Banner ─── */}
                 <button
                     type="button"
-                    onClick={() => setShowEmailWizard(true)}
-                    className="w-full bg-gradient-to-br from-purple-50 to-blue-50 rounded-2xl border border-purple-100 p-8 shadow-sm overflow-hidden relative group hover:shadow-md hover:border-purple-200 transition-all cursor-pointer text-left"
+                    onClick={() => {
+                        if (canGenerateDraftFromEmail) {
+                            setShowEmailWizard(true);
+                            return;
+                        }
+                        navigate("/vibe-raising/companies");
+                    }}
+                    className={clsx(
+                        "w-full rounded-2xl border p-8 shadow-sm overflow-hidden relative text-left transition-all",
+                        canGenerateDraftFromEmail
+                            ? "bg-gradient-to-br from-purple-50 to-blue-50 border-purple-100 group hover:shadow-md hover:border-purple-200 cursor-pointer"
+                            : "bg-gray-50 border-gray-200 cursor-pointer hover:border-gray-300",
+                    )}
                 >
-                    <div className="absolute top-0 right-0 -mt-8 -mr-8 w-32 h-32 bg-purple-200/20 blur-3xl rounded-full" />
+                    <div className={clsx(
+                        "absolute top-0 right-0 -mt-8 -mr-8 w-32 h-32 blur-3xl rounded-full",
+                        canGenerateDraftFromEmail ? "bg-purple-200/20" : "bg-gray-300/20",
+                    )} />
                     <div className="relative z-10 flex items-center gap-5">
-                        <div className="flex-shrink-0 w-14 h-14 rounded-xl bg-purple-100 flex items-center justify-center group-hover:bg-purple-200 transition-colors">
-                            <SparklesIcon className="w-7 h-7 text-purple-600" />
+                        <div className={clsx(
+                            "flex-shrink-0 w-14 h-14 rounded-xl flex items-center justify-center transition-colors",
+                            canGenerateDraftFromEmail ? "bg-purple-100 group-hover:bg-purple-200" : "bg-gray-200",
+                        )}>
+                            <SparklesIcon className={clsx("w-7 h-7", canGenerateDraftFromEmail ? "text-purple-600" : "text-gray-500")} />
                         </div>
                         <div className="flex-1">
                             <h2 className="text-lg font-bold text-gray-900">
                                 Generate Draft from Email
                             </h2>
                             <p className="text-sm text-gray-500 mt-0.5">
-                                Connect your inbox and let AI analyze recent emails to auto-fill metrics, highlights, and past months in seconds.
+                                {canGenerateDraftFromEmail
+                                    ? "Connect your inbox and let AI analyze recent emails to auto-fill metrics, highlights, and past months in seconds."
+                                    : "Add a company domain first so Gmail emails can be matched to the right startup."}
                             </p>
                         </div>
-                        <ArrowRightIcon className="w-5 h-5 text-purple-400 group-hover:translate-x-1 transition-transform flex-shrink-0" />
+                        <ArrowRightIcon className={clsx(
+                            "w-5 h-5 transition-transform flex-shrink-0",
+                            canGenerateDraftFromEmail ? "text-purple-400 group-hover:translate-x-1" : "text-gray-400",
+                        )} />
                     </div>
                 </button>
 

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -52,10 +52,23 @@ export interface VibeRaisingDraftedContent {
 
 export type VibeRaisingStartupUpdateState =
   | "needs_domain"
-  | "needs_google_auth"
-  | "processing"
-  | "ready"
+  | "auth_required"
+  | "queued"
+  | "running"
+  | "completed"
   | "failed";
+
+export interface VibeRaisingStartupUpdateStepState {
+  name: string;
+  required: boolean;
+  status: string;
+  attempts: number;
+  message?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  error?: string | null;
+  artifacts?: unknown[];
+}
 
 export interface VibeRaisingStartupUpdateBindingSummary {
   organizationId: number;
@@ -69,8 +82,20 @@ export interface VibeRaisingStartupUpdateRunSummary {
   domain: string;
   status: string;
   currentStep?: string | null;
+  stepStates?: Record<string, VibeRaisingStartupUpdateStepState>;
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface VibeRaisingEmailDraftMonth {
+  draftId?: number;
+  isoMonth?: string;
+  month: string;
+  year?: number;
+  highlights: string;
+  challenges: string;
+  asks: string;
+  metrics?: Record<string, string>;
 }
 
 export interface VibeRaisingStartupUpdateBootstrapResponse {
@@ -82,9 +107,16 @@ export interface VibeRaisingStartupUpdateBootstrapResponse {
 
 export interface VibeRaisingStartupUpdateStatusResponse {
   state: VibeRaisingStartupUpdateState;
-  googleConnected: boolean;
+  gmailConnected: boolean;
+  authUrl?: string | null;
   company: VibeRaisingCompany | null;
   run: VibeRaisingStartupUpdateRunSummary | null;
   draft: VibeRaisingDraftedContent | null;
+  runId?: string | null;
+  status?: string | null;
+  currentStep?: string | null;
+  stepStates?: Record<string, VibeRaisingStartupUpdateStepState>;
+  currentMonth?: VibeRaisingEmailDraftMonth | null;
+  pastMonths: VibeRaisingEmailDraftMonth[];
   error?: string | null;
 }


### PR DESCRIPTION
## Summary
- switch the Vibe Raising Gmail drafting flow to the backend email-draft start/status contract
- resume draft generation automatically after Google OAuth and handle queued/running/completed states in the wizard
- redact cookie headers from frontend API debug logging

## Testing
- bun run typecheck

## Notes
- This PR is stacked on valley-landing-page because the Vibe Raising email-draft flow files are not on main yet.
