### PR TITLE
[codex] Curated Vibe Raising PR 386 port

### DIFF
--- a/app/components/DraftFromEmailWizard.tsx
+++ b/app/components/DraftFromEmailWizard.tsx
@@ -1,7 +1,9 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
+import { Link } from "react-router";
 import { Dialog, Transition } from "@headlessui/react";
 import { clsx } from "clsx";
 import {
+  ShieldCheckIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 
@@ -32,12 +34,18 @@ function ProviderStep({
   companyDomain,
   connectingProvider,
   errorMessage,
+  showGmailNotice,
   onConnectGmail,
+  onReviewGmailNotice,
+  onCancelGmailNotice,
 }: {
   companyDomain?: string | null;
   connectingProvider: Provider | null;
   errorMessage: string | null;
+  showGmailNotice: boolean;
   onConnectGmail: () => void;
+  onReviewGmailNotice: () => void;
+  onCancelGmailNotice: () => void;
 }) {
   const gmailBusy = connectingProvider === "gmail";
 
@@ -47,13 +55,13 @@ function ProviderStep({
         Connect Your Email
       </h3>
       <p className="mb-8 text-center text-sm text-gray-500">
-        We&apos;ll scan your recent emails to draft your investor update.
+        We&apos;ll only scan filtered emails relevant to drafting your investor update.
       </p>
 
       <div className="grid grid-cols-1 gap-4">
         <button
           type="button"
-          onClick={onConnectGmail}
+          onClick={onReviewGmailNotice}
           disabled={connectingProvider !== null}
           className={clsx(
             "relative flex flex-col items-center gap-4 rounded-xl border-2 p-6 transition-all duration-200",
@@ -91,6 +99,49 @@ function ProviderStep({
         </button>
       </div>
 
+      {showGmailNotice && (
+        <div className="mt-5 rounded-2xl border border-violet-100 bg-violet-50/70 p-4">
+          <div className="flex items-start gap-3">
+            <div className="rounded-xl bg-white p-2 text-violet-600 shadow-sm">
+              <ShieldCheckIcon className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h4 className="text-sm font-bold text-gray-900">Before you connect Gmail</h4>
+              <p className="mt-1 text-sm leading-relaxed text-gray-600">
+                We request Gmail access only to locate emails that match your company context and draft this update.
+                You can disconnect Google access at any time from your Google account.
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-semibold text-violet-700">
+                <Link to="/privacy" target="_blank" className="hover:text-violet-900">
+                  Privacy Policy
+                </Link>
+                <Link to="/terms" target="_blank" className="hover:text-violet-900">
+                  Terms
+                </Link>
+              </div>
+              <div className="mt-4 flex gap-2">
+                <button
+                  type="button"
+                  onClick={onCancelGmailNotice}
+                  disabled={connectingProvider !== null}
+                  className="flex-1 rounded-xl border border-violet-200 bg-white px-4 py-2 text-sm font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:opacity-60"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={onConnectGmail}
+                  disabled={connectingProvider !== null}
+                  className="flex-1 rounded-xl bg-violet-600 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-violet-700 disabled:opacity-60"
+                >
+                  {gmailBusy ? "Connecting..." : "Continue"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {!companyDomain && (
         <p className="mt-4 text-sm text-amber-700">
           Add a company domain in{" "}
@@ -119,6 +170,7 @@ export default function DraftFromEmailWizard({
 }: DraftFromEmailWizardProps) {
   const [connectingProvider, setConnectingProvider] = useState<Provider | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showGmailNotice, setShowGmailNotice] = useState(false);
 
   const handleGmailConnect = useCallback(async () => {
     if (!companyDomain?.trim()) {
@@ -154,6 +206,7 @@ export default function DraftFromEmailWizard({
     if (!isOpen) {
       setConnectingProvider(null);
       setErrorMessage(null);
+      setShowGmailNotice(false);
     }
   }, [isOpen]);
 
@@ -200,7 +253,10 @@ export default function DraftFromEmailWizard({
                   companyDomain={companyDomain}
                   connectingProvider={connectingProvider}
                   errorMessage={errorMessage}
+                  showGmailNotice={showGmailNotice}
                   onConnectGmail={handleGmailConnect}
+                  onReviewGmailNotice={() => setShowGmailNotice(true)}
+                  onCancelGmailNotice={() => setShowGmailNotice(false)}
                 />
               </Dialog.Panel>
             </Transition.Child>

--- a/app/components/ResponsibleInvestorsSection.tsx
+++ b/app/components/ResponsibleInvestorsSection.tsx
@@ -1,0 +1,14 @@
+export default function ResponsibleInvestorsSection() {
+  return (
+    <div className="bg-black px-6 py-5 text-white sm:px-8 lg:px-10">
+      <div className="mx-auto flex max-w-5xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/55">
+          Investor Onboard
+        </p>
+        <p className="text-lg font-semibold tracking-tight sm:text-xl lg:text-2xl">
+          Ryan Cheah, Founder of The 21st, is onboard.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/components/StartupRegionBadge.tsx
+++ b/app/components/StartupRegionBadge.tsx
@@ -1,0 +1,118 @@
+import { clsx } from "clsx";
+
+type StartupRegionBadgeVariant = "default" | "inverse";
+
+interface StartupRegionBadgeProps {
+  location?: string | null;
+  className?: string;
+  variant?: StartupRegionBadgeVariant;
+}
+
+interface RegionBadge {
+  code: string;
+  countryCode?: string;
+}
+
+const COUNTRY_BADGE_PATTERNS: Array<{ pattern: RegExp; badge: RegionBadge }> = [
+  { pattern: /\b(australia|australian|aus)\b/i, badge: { countryCode: "AU", code: "AUS" } },
+  { pattern: /\b(united states|usa|u\.s\.a)\b/i, badge: { countryCode: "US", code: "USA" } },
+  { pattern: /\b(united kingdom|great britain|britain|england|scotland|wales|gbr|uk)\b/i, badge: { countryCode: "GB", code: "GBR" } },
+  { pattern: /\b(canada|can)\b/i, badge: { countryCode: "CA", code: "CAN" } },
+  { pattern: /\b(new zealand|nzl)\b/i, badge: { countryCode: "NZ", code: "NZL" } },
+  { pattern: /\b(singapore|sgp)\b/i, badge: { countryCode: "SG", code: "SGP" } },
+  { pattern: /\b(india|ind)\b/i, badge: { countryCode: "IN", code: "IND" } },
+  { pattern: /\b(germany|deu)\b/i, badge: { countryCode: "DE", code: "DEU" } },
+  { pattern: /\b(france|fra)\b/i, badge: { countryCode: "FR", code: "FRA" } },
+  { pattern: /\b(japan|jpn)\b/i, badge: { countryCode: "JP", code: "JPN" } },
+  { pattern: /\b(china|chn)\b/i, badge: { countryCode: "CN", code: "CHN" } },
+  { pattern: /\b(hong kong|hkg)\b/i, badge: { countryCode: "HK", code: "HKG" } },
+  { pattern: /\b(united arab emirates|uae)\b/i, badge: { countryCode: "AE", code: "UAE" } },
+  { pattern: /\b(israel|isr)\b/i, badge: { countryCode: "IL", code: "ISR" } },
+  { pattern: /\b(netherlands|nld)\b/i, badge: { countryCode: "NL", code: "NLD" } },
+];
+
+const REGION_PATTERNS: Array<{ pattern: RegExp; badge: RegionBadge }> = [
+  { pattern: /\b(melbourne|victoria|vic)\b/i, badge: { countryCode: "AU", code: "MEL" } },
+  { pattern: /\b(sydney|new south wales|nsw)\b/i, badge: { countryCode: "AU", code: "SYD" } },
+  { pattern: /\b(brisbane|queensland|qld)\b/i, badge: { countryCode: "AU", code: "BNE" } },
+  { pattern: /\b(perth|western australia|wa)\b/i, badge: { countryCode: "AU", code: "PER" } },
+  { pattern: /\b(adelaide|south australia|sa)\b/i, badge: { countryCode: "AU", code: "ADL" } },
+  { pattern: /\b(canberra|australian capital territory|act)\b/i, badge: { countryCode: "AU", code: "CBR" } },
+  { pattern: /\b(hobart|tasmania|tas)\b/i, badge: { countryCode: "AU", code: "HBA" } },
+  { pattern: /\b(darwin|northern territory|nt)\b/i, badge: { countryCode: "AU", code: "DRW" } },
+  { pattern: /\b(san francisco|bay area|silicon valley)\b/i, badge: { countryCode: "US", code: "SFO" } },
+  { pattern: /\b(new york|nyc)\b/i, badge: { countryCode: "US", code: "NYC" } },
+  { pattern: /\b(seattle)\b/i, badge: { countryCode: "US", code: "SEA" } },
+  { pattern: /\b(austin)\b/i, badge: { countryCode: "US", code: "ATX" } },
+  { pattern: /\b(london)\b/i, badge: { countryCode: "GB", code: "LDN" } },
+  { pattern: /\b(singapore)\b/i, badge: { countryCode: "SG", code: "SGP" } },
+  { pattern: /\b(auckland)\b/i, badge: { countryCode: "NZ", code: "AKL" } },
+  { pattern: /\b(wellington)\b/i, badge: { countryCode: "NZ", code: "WLG" } },
+  { pattern: /\b(toronto)\b/i, badge: { countryCode: "CA", code: "TOR" } },
+  { pattern: /\b(vancouver)\b/i, badge: { countryCode: "CA", code: "YVR" } },
+  { pattern: /\b(bengaluru|bangalore)\b/i, badge: { countryCode: "IN", code: "BLR" } },
+  { pattern: /\b(delhi|new delhi)\b/i, badge: { countryCode: "IN", code: "DEL" } },
+  { pattern: /\b(mumbai)\b/i, badge: { countryCode: "IN", code: "BOM" } },
+  { pattern: /\b(berlin)\b/i, badge: { countryCode: "DE", code: "BER" } },
+  { pattern: /\b(paris)\b/i, badge: { countryCode: "FR", code: "PAR" } },
+  { pattern: /\b(tokyo)\b/i, badge: { countryCode: "JP", code: "TYO" } },
+  { pattern: /\b(hong kong)\b/i, badge: { countryCode: "HK", code: "HKG" } },
+  { pattern: /\b(dubai)\b/i, badge: { countryCode: "AE", code: "DXB" } },
+  { pattern: /\b(tel aviv)\b/i, badge: { countryCode: "IL", code: "TLV" } },
+  { pattern: /\b(amsterdam)\b/i, badge: { countryCode: "NL", code: "AMS" } },
+  { pattern: /\b(global|remote)\b/i, badge: { code: "GLB" } },
+];
+
+function getFlagAssetUrl(countryCode: string): string {
+  return `https://flagcdn.com/${countryCode.toLowerCase()}.svg`;
+}
+
+export function getStartupRegionBadge(location?: string | null): RegionBadge {
+  const normalizedLocation = location?.trim();
+
+  if (!normalizedLocation) {
+    return { countryCode: "AU", code: "AUS" };
+  }
+
+  const matchedRegion = REGION_PATTERNS.find(({ pattern }) => pattern.test(normalizedLocation));
+  if (matchedRegion) {
+    return matchedRegion.badge;
+  }
+
+  const matchedCountry = COUNTRY_BADGE_PATTERNS.find(({ pattern }) => pattern.test(normalizedLocation));
+  return matchedCountry?.badge ?? { countryCode: "AU", code: "AUS" };
+}
+
+export default function StartupRegionBadge({
+  location,
+  className,
+  variant = "default",
+}: StartupRegionBadgeProps) {
+  const { code, countryCode } = getStartupRegionBadge(location);
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[10px] font-bold leading-none tracking-widest",
+        variant === "inverse"
+          ? "border-white/20 bg-white/15 text-white shadow-none backdrop-blur-sm"
+          : "border-gray-200 bg-gray-100 text-gray-600 shadow-sm",
+        className,
+      )}
+      title={location || code}
+    >
+      {countryCode ? (
+        <img
+          src={getFlagAssetUrl(countryCode)}
+          alt=""
+          aria-hidden="true"
+          className="h-3.5 w-5 rounded-[2px] object-cover"
+          loading="lazy"
+          decoding="async"
+          referrerPolicy="no-referrer"
+        />
+      ) : null}
+      <span>{code}</span>
+    </span>
+  );
+}

--- a/app/components/VibeRaisingDateTabs.tsx
+++ b/app/components/VibeRaisingDateTabs.tsx
@@ -1,0 +1,69 @@
+import { clsx } from "clsx";
+
+export const VIBE_RAISING_MONTH_OPTIONS = [
+  { name: "January", tabClass: "bg-[#2563eb] shadow-blue-500/25", borderClass: "border-blue-300", ringClass: "ring-blue-100", softClass: "bg-blue-50/60", inputClass: "border-blue-300 focus:border-blue-500" },
+  { name: "February", tabClass: "bg-[#db2777] shadow-pink-500/25", borderClass: "border-pink-300", ringClass: "ring-pink-100", softClass: "bg-pink-50/60", inputClass: "border-pink-300 focus:border-pink-500" },
+  { name: "March", tabClass: "bg-[#16a34a] shadow-green-500/25", borderClass: "border-green-300", ringClass: "ring-green-100", softClass: "bg-green-50/60", inputClass: "border-green-300 focus:border-green-500" },
+  { name: "April", tabClass: "bg-[#7c3aed] shadow-violet-500/25", borderClass: "border-violet-300", ringClass: "ring-violet-100", softClass: "bg-violet-50/60", inputClass: "border-violet-300 focus:border-violet-500" },
+  { name: "May", tabClass: "bg-[#ea580c] shadow-orange-500/25", borderClass: "border-orange-300", ringClass: "ring-orange-100", softClass: "bg-orange-50/60", inputClass: "border-orange-300 focus:border-orange-500" },
+  { name: "June", tabClass: "bg-[#0891b2] shadow-cyan-500/25", borderClass: "border-cyan-300", ringClass: "ring-cyan-100", softClass: "bg-cyan-50/60", inputClass: "border-cyan-300 focus:border-cyan-500" },
+  { name: "July", tabClass: "bg-[#be123c] shadow-rose-500/25", borderClass: "border-rose-300", ringClass: "ring-rose-100", softClass: "bg-rose-50/60", inputClass: "border-rose-300 focus:border-rose-500" },
+  { name: "August", tabClass: "bg-[#4f46e5] shadow-indigo-500/25", borderClass: "border-indigo-300", ringClass: "ring-indigo-100", softClass: "bg-indigo-50/60", inputClass: "border-indigo-300 focus:border-indigo-500" },
+  { name: "September", tabClass: "bg-[#65a30d] shadow-lime-500/25", borderClass: "border-lime-300", ringClass: "ring-lime-100", softClass: "bg-lime-50/60", inputClass: "border-lime-300 focus:border-lime-500" },
+  { name: "October", tabClass: "bg-[#c026d3] shadow-fuchsia-500/25", borderClass: "border-fuchsia-300", ringClass: "ring-fuchsia-100", softClass: "bg-fuchsia-50/60", inputClass: "border-fuchsia-300 focus:border-fuchsia-500" },
+  { name: "November", tabClass: "bg-[#0f766e] shadow-teal-500/25", borderClass: "border-teal-300", ringClass: "ring-teal-100", softClass: "bg-teal-50/60", inputClass: "border-teal-300 focus:border-teal-500" },
+  { name: "December", tabClass: "bg-[#dc2626] shadow-red-500/25", borderClass: "border-red-300", ringClass: "ring-red-100", softClass: "bg-red-50/60", inputClass: "border-red-300 focus:border-red-500" },
+];
+
+export function getVibeRaisingMonthTheme(month: string) {
+  return VIBE_RAISING_MONTH_OPTIONS.find((option) => option.name === month) || VIBE_RAISING_MONTH_OPTIONS[0];
+}
+
+export function parseVibeRaisingMonthYear(value?: string | null) {
+  const parts = (value || "").trim().split(/\s+/).filter(Boolean);
+  const parsedYear = Number(parts[parts.length - 1]);
+  const year = Number.isFinite(parsedYear) ? parsedYear : new Date().getFullYear();
+  const monthText = Number.isFinite(parsedYear) ? parts.slice(0, -1).join(" ") : parts.join(" ");
+  const month = VIBE_RAISING_MONTH_OPTIONS.find((option) => option.name === monthText)?.name || monthText || "Update";
+
+  return { month, year };
+}
+
+export function VibeRaisingDateTabs({
+  month,
+  year,
+  className,
+  size = "default",
+}: {
+  month: string;
+  year: number | string;
+  className?: string;
+  size?: "default" | "compact";
+}) {
+  const monthTheme = getVibeRaisingMonthTheme(month);
+  const isCompact = size === "compact";
+
+  return (
+    <div className={clsx("flex items-stretch gap-2", className)}>
+      <div
+        className={clsx(
+          "flex items-center rounded-t-2xl rounded-b-lg text-white shadow-lg ring-1 ring-white/30",
+          isCompact
+            ? "min-w-[124px] px-3 py-1.5 text-[11px] font-black uppercase tracking-[0.1em]"
+            : "min-w-[176px] px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em]",
+          monthTheme.tabClass,
+        )}
+      >
+        {month}
+      </div>
+      <div
+        className={clsx(
+          "flex items-center justify-center rounded-t-2xl rounded-b-lg bg-gray-950 font-black tracking-[0.12em] text-white shadow-lg shadow-black/20 ring-1 ring-white/10",
+          isCompact ? "min-w-[82px] px-3 py-1.5 text-[11px]" : "min-w-[108px] px-4 py-2.5 text-sm",
+        )}
+      >
+        {year}
+      </div>
+    </div>
+  );
+}

--- a/app/components/VibeRaisingIntroPopup.tsx
+++ b/app/components/VibeRaisingIntroPopup.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+
+type VibeRaisingIntroPopupProps = {
+  onDismiss: () => void;
+  onComplete?: () => void;
+  onSkip?: () => void;
+};
+
+export default function VibeRaisingIntroPopup({
+  onDismiss,
+  onComplete,
+  onSkip,
+}: VibeRaisingIntroPopupProps) {
+  const handleComplete = () => {
+    onDismiss();
+    onComplete?.();
+  };
+
+  const handleSkip = () => {
+    onDismiss();
+    onSkip?.();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onDismiss}
+      />
+
+      <div className="relative z-[110] flex max-h-[calc(100vh-2rem)] w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl sm:h-[560px] sm:flex-row">
+        <div className="relative h-[260px] flex-shrink-0 overflow-hidden bg-black sm:h-full sm:w-[315px]">
+          <iframe
+            src="https://player.vimeo.com/video/1174236138?autoplay=1&muted=1&loop=0&title=0&byline=0&portrait=0"
+            className="absolute left-0 top-0 h-full w-full"
+            allow="autoplay; fullscreen; picture-in-picture"
+            allowFullScreen
+            title="Vibe Raising Intro"
+          />
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-3 border-b border-gray-100 px-6 pb-4 pt-6">
+            <button
+              onClick={onDismiss}
+              className="flex-shrink-0 text-gray-400 transition-colors hover:text-gray-600"
+              aria-label="Back"
+            >
+              <ArrowLeftIcon className="h-5 w-5" />
+            </button>
+            <h2 className="flex-1 text-xl font-bold text-gray-900">Welcome to Vibe Raising</h2>
+          </div>
+
+          <div className="flex-1 px-6 py-6">
+            <p className="text-sm leading-relaxed text-gray-600">
+              Watch this short intro on how Vibe Raising connects founders with investors through
+              consistent, transparent monthly updates.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 px-6 pb-6">
+            <button
+              onClick={handleComplete}
+              className="w-full rounded-xl bg-violet-600 px-6 py-3.5 font-bold text-white shadow-lg shadow-violet-500/20 transition-all duration-200 hover:bg-violet-700 active:scale-[0.98]"
+            >
+              Get Started
+            </button>
+            <button
+              onClick={handleSkip}
+              className="text-center text-sm text-gray-400 transition-colors hover:text-gray-600"
+            >
+              Skip for now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -93,6 +93,11 @@ function normalizeCompany(raw: unknown): VibeRaisingCompany {
     asNullableString(payload.abn) ??
     asNullableString(payload.companyAbn) ??
     asNullableString(payload.company_abn);
+  const location =
+    asNullableString(payload.location) ??
+    asNullableString(payload.companyLocation) ??
+    asNullableString(payload.company_location) ??
+    asNullableString(payload.region);
   const registered = Boolean(
     payload.registered ??
       payload.isRegistered ??
@@ -106,6 +111,7 @@ function normalizeCompany(raw: unknown): VibeRaisingCompany {
     name,
     domain,
     abn,
+    location,
     registered,
   };
 }
@@ -140,6 +146,7 @@ function normalizeProfile(raw: unknown): VibeRaisingProfile {
         name: topLevelCompanyName,
         domain: payload.domain ?? payload.company_domain,
         abn: payload.abn ?? payload.company_abn,
+        location: payload.location ?? payload.company_location,
         registered:
           payload.companyRegistered ??
           payload.company_registered ??
@@ -203,6 +210,12 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
   if (!raw || typeof raw !== "object") return null;
 
   const payload = unwrapPayload(raw) as Record<string, unknown>;
+  const structuredMemo =
+    payload.structuredMemo && typeof payload.structuredMemo === "object"
+      ? (payload.structuredMemo as Record<string, unknown>)
+      : payload.structured_memo && typeof payload.structured_memo === "object"
+        ? (payload.structured_memo as Record<string, unknown>)
+        : {};
   const rawYear = payload.year;
   let yearValue: number | undefined;
   if (typeof rawYear === "number" && Number.isFinite(rawYear)) {
@@ -217,6 +230,19 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
   return {
     month: asNullableString(payload.month) ?? undefined,
     year: yearValue,
+    summary:
+      asNullableString(payload.summary) ??
+      asNullableString(payload.topline) ??
+      asNullableString(structuredMemo.topline) ??
+      undefined,
+    sourceUrl:
+      asNullableString(payload.sourceUrl) ??
+      asNullableString(payload.source_url) ??
+      undefined,
+    videoUrl:
+      asNullableString(payload.videoUrl) ??
+      asNullableString(payload.video_url) ??
+      undefined,
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
@@ -287,6 +313,18 @@ function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | nu
       undefined,
     month,
     year: typeof year === "number" && Number.isFinite(year) ? year : undefined,
+    summary:
+      asNullableString(payload.summary) ??
+      asNullableString(payload.topline) ??
+      undefined,
+    sourceUrl:
+      asNullableString(payload.sourceUrl) ??
+      asNullableString(payload.source_url) ??
+      undefined,
+    videoUrl:
+      asNullableString(payload.videoUrl) ??
+      asNullableString(payload.video_url) ??
+      undefined,
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
@@ -336,6 +374,13 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
       asNullableString(payload.updated_at) ??
       new Date().toISOString(),
     status: asNullableString(payload.status),
+    summary: asNullableString(payload.summary),
+    sourceUrl:
+      asNullableString(payload.sourceUrl) ??
+      asNullableString(payload.source_url),
+    videoUrl:
+      asNullableString(payload.videoUrl) ??
+      asNullableString(payload.video_url),
     metrics: normalizeMetrics(payload.metrics),
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
@@ -771,6 +816,7 @@ export function buildVibeRaisingAppUser(
     companyName: activeCompany?.name ?? "",
     domain: activeCompany?.domain ?? null,
     abn: activeCompany?.abn ?? null,
+    location: activeCompany?.location ?? null,
     companyRegistered: activeCompany?.registered ?? false,
   };
 }
@@ -822,6 +868,7 @@ const DEV_VIBE_PROFILE_STUB: VibeRaisingProfile | null = {
       name: "Dev Startup Pty Ltd",
       domain: "devstartup.com",
       abn: "51 824 753 556",
+      location: "Melbourne, Australia",
       registered: true,
     },
   ],
@@ -943,6 +990,7 @@ export async function saveVibeRaisingCompany(
     name: string;
     domain?: string | null;
     abn?: string | null;
+    location?: string | null;
     registered?: boolean;
   },
 ): Promise<string | null> {
@@ -971,6 +1019,8 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     year: 2026,
     date: "2026-04-01T00:00:00.000Z",
     status: "draft",
+    summary: "AI workflow automation for mid-market teams, with enterprise pilots converting into paid deployments.",
+    sourceUrl: "https://example.com/dev-update-april",
     metrics: {
       revenue: "$62,400 MRR",
       growth: "+18% MoM",
@@ -992,6 +1042,7 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     year: 2026,
     date: "2026-03-01T00:00:00.000Z",
     status: "sent",
+    summary: "Analytics v2 increased engagement while the team tested pricing and retention improvements.",
     metrics: {
       revenue: "$52,900 MRR",
       growth: "+12% MoM",
@@ -1013,6 +1064,7 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     year: 2026,
     date: "2026-02-01T00:00:00.000Z",
     status: "sent",
+    summary: "Healthcare design partnership and engineering hires moved the product toward a vertical AI wedge.",
     metrics: {
       revenue: "$47,200 MRR",
       growth: "+9% MoM",
@@ -1060,11 +1112,32 @@ export async function saveVibeRaisingMonthlyUpdate(
     challenges: string;
     asks: string;
     metrics: Record<string, string>;
+    summary?: string | null;
+    sourceUrl?: string | null;
+    videoUrl?: string | null;
   },
 ): Promise<VibeRaisingMonthlyUpdate | null> {
   const client = createApiClient(env, request);
-  const response = await client.post(UPDATES_PATH, body);
-  return normalizeMonthlyUpdate(response.data?.update ?? response.data);
+  try {
+    const response = await client.post(UPDATES_PATH, body);
+    return normalizeMonthlyUpdate(response.data?.update ?? response.data);
+  } catch (error: any) {
+    const status = error.response?.status;
+    const hasOptionalFields = Boolean(body.summary || body.sourceUrl || body.videoUrl);
+    if (!hasOptionalFields || (status !== 400 && status !== 422)) {
+      throw error;
+    }
+
+    const response = await client.post(UPDATES_PATH, {
+      month: body.month,
+      year: body.year,
+      highlights: body.highlights,
+      challenges: body.challenges,
+      asks: body.asks,
+      metrics: body.metrics,
+    });
+    return normalizeMonthlyUpdate(response.data?.update ?? response.data);
+  }
 }
 
 export async function bootstrapVibeRaisingStartupUpdate(

--- a/app/routes/platform.login.tsx
+++ b/app/routes/platform.login.tsx
@@ -29,10 +29,16 @@ function parseAuthApp(value: string | null): AuthAppName | null {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
-    const user = await getCurrentUser(env, request);
+    let user = null;
     const url = new URL(request.url);
     const app = parseAuthApp(url.searchParams.get("app"));
     const next = url.searchParams.get("next") || getDefaultNext(app);
+
+    try {
+        user = await getCurrentUser(env, request);
+    } catch (error) {
+        console.warn("Skipping logged-in redirect because current user lookup failed.", error);
+    }
 
     if (user) {
         return redirect(next);

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -32,7 +32,12 @@ import {
     QuestionMarkCircleIcon,
     ExclamationCircleIcon,
     FireIcon,
+    LinkIcon,
+    ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
+import ResponsibleInvestorsSection from "~/components/ResponsibleInvestorsSection";
+import StartupRegionBadge from "~/components/StartupRegionBadge";
+import { parseVibeRaisingMonthYear, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
@@ -202,6 +207,12 @@ function UpdateCard({ update, isCurrent, user }: { update: any; isCurrent: boole
     // Hash numeric or string ID to pick a deterministic gradient
     const hashId = typeof update.id === 'number' ? update.id : update.id?.split('').reduce((acc: number, char: string) => acc + char.charCodeAt(0), 0) || 0;
     const gradientClass = GRADIENTS[hashId % GRADIENTS.length];
+    const updatePeriod = update.year
+        ? { month: update.monthName || parseVibeRaisingMonthYear(update.month).month, year: update.year }
+        : parseVibeRaisingMonthYear(update.month);
+    const updateSummary = update.summary || "";
+    const updateSourceUrl = update.sourceUrl || "";
+    const cardExcerpt = updateSummary || highlights;
 
     const highlightsRef = useAutoResize(highlights);
     const challengesRef = useAutoResize(challenges);
@@ -276,7 +287,7 @@ function UpdateCard({ update, isCurrent, user }: { update: any; isCurrent: boole
                             {(update.investorsSentTo > 0 || update.investorsViewed > 0) && (
                                 <span className="w-px h-3 bg-gray-200" />
                             )}
-                            <span className="text-xs text-gray-600 max-w-[200px] truncate">{highlights.slice(0, 60)}...</span>
+                            <span className="text-xs text-gray-600 max-w-[200px] truncate">{cardExcerpt.slice(0, 60)}...</span>
                         </div>
                         <ChevronDownIcon className="w-4 h-4 text-gray-400 flex-shrink-0" />
                     </div>
@@ -316,7 +327,8 @@ function UpdateCard({ update, isCurrent, user }: { update: any; isCurrent: boole
                             </>
                         )}
                         {/* Top row: date + collapse chevron */}
-                        <div className="absolute top-0 left-0 right-0 px-5 pt-3 flex items-center justify-between">
+                        <div className="absolute top-0 left-0 right-0 px-5 pt-3 flex flex-wrap items-center justify-between gap-2">
+                            <VibeRaisingDateTabs month={updatePeriod.month} year={updatePeriod.year} size="compact" />
                             <span className="text-white/60 text-[11px] font-medium">{format(new Date(update.date), "MMMM d, yyyy")}</span>
                             <ChevronDownIcon className="w-4 h-4 text-white/60 rotate-180" />
                         </div>
@@ -342,6 +354,7 @@ function UpdateCard({ update, isCurrent, user }: { update: any; isCurrent: boole
                                         {update.score && (
                                             <span className="text-[9px] font-bold text-white bg-white/20 backdrop-blur-sm px-1.5 py-0.5 rounded-full">{update.score}</span>
                                         )}
+                                        <StartupRegionBadge location={user?.location} variant="inverse" />
                                     </div>
                                     <p className="text-white/60 text-[11px]">{user?.companyName}</p>
                                 </div>
@@ -439,6 +452,26 @@ function UpdateCard({ update, isCurrent, user }: { update: any; isCurrent: boole
                             ))}
                         </div>
 
+                        {(updateSummary || updateSourceUrl) && (
+                            <div className="space-y-3 rounded-xl border border-gray-100 bg-gray-50/60 p-4">
+                                {updateSummary && (
+                                    <p className="text-sm font-medium leading-relaxed text-gray-700">{updateSummary}</p>
+                                )}
+                                {updateSourceUrl && (
+                                    <a
+                                        href={updateSourceUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-2 text-xs font-bold text-violet-700 hover:text-violet-900"
+                                    >
+                                        <LinkIcon className="h-3.5 w-3.5" />
+                                        Source materials
+                                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                                    </a>
+                                )}
+                            </div>
+                        )}
+
                         {/* Highlights */}
                         <div>
                             <h4 className="text-xs font-bold text-gray-900 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
@@ -530,7 +563,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
 
                     {/* Content over the image */}
                     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center text-center px-6 py-16">
-                        <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-white mb-4 tracking-tight drop-shadow-lg whitespace-nowrap">
+                        <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-white mb-4 tracking-tight drop-shadow-lg">
                             Let's get you ready to raise, {firstName}.
                         </h1>
                         <p className="text-base sm:text-lg text-white/80 max-w-md mx-auto mb-8 leading-snug">
@@ -547,6 +580,8 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         </button>
                     </div>
                 </div>
+
+                <ResponsibleInvestorsSection />
 
                 {/* How It Works - thin vertical line separators */}
                 <div className="px-6 py-14">

--- a/app/routes/vibe-raising-app.companies.tsx
+++ b/app/routes/vibe-raising-app.companies.tsx
@@ -7,6 +7,7 @@ import {
     setVibeRaisingActiveCompany,
 } from "~/lib/vibe-raising";
 import { PlusIcon, BuildingOffice2Icon, CheckCircleIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
+import StartupRegionBadge from "~/components/StartupRegionBadge";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
@@ -82,9 +83,12 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                                 </div>
                                 
                                 <h3 className="text-lg font-bold text-gray-900 mb-1">{company.name}</h3>
-                                {company.domain && (
-                                    <p className="text-sm text-gray-500 truncate">{company.domain}</p>
-                                )}
+                                <div className="flex flex-wrap items-center gap-2">
+                                    {company.domain && (
+                                        <p className="text-sm text-gray-500 truncate">{company.domain}</p>
+                                    )}
+                                    <StartupRegionBadge location={company.location} />
+                                </div>
                             </div>
 
                             <div className="p-4 border-t border-gray-50 bg-gray-50/50 mt-auto">

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -1,6 +1,6 @@
 import { Form, redirect, useLoaderData, useNavigation } from "react-router";
 import type { Route } from "./+types/vibe-raising-app.company-setup";
-import { ArrowPathIcon, BuildingOffice2Icon, GlobeAltIcon, IdentificationIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon, BuildingOffice2Icon, GlobeAltIcon, IdentificationIcon, MapPinIcon } from "@heroicons/react/24/outline";
 import { getEnv } from "~/lib/env.server";
 import {
     getActiveVibeRaisingCompany,
@@ -36,11 +36,13 @@ export async function action({ request, context }: Route.ActionArgs) {
         formData.get("companyName")?.toString() || activeCompany?.name || user.companyName;
     const domain = formData.get("domain")?.toString() || "";
     const abn = formData.get("abn")?.toString() || "";
+    const location = formData.get("location")?.toString().trim() || "";
     const companyId = await saveVibeRaisingCompany(env, request, {
         companyId: isAddingNew ? null : activeCompany?.id ?? null,
         name: companyName,
         domain,
         abn,
+        ...(location ? { location } : {}),
         registered: true,
     });
 
@@ -96,6 +98,26 @@ export default function CompanySetup() {
                                     className="w-full pl-11 pr-4 py-3.5 rounded-xl border border-gray-200 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 outline-none transition-all duration-200 text-gray-900 placeholder:text-gray-400 font-medium"
                                 />
                             </div>
+                        </div>
+
+                        {/* Location */}
+                        <div>
+                            <label htmlFor="location" className="block text-sm font-bold text-gray-700 mb-2">
+                                Startup Location
+                            </label>
+                            <div className="relative">
+                                <MapPinIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                                <input
+                                    type="text"
+                                    id="location"
+                                    name="location"
+                                    defaultValue={isAddingNew ? "" : activeCompany?.location || ""}
+                                    placeholder="Melbourne, Australia"
+                                    autoComplete="address-level2"
+                                    className="w-full pl-11 pr-4 py-3.5 rounded-xl border border-gray-200 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 outline-none transition-all duration-200 text-gray-900 placeholder:text-gray-400 font-medium"
+                                />
+                            </div>
+                            <p className="mt-1.5 text-xs text-gray-400">Used to show your startup region on update cards.</p>
                         </div>
 
                         {/* Domain */}

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -28,11 +28,15 @@ import {
     FireIcon,
     ArrowRightIcon,
     BanknotesIcon,
+    LinkIcon,
+    ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
 import { useDropzone } from 'react-dropzone';
 import { clsx } from "clsx";
 import DraftFromEmailWizard from "~/components/DraftFromEmailWizard";
 import EmailDraftInProgressCard from "~/components/EmailDraftInProgressCard";
+import StartupRegionBadge from "~/components/StartupRegionBadge";
+import { getVibeRaisingMonthTheme, VIBE_RAISING_MONTH_OPTIONS, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
 import type { VibeRaisingStartupUpdateStatusResponse } from "~/types/vibe-raising";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -110,10 +114,14 @@ export async function action({ request, context }: Route.ActionArgs) {
                 .map((key) => [key, String(formData.get(key) || "").trim()] as const)
                 .filter(([, value]) => value.length > 0),
         );
+        const rawVideoUrl = String(formData.get("videoUrl") || "").trim();
 
         await saveVibeRaisingMonthlyUpdate(env, request, {
             month: String(formData.get("month") || "").trim(),
             year: Number(formData.get("year") || 0),
+            summary: String(formData.get("summary") || "").trim() || null,
+            sourceUrl: String(formData.get("sourceUrl") || "").trim() || null,
+            videoUrl: rawVideoUrl && !rawVideoUrl.startsWith("blob:") ? rawVideoUrl : null,
             highlights: String(formData.get("highlights") || ""),
             challenges: String(formData.get("challenges") || ""),
             asks: String(formData.get("asks") || ""),
@@ -152,6 +160,8 @@ type PersistedEmailDraftRun = {
     bindingId?: number | null;
     googleConnectionId?: number | null;
 };
+
+type RecordedMediaKind = "video" | "audio";
 
 function getEmailDraftStorageKey(domain?: string | null) {
     const normalized = String(domain || "").trim().toLowerCase() || "unknown";
@@ -768,6 +778,9 @@ export default function CreateUpdate() {
     const [dismissedFeedback, setDismissedFeedback] = useState(false);
     const [isRecording, setIsRecording] = useState(false);
     const [videoPreviewUrl, setVideoPreviewUrl] = useState<string | null>(null);
+    const [previewMediaKind, setPreviewMediaKind] = useState<RecordedMediaKind | null>(null);
+    const [recordingMode, setRecordingMode] = useState<RecordedMediaKind | null>(null);
+    const [recordingError, setRecordingError] = useState<string | null>(null);
     const [draftSaved, setDraftSaved] = useState(false);
     const [showConfirmPopup, setShowConfirmPopup] = useState(false);
     const [hasDraft, setHasDraft] = useState<boolean>(() => {
@@ -785,6 +798,11 @@ export default function CreateUpdate() {
     // State declarations
     const [isClientMounted, setIsClientMounted] = useState(false);
     const [showEmailWizard, setShowEmailWizard] = useState(false);
+    const [summary, setSummary] = useState<string>(defaultData?.summary || "");
+    const [sourceUrl, setSourceUrl] = useState<string>(defaultData?.sourceUrl || "");
+    const [showImportPanel, setShowImportPanel] = useState<boolean>(
+        Boolean(defaultData?.summary || defaultData?.sourceUrl || defaultData?.videoUrl),
+    );
     const [highlights, setHighlights] = useState<string>(defaultData?.highlights || "");
     const [challenges, setChallenges] = useState<string>(defaultData?.challenges || "");
     const [asks, setAsks] = useState<string>(defaultData?.asks || "");
@@ -800,6 +818,8 @@ export default function CreateUpdate() {
 
     const [selectedMonth, setSelectedMonth] = useState<string>(defaultData?.month || "February");
     const [selectedYear, setSelectedYear] = useState<number>(defaultData?.year || 2026);
+    const [activePeriodKey, setActivePeriodKey] = useState("current");
+    const selectedMonthTheme = getVibeRaisingMonthTheme(selectedMonth);
     
     const [metricValues, setMetricValues] = useState<Record<string, string>>(() => {
         const initial: Record<string, string> = {};
@@ -832,13 +852,26 @@ export default function CreateUpdate() {
     const [emailDraftPollDelayMs, setEmailDraftPollDelayMs] = useState(EMAIL_DRAFT_POLL_INTERVAL_MS);
     const emailDraftRecoveryKeyRef = useRef<string | null>(null);
     const emailDraftIgnoredRunIdRef = useRef<string | null>(null);
+    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+    const mediaStreamRef = useRef<MediaStream | null>(null);
+    const recordedChunksRef = useRef<BlobPart[]>([]);
 
     const handleDraftComplete = (data: any) => {
+        setActivePeriodKey("current");
         if (data.month) setSelectedMonth(data.month);
         if (data.year) setSelectedYear(data.year);
         setHighlights(data.highlights);
         setChallenges(data.challenges);
         setAsks(data.asks || "");
+        setSummary(data.summary || "");
+        setSourceUrl(data.sourceUrl || data.source_url || "");
+        if (data.videoUrl || data.video_url) {
+            setVideoPreviewUrl(data.videoUrl || data.video_url);
+            setPreviewMediaKind("video");
+        }
+        if (data.summary || data.sourceUrl || data.source_url || data.videoUrl || data.video_url) {
+            setShowImportPanel(true);
+        }
         setMetricValues(data.metrics || {});
         setPastMonthCards((data.pastMonths || []).map((pm: any) => ({
             ...pm,
@@ -1260,6 +1293,81 @@ export default function CreateUpdate() {
         emailDraftStatus?.runId,
     ]);
 
+    const stopMediaStream = useCallback(() => {
+        mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+        mediaStreamRef.current = null;
+    }, []);
+
+    const startRecording = useCallback(async () => {
+        if (typeof window === "undefined" || typeof navigator === "undefined") {
+            return;
+        }
+        if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+            setRecordingError("Recording is not supported in this browser. Upload a file or add a source URL instead.");
+            return;
+        }
+
+        try {
+            setRecordingError(null);
+            const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+                .catch(() => navigator.mediaDevices.getUserMedia({ audio: true }));
+            const hasVideo = stream.getVideoTracks().length > 0;
+            recordedChunksRef.current = [];
+            mediaStreamRef.current = stream;
+            setRecordingMode(hasVideo ? "video" : "audio");
+
+            const recorder = new MediaRecorder(stream);
+            mediaRecorderRef.current = recorder;
+            recorder.ondataavailable = (event) => {
+                if (event.data.size > 0) {
+                    recordedChunksRef.current.push(event.data);
+                }
+            };
+            recorder.onstop = () => {
+                const blob = new Blob(recordedChunksRef.current, {
+                    type: recorder.mimeType || (hasVideo ? "video/webm" : "audio/webm"),
+                });
+                if (blob.size > 0) {
+                    setVideoPreviewUrl(URL.createObjectURL(blob));
+                    setPreviewMediaKind(hasVideo ? "video" : "audio");
+                    setShowImportPanel(true);
+                }
+                recordedChunksRef.current = [];
+                mediaRecorderRef.current = null;
+                setIsRecording(false);
+                setRecordingMode(null);
+                stopMediaStream();
+            };
+            recorder.start();
+            setIsRecording(true);
+        } catch {
+            setRecordingError("We couldn't access your camera or microphone. Upload a file or add a source URL instead.");
+            setIsRecording(false);
+            setRecordingMode(null);
+            stopMediaStream();
+        }
+    }, [stopMediaStream]);
+
+    const stopRecording = useCallback(() => {
+        const recorder = mediaRecorderRef.current;
+        if (recorder?.state === "recording") {
+            recorder.stop();
+            return;
+        }
+        setIsRecording(false);
+        setRecordingMode(null);
+        stopMediaStream();
+    }, [stopMediaStream]);
+
+    useEffect(() => {
+        return () => {
+            if (mediaRecorderRef.current?.state === "recording") {
+                mediaRecorderRef.current.stop();
+            }
+            stopMediaStream();
+        };
+    }, [stopMediaStream]);
+
     const resumeDraft = () => {
         try {
             const raw = localStorage.getItem("vibe_draft");
@@ -1269,6 +1377,11 @@ export default function CreateUpdate() {
             // Restore current month fields
             if (draft.month) setSelectedMonth(draft.month);
             if (draft.year) setSelectedYear(Number(draft.year));
+            setSummary(draft.summary || "");
+            setSourceUrl(draft.sourceUrl || "");
+            setVideoPreviewUrl(draft.videoUrl || null);
+            setPreviewMediaKind(draft.videoUrl ? "video" : null);
+            setShowImportPanel(Boolean(draft.summary || draft.sourceUrl || draft.videoUrl));
             setHighlights(draft.highlights || "");
             setChallenges(draft.challenges || "");
             setAsks(draft.asks || "");
@@ -1370,10 +1483,13 @@ export default function CreateUpdate() {
     // Chart click: always expand + scroll
     const expandCardFromChart = (index: number) => {
         if (index === pastMonthCards.length) {
+            setActivePeriodKey("current");
             const el = document.getElementById("current-month-card");
             if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
             return;
         }
+
+        setActivePeriodKey(`past-${index}`);
 
         setExpandedCards(prev => {
             const next = new Set(prev);
@@ -1397,12 +1513,38 @@ export default function CreateUpdate() {
         });
     };
 
+    const selectPeriod = (periodKey: string) => {
+        setActivePeriodKey(periodKey);
+        if (periodKey === "current") {
+            document.getElementById("current-month-card")?.scrollIntoView({ behavior: "smooth", block: "center" });
+            return;
+        }
+
+        const index = Number(periodKey.replace("past-", ""));
+        if (!Number.isFinite(index)) return;
+        setExpandedCards((prev) => {
+            const next = new Set(prev);
+            next.add(index);
+            return next;
+        });
+        setTimeout(() => {
+            document.getElementById(`past-month-${index}`)?.scrollIntoView({ behavior: "smooth", block: "center" });
+        }, 100);
+    };
+
     // Dropzone setup
     const onDrop = useCallback((acceptedFiles: File[]) => {
         console.log(acceptedFiles);
         const video = acceptedFiles.find(f => f.type.startsWith("video/"));
+        const audio = acceptedFiles.find(f => f.type.startsWith("audio/"));
         if (video) {
             setVideoPreviewUrl(URL.createObjectURL(video));
+            setPreviewMediaKind("video");
+            setShowImportPanel(true);
+        } else if (audio) {
+            setVideoPreviewUrl(URL.createObjectURL(audio));
+            setPreviewMediaKind("audio");
+            setShowImportPanel(true);
         }
     }, []);
     const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -1424,6 +1566,12 @@ export default function CreateUpdate() {
     // 1. Feedback View — preview-dominant with rating sidebar
     if (actionData?.step === "feedback" && !dismissedFeedback) {
         const { feedback, data } = actionData;
+        const reviewData = data as any;
+        const reviewMonth = String(reviewData?.month || selectedMonth);
+        const reviewYear = Number(reviewData?.year || selectedYear);
+        const reviewSummary = String(reviewData?.summary || "").trim();
+        const reviewSourceUrl = String(reviewData?.sourceUrl || "").trim();
+        const reviewVideoUrl = String(reviewData?.videoUrl || videoPreviewUrl || "").trim();
 
         const handleSaveDraft = () => {
             try {
@@ -1466,10 +1614,10 @@ export default function CreateUpdate() {
                     <div className="flex-1 min-w-0">
                         <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
                             {/* Hero banner — video or gradient */}
-                            {videoPreviewUrl ? (
+                            {reviewVideoUrl ? (
                                 <div className="relative w-full aspect-video bg-black">
                                     <video
-                                        src={videoPreviewUrl}
+                                        src={reviewVideoUrl}
                                         controls
                                         className="w-full h-full object-contain"
                                         poster=""
@@ -1508,10 +1656,16 @@ export default function CreateUpdate() {
 
                             {/* Preview header */}
                             <div className="px-6 pt-6 pb-4 border-b border-gray-100">
-                                <div className="flex items-center justify-between">
-                                    <h3 className="text-lg font-bold text-gray-900">
-                                        {(data as any)?.month} {(data as any)?.year} Update
-                                    </h3>
+                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                    <div>
+                                        <h3 className="text-lg font-bold text-gray-900">
+                                            {reviewMonth} {reviewYear} Update
+                                        </h3>
+                                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                                            <VibeRaisingDateTabs month={reviewMonth} year={reviewYear} size="compact" />
+                                            <StartupRegionBadge location={user.location} />
+                                        </div>
+                                    </div>
                                     <span className="text-xs text-gray-400">{new Date().toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}</span>
                                 </div>
                             </div>
@@ -1555,6 +1709,25 @@ export default function CreateUpdate() {
 
                             {/* Content sections */}
                             <div className="px-6 py-5 space-y-5">
+                                {(reviewSummary || reviewSourceUrl) && (
+                                    <div className="space-y-3 rounded-xl border border-gray-100 bg-gray-50/70 p-4">
+                                        {reviewSummary && (
+                                            <p className="text-sm font-medium leading-relaxed text-gray-700">{reviewSummary}</p>
+                                        )}
+                                        {reviewSourceUrl && (
+                                            <a
+                                                href={reviewSourceUrl}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="inline-flex items-center gap-2 text-xs font-bold text-violet-700 hover:text-violet-900"
+                                            >
+                                                <LinkIcon className="h-3.5 w-3.5" />
+                                                Source materials
+                                                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                                            </a>
+                                        )}
+                                    </div>
+                                )}
                                 {(data as any)?.highlights && (
                                     <div>
                                         <h4 className="text-xs font-bold text-gray-900 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
@@ -1761,9 +1934,14 @@ export default function CreateUpdate() {
                                         }}
                                     >
                                         <input type="hidden" name="intent" value="publish" />
-                                        {Object.entries(data || {}).map(([key, value]) => (
-                                            <input key={key} type="hidden" name={key} value={value as any} />
-                                        ))}
+                                        <input type="hidden" name="summary" value={reviewSummary} />
+                                        <input type="hidden" name="sourceUrl" value={reviewSourceUrl} />
+                                        <input type="hidden" name="videoUrl" value={reviewVideoUrl} />
+                                        {Object.entries(data || {})
+                                            .filter(([key]) => !["summary", "sourceUrl", "videoUrl"].includes(key))
+                                            .map(([key, value]) => (
+                                                <input key={key} type="hidden" name={key} value={value as any} />
+                                            ))}
                                         
                                         <button
                                             type="submit"
@@ -1804,6 +1982,7 @@ export default function CreateUpdate() {
                             {user.domain && (
                                 <p className="text-[11px] text-gray-400 mt-0.5">{user.domain}</p>
                             )}
+                            <StartupRegionBadge location={user.location} className="mt-3" />
                             {feedback?.grade && (
                                 <div className="mt-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-50 border border-green-200">
                                     <span className="text-[10px] font-semibold uppercase tracking-wide text-green-700">AI Grade</span>
@@ -1905,6 +2084,9 @@ export default function CreateUpdate() {
 
             <Form method="POST" className="space-y-6">
                 <input type="hidden" name="intent" value="review" />
+                <input type="hidden" name="summary" value={summary} />
+                <input type="hidden" name="sourceUrl" value={sourceUrl} />
+                <input type="hidden" name="videoUrl" value={videoPreviewUrl || ""} />
 
                 <div className="relative">
                     <fieldset disabled={isEmailDraftBusy} className={clsx(isEmailDraftBusy && "opacity-80")}>
@@ -1940,7 +2122,11 @@ export default function CreateUpdate() {
                                         type="button"
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            setIsRecording(!isRecording);
+                                            if (isRecording) {
+                                                stopRecording();
+                                            } else {
+                                                void startRecording();
+                                            }
                                         }}
                                         disabled={isEmailDraftBusy}
                                         className={clsx(
@@ -1965,7 +2151,85 @@ export default function CreateUpdate() {
                                         Select file
                                     </button>
                                 </div>
+                                {isRecording && (
+                                    <p className="mt-4 text-sm font-semibold text-red-600">
+                                        {recordingMode === "audio" ? "Recording audio. Click Stop Recording when done." : "Recording video. Click Stop Recording when done."}
+                                    </p>
+                                )}
+                                {recordingError && (
+                                    <p className="mt-4 text-sm font-semibold text-red-600">{recordingError}</p>
+                                )}
                             </div>
+                        </div>
+
+                        <div className="mt-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+                            <button
+                                type="button"
+                                onClick={() => setShowImportPanel((value) => !value)}
+                                className="flex w-full items-center justify-between gap-4 text-left"
+                            >
+                                <div>
+                                    <h2 className="text-sm font-bold text-gray-900">Manual materials</h2>
+                                    <p className="mt-1 text-sm text-gray-500">
+                                        Add a source URL, a short summary, or a quick recorded note for this update.
+                                    </p>
+                                </div>
+                                <ChevronDownIcon className={clsx("h-5 w-5 flex-shrink-0 text-gray-400 transition-transform", showImportPanel && "rotate-180")} />
+                            </button>
+
+                            {showImportPanel && (
+                                <div className="mt-5 space-y-4">
+                                    <label className="block">
+                                        <span className="mb-1.5 flex items-center gap-2 text-sm font-bold text-gray-700">
+                                            <LinkIcon className="h-4 w-4 text-gray-400" />
+                                            Source URL
+                                        </span>
+                                        <input
+                                            type="url"
+                                            value={sourceUrl}
+                                            onChange={(event) => setSourceUrl(event.target.value)}
+                                            placeholder="https://docs.google.com/document/..."
+                                            className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 outline-none transition-all placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                                        />
+                                    </label>
+
+                                    <label className="block">
+                                        <span className="mb-1.5 block text-sm font-bold text-gray-700">Short summary</span>
+                                        <textarea
+                                            value={summary}
+                                            onChange={(event) => setSummary(event.target.value)}
+                                            rows={3}
+                                            placeholder="Topline context investors should read before the detailed sections..."
+                                            className="w-full resize-none rounded-xl border border-gray-200 px-4 py-3 text-sm leading-relaxed text-gray-900 outline-none transition-all placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                                        />
+                                    </label>
+
+                                    {videoPreviewUrl && (
+                                        <div className="rounded-xl border border-gray-100 bg-gray-50 p-3">
+                                            <div className="mb-2 flex items-center justify-between gap-3">
+                                                <p className="text-xs font-bold uppercase tracking-wide text-gray-500">
+                                                    {previewMediaKind === "audio" ? "Recorded audio" : "Recorded video"}
+                                                </p>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => {
+                                                        setVideoPreviewUrl(null);
+                                                        setPreviewMediaKind(null);
+                                                    }}
+                                                    className="text-xs font-bold text-gray-400 hover:text-gray-700"
+                                                >
+                                                    Remove
+                                                </button>
+                                            </div>
+                                            {previewMediaKind === "audio" ? (
+                                                <audio src={videoPreviewUrl} controls className="w-full" />
+                                            ) : (
+                                                <video src={videoPreviewUrl} controls className="aspect-video w-full rounded-lg bg-black object-contain" />
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            )}
                         </div>
                     </fieldset>
                     {isEmailDraftBusy && (
@@ -2036,6 +2300,45 @@ export default function CreateUpdate() {
 
                 <div className="relative">
                     <fieldset disabled={isEmailDraftBusy} className={clsx(isEmailDraftBusy && "opacity-80")}>
+                        {pastMonthCards.length > 0 && (
+                            <div className="mb-4 flex flex-wrap items-center gap-2 rounded-2xl border border-gray-100 bg-white p-3 shadow-sm">
+                                {pastMonthCards.map((card, index) => {
+                                    const periodKey = `past-${index}`;
+                                    const isActive = activePeriodKey === periodKey;
+                                    return (
+                                        <button
+                                            key={periodKey}
+                                            type="button"
+                                            onClick={() => selectPeriod(periodKey)}
+                                            className={clsx(
+                                                "rounded-xl px-3 py-2 text-xs font-black uppercase tracking-[0.1em] transition-all",
+                                                isActive
+                                                    ? "bg-gray-950 text-white shadow-sm"
+                                                    : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+                                            )}
+                                        >
+                                            {card.month}
+                                        </button>
+                                    );
+                                })}
+                                <button
+                                    type="button"
+                                    onClick={() => selectPeriod("current")}
+                                    className={clsx(
+                                        "rounded-xl px-3 py-2 text-xs font-black uppercase tracking-[0.1em] transition-all",
+                                        activePeriodKey === "current"
+                                            ? `${selectedMonthTheme.tabClass} text-white shadow-sm`
+                                            : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+                                    )}
+                                >
+                                    {selectedMonth} {selectedYear}
+                                </button>
+                                <span className="ml-auto text-[11px] font-medium text-gray-400">
+                                    {activePeriodKey === "current" ? "Current update" : "Previous update"}
+                                </span>
+                            </div>
+                        )}
+
                         {/* ─── Growth Charts ─── */}
                         {pastMonthCards.length > 0 && (
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -2182,7 +2485,14 @@ export default function CreateUpdate() {
                         ))}
 
                         {/* Current month card — prominent, always visible */}
-                        <div id="current-month-card" className="rounded-xl border-2 border-purple-300 bg-white p-6 space-y-5 shadow-md ring-1 ring-purple-100 scroll-mt-24">
+                        <div
+                            id="current-month-card"
+                            className={clsx(
+                                "rounded-xl border-2 bg-white p-6 space-y-5 shadow-md ring-1 scroll-mt-24",
+                                selectedMonthTheme.borderClass,
+                                selectedMonthTheme.ringClass,
+                            )}
+                        >
                             <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-2">
                                     <div className="w-3.5 h-3.5 rounded-full bg-purple-600" />
@@ -2190,18 +2500,19 @@ export default function CreateUpdate() {
                                 </div>
                                 <span className="text-xs font-semibold text-purple-600 bg-purple-50 px-2.5 py-1 rounded-full">Current Update</span>
                             </div>
+                            <VibeRaisingDateTabs month={selectedMonth} year={selectedYear} size="compact" />
 
                             {/* Month/Year selector */}
-                            <div className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
                                 <select
                                     name="month"
                                     value={selectedMonth}
                                     onChange={(e) => setSelectedMonth(e.target.value)}
                                     className="text-sm border-gray-200 rounded-md py-1.5 pl-2 pr-7 focus:ring-purple-500 focus:border-purple-500 border bg-gray-50"
                                 >
-                                    <option>January</option>
-                                    <option>February</option>
-                                    <option>March</option>
+                                    {VIBE_RAISING_MONTH_OPTIONS.map((option) => (
+                                        <option key={option.name}>{option.name}</option>
+                                    ))}
                                 </select>
                                 <input
                                     type="number"
@@ -2296,18 +2607,25 @@ export default function CreateUpdate() {
 
                 {/* ─── Default Form (when no email draft) ─── */}
                 {pastMonthCards.length === 0 && (
-                    <div className="rounded-xl border border-gray-200 bg-white p-6 space-y-5">
+                    <div
+                        className={clsx(
+                            "rounded-xl border bg-white p-6 space-y-5 ring-1",
+                            selectedMonthTheme.borderClass,
+                            selectedMonthTheme.ringClass,
+                        )}
+                    >
                         {/* Month/Year */}
-                        <div className="flex items-center gap-3">
+                        <div className="flex flex-wrap items-center gap-3">
+                            <VibeRaisingDateTabs month={selectedMonth} year={selectedYear} size="compact" />
                             <select
                                 name="month"
                                 value={selectedMonth}
                                 onChange={(e) => setSelectedMonth(e.target.value)}
                                 className="text-sm border-gray-200 rounded-md py-1.5 pl-2 pr-7 focus:ring-violet-500 focus:border-violet-500 border bg-gray-50"
                             >
-                                <option>January</option>
-                                <option>February</option>
-                                <option>March</option>
+                                {VIBE_RAISING_MONTH_OPTIONS.map((option) => (
+                                    <option key={option.name}>{option.name}</option>
+                                ))}
                             </select>
                             <input
                                 type="number"

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-router";
 import AuthenticatedLayout from "~/components/AuthenticatedLayout";
 import VibeRaisingOnboardingCard from "~/components/VibeRaisingOnboardingCard";
+import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import { getEnv } from "~/lib/env.server";
 import {
   getOptionalVibeRaisingContext,
@@ -19,7 +20,6 @@ import {
 } from "~/lib/vibe-raising";
 import {
   BuildingOffice2Icon,
-  ArrowLeftIcon,
   DocumentTextIcon,
   UsersIcon,
 } from "@heroicons/react/24/outline";
@@ -105,77 +105,6 @@ export async function action({ request, context }: Route.ActionArgs) {
   }
 }
 
-function AnnouncementPopup({
-  onDismiss,
-  onComplete,
-}: {
-  onDismiss: () => void;
-  onComplete?: () => void;
-}) {
-  const handleComplete = () => {
-    onDismiss();
-    if (onComplete) onComplete();
-  };
-
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-      <div
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-        onClick={onDismiss}
-      />
-
-      <div className="relative z-[110] flex w-full max-w-3xl h-[560px] bg-white rounded-2xl shadow-2xl overflow-hidden">
-        <div className="relative flex-shrink-0 w-[315px] h-full bg-black overflow-hidden">
-          <iframe
-            src="https://player.vimeo.com/video/1174236138?autoplay=1&muted=1&loop=0&title=0&byline=0&portrait=0"
-            className="absolute top-0 left-0 w-full h-full"
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
-            title="Vibe Raising Intro"
-          />
-        </div>
-
-        <div className="flex flex-col flex-1 min-w-0">
-          <div className="flex items-center gap-3 px-6 pt-6 pb-4 border-b border-gray-100">
-            <button
-              onClick={onDismiss}
-              className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
-              aria-label="Back"
-            >
-              <ArrowLeftIcon className="w-5 h-5" />
-            </button>
-            <h2 className="text-xl font-bold text-gray-900 flex-1">
-              Welcome to Vibe Raising
-            </h2>
-          </div>
-
-          <div className="flex-1 px-6 py-6">
-            <p className="text-gray-600 text-sm leading-relaxed">
-              Watch this short intro on how Vibe Raising connects founders with
-              investors through consistent, transparent monthly updates.
-            </p>
-          </div>
-
-          <div className="px-6 pb-6 flex flex-col gap-3">
-            <button
-              onClick={handleComplete}
-              className="w-full py-3.5 px-6 bg-violet-600 text-white font-bold rounded-xl hover:bg-violet-700 active:scale-[0.98] transition-all duration-200 shadow-lg shadow-violet-500/20"
-            >
-              Get Started →
-            </button>
-            <button
-              onClick={onDismiss}
-              className="text-sm text-gray-400 hover:text-gray-600 transition-colors text-center"
-            >
-              Skip for now
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export default function VibeRaisingApp() {
   const { user, profile, appUser } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
@@ -218,9 +147,10 @@ export default function VibeRaisingApp() {
       logoutAction="/vibe-raising/logout"
     >
       {appUser.role === "founder" && showAnnouncement ? (
-        <AnnouncementPopup
+        <VibeRaisingIntroPopup
           onDismiss={() => setShowAnnouncement(false)}
           onComplete={onCompleteCallback}
+          onSkip={onCompleteCallback}
         />
       ) : null}
 

--- a/app/routes/vibe-raising-landing.tsx
+++ b/app/routes/vibe-raising-landing.tsx
@@ -1,481 +1,142 @@
-import { useState } from "react";
-import { Link } from "react-router";
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router";
 import {
-    ChartBar,
-    Rocket,
-    ArrowLeftRight,
-    Sparkles,
-    Send,
-    Search,
-    Zap,
-    TrendingUp,
-    Handshake,
-    Clock,
-    Globe,
-    Lightbulb,
-    Target
-} from "lucide-react";
+  ArrowRightIcon,
+  ChartBarIcon,
+  ExclamationTriangleIcon,
+  SparklesIcon,
+  UserGroupIcon,
+} from "@heroicons/react/24/outline";
+import ResponsibleInvestorsSection from "~/components/ResponsibleInvestorsSection";
+import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import type { Route } from "./+types/vibe-raising-landing";
 
-const PAGE_TITLE = 'Vibe Raising: Unlock Capital with Monthly Founder Updates.';
+const PAGE_TITLE = "Vibe Raising";
 const PAGE_DESCRIPTION =
-    'Regular, authentic updates are crucial for keeping investors engaged and informed about your progress.';
+  "Build investor trust with consistent, transparent monthly founder updates.";
 
-export function meta({ }: Route.MetaArgs) {
-    return [
-        { title: 'Vibe Raising | MLAI Community' },
-        { name: "description", content: PAGE_DESCRIPTION },
-        { tagName: "link", rel: "canonical", href: "https://mlai.au/vibe-raising-landing" },
-    ];
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Vibe Raising | MLAI Community" },
+    { name: "description", content: PAGE_DESCRIPTION },
+    { tagName: "link", rel: "canonical", href: "https://mlai.au/vibe-raising-landing" },
+  ];
 }
 
-export async function loader({ }: Route.LoaderArgs) {
-    return {};
+export async function loader({}: Route.LoaderArgs) {
+  return {};
 }
 
-export default function VibeRaisingPage({ }: Route.ComponentProps) {
-    const [activeTab, setActiveTab] = useState<'investors' | 'founders'>('investors');
+export default function VibeRaisingPage({}: Route.ComponentProps) {
+  const navigate = useNavigate();
+  const [showIntro, setShowIntro] = useState(false);
 
-    return (
-        <main className="bg-[var(--brutalist-beige)]">
-            {/* Hero Section */}
-            <div className="pt-2 lg:pt-3">
-                <div className="max-w-6xl mx-auto px-4 lg:px-6">
-                    <section className="bg-[var(--brutalist-mint)] rounded-xl p-8 lg:p-12">
-                        <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-zinc-900 tracking-tight">
-                            {PAGE_TITLE}
-                        </h1>
-                    </section>
-                </div>
+  const enterApp = useCallback(() => {
+    navigate("/vibe-raising");
+  }, [navigate]);
+
+  return (
+    <main className="bg-white text-gray-950">
+      {showIntro ? (
+        <VibeRaisingIntroPopup
+          onDismiss={() => setShowIntro(false)}
+          onComplete={enterApp}
+          onSkip={enterApp}
+        />
+      ) : null}
+
+      <section className="relative min-h-[86vh] overflow-hidden">
+        <img
+          src="/hero-bg.jpg"
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover object-top"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/45 via-black/55 to-black/75" />
+
+        <div className="relative z-10 mx-auto flex min-h-[86vh] max-w-6xl flex-col justify-center px-6 py-20 lg:px-8">
+          <div className="max-w-3xl">
+            <p className="mb-4 text-sm font-black uppercase tracking-[0.28em] text-white/70">
+              Monthly founder updates
+            </p>
+            <h1 className="text-5xl font-black tracking-tight text-white sm:text-6xl lg:text-7xl">
+              {PAGE_TITLE}
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg font-medium leading-8 text-white/78 sm:text-xl">
+              Build investor trust before you need capital. Publish progress, metrics,
+              challenges, and asks in a format investors can scan and act on.
+            </p>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => setShowIntro(true)}
+                className="inline-flex items-center justify-center gap-3 rounded-xl bg-white px-7 py-4 text-sm font-black text-gray-950 shadow-xl shadow-black/20 transition hover:bg-gray-100 active:scale-[0.98]"
+              >
+                Start your update
+                <ArrowRightIcon className="h-5 w-5" />
+              </button>
+              <a
+                href="mailto:hi@mlai.au?subject=Investor Interest in Vibe Raising"
+                className="inline-flex items-center justify-center rounded-xl border border-white/25 bg-white/10 px-7 py-4 text-sm font-black text-white backdrop-blur-sm transition hover:bg-white/15"
+              >
+                Investor access
+              </a>
             </div>
+          </div>
+        </div>
+      </section>
 
-            {/* Tab Navigation */}
-            <div className="mt-8">
-                <div className="max-w-6xl mx-auto px-4 lg:px-6">
-                    <div className="flex gap-1">
-                        <button
-                            onClick={() => setActiveTab('investors')}
-                            className={`px-8 py-4 font-bold transition-all rounded-t-xl ${activeTab === 'investors'
-                                ? 'bg-[#ff3d00] text-white relative z-10'
-                                : 'bg-white text-zinc-700 hover:bg-zinc-100'
-                                }`}
-                        >
-                            For Investors
-                        </button>
-                        <button
-                            onClick={() => setActiveTab('founders')}
-                            className={`px-8 py-4 font-bold transition-all rounded-t-xl ${activeTab === 'founders'
-                                ? 'bg-[#4b0db3] text-white relative z-10'
-                                : 'bg-white text-zinc-700 hover:bg-zinc-100'
-                                }`}
-                        >
-                            For Founders
-                        </button>
-                    </div>
-                </div>
+      <ResponsibleInvestorsSection />
+
+      <section className="px-6 py-16">
+        <div className="mx-auto grid max-w-6xl gap-5 md:grid-cols-3">
+          {[
+            {
+              icon: SparklesIcon,
+              title: "Founders share",
+              copy: "Regular updates turn wins, asks, and challenges into visible momentum.",
+            },
+            {
+              icon: ChartBarIcon,
+              title: "Signals compound",
+              copy: "Investors can scan monthly metrics and context without stale directory noise.",
+            },
+            {
+              icon: UserGroupIcon,
+              title: "The right people help",
+              copy: "Consistent transparency makes investor follow-up and introductions easier.",
+            },
+          ].map((item) => (
+            <div key={item.title} className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="mb-5 flex h-11 w-11 items-center justify-center rounded-xl bg-violet-50 text-violet-600">
+                <item.icon className="h-6 w-6" />
+              </div>
+              <h2 className="text-xl font-black tracking-tight text-gray-950">{item.title}</h2>
+              <p className="mt-3 text-sm leading-6 text-gray-600">{item.copy}</p>
             </div>
+          ))}
+        </div>
+      </section>
 
-            {/* Tab Content Container */}
-            <div className="max-w-6xl mx-auto px-4 lg:px-6">
-                <div className="bg-white rounded-b-xl rounded-tr-xl p-8">
-                    {/* Investors Tab Content */}
-                    {activeTab === 'investors' && (
-                        <div>
-                            {/* Two-Column Layout: Key Facts + Image */}
-                            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-12">
-                                {/* Left Column: Key Facts */}
-                                <div className="bg-[#ff3d00] rounded-xl p-8 text-white">
-                                    <h2 className="text-2xl font-bold mb-6">FOR INVESTORS: WHY VIBE RAISING MATTERS</h2>
-
-                                    <p className="text-base leading-relaxed mb-6">
-                                        Stay informed about your portfolio companies with consistent, high-quality monthly updates.
-                                    </p>
-
-                                    <div className="space-y-6">
-                                        <div className="flex gap-3">
-                                            <span className="text-2xl flex-shrink-0">•</span>
-                                            <div>
-                                                <p className="font-bold mb-2">How do I track my portfolio companies?</p>
-                                                <p className="text-sm leading-relaxed opacity-95">
-                                                    Get standardized updates across all your investments, making it easy to monitor progress and identify opportunities to help.
-                                                </p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex gap-3">
-                                            <span className="text-2xl flex-shrink-0">•</span>
-                                            <div>
-                                                <p className="font-bold mb-2">Where can I find active fundraising startups?</p>
-                                                <p className="text-sm leading-relaxed opacity-95">
-                                                    Access vetted startups that are actively fundraising. Founders who maintain regular updates demonstrate transparency and strong execution.
-                                                </p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex gap-3">
-                                            <span className="text-2xl flex-shrink-0">•</span>
-                                            <div>
-                                                <p className="font-bold mb-2">How do I discover high-quality deal flow?</p>
-                                                <p className="text-sm leading-relaxed opacity-95">
-                                                    Surface active, funded-ready startups with live metrics and growth signals you won't find elsewhere.
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {/* Right Column: Image */}
-                                <div className="bg-zinc-100 rounded-xl overflow-hidden">
-                                    <img
-                                        src="https://images.unsplash.com/photo-1521737711867-e3b97375f902?w=800&h=600&fit=crop"
-                                        alt="Founders discussing business strategy"
-                                        className="w-full h-full object-cover"
-                                    />
-                                </div>
-                            </div>
-
-                            {/* How the Loop Works */}
-                            <div className="mb-12">
-                                <h2 className="text-3xl font-bold text-zinc-900 mb-8">How the Loop Works:</h2>
-                                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                                    <div className="bg-[#ff3d00] rounded-xl p-6 text-white">
-                                        <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center mb-6">
-                                            <Send className="w-[14px] h-[14px] text-white" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3">Founders share</h3>
-                                        <p className="text-sm">
-                                            Regular updates keep profiles fresh and momentum visible.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[#4b0db3] rounded-xl p-6 text-white">
-                                        <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center mb-6">
-                                            <Search className="w-[14px] h-[14px] text-white" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3">Investors discover</h3>
-                                        <p className="text-sm">
-                                            Relevant, timely information about startups that match your thesis.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[#FFF500] rounded-xl p-6">
-                                        <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center mb-6">
-                                            <Sparkles className="w-[14px] h-[14px] text-zinc-900" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3 text-zinc-900">Vibe Raising connects</h3>
-                                        <p className="text-sm text-zinc-700">
-                                            Unique data enables smarter, more meaningful introductions.
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            {/* The Problem & Solution */}
-                            <div className="mb-12">
-                                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                                    <div className="bg-[var(--brutalist-beige)] rounded-xl p-8">
-                                        <p className="text-[#4b0db3] font-bold text-sm uppercase mb-3">THE PROBLEM</p>
-                                        <h3 className="text-2xl font-bold text-zinc-900 mb-4">
-                                            Australia has incredible startups, but discovering them is hard.
-                                        </h3>
-                                        <p className="text-zinc-600">
-                                            Existing directories go stale. Opportunities get missed. The ecosystem lacks a living, breathing source of truth.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[var(--brutalist-mint)] rounded-xl p-8">
-                                        <p className="text-zinc-700 font-bold text-sm uppercase mb-3">OUR SOLUTION</p>
-                                        <h3 className="text-2xl font-bold text-zinc-900 mb-4">
-                                            Vibe Raising makes freshness the core feature.
-                                        </h3>
-                                        <p className="text-zinc-700">
-                                            Not an afterthought. Regular founder updates create a self-sustaining loop that keeps our directory perpetually current.
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            {/* For Investors & VCs */}
-                            <div>
-                                <h2 className="text-3xl font-bold text-zinc-900 mb-8">For Investors & VCs:</h2>
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                                    <div className="bg-[#3537dc] rounded-xl p-6 text-white">
-                                        <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center mb-6">
-                                            <ChartBar className="w-[14px] h-[14px] text-white" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3">Exclusive data</h3>
-                                        <p className="text-sm">
-                                            Access insights you won't find elsewhere—live metrics and growth signals.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[#ff3d00] rounded-xl p-6 text-white">
-                                        <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center mb-6">
-                                            <Rocket className="w-[14px] h-[14px] text-white" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3">Time Saving</h3>
-                                        <p className="text-sm">
-                                            No more stale directories. Surface active, funded-ready startups.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[var(--brutalist-mint)] rounded-xl p-6">
-                                        <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center mb-6">
-                                            <ArrowLeftRight className="w-[14px] h-[14px] text-zinc-900" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3 text-zinc-900">Better matching</h3>
-                                        <p className="text-sm text-zinc-700">
-                                            Intelligent matching between investor preferences and startup trajectories.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[#FFF500] rounded-xl p-6">
-                                        <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center mb-6">
-                                            <Sparkles className="w-[14px] h-[14px] text-zinc-900" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3 text-zinc-900">Early access</h3>
-                                        <p className="text-sm text-zinc-700">
-                                            See emerging startups before they hit the mainstream radar.
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            {/* Investor Call to Action */}
-                            <div className="mt-12 bg-[#3537dc] rounded-xl p-8 text-center">
-                                <h3 className="text-3xl font-bold text-white mb-4">
-                                    Interested in Accessing Our Deal Flow?
-                                </h3>
-                                <p className="text-white text-lg mb-6 max-w-2xl mx-auto">
-                                    Get in touch to learn more about how you can discover high-quality startups through Vibe Raising.
-                                </p>
-                                <a
-                                    href="mailto:hi@mlai.au?subject=Investor Interest in Vibe Raising"
-                                    className="inline-block px-8 py-4 bg-white text-[#3537dc] font-bold rounded-lg hover:bg-zinc-100 transition text-lg"
-                                >
-                                    Email Us at hi@mlai.au
-                                </a>
-                            </div>
-                        </div>
-                    )}
-
-                    {/* Founders Tab Content */}
-                    {activeTab === 'founders' && (
-                        <div>
-                            {/* How the Loop Works */}
-                            <div className="mb-12">
-                                <h2 className="text-3xl font-bold text-zinc-900 mb-8">How the Loop Works:</h2>
-                                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                                    <div className="bg-[#ff3d00] rounded-xl p-6 text-white">
-                                        <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center mb-6">
-                                            <Send className="w-[14px] h-[14px] text-white" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3">Founders share</h3>
-                                        <p className="text-sm">
-                                            Regular updates keep profiles fresh and momentum visible.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[#4b0db3] rounded-xl p-6 text-white">
-                                        <div className="w-8 h-8 rounded-lg bg-white/20 flex items-center justify-center mb-6">
-                                            <Search className="w-[14px] h-[14px] text-white" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3">Investors discover</h3>
-                                        <p className="text-sm">
-                                            Relevant, timely information about startups that match your thesis.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[#FFF500] rounded-xl p-6">
-                                        <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center mb-6">
-                                            <Zap className="w-[14px] h-[14px] text-zinc-900" />
-                                        </div>
-                                        <h3 className="text-xl font-bold mb-3 text-zinc-900">Vibe Raising connects</h3>
-                                        <p className="text-sm text-zinc-700">
-                                            Unique data enables smarter, more meaningful introductions.
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            {/* The Problem & Solution */}
-                            <div className="mb-12">
-                                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                                    <div className="bg-[var(--brutalist-beige)] rounded-xl p-8">
-                                        <p className="text-[#4b0db3] font-bold text-sm uppercase mb-3">THE PROBLEM</p>
-                                        <h3 className="text-2xl font-bold text-zinc-900 mb-4">
-                                            Australia has incredible startups, but discovering them is hard.
-                                        </h3>
-                                        <p className="text-zinc-600">
-                                            Existing directories go stale. Opportunities get missed. The ecosystem lacks a living, breathing source of truth.
-                                        </p>
-                                    </div>
-                                    <div className="bg-[var(--brutalist-mint)] rounded-xl p-8">
-                                        <p className="text-zinc-700 font-bold text-sm uppercase mb-3">OUR SOLUTION</p>
-                                        <h3 className="text-2xl font-bold text-zinc-900 mb-4">
-                                            Vibe Raising makes freshness the core feature.
-                                        </h3>
-                                        <p className="text-zinc-700">
-                                            Not an afterthought. Regular founder updates create a self-sustaining loop that keeps our directory perpetually current.
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            {/* For Founders Section */}
-                            <div>
-
-                                <h2 className="text-3xl font-bold text-zinc-900 mb-8">How It Works</h2>
-
-                                <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                                    <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                        <div className="text-3xl font-bold text-[#ff3d00] mb-3">1</div>
-                                        <h3 className="text-xl font-bold text-zinc-900 mb-3">Create Your Update</h3>
-                                        <p className="text-zinc-700">
-                                            Use our streamlined template to quickly document your monthly progress, metrics, wins, and challenges. No more wrestling with formatting or wondering what to include.
-                                        </p>
-                                    </div>
-
-                                    <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                        <div className="text-3xl font-bold text-[#4b0db3] mb-3">2</div>
-                                        <h3 className="text-xl font-bold text-zinc-900 mb-3">Publish to Your Network</h3>
-                                        <p className="text-zinc-700">
-                                            Share your update with existing investors through our platform. They receive a professional, well-formatted report that keeps them engaged and informed.
-                                        </p>
-                                    </div>
-
-                                    <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                        <div className="text-3xl font-bold text-[#3537dc] mb-3">3</div>
-                                        <h3 className="text-xl font-bold text-zinc-900 mb-3">Get Introductions</h3>
-                                        <p className="text-zinc-700">
-                                            When you're raising capital, we connect you with warm introductions to relevant investors who match your stage, industry, and geography.
-                                        </p>
-                                    </div>
-                                </div>
-
-                                {/* Why We're Building This */}
-                                <div className="bg-[var(--brutalist-mint)] rounded-xl p-8 mb-12">
-                                    <h2 className="text-3xl font-bold text-zinc-900 mb-6">Why We're Building This</h2>
-                                    <div className="prose prose-zinc max-w-none">
-                                        <p className="text-zinc-700 mb-4 text-lg">
-                                            We've seen too many founders struggle with the same challenges:
-                                        </p>
-                                        <ul className="space-y-3 text-zinc-700">
-                                            <li className="flex gap-3">
-                                                <span className="text-[#ff3d00] font-bold">→</span>
-                                                <span><strong>Investor updates get deprioritized</strong> when founders are busy building product and serving customers</span>
-                                            </li>
-                                            <li className="flex gap-3">
-                                                <span className="text-[#ff3d00] font-bold">→</span>
-                                                <span><strong>Cold outreach to investors is painful</strong> and has incredibly low conversion rates</span>
-                                            </li>
-                                            <li className="flex gap-3">
-                                                <span className="text-[#ff3d00] font-bold">→</span>
-                                                <span><strong>Existing investors lose track of progress</strong> and can't help when they don't know what's happening</span>
-                                            </li>
-                                            <li className="flex gap-3">
-                                                <span className="text-[#ff3d00] font-bold">→</span>
-                                                <span><strong>The best investor relationships</strong> come from warm introductions, but they're hard to come by</span>
-                                            </li>
-                                        </ul>
-                                        <p className="text-zinc-700 mt-6 text-lg">
-                                            Vibe Raising solves these problems by making it easy to maintain regular communication with your investor network while opening doors to new capital when you need it.
-                                        </p>
-                                    </div>
-                                </div>
-
-                                {/* Benefits Section */}
-                                <div className="mb-12">
-                                    <h2 className="text-3xl font-bold text-zinc-900 mb-6">The Benefits of Publishing Through Our Platform</h2>
-
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                        <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                            <h3 className="text-xl font-bold text-zinc-900 mb-3 flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center">
-                                                    <TrendingUp className="w-[18px] h-[18px] text-zinc-900" />
-                                                </div>
-                                                Build Investor Confidence
-                                            </h3>
-                                            <p className="text-zinc-700">
-                                                Consistent, transparent updates demonstrate professionalism and build trust. Investors are more likely to double down or make introductions when they're actively engaged with your journey.
-                                            </p>
-                                        </div>
-
-                                        <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                            <h3 className="text-xl font-bold text-zinc-900 mb-3 flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center">
-                                                    <Handshake className="w-[18px] h-[18px] text-zinc-900" />
-                                                </div>
-                                                Access Warm Introductions
-                                            </h3>
-                                            <p className="text-zinc-700">
-                                                When you're ready to raise, we leverage your track record of updates to connect you with investors who have funded similar companies. Warm intros convert at 10-20x the rate of cold outreach.
-                                            </p>
-                                        </div>
-
-                                        <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                            <h3 className="text-xl font-bold text-zinc-900 mb-3 flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center">
-                                                    <Clock className="w-[18px] h-[18px] text-zinc-900" />
-                                                </div>
-                                                Save Time Every Month
-                                            </h3>
-                                            <p className="text-zinc-700">
-                                                Our structured templates and automation cut your reporting time from hours to minutes. Spend less time writing emails and more time building your business.
-                                            </p>
-                                        </div>
-
-                                        <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                            <h3 className="text-xl font-bold text-zinc-900 mb-3 flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center">
-                                                    <Globe className="w-[18px] h-[18px] text-zinc-900" />
-                                                </div>
-                                                Connect Globally
-                                            </h3>
-                                            <p className="text-zinc-700">
-                                                Access investors across Australia and internationally. We work with angels, VCs, and family offices who actively invest in early-stage companies across multiple sectors.
-                                            </p>
-                                        </div>
-
-                                        <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                            <h3 className="text-xl font-bold text-zinc-900 mb-3 flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center">
-                                                    <Lightbulb className="w-[18px] h-[18px] text-zinc-900" />
-                                                </div>
-                                                Get Valuable Feedback
-                                            </h3>
-                                            <p className="text-zinc-700">
-                                                Regular updates create opportunities for investors to provide advice, make introductions to customers, and help you navigate challenges they've seen before.
-                                            </p>
-                                        </div>
-
-                                        <div className="bg-[var(--brutalist-beige)] rounded-xl p-6">
-                                            <h3 className="text-xl font-bold text-zinc-900 mb-3 flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-black/5 flex items-center justify-center">
-                                                    <Target className="w-[18px] h-[18px] text-zinc-900" />
-                                                </div>
-                                                Track Your Progress
-                                            </h3>
-                                            <p className="text-zinc-700">
-                                                Looking back at your monthly updates gives you a clear view of your startup's trajectory. See how far you've come and spot trends you might have missed.
-                                            </p>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {/* Founder Call to Action */}
-                                <div className="mt-12 bg-[#4b0db3] rounded-xl p-8 text-center">
-                                    <h3 className="text-3xl font-bold text-white mb-4">
-                                        Ready to Get Started?
-                                    </h3>
-                                    <p className="text-white text-lg mb-6 max-w-2xl mx-auto">
-                                        Email us and tell us about your startup. We'll help you get set up with Vibe Raising and start building momentum with your investors.
-                                    </p>
-                                    <a
-                                        href="mailto:hi@mlai.au?subject=Founder Interest in Vibe Raising"
-                                        className="inline-block px-8 py-4 bg-white text-[#4b0db3] font-bold rounded-lg hover:bg-zinc-100 transition text-lg"
-                                    >
-                                        Email Us at hi@mlai.au
-                                    </a>
-                                </div>
-
-                            </div>
-                        </div>
-                    )}
-                </div>
+      <section className="mx-auto max-w-4xl px-6 pb-16">
+        <div className="relative rounded-2xl border border-red-100 bg-white p-8 shadow-[0_8px_30px_rgb(0,0,0,0.04)] sm:p-10">
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+            <div className="rounded-lg bg-red-50 p-2">
+              <ExclamationTriangleIcon className="h-7 w-7 text-red-500" />
             </div>
-        </main>
-    );
+            <div className="space-y-4">
+              <h2 className="text-2xl font-bold text-gray-900">
+                Don't Wait Until You Need Money
+              </h2>
+              <p className="text-lg leading-relaxed text-gray-600">
+                The best founders build investor trust before the round starts.
+                Send consistent updates, stay transparent about progress and challenges,
+                and make it easy for the right investors to understand your momentum.
+              </p>
+            </div>
+          </div>
+          <div className="absolute bottom-0 left-0 top-0 w-1.5 rounded-l-2xl bg-red-400" />
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -7,6 +7,7 @@ export interface VibeRaisingCompany {
   name: string;
   domain?: string | null;
   abn?: string | null;
+  location?: string | null;
   registered: boolean;
 }
 
@@ -29,6 +30,7 @@ export interface VibeRaisingAppUser {
   companyName: string;
   domain?: string | null;
   abn?: string | null;
+  location?: string | null;
   companyRegistered: boolean;
 }
 
@@ -43,6 +45,9 @@ export interface VibeRaisingPastMonthSummary {
 export interface VibeRaisingDraftedContent {
   month?: string;
   year?: number;
+  summary?: string;
+  sourceUrl?: string;
+  videoUrl?: string;
   highlights: string;
   challenges: string;
   asks: string;
@@ -58,6 +63,9 @@ export interface VibeRaisingMonthlyUpdate {
   year?: number;
   date: string;
   status?: string | null;
+  summary?: string | null;
+  sourceUrl?: string | null;
+  videoUrl?: string | null;
   metrics: Record<string, string>;
   highlights: string;
   challenges: string;
@@ -122,6 +130,9 @@ export interface VibeRaisingEmailDraftMonth {
   isoMonth?: string;
   month: string;
   year?: number;
+  summary?: string;
+  sourceUrl?: string;
+  videoUrl?: string;
   highlights: string;
   challenges: string;
   asks: string;


### PR DESCRIPTION
## Summary
- Ports the useful PR #386 Vibe Raising frontend/product updates onto current `main` after #389.
- Keeps the current backend-backed auth/profile/update/email-draft architecture and route contract.
- Adds shared Vibe Raising UI components for the landing intro popup, responsible-investor band, region badges, and date tabs.
- Enhances create-update, dashboard, review, company setup, Gmail draft, and platform login flows without reintroducing stale local-cookie auth or mock backend behavior.

## What Changed
- Refreshed `/vibe-raising-landing` with the new hero/intro treatment and shared intro popup, while keeping `/vibe-raising` as the authenticated app route.
- Added optional company/app user `location` support and optional monthly update `summary`, `sourceUrl`, and `videoUrl` support with snake_case/camelCase normalizers.
- Made monthly update publish backward-compatible by retrying with the legacy payload if the backend rejects optional new fields.
- Added region badges, date tabs, summary/source display, manual materials fields, and recorder/audio fallback UI across Vibe Raising dashboard and create/update flows.
- Added a Gmail privacy notice to the existing backend OAuth wizard and made `/platform/login` resilient to transient `getCurrentUser` failures.

## Explicitly Excluded
- No `app/lib/vibe-raising-session.ts` or `app/lib/google-auth.ts`.
- No `package-lock.json`.
- No `/vibe-raising/app` route move.
- No `VITE_GOOGLE_CLIENT_ID`, local-cookie auth, Google sign-in, or mock publish cookies.

## Validation
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- Verified the final diff excludes stale PR #386 files/routes/env additions.
