### PR TITLE
[codex] fix Google legacy 404 redirects

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,9 @@
+- [x] Add targeted 301 redirects for Google legacy 404 URLs
+- [x] Restore registry entries for the missing canonical article targets
+- [x] Regenerate `public/sitemap.xml`
+- [x] Run `bun run typecheck`
+- [x] Run `bun run build`
+- [x] Curl-check legacy redirects and canonical targets
 - [x] Add cleanup redirects for broken internal article CTA URLs
 - [x] Replace broken article CTA hrefs and copy with live destinations
 - [x] Add an internal article-link validator to `bun run typecheck`

--- a/app/articles/registry.ts
+++ b/app/articles/registry.ts
@@ -307,6 +307,18 @@ export const ARTICLE_REGISTRY: Record<string, ArticleWithSlug> = {
       "Team collaborating on AI data charts with laptops and whiteboard",
     hasContent: true,
   },
+  "featured/best-way-to-learn-about-ai-2026": {
+    title: "Best way to learn about AI in 2026",
+    date: "2025-01-15",
+    description:
+      "A 2026-ready roadmap for Australians to learn AI: fundamentals, hands-on projects, ethics, and career moves tailored to local pathways.",
+    author: "Dr Sam Donegan",
+    slug: "featured/best-way-to-learn-about-ai-2026",
+    image:
+      "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/content-factory%2FU05QPB483K9%2FMLAI-AUS-Inc%2Fmlai-au%2Fimages%2Fhero-1d8313de-82ba-4ddc-a776-52cee7f2fa1b.jpg?alt=media&token=e14f4ba6-f385-40ec-8453-017f0d7efffa",
+    imageAlt: "Person studying AI concepts on a laptop with diagrams on screen",
+    hasContent: true,
+  },
   "featured/learn-ai-melbourne": {
     title: "Learn AI Melbourne: courses, meetups, and pathways",
     date: "2026-01-28",
@@ -331,6 +343,18 @@ export const ARTICLE_REGISTRY: Record<string, ArticleWithSlug> = {
       "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/content-factory%2FU05QPB483K9%2FMLAI-AUS-Inc%2Fmlai-au%2Fimages%2Fhero-e8d91d69-4aa4-49a0-b1e4-a8b32d3f54ab.jpg?alt=media&token=3d3573bf-5a7d-416f-a7be-61be2dd87a04",
     imageAlt:
       "Retro 90s tech startup scene with diverse individuals brainstorming and collaborating in a creative workspace.",
+  },
+  "featured/how-vcs-value-startups": {
+    title: "How VCs value startups",
+    date: "2026-01-22",
+    description:
+      "How venture capital investors value startups in 2026: methods, metrics, and term-sheet mechanics with context for Australian founders and AI teams.",
+    author: "Dr Sam Donegan",
+    slug: "featured/how-vcs-value-startups",
+    image:
+      "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/content-factory%2FU05QPB483K9%2FMLAI-AUS-Inc%2Fmlai-au%2Fimages%2Fhero-aab7aebb-f326-4ee4-b06c-48702edb6ddf.jpg?alt=media&token=fc7e98eb-7918-4997-a2e0-26a4964b64e6",
+    imageAlt: "Founders reviewing a cap table and metrics on paper and laptop",
+    hasContent: true,
   },
   "featured/how-to-foster-community-engagement": {
     title: "How to foster community engagement (2026)",

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ export default [
   route("/terms", "routes/terms.tsx"),
   route("/resources", "routes/resources.tsx"),
   route("/roo", "routes/roo.tsx"),
+  route("/&", "routes/article-link-cleanups.tsx", { id: "cleanup-root-ampersand" }),
   route("/practical-ai-learning-beginners-builders", "routes/article-link-cleanups.tsx", { id: "cleanup-practical-ai-learning" }),
   route("/ai-startup-building-pitching", "routes/article-link-cleanups.tsx", { id: "cleanup-ai-startup-building-pitching" }),
   route("/templates/startup-traction", "routes/article-link-cleanups.tsx", { id: "cleanup-startup-traction-template" }),
@@ -59,6 +60,7 @@ export default [
   ]),
 
   // Hackathon pages
+  route("/hackathon", "routes/article-link-cleanups.tsx", { id: "cleanup-hackathon-singular" }),
   route("/hackathons", "routes/hackathons.tsx"),
   route("/medhack", "routes/medhack.tsx"),
 
@@ -67,6 +69,12 @@ export default [
 
   // Article Routes
   route("/articles", "routes/articles.index.tsx"),
+  route("/articles/featured/weekly-deep-dive-into-ai-and-ml-advancements-updates", "routes/article-link-cleanups.tsx", { id: "cleanup-featured-weekly-deep-dive" }),
+  route("/articles/featured/weekly-deep-dive-into-ai-and-ml-advancements-updates-issue-2", "routes/article-link-cleanups.tsx", { id: "cleanup-featured-weekly-deep-dive-issue-2" }),
+  route("/articles/careers/best-way-to-learn-about-ai-2026", "routes/article-link-cleanups.tsx", { id: "cleanup-careers-best-way-to-learn-ai-2026" }),
+  route("/articles/startups/how-vcs-value-startups", "routes/article-link-cleanups.tsx", { id: "cleanup-startups-how-vcs-value-startups" }),
+  route("/articles/ai-startup-accelerator", "routes/article-link-cleanups.tsx", { id: "cleanup-ai-startup-accelerator" }),
+  route("/articles/featured/ai-startup-accelerator", "routes/article-link-cleanups.tsx", { id: "cleanup-featured-ai-startup-accelerator" }),
   route("/articles/*", "routes/articles.slug.tsx"),
 
   // Vibe Raising public landing

--- a/app/routes/article-link-cleanups.tsx
+++ b/app/routes/article-link-cleanups.tsx
@@ -2,6 +2,7 @@ import { redirect } from "react-router";
 import type { Route } from "./+types/article-link-cleanups";
 
 const ARTICLE_LINK_CLEANUPS: Record<string, string> = {
+  "/&": "/",
   "/practical-ai-learning-beginners-builders": "/articles",
   "/ai-startup-building-pitching": "/articles/featured/how-to-test-for-a-cofounder-values-match-before-you-commit",
   "/templates/startup-traction": "/articles/featured/go-to-market-for-startups",
@@ -9,6 +10,13 @@ const ARTICLE_LINK_CLEANUPS: Record<string, string> = {
   "/ai-engineering-development": "/articles",
   "/ai-founder-community-pitching-ideas": "/articles",
   "/ai-events-meetups-australia": "/articles/featured/how-to-find-networking-events",
+  "/hackathon": "/hackathons",
+  "/articles/featured/weekly-deep-dive-into-ai-and-ml-advancements-updates": "/articles/community/weekly-deep-dive-into-ai-and-ml-advancements-updates",
+  "/articles/featured/weekly-deep-dive-into-ai-and-ml-advancements-updates-issue-2": "/articles/community/weekly-deep-dive-into-ai-and-ml-advancements-updates-issue-2",
+  "/articles/careers/best-way-to-learn-about-ai-2026": "/articles/featured/best-way-to-learn-about-ai-2026",
+  "/articles/startups/how-vcs-value-startups": "/articles/featured/how-vcs-value-startups",
+  "/articles/ai-startup-accelerator": "/articles/featured/startup-accelerator-australia",
+  "/articles/featured/ai-startup-accelerator": "/articles/featured/startup-accelerator-australia",
 };
 
 export function loader({ request }: Route.LoaderArgs) {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -66,6 +66,42 @@
   <priority>0.3</priority>
  </url>
  <url>
+  <loc>https://mlai.au/articles/featured/what-is-a-unicorn-startup-and-why-it-matters</loc>
+  <lastmod>2026-04-23</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
+  <loc>https://mlai.au/articles/featured/what-an-entrepreneur-does-and-how-to-start-well</loc>
+  <lastmod>2026-04-20</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
+  <loc>https://mlai.au/articles/featured/what-is-artificial-intelligence-in-simple-words</loc>
+  <lastmod>2026-04-18</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
+  <loc>https://mlai.au/articles/featured/what-is-an-agent-in-artificial-intelligence</loc>
+  <lastmod>2026-04-17</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
+  <loc>https://mlai.au/articles/featured/how-to-startup-a-small-business-in-australia</loc>
+  <lastmod>2026-04-14</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
+  <loc>https://mlai.au/articles/featured/what-is-general-artificial-intelligence-and-why-it-matters</loc>
+  <lastmod>2026-04-12</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
   <loc>https://mlai.au/articles/featured/what-constitutes-a-startup-in-practice</loc>
   <lastmod>2026-04-06</lastmod>
   <changefreq>monthly</changefreq>
@@ -168,6 +204,12 @@
   <priority>0.8</priority>
  </url>
  <url>
+  <loc>https://mlai.au/articles/featured/best-way-to-learn-about-ai-2026</loc>
+  <lastmod>2025-01-15</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
   <loc>https://mlai.au/articles/featured/learn-ai-melbourne</loc>
   <lastmod>2026-01-28</lastmod>
   <changefreq>monthly</changefreq>
@@ -175,6 +217,12 @@
  </url>
  <url>
   <loc>https://mlai.au/articles/featured/how-small-business-owners-can-get-started-with-ai-2026</loc>
+  <lastmod>2026-01-22</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
+ </url>
+ <url>
+  <loc>https://mlai.au/articles/featured/how-vcs-value-startups</loc>
   <lastmod>2026-01-22</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.8</priority>


### PR DESCRIPTION
## Summary
- add targeted 301 redirects for legacy Google-indexed article and hackathon URLs
- restore registry entries for the canonical `best-way-to-learn-about-ai-2026` and `how-vcs-value-startups` article targets
- regenerate the public sitemap with canonical URLs only

## Root Cause
Google was crawling historical URLs that no longer matched the app's current canonical article paths. Some canonical targets also existed as content files but were missing from `ARTICLE_REGISTRY`, so they were not routable or included in the sitemap.

## Validation
- `bun run typecheck`
- `bun run build` completed; existing IndexNow postbuild submission returned `403 Forbidden`
- local curl checks confirmed legacy URLs return `301`, canonical targets return `200`, and `/hackathon?trk=public_post_main-feed-card-text` resolves to `/hackathons`

## Cleanup
Removed local ignored build/typegen/dev artifacts before committing: `build/`, `.react-router/`, `.wrangler/`, `.local/`.