### PR TITLE
[codex] Use direct Vibe Raising video uploads

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -19,14 +19,17 @@ import type {
   VibeRaisingStartupUpdateStepState,
   VibeRaisingStartupUpdateState,
   VibeRaisingStartupUpdateStatusResponse,
+  VibeRaisingVideoCompressionMetadata,
   VibeRaisingVideoUploadResponse,
+  VibeRaisingVideoUploadSessionResponse,
 } from "~/types/vibe-raising";
 
 const PROFILE_PATH = "/api/v1/vibe-raising/profile/";
 const COMPANIES_PATH = "/api/v1/vibe-raising/companies/";
 const ACTIVE_COMPANY_PATH = "/api/v1/vibe-raising/active-company/";
 const UPDATES_PATH = "/api/v1/vibe-raising/updates/";
-const VIDEO_UPLOAD_PATH = "/api/v1/vibe-raising/uploads/video/";
+const VIDEO_UPLOAD_SESSION_PATH = "/api/v1/vibe-raising/uploads/video/session/";
+const VIDEO_UPLOAD_COMPLETE_PATH = "/api/v1/vibe-raising/uploads/video/complete/";
 const STARTUP_UPDATE_BOOTSTRAP_PATH = "/api/v1/vibe-raising/startup-update/bootstrap/";
 const EMAIL_DRAFT_START_PATH = "/api/v1/vibe-raising/email-draft/start/";
 const EMAIL_DRAFT_STATUS_PATH = "/api/v1/vibe-raising/email-draft/status/";
