### PR TITLE
feat(design-system): Vibe Raising tokens + component styles (scoped)

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,6 +1,8 @@
 @import "tailwindcss" source(".");
 @plugin "@tailwindcss/typography";
 @import "tw-animate-css";
+@import "./styles/vibe-raising-tokens.css";
+@import "./styles/vibe-raising-components.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -44,6 +44,11 @@ export const links: Route.LinksFunction = () => [
     rel: "stylesheet",
     href: "https://fonts.googleapis.com/css2?family=Anton&family=Oswald:wght@200..700&family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap",
   },
+  {
+    // DM Sans — used by the Vibe Raising design system (scoped via .vr-scope).
+    rel: "stylesheet",
+    href: "https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&display=swap",
+  },
 ];
 
 export default function Layout() {

--- a/app/styles/vibe-raising-components.css
+++ b/app/styles/vibe-raising-components.css
@@ -1,0 +1,540 @@
+/* ============================================================
+   VIBE RAISING — Component Styles
+   MLAI · Founder Tools
+   Ported from the vibe-raising-prototype HTML.
+
+   IMPORTANT: Everything here is scoped under .vr-scope so it
+   only applies on pages that opt in.
+   ============================================================ */
+
+/* ── Dashboard metrics row ────────────────────────────────── */
+
+.vr-scope .vr-metrics-row {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 1023px) {
+  .vr-scope .vr-metrics-row {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .vr-scope .vr-metrics-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.vr-scope .vr-metric-card {
+  background: var(--vr-color-bg);
+  border: 1px solid var(--vr-color-border);
+  border-radius: 10px;
+  padding: 20px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--vr-shadow-sm);
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.vr-scope .vr-metric-card:hover {
+  box-shadow: var(--vr-shadow-md);
+  transform: translateY(-2px);
+}
+
+.vr-scope .vr-metric-card-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+}
+
+.vr-scope .vr-metric-eyebrow {
+  font-family: var(--vr-font-body);
+  font-size: 10px;
+  font-weight: var(--vr-font-weight-semibold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vr-color-text-sub);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.vr-scope .vr-metric-value {
+  font-family: var(--vr-font-title);
+  font-weight: var(--vr-font-weight-bold);
+  font-size: 30px;
+  color: var(--vr-color-text);
+  line-height: 1;
+  margin-bottom: 6px;
+}
+
+.vr-scope .vr-metric-delta {
+  font-size: var(--vr-font-size-sm);
+  font-weight: var(--vr-font-weight-medium);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.vr-scope .vr-delta-up    { color: #00956E; }
+.vr-scope .vr-delta-down  { color: var(--vr-color-brand-orange); }
+.vr-scope .vr-delta-neutral { color: var(--vr-color-text-sub); }
+
+.vr-scope .vr-badge-orange {
+  background: rgba(232, 69, 33, 0.1);
+  color: var(--vr-color-brand-orange);
+  border: 1px solid rgba(232, 69, 33, 0.2);
+}
+
+/* ── Alerts ───────────────────────────────────────────────── */
+
+.vr-scope .vr-alert {
+  display: flex;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--vr-radius-md);
+  border-left: 3px solid;
+  font-size: var(--vr-font-size-md);
+  line-height: var(--vr-line-height-normal);
+  align-items: flex-start;
+}
+
+.vr-scope .vr-alert-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vr-scope .vr-alert-title {
+  font-weight: var(--vr-font-weight-semibold);
+  font-size: var(--vr-font-size-md);
+  margin-bottom: 2px;
+}
+
+.vr-scope .vr-alert-body {
+  font-size: var(--vr-font-size-sm);
+  opacity: 0.85;
+}
+
+.vr-scope .vr-alert-info {
+  background: var(--vr-color-purple-50);
+  border-color: var(--vr-color-primary);
+  color: var(--vr-color-purple-700);
+}
+
+.vr-scope .vr-alert-success {
+  background: rgba(0, 200, 204, 0.07);
+  border-color: var(--vr-color-featured);
+  color: #007a7d;
+}
+
+.vr-scope .vr-alert-warning {
+  background: rgba(245, 166, 35, 0.07);
+  border-color: var(--vr-color-warning);
+  color: #8a5a00;
+}
+
+.vr-scope .vr-alert-danger {
+  background: rgba(232, 69, 33, 0.07);
+  border-color: var(--vr-color-danger);
+  color: #a02d13;
+}
+
+/* ── Tabs ─────────────────────────────────────────────────── */
+
+.vr-scope .vr-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--vr-color-border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.vr-scope .vr-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.vr-scope .vr-tab {
+  padding: 12px 20px;
+  font-family: var(--vr-font-body);
+  font-size: var(--vr-font-size-md);
+  font-weight: var(--vr-font-weight-medium);
+  color: var(--vr-color-text-mid);
+  cursor: pointer;
+  white-space: nowrap;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  background: none;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.vr-scope .vr-tab:hover {
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-tab.is-active {
+  color: var(--vr-color-primary);
+  border-bottom-color: var(--vr-color-primary);
+  font-weight: var(--vr-font-weight-semibold);
+}
+
+/* ── Update Card (current, expanded) ──────────────────────── */
+
+.vr-scope .vr-update-card {
+  background: var(--vr-color-bg);
+  border: 1px solid var(--vr-color-border);
+  border-radius: var(--vr-radius-lg);
+  overflow: hidden;
+  box-shadow: var(--vr-shadow-sm);
+  transition: box-shadow 0.15s;
+}
+
+.vr-scope .vr-update-card:hover {
+  box-shadow: var(--vr-shadow-md);
+}
+
+.vr-scope .vr-uch {
+  padding: 20px 24px;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(
+    135deg,
+    var(--vr-color-brand-teal) 0%,
+    var(--vr-color-brand-teal-light) 100%
+  );
+}
+
+.vr-scope .vr-uch-bubble-1 {
+  position: absolute;
+  top: -30px;
+  right: 30px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+}
+
+.vr-scope .vr-uch-bubble-2 {
+  position: absolute;
+  top: 10px;
+  right: -10px;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.07);
+  pointer-events: none;
+}
+
+/* Hover-triggered purple glow on the teal header.
+   Gradient radiates from the top-left corner. Fades in on hover,
+   stays while the cursor is over the header, fades out on leave. */
+.vr-scope .vr-uch-glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.6s ease-out;
+  background: radial-gradient(
+    circle at 0% 0%,
+    var(--vr-color-primary),
+    transparent 65%
+  );
+}
+
+.vr-scope .vr-uch:hover .vr-uch-glow {
+  opacity: 0.55;
+}
+
+.vr-scope .vr-uch-date {
+  font-size: var(--vr-font-size-xs);
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.vr-scope .vr-uch-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.vr-scope .vr-uch-emoji {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--vr-radius-md);
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.22);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: #fff;
+}
+
+.vr-scope .vr-uch-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.vr-scope .vr-uch-title {
+  font-family: var(--vr-font-title);
+  font-size: 19px;
+  font-weight: var(--vr-font-weight-semibold);
+  color: #fff;
+  letter-spacing: 0.03em;
+}
+
+.vr-scope .vr-current-chip {
+  background: rgba(255, 255, 255, 0.28);
+  color: #fff;
+  font-size: 10px;
+  font-weight: var(--vr-font-weight-bold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 2px 9px;
+  border-radius: var(--vr-radius-full);
+}
+
+.vr-scope .vr-uch-company {
+  font-size: var(--vr-font-size-sm);
+  color: rgba(255, 255, 255, 0.75);
+  margin-top: 2px;
+}
+
+.vr-scope .vr-ucb {
+  padding: 24px;
+}
+
+.vr-scope .vr-ucb-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+/* Sections inside the update card body */
+
+.vr-scope .vr-us-block {
+  margin-bottom: 16px;
+}
+
+.vr-scope .vr-us-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.vr-scope .vr-us-heading-icon {
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vr-scope .vr-us-heading-text {
+  font-family: var(--vr-font-body);
+  font-size: var(--vr-font-size-sm);
+  font-weight: var(--vr-font-weight-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-us-list {
+  padding-left: 4px;
+}
+
+.vr-scope .vr-us-item {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 5px;
+  padding-left: 18px;
+}
+
+.vr-scope .vr-us-item-dot {
+  color: var(--vr-color-text-sub);
+  flex-shrink: 0;
+}
+
+.vr-scope .vr-us-item-text {
+  font-size: var(--vr-font-size-md);
+  color: var(--vr-color-text);
+  line-height: var(--vr-line-height-normal);
+}
+
+/* Footer */
+
+.vr-scope .vr-ucf {
+  padding: 14px 24px;
+  border-top: 1px solid var(--vr-color-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.vr-scope .vr-ucf-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.vr-scope .vr-ucf-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--vr-radius-full);
+  background: var(--vr-color-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--vr-font-size-xs);
+  font-weight: var(--vr-font-weight-bold);
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.vr-scope .vr-ucf-name {
+  font-size: var(--vr-font-size-md);
+  font-weight: var(--vr-font-weight-medium);
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-ucf-company {
+  font-size: var(--vr-font-size-sm);
+  color: var(--vr-color-text-sub);
+}
+
+/* ── Past update row (collapsed) ──────────────────────────── */
+
+.vr-scope .vr-past-row {
+  background: var(--vr-color-bg);
+  border: 1px solid var(--vr-color-border);
+  border-radius: var(--vr-radius-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  cursor: pointer;
+  transition: box-shadow 0.15s, transform 0.15s;
+  text-align: left;
+  width: 100%;
+}
+
+.vr-scope .vr-past-row:hover {
+  box-shadow: var(--vr-shadow-md);
+  transform: translateY(-1px);
+}
+
+.vr-scope .vr-past-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.vr-scope .vr-past-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vr-color-border-md);
+  flex-shrink: 0;
+}
+
+.vr-scope .vr-past-month {
+  font-size: var(--vr-font-size-base);
+  font-weight: var(--vr-font-weight-semibold);
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-past-preview {
+  font-size: var(--vr-font-size-md);
+  color: var(--vr-color-text-sub);
+}
+
+.vr-scope .vr-past-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.vr-scope .vr-past-arrow {
+  color: var(--vr-color-text-sub);
+  font-size: 18px;
+  line-height: 1;
+}
+
+/* ── Badges ───────────────────────────────────────────────── */
+
+.vr-scope .vr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: var(--vr-radius-full);
+  font-size: var(--vr-font-size-xs);
+  font-weight: var(--vr-font-weight-semibold);
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.vr-scope .vr-badge-purple {
+  background: var(--vr-color-purple-50);
+  color: var(--vr-color-primary);
+  border: 1px solid var(--vr-color-purple-100);
+}
+
+.vr-scope .vr-badge-teal {
+  background: rgba(0, 200, 204, 0.1);
+  color: #007a7d;
+  border: 1px solid rgba(0, 200, 204, 0.2);
+}
+
+.vr-scope .vr-badge-blue {
+  background: rgba(80, 87, 228, 0.1);
+  color: var(--vr-color-secondary);
+  border: 1px solid rgba(80, 87, 228, 0.2);
+}
+
+.vr-scope .vr-badge-neutral {
+  background: var(--vr-color-surface);
+  color: var(--vr-color-text-mid);
+  border: 1px solid var(--vr-color-border-md);
+}
+
+/* ── Responsive tweaks ────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .vr-scope .vr-uch {
+    padding: 16px 18px;
+  }
+  .vr-scope .vr-ucb {
+    padding: 18px;
+  }
+  .vr-scope .vr-ucf {
+    padding: 12px 18px;
+  }
+  .vr-scope .vr-past-row {
+    padding: 12px 14px;
+  }
+  .vr-scope .vr-past-preview {
+    display: none;
+  }
+}

--- a/app/styles/vibe-raising-tokens.css
+++ b/app/styles/vibe-raising-tokens.css
@@ -1,0 +1,188 @@
+/* ============================================================
+   VIBE RAISING — Design Tokens
+   MLAI · Founder Tools
+   Generated from the W3C DTCG token set.
+
+   IMPORTANT: Scoped to the Vibe Raising surface only.
+   Do NOT apply .text-*, .color-* utility classes or
+   vibe-raising design tokens on other routes.
+
+   Font loading note: Oswald + DM Sans are loaded via a
+   <link rel="stylesheet"> in app/root.tsx (not via @import
+   here, since Tailwind's bundle hoists later @imports and
+   breaks the spec requirement that @import precede all
+   other rules).
+   ============================================================ */
+
+:root {
+
+  /* ── Brand Colors ────────────────────────────────────── */
+  --vr-color-brand-purple: #6B30D9;   /* Primary action — CTA, links, focus */
+  --vr-color-brand-blue:   #5057E4;   /* Secondary — info, data metrics */
+  --vr-color-brand-orange: #E84521;   /* MLAI brand accent — brand moments only */
+  --vr-color-brand-teal:   #00C8CC;   /* Featured state — current update gradient */
+  --vr-color-brand-teal-light: #00E0A0;
+
+  /* ── Purple Scale ────────────────────────────────────── */
+  --vr-color-purple-50:  #F3EEFF;
+  --vr-color-purple-100: #E0CFFF;
+  --vr-color-purple-200: #B89EFF;
+  --vr-color-purple-500: #6B30D9;
+  --vr-color-purple-700: #4A1FA0;
+  --vr-color-purple-900: #2D1263;
+
+  /* ── Neutral Scale ───────────────────────────────────── */
+  --vr-color-neutral-white: #FFFFFF;
+  --vr-color-neutral-50:    #F7F7F8;
+  --vr-color-neutral-100:   #EDEDF0;
+  --vr-color-neutral-300:   #C8C8D4;
+  --vr-color-neutral-500:   #9090A8;
+  --vr-color-neutral-700:   #5A5A72;
+  --vr-color-neutral-900:   #1A1A2E;
+
+  /* ── Semantic Color Roles ────────────────────────────── */
+  --vr-color-bg:        var(--vr-color-neutral-white);
+  --vr-color-surface:   var(--vr-color-neutral-50);
+  --vr-color-border:    #E8E8EC;
+  --vr-color-border-md: #D0D0D8;
+  --vr-color-text:      var(--vr-color-neutral-900);
+  --vr-color-text-mid:  var(--vr-color-neutral-700);
+  --vr-color-text-sub:  var(--vr-color-neutral-500);
+  --vr-color-primary:   var(--vr-color-brand-purple);
+  --vr-color-secondary: var(--vr-color-brand-blue);
+  --vr-color-accent:    var(--vr-color-brand-orange);
+  --vr-color-featured:  var(--vr-color-brand-teal);
+  --vr-color-success:   var(--vr-color-brand-teal);
+  --vr-color-danger:    var(--vr-color-brand-orange);
+  --vr-color-warning:   #F5A623;
+
+  /* ── Typography ──────────────────────────────────────── */
+  --vr-font-title: 'Oswald', sans-serif;           /* Headings & titles ONLY */
+  --vr-font-body:  'DM Sans', system-ui, sans-serif; /* All UI text */
+
+  /* ── Font Weights ────────────────────────────────────── */
+  --vr-font-weight-light:    300;
+  --vr-font-weight-regular:  400;
+  --vr-font-weight-medium:   500;
+  --vr-font-weight-semibold: 600;
+  --vr-font-weight-bold:     700;
+
+  /* ── Font Sizes ──────────────────────────────────────── */
+  --vr-font-size-xs:   11px;
+  --vr-font-size-sm:   12px;
+  --vr-font-size-md:   13px;
+  --vr-font-size-base: 14px;
+  --vr-font-size-lg:   16px;
+  --vr-font-size-xl:   20px;
+  --vr-font-size-2xl:  26px;
+  --vr-font-size-3xl:  28px;
+  --vr-font-size-4xl:  36px;
+
+  /* ── Line Heights ────────────────────────────────────── */
+  --vr-line-height-tight:   1.2;
+  --vr-line-height-snug:    1.3;
+  --vr-line-height-normal:  1.5;
+  --vr-line-height-relaxed: 1.6;
+
+  /* ── Spacing (8pt grid) ──────────────────────────────── */
+  --vr-space-1: 4px;
+  --vr-space-2: 8px;
+  --vr-space-3: 12px;
+  --vr-space-4: 16px;
+  --vr-space-5: 24px;
+  --vr-space-6: 32px;
+  --vr-space-7: 48px;
+  --vr-space-8: 64px;
+
+  /* ── Border Radius ───────────────────────────────────── */
+  --vr-radius-sm:   4px;
+  --vr-radius-md:   8px;
+  --vr-radius-lg:   12px;
+  --vr-radius-full: 999px;
+
+  /* ── Border Widths ───────────────────────────────────── */
+  --vr-border-subtle:  1px;
+  --vr-border-default: 1.5px;
+  --vr-border-accent:  3px;
+
+  /* ── Shadows (purple-tinted) ─────────────────────────── */
+  --vr-shadow-sm: 0 1px 4px  rgba(107, 48, 217, 0.06);
+  --vr-shadow-md: 0 4px 16px rgba(107, 48, 217, 0.10);
+  --vr-shadow-lg: 0 8px 32px rgba(107, 48, 217, 0.14);
+
+}
+
+/* ── Composite Text Styles ─────────────────────────────────
+   Scoped under .vr-scope so they only apply where we opt in
+   (e.g. on /vibe-raising). Put the class on a page wrapper.
+   ──────────────────────────────────────────────────────── */
+
+.vr-scope .vr-text-page-title {
+  font-family: var(--vr-font-title);
+  font-weight: var(--vr-font-weight-semibold);
+  font-size:   var(--vr-font-size-3xl);
+  line-height: var(--vr-line-height-tight);
+  letter-spacing: 0.03em;
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-text-section-head {
+  font-family: var(--vr-font-title);
+  font-weight: var(--vr-font-weight-semibold);
+  font-size:   var(--vr-font-size-xl);
+  line-height: var(--vr-line-height-tight);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-text-card-title {
+  font-family: var(--vr-font-body);
+  font-weight: var(--vr-font-weight-semibold);
+  font-size:   var(--vr-font-size-lg);
+  line-height: var(--vr-line-height-snug);
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-text-body {
+  font-family: var(--vr-font-body);
+  font-weight: var(--vr-font-weight-regular);
+  font-size:   var(--vr-font-size-base);
+  line-height: var(--vr-line-height-relaxed);
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-text-body-small {
+  font-family: var(--vr-font-body);
+  font-weight: var(--vr-font-weight-regular);
+  font-size:   var(--vr-font-size-md);
+  line-height: var(--vr-line-height-normal);
+  color: var(--vr-color-text);
+}
+
+.vr-scope .vr-text-ui-label {
+  font-family:     var(--vr-font-body);
+  font-weight:     var(--vr-font-weight-semibold);
+  font-size:       var(--vr-font-size-xs);
+  line-height:     var(--vr-line-height-tight);
+  letter-spacing:  0.1em;
+  text-transform:  uppercase;
+  color: var(--vr-color-text-sub);
+}
+
+.vr-scope .vr-text-caption {
+  font-family: var(--vr-font-body);
+  font-weight: var(--vr-font-weight-regular);
+  font-size:   var(--vr-font-size-sm);
+  line-height: var(--vr-line-height-snug);
+  color:       var(--vr-color-text-sub);
+}
+
+.vr-scope .vr-text-eyebrow {
+  font-family:    var(--vr-font-body);
+  font-weight:    var(--vr-font-weight-semibold);
+  font-size:      var(--vr-font-size-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color:          var(--vr-color-text-sub);
+}


### PR DESCRIPTION
Introduces the Vibe Raising design system foundations. All rules are scoped under .vr-scope, so nothing applies unless a page opts in by wrapping its content in that class. No visible change until a page starts using the classes (that happens in a follow-up PR).

New files
- app/styles/vibe-raising-tokens.css — colour palette (brand + purple scale + neutral scale + semantic roles), typography (Oswald + DM Sans with weight/size/line-height scales), 8pt spacing, radius, border widths, purple-tinted shadow scale, plus composite text utility classes (vr-text-page-title, vr-text-eyebrow, vr-text-body, vr-text-ui-label, etc.)
- app/styles/vibe-raising-components.css — dashboard metric cards (gradient bar + Oswald value + delta line), alerts, tabs, update card with teal-gradient header + purple hover glow, past-row, badges, responsive tweaks

Modified
- app/app.css — adds @import for the two new stylesheets
- app/root.tsx — loads DM Sans via a new Google Fonts <link> (Oswald was already loaded by an existing link)

Font loading note: @import url(...) inside the tokens file would be hoisted by Vite and break the spec rule that @import must precede all other rules. Loading via <link rel="stylesheet"> in root.tsx avoids that problem and is faster (preconnect + parallel fetch).