@@ -1219,16 +1222,70 @@ export async function uploadVibeRaisingUpdateVideo(
   backendBaseUrl: string,
   file: File,
   signal?: AbortSignal,
+  compression?: VibeRaisingVideoCompressionMetadata,
+  onPhase?: (phase: "creating_session" | "uploading" | "finalizing") => void,
 ): Promise<VibeRaisingVideoUploadResponse> {
-  const formData = new FormData();
-  formData.append("video", file);
-
-  return requestBrowserJson<VibeRaisingVideoUploadResponse>(
+  onPhase?.("creating_session");
+  const session = await requestBrowserJson<VibeRaisingVideoUploadSessionResponse>(
     backendBaseUrl,
-    VIDEO_UPLOAD_PATH,
+    VIDEO_UPLOAD_SESSION_PATH,
     {
       method: "POST",
-      body: formData,
+      body: JSON.stringify({
+        originalFilename: file.name,
+        contentType: file.type,
+        fileSizeBytes: file.size,
+      }),
+      signal,
+    },
+  );
+
+  const uploadHeaders = new Headers(session.requiredHeaders || {});
+  if (!uploadHeaders.has("Content-Type")) {
+    uploadHeaders.set("Content-Type", session.contentType || file.type || "application/octet-stream");
+  }
+
+  onPhase?.("uploading");
+  let uploadResponse: Response;
+  try {
+    uploadResponse = await fetch(session.uploadUrl, {
+      method: "PUT",
+      headers: uploadHeaders,
+      body: file,
+      signal,
+    });
+  } catch (error: any) {
+    error.requestPath = "signed-storage-upload";
+    error.message = "Storage upload failed before the file reached Firebase. Check Firebase Storage CORS and try again.";
+    throw error;
+  }
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text().catch(() => "");
+    const error: any = new Error(
+      uploadResponse.status === 403
+        ? "The video upload session expired. Please select the video again."
+        : errorText || `Storage upload failed with status ${uploadResponse.status}`,
+    );
+    error.status = uploadResponse.status;
+    error.data = errorText;
+    error.requestPath = "signed-storage-upload";
+    throw error;
+  }
+
+  onPhase?.("finalizing");
+  return requestBrowserJson<VibeRaisingVideoUploadResponse>(
+    backendBaseUrl,
+    VIDEO_UPLOAD_COMPLETE_PATH,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        storagePath: session.storagePath,
+        originalFilename: file.name,
+        contentType: session.contentType || file.type,
+        fileSizeBytes: file.size,
+        compression,
+      }),
       signal,
     },
   );

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -40,7 +40,7 @@ import DraftFromEmailWizard from "~/components/DraftFromEmailWizard";
 import EmailDraftInProgressCard from "~/components/EmailDraftInProgressCard";
 import StartupRegionBadge from "~/components/StartupRegionBadge";
 import { getVibeRaisingMonthTheme, parseVibeRaisingMonthYear, VIBE_RAISING_MONTH_OPTIONS, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
-import type { VibeRaisingStartupUpdateStatusResponse } from "~/types/vibe-raising";
+import type { VibeRaisingStartupUpdateStatusResponse, VibeRaisingVideoCompressionMetadata } from "~/types/vibe-raising";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
@@ -431,9 +431,12 @@ type PersistedEmailDraftRun = {
 };
 
 type RecordedMediaKind = "video" | "audio";
-type VideoUploadStatus = "idle" | "validating" | "uploading" | "ready" | "error";
+type VideoUploadStatus = "idle" | "validating" | "compressing" | "creating_session" | "uploading" | "finalizing" | "ready" | "error";
 
 const MAX_VIDEO_UPLOAD_BYTES = 250 * 1024 * 1024;
+const MAX_SOURCE_VIDEO_BYTES = 750 * 1024 * 1024;
+const VIDEO_COMPRESSION_THRESHOLD_BYTES = 75 * 1024 * 1024;
+const FFMPEG_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 const SUPPORTED_VIDEO_EXTENSIONS = [
     ".mp4",
     ".mov",
@@ -481,6 +484,11 @@ const BROWSER_PLAYABLE_VIDEO_TYPES = new Set([
     "video/quicktime",
 ]);
 
+let ffmpegLoaderPromise: Promise<{
+    ffmpeg: any;
+    fetchFile: (input: File | Blob | string) => Promise<Uint8Array>;
+}> | null = null;
+
 function formatFileSize(bytes?: number | null) {
     if (!bytes || !Number.isFinite(bytes)) return "";
     if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(bytes >= 10 * 1024 * 1024 ? 0 : 1)} MB`;
@@ -517,11 +525,119 @@ function isSupportedVideoFile(file: File) {
 function getDropzoneRejectionMessage(fileRejections: Array<{ errors: Array<{ code: string; message: string }> }>) {
     const firstError = fileRejections[0]?.errors[0];
     if (!firstError) return "We couldn't use that file. Please try another video.";
-    if (firstError.code === "file-too-large") return "Video exceeds the 250 MB upload limit.";
+    if (firstError.code === "file-too-large") return "Video is too large to compress in the browser. Use a file under 750 MB.";
     if (firstError.code === "file-invalid-type") {
         return "Use a common video format: MP4, MOV, M4V, WebM, AVI, MPEG, 3GP, OGV, or MKV.";
     }
     return firstError.message || "We couldn't use that file. Please try another video.";
+}
+
+function shouldCompressVideo(file: File, forceCompress?: boolean) {
+    return forceCompress || file.size > VIDEO_COMPRESSION_THRESHOLD_BYTES;
+}
+
+function getCompressedVideoName(file: File) {
+    const stem = String(file.name || "update-video").replace(/\.[^.]+$/, "") || "update-video";
+    return `${stem}-compressed.mp4`;
+}
+
+async function getFfmpegVideoCompressor() {
+    if (!ffmpegLoaderPromise) {
+        ffmpegLoaderPromise = (async () => {
+            const [{ FFmpeg }, { fetchFile, toBlobURL }] = await Promise.all([
+                import("@ffmpeg/ffmpeg"),
+                import("@ffmpeg/util"),
+            ]);
+            const ffmpeg = new FFmpeg();
+            await ffmpeg.load({
+                coreURL: await toBlobURL(`${FFMPEG_CORE_BASE_URL}/ffmpeg-core.js`, "text/javascript"),
+                wasmURL: await toBlobURL(`${FFMPEG_CORE_BASE_URL}/ffmpeg-core.wasm`, "application/wasm"),
+            });
+            return { ffmpeg, fetchFile };
+        })();
+    }
+    return ffmpegLoaderPromise;
+}
+
+async function compressVideoForUpload(file: File, signal: AbortSignal): Promise<{ file: File; metadata: VibeRaisingVideoCompressionMetadata }> {
+    if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
+
+    const { ffmpeg, fetchFile } = await getFfmpegVideoCompressor();
+    if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
+
+    const inputName = `input-${Date.now()}${getFileExtension(file.name) || ".video"}`;
+    const outputName = `output-${Date.now()}.mp4`;
+    await ffmpeg.writeFile(inputName, await fetchFile(file));
+    const exitCode = await ffmpeg.exec([
+        "-i",
+        inputName,
+        "-vf",
+        "scale='min(1280,iw)':-2",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-b:v",
+        "2000k",
+        "-maxrate",
+        "2400k",
+        "-bufsize",
+        "4000k",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-movflags",
+        "faststart",
+        outputName,
+    ]);
+    if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
+    if (exitCode !== 0) throw new Error("Video compression failed.");
+
+    const data = await ffmpeg.readFile(outputName);
+    await Promise.allSettled([
+        ffmpeg.deleteFile(inputName),
+        ffmpeg.deleteFile(outputName),
+    ]);
+    const bytes = data instanceof Uint8Array ? data : new TextEncoder().encode(String(data));
+    const outputBuffer = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(outputBuffer).set(bytes);
+    const compressedFile = new File([outputBuffer], getCompressedVideoName(file), { type: "video/mp4" });
+    return {
+        file: compressedFile,
+        metadata: {
+            compressed: true,
+            originalFilename: file.name,
+            originalContentType: file.type || inferVideoContentType(null, file.name),
+            originalFileSizeBytes: file.size,
+            compressedFileSizeBytes: compressedFile.size,
+            compressionRatio: file.size > 0 ? Number((compressedFile.size / file.size).toFixed(4)) : null,
+        },
+    };
+}
+
+function getVideoUploadErrorMessage(error: unknown) {
+    const statusCode = (error as { status?: number })?.status;
+    const requestPath = String((error as { requestPath?: string })?.requestPath || "");
+    const data = (error as { data?: { detail?: string; error?: string } | string })?.data;
+    const detail =
+        typeof data === "string"
+            ? data
+            : data?.detail || data?.error || (error instanceof Error ? error.message : "");
+
+    if (statusCode === 404 && requestPath.includes("/uploads/video/session/")) {
+        return "Video uploads are not available on the backend yet. Deploy the latest backend release and try again.";
+    }
+    if (statusCode === 413) {
+        return "This video is too large for the current upload path. Try a shorter clip or compress it before uploading.";
+    }
+    if (statusCode === 403 && requestPath === "signed-storage-upload") {
+        return "The video upload session expired. Please select the video again.";
+    }
+    if (requestPath === "signed-storage-upload") {
+        return "Firebase Storage rejected the upload. Check Storage CORS and try again.";
+    }
+    return detail || "Video upload failed. Please try again.";
 }
 
 function VideoAssetPreview({
@@ -1374,7 +1490,7 @@ export default function CreateUpdate() {
         setVideoUploadError(null);
     }, [revokeVideoPreviewObjectUrl]);
 
-    const uploadVideoFile = useCallback(async (file: File) => {
+    const uploadVideoFile = useCallback(async (file: File, options?: { forceCompress?: boolean }) => {
         const sequence = videoUploadSequenceRef.current + 1;
         videoUploadSequenceRef.current = sequence;
         videoUploadAbortRef.current?.abort();
@@ -1399,37 +1515,69 @@ export default function CreateUpdate() {
             return;
         }
 
-        if (file.size > MAX_VIDEO_UPLOAD_BYTES) {
+        if (file.size > MAX_SOURCE_VIDEO_BYTES) {
             setVideoUploadStatus("error");
-            setVideoUploadError("Video exceeds the 250 MB upload limit.");
+            setVideoUploadError("Video is too large to compress in the browser. Use a file under 750 MB.");
             return;
         }
 
         const localPreviewUrl = URL.createObjectURL(file);
         videoPreviewObjectUrlRef.current = localPreviewUrl;
         setVideoPreviewUrl(localPreviewUrl);
-        setVideoUploadStatus("uploading");
 
         try {
-            const uploaded = await uploadVibeRaisingUpdateVideo(backendBaseUrl, file, abortController.signal);
+            let uploadCandidate = file;
+            let compression: VibeRaisingVideoCompressionMetadata | undefined;
+            if (shouldCompressVideo(file, options?.forceCompress)) {
+                setVideoUploadStatus("compressing");
+                try {
+                    const compressed = await compressVideoForUpload(file, abortController.signal);
+                    if (videoUploadSequenceRef.current !== sequence) return;
+                    if (compressed.file.size < file.size) {
+                        uploadCandidate = compressed.file;
+                        compression = compressed.metadata;
+                    }
+                } catch (compressionError) {
+                    if (abortController.signal.aborted || videoUploadSequenceRef.current !== sequence) return;
+                    if (file.size > MAX_VIDEO_UPLOAD_BYTES) {
+                        throw new Error("Video exceeds the 250 MB upload limit after compression. Try a shorter clip.");
+                    }
+                }
+            }
+
+            if (uploadCandidate.size > MAX_VIDEO_UPLOAD_BYTES) {
+                throw new Error("Video exceeds the 250 MB upload limit.");
+            }
+
+            setVideoContentType(uploadCandidate.type || inferVideoContentType(null, uploadCandidate.name));
+            setVideoFileSizeBytes(uploadCandidate.size);
+            setVideoOriginalFilename(uploadCandidate.name);
+
+            const uploaded = await uploadVibeRaisingUpdateVideo(
+                backendBaseUrl,
+                uploadCandidate,
+                abortController.signal,
+                compression,
+                (phase) => {
+                    if (videoUploadSequenceRef.current !== sequence) return;
+                    setVideoUploadStatus(phase);
+                },
+            );
             if (videoUploadSequenceRef.current !== sequence) return;
 
             setUploadedVideoUrl(uploaded.videoUrl);
             setVideoStoragePath(uploaded.storagePath || "");
-            setVideoContentType(uploaded.contentType || file.type || "");
-            setVideoFileSizeBytes(uploaded.fileSizeBytes || file.size);
-            setVideoOriginalFilename(uploaded.originalFilename || file.name);
+            setVideoContentType(uploaded.contentType || uploadCandidate.type || "");
+            setVideoFileSizeBytes(uploaded.fileSizeBytes || uploadCandidate.size);
+            setVideoOriginalFilename(uploaded.originalFilename || uploadCandidate.name);
             setVideoUploadStatus("ready");
             setVideoUploadError(null);
         } catch (error) {
             if (abortController.signal.aborted || videoUploadSequenceRef.current !== sequence) return;
-            const detail = (error as { data?: { detail?: string; error?: string }; message?: string })?.data?.detail ||
-                (error as { data?: { detail?: string; error?: string }; message?: string })?.data?.error ||
-                (error instanceof Error ? error.message : "");
             setUploadedVideoUrl("");
             setVideoStoragePath("");
             setVideoUploadStatus("error");
-            setVideoUploadError(detail || "Video upload failed. Please try again.");
+            setVideoUploadError(getVideoUploadErrorMessage(error));
         } finally {
             if (videoUploadSequenceRef.current === sequence) {
                 videoUploadAbortRef.current = null;
@@ -1798,16 +1946,26 @@ export default function CreateUpdate() {
         : canGenerateDraftFromEmail
             ? "Scan filtered Gmail data for key signals, metrics, wins, and asks, then turn them into a first draft."
             : "Add a company domain first so Gmail emails can be matched to the right startup.";
-    const isVideoUploadPending = videoUploadStatus === "validating" || videoUploadStatus === "uploading";
-    const isVideoUploadBlocking = isVideoUploadPending || videoUploadStatus === "error";
+    const isVideoUploadPending = videoUploadStatus === "validating" ||
+        videoUploadStatus === "compressing" ||
+        videoUploadStatus === "creating_session" ||
+        videoUploadStatus === "uploading" ||
+        videoUploadStatus === "finalizing";
+    const isVideoUploadBlocking = isVideoUploadPending || (videoUploadStatus === "error" && previewMediaKind === "video" && Boolean(videoPreviewUrl));
     const videoUploadStatusLabel =
         videoUploadStatus === "validating"
             ? "Checking video..."
-            : videoUploadStatus === "uploading"
-                ? "Uploading video..."
-                : videoUploadStatus === "ready"
-                    ? "Video ready"
-                    : null;
+            : videoUploadStatus === "compressing"
+                ? "Compressing video..."
+                : videoUploadStatus === "creating_session"
+                    ? "Preparing upload..."
+                    : videoUploadStatus === "uploading"
+                        ? "Uploading video..."
+                        : videoUploadStatus === "finalizing"
+                            ? "Finalizing video..."
+                            : videoUploadStatus === "ready"
+                                ? "Video ready"
+                                : null;
 
     const handleRetryEmailDraft = () => {
         clearPersistedEmailDraftRun();
@@ -1900,7 +2058,7 @@ export default function CreateUpdate() {
                             `recorded-update-${Date.now()}.webm`,
                             { type: blob.type || "video/webm" },
                         );
-                        void uploadVideoFile(recordedVideo);
+                        void uploadVideoFile(recordedVideo, { forceCompress: true });
                     } else {
                         resetVideoUpload();
                         const audioPreviewUrl = URL.createObjectURL(blob);
@@ -2217,7 +2375,7 @@ export default function CreateUpdate() {
         maxFiles: 1,
         multiple: false,
         noClick: true,
-        maxSize: MAX_VIDEO_UPLOAD_BYTES,
+        maxSize: MAX_SOURCE_VIDEO_BYTES,
         accept: VIDEO_ACCEPT,
     });
 
@@ -2786,7 +2944,7 @@ export default function CreateUpdate() {
                                 </p>
 
                                 <p className="text-sm text-gray-500 mb-6">
-                                    Up to 250 MB
+                                    Larger videos are compressed first. Final upload limit: 250 MB.
                                 </p>
 
                                 <div className="flex flex-col sm:flex-row gap-3 w-full">

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -88,6 +88,25 @@ export interface VibeRaisingVideoUploadResponse {
   originalFilename: string;
 }
 
+export interface VibeRaisingVideoUploadSessionResponse {
+  uploadUrl: string;
+  storagePath: string;
+  contentType: string;
+  fileSizeBytes?: number;
+  expiresAt: string;
+  maxUploadBytes: number;
+  requiredHeaders: Record<string, string>;
+}
+
+export interface VibeRaisingVideoCompressionMetadata {
+  compressed?: boolean;
+  originalFilename?: string;
+  originalContentType?: string;
+  originalFileSizeBytes?: number;
+  compressedFileSizeBytes?: number;
+  compressionRatio?: number | null;
+}
+
 export type VibeRaisingStartupUpdateState =
   | "needs_domain"
   | "auth_required"

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "mlai-au",
       "dependencies": {
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
         "@radix-ui/react-slot": "^1.2.4",
@@ -132,6 +134,12 @@
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, ""],
 
     "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.0", "", { "os": "darwin", "cpu": "arm64" }, ""],
+
+    "@ffmpeg/ffmpeg": ["@ffmpeg/ffmpeg@0.12.15", "", { "dependencies": { "@ffmpeg/types": "^0.12.4" } }, "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw=="],
+
+    "@ffmpeg/types": ["@ffmpeg/types@0.12.4", "", {}, "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A=="],
+
+    "@ffmpeg/util": ["@ffmpeg/util@0.12.2", "", {}, "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, ""],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "typecheck": "react-router typegen && tsc -b && bun run check:article-internal-links"
   },
   "dependencies": {
+    "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/util": "^0.12.2",
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
     "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
## Summary
- replace multipart video uploads with session -> signed storage PUT -> complete flow
- add upload phases for validation, compression, session creation, upload, and finalization
- lazy-load ffmpeg.wasm compression for recorded or large videos before upload
- improve errors for stale backend routes, Storage CORS, expired sessions, and oversized files

## Root Cause
The frontend was sending video bytes through the API upload endpoint, which exposed users to Cloudflare/proxy body limits and stale-route failures.

## Validation
- bun run typecheck
- git diff --check