### PR TITLE
[codex] Add Vibe Raising connector step

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -22,10 +22,12 @@ import type { User } from '~/types/user';
 interface AuthenticatedLayoutProps {
     children: React.ReactNode;
     user: User;
-    navigation?: { name: string; href: string; icon: any }[];
+    navigation?: NavigationItem[];
     userNavigation?: { name: string; href: string }[];
     logoutAction?: string;
 }
+
+type NavigationItem = { name: string; href: string; icon: any; exact?: boolean };
 
 function classNames(...classes: (string | undefined | boolean)[]) {
     return classes.filter(Boolean).join(' ');
@@ -37,7 +39,7 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
     const location = useLocation();
     const pathname = location.pathname;
 
-    const defaultNavigation = [
+    const defaultNavigation: NavigationItem[] = [
         { name: 'Dashboard', href: '/esafety/dashboard', icon: HomeIcon },
         { name: 'Profile', href: '/esafety/profile', icon: UserCircleIcon },
         { name: 'Submissions', href: '/esafety/leaderboard', icon: TrophyIcon },
@@ -48,7 +50,9 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
 
     const updatedNavigation = navigation.map(item => ({
         ...item,
-        current: pathname === item.href || (item.href !== '/esafety' && pathname.startsWith(item.href)),
+        current: item.exact
+            ? pathname === item.href
+            : pathname === item.href || (item.href !== '/esafety' && pathname.startsWith(item.href)),
     }));
 
     const defaultUserNavigation = [

--- a/app/components/MonthlyUpdateStepper.tsx
+++ b/app/components/MonthlyUpdateStepper.tsx
@@ -1,0 +1,225 @@
+import { CheckIcon } from "@heroicons/react/24/outline";
+import { clsx } from "clsx";
+
+export type MonthlyUpdateStepKey = "connect" | "draft" | "review" | "publish";
+
+interface MonthlyUpdateStepperProps {
+  activeStep: MonthlyUpdateStepKey;
+  className?: string;
+  compact?: boolean;
+  enabledSteps?: MonthlyUpdateStepKey[];
+  onStepClick?: (step: MonthlyUpdateStepKey) => void;
+}
+
+const STEPS: Array<{
+  key: MonthlyUpdateStepKey;
+  title: string;
+  helper: string;
+}> = [
+  {
+    key: "connect",
+    title: "Connect data",
+    helper: "Choose inputs",
+  },
+  {
+    key: "draft",
+    title: "Draft update",
+    helper: "Generate or edit",
+  },
+  {
+    key: "review",
+    title: "Review",
+    helper: "Preview for investors",
+  },
+  {
+    key: "publish",
+    title: "Publish",
+    helper: "Send when ready",
+  },
+];
+
+export default function MonthlyUpdateStepper({
+  activeStep,
+  className,
+  compact = false,
+  enabledSteps,
+  onStepClick,
+}: MonthlyUpdateStepperProps) {
+  const activeIndex = Math.max(0, STEPS.findIndex((step) => step.key === activeStep));
+  const active = STEPS[activeIndex] ?? STEPS[0];
+  const progressPercent = ((activeIndex + 1) / STEPS.length) * 100;
+  const enabledStepSet = new Set(enabledSteps ?? STEPS.map((step) => step.key));
+  const canSelectStep = (step: MonthlyUpdateStepKey) => Boolean(onStepClick) && enabledStepSet.has(step);
+
+  if (compact) {
+    return (
+      <nav
+        aria-label="Monthly update progress"
+        className={clsx("rounded-2xl border border-violet-100 bg-white p-4 shadow-sm", className)}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wide text-violet-600">
+              Step {activeIndex + 1} of {STEPS.length}
+            </p>
+            <p className="mt-1 text-sm font-black text-gray-950">{active.title}</p>
+          </div>
+          <span className="rounded-full bg-violet-50 px-3 py-1 text-xs font-bold text-violet-700 ring-1 ring-violet-100">
+            {active.helper}
+          </span>
+        </div>
+        <div className="mt-3 h-2 overflow-hidden rounded-full bg-gray-100">
+          <div
+            className="h-full rounded-full bg-violet-600 transition-all"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+        <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+          {STEPS.map((step, index) => {
+            const isActive = index === activeIndex;
+            const isComplete = index < activeIndex;
+            const canSelect = canSelectStep(step.key);
+            return (
+              <button
+                key={step.key}
+                type="button"
+                data-stepper-step={step.key}
+                disabled={!canSelect}
+                onClick={() => onStepClick?.(step.key)}
+                className={clsx(
+                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 transition",
+                  canSelect ? "cursor-pointer hover:bg-violet-100" : "cursor-default",
+                  isActive && "bg-violet-600 text-white ring-violet-600",
+                  isComplete && !isActive && "bg-violet-50 text-violet-700 ring-violet-100",
+                  !isActive && !isComplete && "bg-gray-50 text-gray-500 ring-gray-100",
+                )}
+              >
+                {step.title}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+    );
+  }
+
+  return (
+    <nav
+      aria-label="Monthly update progress"
+      className={clsx("rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5", className)}
+    >
+      <div className="sm:hidden">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wide text-violet-600">
+              Step {activeIndex + 1} of {STEPS.length}
+            </p>
+            <p className="mt-1 text-base font-black text-gray-950">{active.title}</p>
+          </div>
+          <span className="rounded-full bg-violet-50 px-3 py-1 text-xs font-bold text-violet-700 ring-1 ring-violet-100">
+            {active.helper}
+          </span>
+        </div>
+        <div className="mt-4 h-2 overflow-hidden rounded-full bg-gray-100">
+          <div
+            className="h-full rounded-full bg-violet-600 transition-all"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+        <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
+          {STEPS.map((step, index) => {
+            const isActive = index === activeIndex;
+            const isComplete = index < activeIndex;
+            const canSelect = canSelectStep(step.key);
+            return (
+              <button
+                key={step.key}
+                type="button"
+                data-stepper-step={step.key}
+                disabled={!canSelect}
+                onClick={() => onStepClick?.(step.key)}
+                className={clsx(
+                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 transition",
+                  canSelect ? "cursor-pointer hover:bg-violet-100" : "cursor-default",
+                  isActive && "bg-violet-600 text-white ring-violet-600",
+                  isComplete && !isActive && "bg-violet-50 text-violet-700 ring-violet-100",
+                  !isActive && !isComplete && "bg-gray-50 text-gray-500 ring-gray-100",
+                )}
+              >
+                {step.title}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mb-5 hidden items-center justify-between gap-4 sm:flex">
+        <div>
+          <p className="text-xs font-extrabold uppercase tracking-wide text-violet-600">
+            Step {activeIndex + 1} of {STEPS.length}
+          </p>
+          <p className="mt-1 text-sm font-bold text-gray-500">Monthly update workflow</p>
+        </div>
+        <p className="text-sm font-black text-gray-950">{active.title}</p>
+      </div>
+
+      <div className="hidden sm:grid sm:grid-cols-4 sm:gap-3">
+        {STEPS.map((step, index) => {
+          const isActive = index === activeIndex;
+          const isComplete = index < activeIndex;
+          const canSelect = canSelectStep(step.key);
+          return (
+            <div key={step.key} className="relative min-w-0">
+              {index > 0 ? (
+                <div
+                  className={clsx(
+                    "absolute left-[-50%] top-5 hidden h-0.5 w-full sm:block",
+                    index <= activeIndex ? "bg-violet-500" : "bg-gray-200",
+                  )}
+                  aria-hidden
+                />
+              ) : null}
+              <button
+                type="button"
+                data-stepper-step={step.key}
+                disabled={!canSelect}
+                onClick={() => onStepClick?.(step.key)}
+                className={clsx(
+                  "relative flex w-full flex-col items-center rounded-xl px-2 pb-2 text-center transition",
+                  canSelect ? "cursor-pointer hover:bg-violet-50/70" : "cursor-default",
+                )}
+              >
+                <div
+                  className={clsx(
+                    "z-10 flex h-10 w-10 items-center justify-center rounded-full border-2 bg-white text-sm font-black transition",
+                    isComplete && "border-violet-600 bg-violet-600 text-white",
+                    isActive && !isComplete && "border-violet-600 text-violet-700 shadow-[0_0_0_5px_rgba(124,58,237,0.10)]",
+                    !isActive && !isComplete && "border-gray-200 text-gray-400",
+                  )}
+                >
+                  {isComplete ? <CheckIcon className="h-5 w-5" /> : index + 1}
+                </div>
+                <p
+                  className={clsx(
+                    "mt-3 truncate text-sm font-black",
+                    (isActive || isComplete) ? "text-gray-950" : "text-gray-400",
+                  )}
+                >
+                  {step.title}
+                </p>
+                <p
+                  className={clsx(
+                    "mt-1 truncate text-xs font-semibold",
+                    isActive ? "text-violet-600" : "text-slate-400",
+                  )}
+                >
+                  {step.helper}
+                </p>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -4,6 +4,35 @@ export function shouldUseDevBackendStub() {
     return import.meta.env.DEV && import.meta.env.VITE_STUB_BACKEND === "true";
 }
 
+export function shouldUseDevBackendFallback(error?: unknown) {
+    if (!import.meta.env.DEV || shouldUseDevBackendStub()) {
+        return false;
+    }
+
+    const maybeError = error as {
+        response?: unknown;
+        code?: string;
+        message?: string;
+        cause?: { code?: string; message?: string };
+    } | null | undefined;
+    if (maybeError?.response) {
+        return false;
+    }
+
+    const code = String(maybeError?.code || maybeError?.cause?.code || "");
+    const message = String(maybeError?.message || maybeError?.cause?.message || "").toLowerCase();
+    return (
+        code === "ECONNREFUSED" ||
+        code === "ECONNRESET" ||
+        code === "ENOTFOUND" ||
+        code === "ETIMEDOUT" ||
+        message.includes("network connection lost") ||
+        message.includes("network error") ||
+        message.includes("failed to fetch") ||
+        message.includes("connection refused")
+    );
+}
+
 // Catch-all stub adapter for local development only. When
 // VITE_STUB_BACKEND=true, every API request short-circuits and returns a
 // fake empty response instead of hitting api.mlai.au.

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,4 +1,4 @@
-import { axiosInstance, API_URL, shouldUseDevBackendStub } from "./api";
+import { axiosInstance, API_URL, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "./api";
 import axios from "axios";
 
 export type AuthAppName = "esafety" | "hospital" | "innovate-connect-alliance" | "vibe-raising";
@@ -125,6 +125,10 @@ export async function getCurrentUser(env: Env, request?: Request) {
     } catch (error: any) {
         if (error.response && error.response.status === 401) {
             return null;
+        }
+        if (shouldUseDevBackendFallback(error)) {
+            console.warn("Backend unavailable in local dev; using auth stub for preview.");
+            return DEV_AUTH_STUB;
         }
         // Log the error for debugging
         console.error("getCurrentUser error:", error.message, error.response?.status, error.response?.data);

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1,6 +1,6 @@
 import { redirect } from "react-router";
 import type { User } from "~/types/user";
-import { createApiClient, shouldUseDevBackendStub } from "~/lib/api";
+import { createApiClient, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
 import { getCurrentUser } from "~/lib/auth";
 import type {
   VibeRaisingDraftResultsResponse,
@@ -8,6 +8,10 @@ import type {
   VibeRaisingCompany,
   VibeRaisingDraftedContent,
   VibeRaisingEmailDraftMonth,
+  VibeRaisingInputSourceKey,
+  VibeRaisingInputSourceStatus,
+  VibeRaisingInputSourceSummary,
+  VibeRaisingInputSourcesStatusResponse,
   VibeRaisingMonthlyUpdate,
   VibeRaisingProfile,
   VibeRaisingRole,
@@ -36,6 +40,47 @@ const EMAIL_DRAFT_STATUS_PATH = "/api/v1/vibe-raising/email-draft/status/";
 const EMAIL_DRAFT_ACTIVE_RUN_PATH = "/api/v1/vibe-raising/email-draft/active-run/";
 const EMAIL_DRAFT_DRAFT_RESULTS_PATH = "/api/v1/vibe-raising/email-draft/draft-results/";
 const EMAIL_DRAFT_CANCEL_RUNS_PATH = "/api/v1/vibe-raising/email-draft/runs/";
+const INPUT_SOURCES_STATUS_PATH = "/api/v1/integrations/sources/status";
+const FINANCIAL_STATUS_PATH = "/api/v1/integrations/financial/status";
+const FINANCIAL_SYNC_PATH = "/api/v1/integrations/financial/sync";
+
+const INPUT_SOURCE_DEFINITIONS: Record<VibeRaisingInputSourceKey, Omit<VibeRaisingInputSourceSummary, "selected" | "status">> = {
+  gmail: {
+    key: "gmail",
+    label: "Gmail",
+    capabilities: ["context"],
+  },
+  stripe: {
+    key: "stripe",
+    label: "Stripe",
+    capabilities: ["metrics"],
+  },
+  xero: {
+    key: "xero",
+    label: "Xero",
+    capabilities: ["metrics"],
+  },
+  bank_feed: {
+    key: "bank_feed",
+    label: "Bank Feed",
+    capabilities: ["cash_validation"],
+  },
+  notion: {
+    key: "notion",
+    label: "Notion",
+    capabilities: ["docs", "context"],
+  },
+  google_drive: {
+    key: "google_drive",
+    label: "Google Drive",
+    capabilities: ["docs", "context"],
+  },
+  slack: {
+    key: "slack",
+    label: "Slack",
+    capabilities: ["context"],
+  },
+};
 
 type OptionalContext = {
   authUser: User | null;
@@ -754,6 +799,173 @@ async function requestBrowserJson<T>(
   return data as T;
 }
 
+function createInputSourceSummary(
+  key: VibeRaisingInputSourceKey,
+  status: VibeRaisingInputSourceStatus,
+  overrides?: Partial<VibeRaisingInputSourceSummary>,
+): VibeRaisingInputSourceSummary {
+  const base = INPUT_SOURCE_DEFINITIONS[key];
+  return {
+    ...base,
+    selected: status === "connected" || status === "syncing",
+    status,
+    ...overrides,
+  };
+}
+
+function normalizeInputSourceStatus(value: unknown): VibeRaisingInputSourceStatus {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (["connected", "active", "ok", "ready", "valid"].includes(normalized)) return "connected";
+  if (["syncing", "running", "queued", "pending"].includes(normalized)) return "syncing";
+  if (["error", "failed", "revoked", "expired", "needs_reconnect", "reauth_required"].includes(normalized)) return "error";
+  if (["coming_soon", "coming-soon"].includes(normalized)) return "coming_soon";
+  if (["unavailable", "not_available", "not-available", "not_configured", "not-configured"].includes(normalized)) return "unavailable";
+  return "not_connected";
+}
+
+function normalizeInputSourceProvider(value: unknown): VibeRaisingInputSourceKey | null {
+  const normalized = String(value || "").trim().toLowerCase().replace(/[-\s]+/g, "_");
+  if (normalized === "stripe") return "stripe";
+  if (normalized === "xero") return "xero";
+  if (normalized === "gmail" || normalized === "google" || normalized === "google_gmail") return "gmail";
+  if (normalized === "bank_feed" || normalized === "basiq") return "bank_feed";
+  if (normalized === "notion") return "notion";
+  if (normalized === "google_drive" || normalized === "drive") return "google_drive";
+  if (normalized === "slack") return "slack";
+  return null;
+}
+
+function collectRawFinancialConnections(payload: Record<string, unknown>): unknown[] {
+  const candidates = [
+    payload.sources,
+    payload.connections,
+    payload.financialConnections,
+    payload.financial_connections,
+    payload.providers,
+    payload.data,
+  ];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate;
+    if (candidate && typeof candidate === "object") {
+      const nested = candidate as Record<string, unknown>;
+      if (Array.isArray(nested.connections)) return nested.connections;
+      if (Array.isArray(nested.sources)) return nested.sources;
+      if (Array.isArray(nested.financial_connections)) return nested.financial_connections;
+      if (Array.isArray(nested.providers)) return nested.providers;
+    }
+  }
+  return [];
+}
+
+function normalizeFinancialSourceSummaries(raw: unknown): Partial<Record<"stripe" | "xero", VibeRaisingInputSourceSummary>> {
+  const payload = unwrapPayload(raw) as Record<string, unknown>;
+  const summaries: Partial<Record<"stripe" | "xero", VibeRaisingInputSourceSummary>> = {};
+  const connections = collectRawFinancialConnections(payload);
+
+  for (const rawConnection of connections) {
+    if (!rawConnection || typeof rawConnection !== "object") continue;
+    const connection = rawConnection as Record<string, unknown>;
+    const provider = normalizeInputSourceProvider(connection.provider ?? connection.key ?? connection.source);
+    if (provider !== "stripe" && provider !== "xero") continue;
+
+    const status = normalizeInputSourceStatus(
+      connection.status ??
+        connection.connectionStatus ??
+        connection.connection_status ??
+        connection.state,
+    );
+    const accountLabel =
+      asNullableString(connection.accountLabel) ??
+      asNullableString(connection.account_label) ??
+      asNullableString(connection.externalAccountName) ??
+      asNullableString(connection.external_account_name) ??
+      asNullableString(connection.externalAccountId) ??
+      asNullableString(connection.external_account_id) ??
+      asNullableString(connection.tenantName) ??
+      asNullableString(connection.tenant_name) ??
+      asNullableString(connection.name);
+    const lastSyncedAt =
+      asNullableString(connection.lastSyncedAt) ??
+      asNullableString(connection.last_synced_at) ??
+      asNullableString(connection.lastSyncAt) ??
+      asNullableString(connection.last_sync_at);
+    const warning =
+      asNullableString(connection.warning) ??
+      asNullableString(connection.lastError) ??
+      asNullableString(connection.last_error) ??
+      asNullableString(connection.error);
+
+    summaries[provider] = createInputSourceSummary(provider, status, {
+      accountLabel,
+      lastSyncedAt,
+      warning,
+    });
+  }
+
+  return summaries;
+}
+
+function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaisingInputSourceKey, VibeRaisingInputSourceSummary>> {
+  const payload = unwrapPayload(raw) as Record<string, unknown>;
+  const summaries: Partial<Record<VibeRaisingInputSourceKey, VibeRaisingInputSourceSummary>> = {};
+  const connections = collectRawFinancialConnections(payload);
+
+  for (const rawConnection of connections) {
+    if (!rawConnection || typeof rawConnection !== "object") continue;
+    const connection = rawConnection as Record<string, unknown>;
+    const provider = normalizeInputSourceProvider(connection.provider ?? connection.key ?? connection.source);
+    if (!provider) continue;
+
+    const status = normalizeInputSourceStatus(
+      connection.status ??
+        connection.connectionStatus ??
+        connection.connection_status ??
+        connection.state,
+    );
+    const accountLabel =
+      asNullableString(connection.accountLabel) ??
+      asNullableString(connection.account_label) ??
+      asNullableString(connection.externalAccountName) ??
+      asNullableString(connection.external_account_name) ??
+      asNullableString(connection.externalAccountId) ??
+      asNullableString(connection.external_account_id) ??
+      asNullableString(connection.tenantName) ??
+      asNullableString(connection.tenant_name) ??
+      asNullableString(connection.name);
+    const lastSyncedAt =
+      asNullableString(connection.lastSyncedAt) ??
+      asNullableString(connection.last_synced_at) ??
+      asNullableString(connection.lastSyncAt) ??
+      asNullableString(connection.last_sync_at);
+    const warning =
+      asNullableString(connection.warning) ??
+      asNullableString(connection.lastError) ??
+      asNullableString(connection.last_error) ??
+      asNullableString(connection.error);
+    const selected =
+      typeof connection.selected === "boolean"
+        ? connection.selected
+        : status === "connected" || status === "syncing";
+
+    summaries[provider] = createInputSourceSummary(provider, status, {
+      accountLabel,
+      lastSyncedAt,
+      warning,
+      selected,
+    });
+  }
+
+  return summaries;
+}
+
+function buildConnectorReturnPath(nextUrl?: string) {
+  const sanitizedNext =
+    nextUrl && nextUrl.startsWith("/vibe-raising/create-update")
+      ? nextUrl
+      : "/vibe-raising/create-update";
+  return `/vibe-raising/connect-data?next=${encodeURIComponent(sanitizedNext)}`;
+}
+
 function normalizeStartupUpdateStatus(
   raw: unknown,
 ): VibeRaisingStartupUpdateStatusResponse {
@@ -970,6 +1182,11 @@ export async function getVibeRaisingProfile(
       return null;
     }
 
+    if (shouldUseDevBackendFallback(error)) {
+      console.warn("Backend unavailable in local dev; using Vibe Raising profile stub for preview.");
+      return DEV_VIBE_PROFILE_STUB;
+    }
+
     throw error;
   }
 }
@@ -1172,6 +1389,12 @@ export async function getVibeRaisingMonthlyUpdates(
     if (error.response?.status === 404) {
       return [];
     }
+
+    if (shouldUseDevBackendFallback(error)) {
+      console.warn("Backend unavailable in local dev; using Vibe Raising monthly update stubs for preview.");
+      return DEV_MONTHLY_UPDATES_STUB;
+    }
+
     throw error;
   }
 }
@@ -1293,10 +1516,14 @@ export async function uploadVibeRaisingUpdateVideo(
 
 export async function bootstrapVibeRaisingStartupUpdate(
   backendBaseUrl: string,
+  options?: { next?: string },
 ): Promise<VibeRaisingStartupUpdateBootstrapResponse> {
+  const path = options?.next
+    ? `${STARTUP_UPDATE_BOOTSTRAP_PATH}?next=${encodeURIComponent(options.next)}`
+    : STARTUP_UPDATE_BOOTSTRAP_PATH;
   const response = await requestBrowserJson<Record<string, unknown>>(
     backendBaseUrl,
-    STARTUP_UPDATE_BOOTSTRAP_PATH,
+    path,
     { method: "POST" },
   );
 
@@ -1313,16 +1540,143 @@ export async function bootstrapVibeRaisingStartupUpdate(
   };
 }
 
+export async function getVibeRaisingInputSourcesStatus(
+  backendBaseUrl: string,
+): Promise<VibeRaisingInputSourcesStatusResponse> {
+  try {
+    const response = await requestBrowserJson<Record<string, unknown>>(
+      backendBaseUrl,
+      INPUT_SOURCES_STATUS_PATH,
+      { method: "GET" },
+    );
+    const summaries = normalizeInputSourceSummaries(response);
+    const sources = (Object.keys(INPUT_SOURCE_DEFINITIONS) as VibeRaisingInputSourceKey[]).map((key) => (
+      summaries[key] ?? createInputSourceSummary(key, "not_connected")
+    ));
+    return {
+      sources,
+      financeUnavailable: Boolean(response.financeUnavailable ?? response.finance_unavailable),
+    };
+  } catch (error: any) {
+    if (error?.status && error.status !== 404 && error.status !== 405) {
+      throw error;
+    }
+  }
+
+  const [gmailResult, financeResult] = await Promise.allSettled([
+    requestBrowserJson<Record<string, unknown>>(
+      backendBaseUrl,
+      STARTUP_UPDATE_BOOTSTRAP_PATH,
+      { method: "POST" },
+    ),
+    requestBrowserJson<Record<string, unknown>>(
+      backendBaseUrl,
+      FINANCIAL_STATUS_PATH,
+      { method: "GET" },
+    ),
+  ]);
+
+  const sources: VibeRaisingInputSourceSummary[] = [];
+
+  if (gmailResult.status === "fulfilled") {
+    sources.push(createInputSourceSummary(
+      "gmail",
+      Boolean(gmailResult.value.googleConnected ?? gmailResult.value.google_connected)
+        ? "connected"
+        : "not_connected",
+      {
+        accountLabel:
+          asNullableString(gmailResult.value.googleEmail) ??
+          asNullableString(gmailResult.value.google_email) ??
+          asNullableString(gmailResult.value.email),
+      },
+    ));
+  } else {
+    sources.push(createInputSourceSummary("gmail", "error", {
+      warning:
+        (gmailResult.reason as { data?: { error?: string; detail?: string }; message?: string })?.data?.error ??
+        (gmailResult.reason as { data?: { error?: string; detail?: string }; message?: string })?.data?.detail ??
+        (gmailResult.reason instanceof Error ? gmailResult.reason.message : "Gmail status is unavailable."),
+    }));
+  }
+
+  let financeUnavailable = false;
+  let financialSummaries: Partial<Record<"stripe" | "xero", VibeRaisingInputSourceSummary>> = {};
+  if (financeResult.status === "fulfilled") {
+    financialSummaries = normalizeFinancialSourceSummaries(financeResult.value);
+  } else {
+    financeUnavailable = true;
+  }
+
+  for (const key of ["stripe", "xero"] as const) {
+    sources.push(
+      financialSummaries[key] ??
+        createInputSourceSummary(key, financeUnavailable ? "unavailable" : "not_connected", {
+          warning: financeUnavailable ? "Financial connector status is not available on this backend yet." : null,
+        }),
+    );
+  }
+
+  for (const key of ["bank_feed", "notion", "google_drive", "slack"] as const) {
+    sources.push(createInputSourceSummary(key, "unavailable", {
+      selected: false,
+      warning: "This connector is not available on this backend yet.",
+    }));
+  }
+
+  return { sources, financeUnavailable };
+}
+
+const CONNECTOR_PROVIDER_SLUGS: Record<Exclude<VibeRaisingInputSourceKey, "gmail">, string> = {
+  stripe: "stripe",
+  xero: "xero",
+  bank_feed: "bank-feed",
+  notion: "notion",
+  google_drive: "google-drive",
+  slack: "slack",
+};
+
+export function connectVibeRaisingInputSource(
+  backendBaseUrl: string,
+  provider: Exclude<VibeRaisingInputSourceKey, "gmail">,
+  nextUrl?: string,
+): string {
+  const normalizedBase = backendBaseUrl.endsWith("/") ? backendBaseUrl : `${backendBaseUrl}/`;
+  const url = new URL(`integrations/connect/${CONNECTOR_PROVIDER_SLUGS[provider]}`, normalizedBase);
+  url.searchParams.set("next", buildConnectorReturnPath(nextUrl));
+  return url.toString();
+}
+
+export async function syncVibeRaisingFinancialSources(
+  backendBaseUrl: string,
+): Promise<Record<string, unknown>> {
+  return requestBrowserJson<Record<string, unknown>>(
+    backendBaseUrl,
+    FINANCIAL_SYNC_PATH,
+    { method: "POST" },
+  );
+}
+
 export async function runVibeRaisingStartupUpdate(
   backendBaseUrl: string,
-  options?: { forceRegenerate?: boolean },
+  options?: { forceRegenerate?: boolean; inputSources?: VibeRaisingInputSourceKey[] },
 ): Promise<VibeRaisingStartupUpdateStatusResponse> {
+  const body: Record<string, unknown> = {};
+  if (options?.forceRegenerate) {
+    body.forceRegenerate = true;
+  }
+  const inputSources = Array.from(new Set(options?.inputSources ?? []));
+  if (inputSources.length > 0) {
+    body.inputSources = inputSources;
+    body.input_sources = inputSources;
+  }
+
   const response = await requestBrowserJson<Record<string, unknown>>(
     backendBaseUrl,
     EMAIL_DRAFT_START_PATH,
     {
       method: "POST",
-      body: options?.forceRegenerate ? JSON.stringify({ forceRegenerate: true }) : undefined,
+      body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
     },
   );
   return normalizeStartupUpdateStatus(response);

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -84,6 +84,7 @@ export default [
   route("/vibe-raising", "routes/vibe-raising-app.tsx", [
     index("routes/vibe-raising-app._index.tsx"),
     route("company-setup", "routes/vibe-raising-app.company-setup.tsx"),
+    route("connect-data", "routes/vibe-raising-app.connect-data.tsx"),
     route("create-update", "routes/vibe-raising-app.create-update.tsx"),
     route("discover", "routes/vibe-raising-app.investors.tsx"),
     route("companies", "routes/vibe-raising-app.companies.tsx"),

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -814,7 +814,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                             consistent, transparent monthly updates.
                         </p>
                         <button
-                            onClick={() => triggerAnnouncement(() => navigate("/vibe-raising/create-update"))}
+                            onClick={() => triggerAnnouncement(() => navigate("/vibe-raising/connect-data"))}
                             className="inline-flex items-center gap-3 px-8 py-4 bg-white text-gray-900 font-bold rounded-xl transition-all shadow-lg hover:shadow-xl hover:bg-gray-100 active:scale-[0.98]"
                         >
                             Create Your First Update
@@ -898,7 +898,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         Analytics
                     </button>
                     <Link
-                        to="/vibe-raising/create-update"
+                        to="/vibe-raising/connect-data"
                         className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg transition-all"
                         style={{
                             background: "var(--vr-color-primary)",
@@ -1004,7 +1004,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                             </div>
                         </div>
                         <Link
-                            to="/vibe-raising/create-update"
+                            to="/vibe-raising/connect-data"
                             className="px-6 py-3 bg-violet-600 text-white font-bold rounded-lg hover:bg-violet-700 transition-colors shadow-sm whitespace-nowrap"
                         >
                             Create Update Now

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -18,7 +18,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
     // If not adding a new company and already registered, skip setup
     if (!isAddingNew && user.companyRegistered) {
-        throw redirect("/vibe-raising/create-update");
+        throw redirect("/vibe-raising/connect-data");
     }
 
     return { user, activeCompany, isAddingNew };
@@ -57,7 +57,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         await setVibeRaisingActiveCompany(env, request, companyId);
     }
 
-    return redirect("/vibe-raising/create-update");
+    return redirect("/vibe-raising/connect-data");
 }
 
 export default function CompanySetup() {

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -1,0 +1,733 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Route } from "./+types/vibe-raising-app.connect-data";
+import { redirect, useLoaderData, useLocation, useNavigate } from "react-router";
+import { clsx } from "clsx";
+import {
+  ArrowPathIcon,
+  ArrowRightIcon,
+  BuildingLibraryIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  EllipsisHorizontalIcon,
+  EnvelopeIcon,
+  FolderIcon,
+  LockClosedIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+} from "@heroicons/react/24/outline";
+import { getEnv } from "~/lib/env.server";
+import {
+  bootstrapVibeRaisingStartupUpdate,
+  connectVibeRaisingInputSource,
+  getVibeRaisingInputSourcesStatus,
+  requireVibeRaisingFounder,
+  syncVibeRaisingFinancialSources,
+} from "~/lib/vibe-raising";
+import type {
+  VibeRaisingInputSourceKey,
+  VibeRaisingInputSourceStatus,
+  VibeRaisingInputSourceSummary,
+} from "~/types/vibe-raising";
+import MonthlyUpdateStepper, { type MonthlyUpdateStepKey } from "~/components/MonthlyUpdateStepper";
+
+const DEFAULT_NEXT = "/vibe-raising/create-update";
+const FUNCTIONAL_SOURCES = new Set<VibeRaisingInputSourceKey>(["gmail", "stripe", "xero", "bank_feed", "notion", "google_drive", "slack"]);
+const POPULAR_SOURCE_KEYS: VibeRaisingInputSourceKey[] = [
+  "gmail",
+  "stripe",
+  "bank_feed",
+  "notion",
+  "google_drive",
+  "xero",
+];
+const EXTRA_SOURCE_KEYS: VibeRaisingInputSourceKey[] = ["slack"];
+
+const EMPTY_SOURCES: VibeRaisingInputSourceSummary[] = [
+  {
+    key: "gmail",
+    label: "Gmail",
+    capabilities: ["context"],
+    selected: false,
+    status: "not_connected",
+  },
+  {
+    key: "stripe",
+    label: "Stripe",
+    capabilities: ["metrics"],
+    selected: false,
+    status: "not_connected",
+  },
+  {
+    key: "xero",
+    label: "Xero",
+    capabilities: ["metrics"],
+    selected: false,
+    status: "not_connected",
+  },
+  {
+    key: "bank_feed",
+    label: "Bank Feed",
+    capabilities: ["cash_validation"],
+    selected: false,
+    status: "not_connected",
+  },
+  {
+    key: "notion",
+    label: "Notion",
+    capabilities: ["docs", "context"],
+    selected: false,
+    status: "not_connected",
+  },
+  {
+    key: "google_drive",
+    label: "Google Drive",
+    capabilities: ["docs", "context"],
+    selected: false,
+    status: "not_connected",
+  },
+  {
+    key: "slack",
+    label: "Slack",
+    capabilities: ["context"],
+    selected: false,
+    status: "not_connected",
+  },
+];
+
+const SOURCE_COPY: Record<VibeRaisingInputSourceKey, { description: string; connectedUse: string }> = {
+  gmail: {
+    description: "Scan emails for key updates, investor feedback, and important threads.",
+    connectedUse: "Emails, investor threads",
+  },
+  stripe: {
+    description: "Pull revenue, subscriptions, and financial metrics automatically.",
+    connectedUse: "Revenue, subscriptions",
+  },
+  xero: {
+    description: "Use invoices and recurring revenue records from your accounting workspace.",
+    connectedUse: "Invoices, accounting",
+  },
+  bank_feed: {
+    description: "Import transactions and cash flow data from your business accounts.",
+    connectedUse: "Transactions, cash flow",
+  },
+  notion: {
+    description: "Sync notes, docs, and internal updates from your workspace.",
+    connectedUse: "Docs, notes, updates",
+  },
+  google_drive: {
+    description: "Add files, reports, and presentations for deeper context.",
+    connectedUse: "Files, reports, decks",
+  },
+  slack: {
+    description: "Bring in important team updates and customer conversations.",
+    connectedUse: "Team updates, conversations",
+  },
+};
+
+function sanitizeNext(value: string | null) {
+  if (!value) return DEFAULT_NEXT;
+  let candidate = value.trim();
+  if (!candidate) return DEFAULT_NEXT;
+
+  try {
+    if (/^https?:\/\//i.test(candidate)) {
+      const parsed = new URL(candidate);
+      candidate = `${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    return DEFAULT_NEXT;
+  }
+
+  if (!candidate.startsWith("/vibe-raising/create-update")) {
+    return DEFAULT_NEXT;
+  }
+  return candidate;
+}
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  const { appUser: user } = await requireVibeRaisingFounder(env, request);
+
+  if (!user.companyRegistered) {
+    throw redirect("/vibe-raising/company-setup");
+  }
+
+  const url = new URL(request.url);
+  return {
+    user,
+    next: sanitizeNext(url.searchParams.get("next")),
+    backendBaseUrl: String(env.BACKEND_BASE_URL || "http://localhost:8000"),
+  };
+}
+
+function statusLabel(status: VibeRaisingInputSourceStatus) {
+  switch (status) {
+    case "connected":
+      return "Connected";
+    case "syncing":
+      return "Syncing";
+    case "error":
+      return "Needs attention";
+    case "coming_soon":
+      return "Coming soon";
+    case "unavailable":
+      return "Not available yet";
+    default:
+      return "Not connected";
+  }
+}
+
+function statusClassName(status: VibeRaisingInputSourceStatus) {
+  switch (status) {
+    case "connected":
+      return "bg-emerald-50 text-emerald-700 ring-emerald-100";
+    case "syncing":
+      return "bg-blue-50 text-blue-700 ring-blue-100";
+    case "error":
+      return "bg-amber-50 text-amber-700 ring-amber-100";
+    case "coming_soon":
+      return "bg-gray-100 text-gray-500 ring-gray-200";
+    case "unavailable":
+      return "bg-gray-100 text-gray-500 ring-gray-200";
+    default:
+      return "bg-violet-50 text-violet-700 ring-violet-100";
+  }
+}
+
+function capabilityLabel(capability: VibeRaisingInputSourceSummary["capabilities"][number]) {
+  switch (capability) {
+    case "metrics":
+      return "Metrics";
+    case "cash_validation":
+      return "Cash validation";
+    case "docs":
+      return "Docs";
+    default:
+      return "Context";
+  }
+}
+
+function SourceLogo({ sourceKey }: { sourceKey: VibeRaisingInputSourceKey }) {
+  if (sourceKey === "gmail") {
+    return (
+      <div className="relative h-9 w-9 rounded-lg bg-white">
+        <span className="absolute left-1 top-2 h-5 w-1.5 rotate-[-35deg] rounded-full bg-red-500" />
+        <span className="absolute left-[14px] top-2 h-5 w-1.5 rotate-[35deg] rounded-full bg-yellow-400" />
+        <span className="absolute right-1 top-2 h-5 w-1.5 rotate-[35deg] rounded-full bg-emerald-500" />
+        <span className="absolute bottom-2 left-1 h-1.5 w-7 rounded-full bg-blue-500" />
+      </div>
+    );
+  }
+
+  if (sourceKey === "stripe") {
+    return (
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#635bff] text-[10px] font-extrabold lowercase text-white">
+        stripe
+      </div>
+    );
+  }
+
+  if (sourceKey === "xero") {
+    return (
+      <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[#13b5ea] text-sm font-extrabold text-white">
+        xe
+      </div>
+    );
+  }
+
+  if (sourceKey === "bank_feed") {
+    return <BuildingLibraryIcon className="h-9 w-9 text-violet-600" />;
+  }
+
+  if (sourceKey === "notion") {
+    return (
+      <div className="flex h-9 w-9 items-center justify-center rounded-md border-2 border-black bg-white text-xl font-black text-black">
+        N
+      </div>
+    );
+  }
+
+  if (sourceKey === "google_drive") {
+    return (
+      <div className="relative h-9 w-9">
+        <span className="absolute left-3 top-0 h-8 w-3 rotate-[30deg] rounded-sm bg-emerald-500" />
+        <span className="absolute left-1 top-4 h-3 w-8 rounded-sm bg-blue-500" />
+        <span className="absolute right-1 top-4 h-3 w-8 rotate-[-60deg] rounded-sm bg-yellow-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid h-9 w-9 grid-cols-2 gap-1">
+      <span className="rounded-full bg-[#36c5f0]" />
+      <span className="rounded-full bg-[#2eb67d]" />
+      <span className="rounded-full bg-[#ecb22e]" />
+      <span className="rounded-full bg-[#e01e5a]" />
+    </div>
+  );
+}
+
+function ConnectorCard({
+  source,
+  selected,
+  busy,
+  onConnect,
+  onToggle,
+}: {
+  source: VibeRaisingInputSourceSummary;
+  selected: boolean;
+  busy: boolean;
+  onConnect: (source: VibeRaisingInputSourceSummary) => void;
+  onToggle: (source: VibeRaisingInputSourceSummary) => void;
+}) {
+  const selectable = FUNCTIONAL_SOURCES.has(source.key) && (source.status === "connected" || source.status === "syncing");
+  const canConnect = FUNCTIONAL_SOURCES.has(source.key) && source.status !== "connected" && source.status !== "syncing" && source.status !== "unavailable";
+  const disabled = source.status === "coming_soon" || source.status === "unavailable";
+
+  return (
+    <div className="flex min-h-[240px] flex-col rounded-xl border border-gray-200 bg-white p-7 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex items-start justify-between gap-3">
+        <SourceLogo sourceKey={source.key} />
+        <span className={clsx("inline-flex items-center rounded-full px-2 py-1 text-[11px] font-bold ring-1", statusClassName(source.status))}>
+          {statusLabel(source.status)}
+        </span>
+      </div>
+
+      <div className="mt-6">
+        <h3 className="text-base font-bold text-gray-950">{source.label}</h3>
+        <p className="mt-4 min-h-[48px] text-sm leading-6 text-slate-500">{SOURCE_COPY[source.key].description}</p>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-1.5">
+        {source.capabilities.map((capability) => (
+          <span key={capability} className="rounded-full bg-gray-50 px-2 py-1 text-[11px] font-bold text-slate-500">
+            {capabilityLabel(capability)}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-auto pt-6">
+        {selectable ? (
+          <button
+            type="button"
+            onClick={() => onToggle(source)}
+            className={clsx(
+              "flex w-full items-center justify-between rounded-lg px-4 py-3 text-sm font-extrabold transition",
+              selected ? "bg-violet-600 text-white" : "bg-violet-50 text-violet-700 hover:bg-violet-100",
+            )}
+          >
+            <span>{selected ? "Using in this update" : "Use in this update"}</span>
+            <CheckCircleIcon className={clsx("h-5 w-5", selected ? "text-white" : "text-violet-300")} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={disabled || busy || !canConnect}
+            onClick={() => onConnect(source)}
+            className={clsx(
+              "w-full rounded-lg px-4 py-3 text-sm font-extrabold transition",
+              disabled || !canConnect
+                ? "cursor-not-allowed bg-gray-100 text-gray-400"
+                : "bg-violet-50 text-violet-700 hover:bg-violet-100",
+            )}
+          >
+            {busy ? "Connecting..." : disabled ? statusLabel(source.status) : "Connect"}
+          </button>
+        )}
+
+        {source.warning && source.status !== "coming_soon" ? (
+          <p className="mt-3 text-xs font-medium leading-5 text-amber-700">{source.warning}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default function ConnectData() {
+  const { backendBaseUrl, next, user } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [sources, setSources] = useState<VibeRaisingInputSourceSummary[]>(EMPTY_SOURCES);
+  const [selectedSources, setSelectedSources] = useState<Set<VibeRaisingInputSourceKey>>(new Set());
+  const [showAllSources, setShowAllSources] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState(true);
+  const [syncingFinance, setSyncingFinance] = useState(false);
+  const [busyProvider, setBusyProvider] = useState<VibeRaisingInputSourceKey | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const defaultSelectionAppliedRef = useRef(false);
+
+  const sourceByKey = useMemo(() => new Map(sources.map((source) => [source.key, source])), [sources]);
+  const orderedVisibleSources = useMemo(() => {
+    const keys = showAllSources ? [...POPULAR_SOURCE_KEYS, ...EXTRA_SOURCE_KEYS] : POPULAR_SOURCE_KEYS;
+    return keys.map((key) => sourceByKey.get(key)).filter((source): source is VibeRaisingInputSourceSummary => Boolean(source));
+  }, [showAllSources, sourceByKey]);
+  const connectedSources = useMemo(
+    () => sources.filter((source) => FUNCTIONAL_SOURCES.has(source.key) && (source.status === "connected" || source.status === "syncing")),
+    [sources],
+  );
+  const selectedSourceList = useMemo(
+    () => sources.filter((source) => selectedSources.has(source.key)),
+    [selectedSources, sources],
+  );
+  const hasConnectedFinance = connectedSources.some((source) => source.key === "stripe" || source.key === "xero" || source.key === "bank_feed");
+
+  const refreshStatuses = async () => {
+    setLoadingStatus(true);
+    setStatusMessage(null);
+    try {
+      const response = await getVibeRaisingInputSourcesStatus(backendBaseUrl);
+      setSources(response.sources);
+      if (!defaultSelectionAppliedRef.current) {
+        defaultSelectionAppliedRef.current = true;
+        setSelectedSources(new Set(
+          response.sources
+            .filter((source) => FUNCTIONAL_SOURCES.has(source.key) && (source.status === "connected" || source.status === "syncing"))
+            .map((source) => source.key),
+        ));
+      }
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : "We couldn't load connector status.");
+    } finally {
+      setLoadingStatus(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshStatuses();
+  }, [backendBaseUrl]);
+
+  const currentReturnPath = `${location.pathname}${location.search || ""}`;
+
+  const handleConnect = async (source: VibeRaisingInputSourceSummary) => {
+    if (!FUNCTIONAL_SOURCES.has(source.key)) return;
+    setBusyProvider(source.key);
+    setStatusMessage(null);
+
+    try {
+      if (source.key === "gmail") {
+        const bootstrap = await bootstrapVibeRaisingStartupUpdate(backendBaseUrl, { next: currentReturnPath });
+        if (bootstrap.googleConnected) {
+          await refreshStatuses();
+          return;
+        }
+        if (!bootstrap.oauthUrl) {
+          throw new Error("Missing Google OAuth redirect URL.");
+        }
+        window.location.assign(bootstrap.oauthUrl);
+        return;
+      }
+
+      window.location.assign(connectVibeRaisingInputSource(backendBaseUrl, source.key, next));
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : `We couldn't connect ${source.label}.`);
+      setBusyProvider(null);
+    }
+  };
+
+  const handleToggle = (source: VibeRaisingInputSourceSummary) => {
+    if (!FUNCTIONAL_SOURCES.has(source.key)) return;
+    if (source.status !== "connected" && source.status !== "syncing") return;
+
+    setSelectedSources((previous) => {
+      const nextSelected = new Set(previous);
+      if (nextSelected.has(source.key)) {
+        nextSelected.delete(source.key);
+      } else {
+        nextSelected.add(source.key);
+      }
+      return nextSelected;
+    });
+  };
+
+  const handleSyncFinance = async () => {
+    setSyncingFinance(true);
+    setStatusMessage(null);
+    try {
+      await syncVibeRaisingFinancialSources(backendBaseUrl);
+      await refreshStatuses();
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : "We couldn't start the financial sync.");
+    } finally {
+      setSyncingFinance(false);
+    }
+  };
+
+  const navigateBackToUpdates = () => {
+    navigate("/vibe-raising");
+  };
+
+  const navigateToDraft = (includeInputs: boolean) => {
+    const target = new URL(next, "http://mlai.local");
+    if (includeInputs && selectedSources.size > 0) {
+      target.searchParams.set("inputs", Array.from(selectedSources).join(","));
+    } else {
+      target.searchParams.delete("inputs");
+    }
+    navigate(`${target.pathname}${target.search}`);
+  };
+
+  const handleStepperClick = (step: MonthlyUpdateStepKey) => {
+    if (step === "connect") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+      return;
+    }
+
+    if (step === "draft") {
+      navigateToDraft(true);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-10 pb-16">
+      <MonthlyUpdateStepper
+        activeStep="connect"
+        enabledSteps={["connect", "draft"]}
+        onStepClick={handleStepperClick}
+        className="mt-8"
+      />
+
+      <div className="grid gap-6 pt-8 lg:grid-cols-[1fr_430px] lg:items-start">
+        <div>
+          <p className="text-sm font-bold uppercase tracking-wide text-violet-600">Vibe Raising</p>
+          <h1 className="mt-3 text-3xl font-black tracking-tight text-gray-950 sm:text-4xl">Connect your data</h1>
+          <p className="mt-5 max-w-xl text-base leading-7 text-slate-500">
+            Add data sources to give your AI agent the full context it needs to create your monthly investor update.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => navigateToDraft(true)}
+              className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-extrabold text-white shadow-sm transition hover:bg-black"
+            >
+              Continue to draft
+              <ArrowRightIcon className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={navigateBackToUpdates}
+              className="rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-extrabold text-gray-700 shadow-sm transition hover:bg-gray-50"
+            >
+              Back
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-violet-100 bg-violet-50/70 p-6">
+          <div className="flex gap-5">
+            <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-white text-violet-600 shadow-sm">
+              <SparklesIcon className="h-6 w-6" />
+            </div>
+            <div>
+              <h2 className="text-sm font-extrabold text-violet-700">How it works</h2>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Connect your tools below. Our AI securely pulls in the most relevant data and turns it into your monthly update.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {statusMessage ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm font-semibold text-amber-800">
+          {statusMessage}
+        </div>
+      ) : null}
+
+      <section>
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-black text-gray-950">Popular sources</h2>
+            <p className="mt-3 text-sm text-slate-500">Quickly connect the most common tools startups use.</p>
+          </div>
+          {loadingStatus ? (
+            <span className="inline-flex items-center gap-2 text-sm font-bold text-violet-600">
+              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+              Checking status
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {orderedVisibleSources.map((source) => (
+            <ConnectorCard
+              key={source.key}
+              source={source}
+              selected={selectedSources.has(source.key)}
+              busy={busyProvider === source.key}
+              onConnect={handleConnect}
+              onToggle={handleToggle}
+            />
+          ))}
+        </div>
+
+        <div className="mt-8 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setShowAllSources((value) => !value)}
+            className="inline-flex min-w-56 items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-extrabold text-gray-900 shadow-sm transition hover:bg-gray-50"
+          >
+            {showAllSources ? "Show fewer sources" : "View all sources"}
+            <ChevronDownIcon className={clsx("h-4 w-4 text-slate-400 transition", showAllSources && "rotate-180")} />
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-black text-gray-950">Connected sources</h2>
+            <p className="mt-3 text-sm text-slate-500">Manage the data connections available for this update.</p>
+          </div>
+          {hasConnectedFinance ? (
+            <button
+              type="button"
+              onClick={handleSyncFinance}
+              disabled={syncingFinance}
+              className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-extrabold text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-60"
+            >
+              <ArrowPathIcon className={clsx("h-4 w-4", syncingFinance && "animate-spin")} />
+              Sync financials
+            </button>
+          ) : null}
+        </div>
+
+        <div className="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          {connectedSources.length > 0 ? (
+            <div className="divide-y divide-gray-100">
+              {connectedSources.map((source) => (
+                <div key={source.key} className="grid gap-4 px-6 py-5 md:grid-cols-[1.2fr_0.8fr_1.2fr_auto] md:items-center">
+                  <div className="flex items-center gap-4">
+                    <SourceLogo sourceKey={source.key} />
+                    <div>
+                      <p className="text-sm font-extrabold text-gray-950">{source.label}</p>
+                      <p className="mt-1 text-xs font-medium text-slate-500">
+                        {source.accountLabel || (source.key === "gmail" ? user.email : user.companyName)}
+                      </p>
+                    </div>
+                  </div>
+                  <span className={clsx("inline-flex w-fit items-center gap-2 rounded-full px-2 py-1 text-xs font-bold ring-1", statusClassName(source.status))}>
+                    <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                    {statusLabel(source.status)}
+                  </span>
+                  <p className="text-sm text-slate-500">{SOURCE_COPY[source.key].connectedUse}</p>
+                  <button
+                    type="button"
+                    onClick={() => handleToggle(source)}
+                    className="inline-flex items-center justify-center rounded-lg p-2 text-slate-400 transition hover:bg-gray-50 hover:text-slate-700"
+                    aria-label={`Toggle ${source.label}`}
+                    title={selectedSources.has(source.key) ? "Remove from this update" : "Use in this update"}
+                  >
+                    <EllipsisHorizontalIcon className="h-5 w-5" />
+                  </button>
+                </div>
+              ))}
+              <div className="px-5 py-4">
+                <button
+                  type="button"
+                  onClick={() => navigateToDraft(true)}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 px-4 py-3 text-sm font-extrabold text-gray-900 transition hover:bg-gray-50"
+                >
+                  Continue to draft with {selectedSourceList.length || "no"} selected source{selectedSourceList.length === 1 ? "" : "s"}
+                  <ArrowRightIcon className="h-4 w-4 text-slate-400" />
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="px-6 py-8 text-center">
+              <p className="text-sm font-bold text-gray-950">No active connections yet</p>
+              <p className="mt-2 text-sm text-slate-500">Connect a source to make it available for this update.</p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-xl bg-black p-8 text-white sm:p-10">
+        <h2 className="text-2xl font-black">Your data, transformed</h2>
+        <p className="mt-4 max-w-xl text-sm leading-6 text-white/72">
+          Your connected data is securely processed to generate your monthly investor update.
+        </p>
+        <div className="mt-10 grid gap-6 lg:grid-cols-3">
+          {[
+            { title: "1. Connect", body: "Add your data sources in a few clicks.", icon: EnvelopeIcon },
+            { title: "2. Process", body: "Our AI extracts key signals, metrics, wins, and asks.", icon: ArrowPathIcon },
+            { title: "3. Generate", body: "Get a clear, investor-ready monthly update.", icon: SparklesIcon },
+          ].map((step, index) => (
+            <div key={step.title} className="flex items-center gap-5">
+              <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full bg-white/10 text-violet-300">
+                <step.icon className="h-6 w-6" />
+              </div>
+              <div>
+                <h3 className="text-base font-black">{step.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-white/72">{step.body}</p>
+              </div>
+              {index < 2 ? <ArrowRightIcon className="ml-auto hidden h-5 w-5 text-white/35 xl:block" /> : null}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <section className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+          <h2 className="text-lg font-black text-gray-950">What we pull in</h2>
+          <ul className="mt-6 space-y-4 text-sm font-semibold text-slate-600">
+            {["Revenue and financial metrics", "Key milestones and updates", "Team and operational highlights", "Challenges and risks", "Upcoming asks and needs"].map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircleIcon className="h-5 w-5 text-slate-400" />
+                {item}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex items-center gap-3 rounded-lg bg-violet-50 px-4 py-4 text-sm font-bold text-violet-700">
+            <ShieldCheckIcon className="h-5 w-5" />
+            We only access the data you authorize and never share it.
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+          <h2 className="text-lg font-black text-gray-950">Privacy and security</h2>
+          <ul className="mt-6 space-y-4 text-sm font-semibold text-slate-600">
+            {["Bank-level encryption", "Read-only access", "You're in control"].map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircleIcon className="h-5 w-5 text-slate-400" />
+                {item}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex items-center gap-3 rounded-lg bg-violet-50 px-4 py-4 text-sm font-bold text-violet-700">
+            <LockClosedIcon className="h-5 w-5" />
+            Your data is safe and secure with us.
+          </div>
+        </section>
+      </div>
+
+      <div className="sticky bottom-4 z-10 flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <FolderIcon className="h-5 w-5 text-violet-600" />
+          <p className="text-sm font-bold text-gray-950">
+            {selectedSourceList.length > 0
+              ? `${selectedSourceList.length} source${selectedSourceList.length === 1 ? "" : "s"} selected`
+              : "No external sources selected"}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={navigateBackToUpdates}
+            className="rounded-xl px-4 py-2.5 text-sm font-extrabold text-gray-500 transition hover:bg-gray-50"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={() => navigateToDraft(true)}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-2.5 text-sm font-extrabold text-white shadow-sm transition hover:bg-violet-700"
+          >
+            Continue to draft
+            <ArrowRightIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -38,9 +38,44 @@ import { useDropzone } from 'react-dropzone';
 import { clsx } from "clsx";
 import DraftFromEmailWizard from "~/components/DraftFromEmailWizard";
 import EmailDraftInProgressCard from "~/components/EmailDraftInProgressCard";
+import MonthlyUpdateStepper, { type MonthlyUpdateStepKey } from "~/components/MonthlyUpdateStepper";
 import StartupRegionBadge from "~/components/StartupRegionBadge";
 import { getVibeRaisingMonthTheme, parseVibeRaisingMonthYear, VIBE_RAISING_MONTH_OPTIONS, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
-import type { VibeRaisingStartupUpdateStatusResponse, VibeRaisingVideoCompressionMetadata } from "~/types/vibe-raising";
+import type { VibeRaisingInputSourceKey, VibeRaisingStartupUpdateStatusResponse, VibeRaisingVideoCompressionMetadata } from "~/types/vibe-raising";
+
+const VALID_INPUT_SOURCE_KEYS = new Set<VibeRaisingInputSourceKey>([
+    "gmail",
+    "stripe",
+    "xero",
+    "bank_feed",
+    "notion",
+    "google_drive",
+    "slack",
+]);
+
+const INPUT_SOURCE_LABELS: Record<VibeRaisingInputSourceKey, string> = {
+    gmail: "Gmail",
+    stripe: "Stripe",
+    xero: "Xero",
+    bank_feed: "Bank Feed",
+    notion: "Notion",
+    google_drive: "Google Drive",
+    slack: "Slack",
+};
+
+function parseInputSources(value: string | null): VibeRaisingInputSourceKey[] {
+    if (!value) return [];
+    const seen = new Set<VibeRaisingInputSourceKey>();
+    value
+        .split(",")
+        .map((item) => item.trim().toLowerCase())
+        .forEach((item) => {
+            if (VALID_INPUT_SOURCE_KEYS.has(item as VibeRaisingInputSourceKey)) {
+                seen.add(item as VibeRaisingInputSourceKey);
+            }
+        });
+    return Array.from(seen);
+}
 
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
@@ -57,6 +92,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const resumeEmailDrafting =
         url.searchParams.get("email_draft") === "1" ||
         url.searchParams.get("draft_from_email") === "1";
+    const selectedInputSources = parseInputSources(url.searchParams.get("inputs"));
 
     let existingData = null;
     if (editId) {
@@ -79,6 +115,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         isEdit: !!editId,
         backendBaseUrl: String(env.BACKEND_BASE_URL || "http://localhost:8000"),
         resumeEmailDrafting,
+        selectedInputSources,
     };
 }
 
@@ -1330,12 +1367,27 @@ export default function CreateUpdate() {
         isEdit,
         backendBaseUrl,
         resumeEmailDrafting,
+        selectedInputSources,
     } = useLoaderData<typeof loader>();
     const actionData = useActionData<typeof action>() as any;
     const navigate = useNavigate();
     const location = useLocation();
     const navigation = useNavigation();
     const isSubmitting = navigation.state === "submitting";
+    const goToConnectDataStep = useCallback(() => {
+        const returnPath = `${location.pathname}${location.search || ""}`;
+        navigate(`/vibe-raising/connect-data?next=${encodeURIComponent(returnPath)}`);
+    }, [location.pathname, location.search, navigate]);
+    const handleDraftStepperClick = useCallback((step: MonthlyUpdateStepKey) => {
+        if (step === "connect") {
+            goToConnectDataStep();
+            return;
+        }
+
+        if (step === "draft") {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+    }, [goToConnectDataStep]);
     const defaultData = actionData?.step === "feedback" ? (actionData.data as any) : (existingData || {});
     const [dismissedFeedback, setDismissedFeedback] = useState(false);
     const [isRecording, setIsRecording] = useState(false);
@@ -1408,6 +1460,10 @@ export default function CreateUpdate() {
         if (initial.size === 0) initial.add("revenue");
         return initial;
     });
+    const selectedInputSourceLabels = selectedInputSources.map((key) => INPUT_SOURCE_LABELS[key]);
+    const selectedInputSourceDescription = selectedInputSourceLabels.length > 0
+        ? selectedInputSourceLabels.join(", ")
+        : "Manual materials only";
     const canGenerateDraftFromEmail = Boolean((user.domain || "").trim());
     const emailDraftStorageKey = getEmailDraftStorageKey(user.domain);
     const emailDraftForceRegenerateKey = getEmailDraftForceRegenerateKey(user.domain);
@@ -1736,7 +1792,10 @@ export default function CreateUpdate() {
             );
             const statusResponse = await runVibeRaisingStartupUpdate(
                 backendBaseUrl,
-                shouldForceRegenerate ? { forceRegenerate: true } : undefined,
+                {
+                    ...(shouldForceRegenerate ? { forceRegenerate: true } : {}),
+                    inputSources: selectedInputSources,
+                },
             );
             emailDraftIgnoredRunIdRef.current = null;
             if (statusResponse.state === "auth_required") {
@@ -1756,7 +1815,7 @@ export default function CreateUpdate() {
         } finally {
             setEmailDraftActionBusy(false);
         }
-    }, [backendBaseUrl, emailDraftForceRegenerateKey]);
+    }, [backendBaseUrl, emailDraftForceRegenerateKey, selectedInputSources]);
 
     const handleGenerateDraftFromEmailClick = useCallback(async () => {
         if (!canGenerateDraftFromEmail) {
@@ -1767,6 +1826,10 @@ export default function CreateUpdate() {
         setEmailDraftActionBusy(true);
         setEmailDraftUiError(null);
         try {
+            if (!selectedInputSources.includes("gmail")) {
+                await startOrResumeEmailDraft();
+                return;
+            }
             const bootstrap = await bootstrapVibeRaisingStartupUpdate(backendBaseUrl);
             if (bootstrap.googleConnected) {
                 await startOrResumeEmailDraft();
@@ -1781,7 +1844,7 @@ export default function CreateUpdate() {
         } finally {
             setEmailDraftActionBusy(false);
         }
-    }, [backendBaseUrl, canGenerateDraftFromEmail, navigate, startOrResumeEmailDraft]);
+    }, [backendBaseUrl, canGenerateDraftFromEmail, navigate, selectedInputSources, startOrResumeEmailDraft]);
 
     const handleEmailWizardConnected = useCallback(() => {
         setShowEmailWizard(false);
@@ -1939,13 +2002,13 @@ export default function CreateUpdate() {
             ? emailDraftUiError
             : null;
     const emailDraftButtonTitle = emailDraftActionBusy
-        ? "Checking Gmail connection..."
-        : "AI Drafting";
+        ? "Checking selected inputs..."
+        : "Generate update from selected inputs";
     const emailDraftButtonDescription = emailDraftActionBusy
-        ? "Contacting the MLAI backend and checking whether Gmail is already connected."
+        ? "Contacting the MLAI backend and preparing the selected sources for drafting."
         : canGenerateDraftFromEmail
-            ? "Scan filtered Gmail data for key signals, metrics, wins, and asks, then turn them into a first draft."
-            : "Add a company domain first so Gmail emails can be matched to the right startup.";
+            ? `Use ${selectedInputSourceDescription} to find key signals, metrics, wins, and asks, then turn them into a first draft.`
+            : "Add a company domain first so inputs can be matched to the right startup.";
     const isVideoUploadPending = videoUploadStatus === "validating" ||
         videoUploadStatus === "compressing" ||
         videoUploadStatus === "creating_session" ||
@@ -2403,8 +2466,38 @@ export default function CreateUpdate() {
             }
         };
 
+        const handleReviewStepperClick = (step: MonthlyUpdateStepKey) => {
+            if (step === "connect") {
+                goToConnectDataStep();
+                return;
+            }
+
+            if (step === "draft") {
+                setShowConfirmPopup(false);
+                setDismissedFeedback(true);
+                return;
+            }
+
+            if (step === "review") {
+                setShowConfirmPopup(false);
+                window.scrollTo({ top: 0, behavior: "smooth" });
+                return;
+            }
+
+            if (step === "publish") {
+                setShowConfirmPopup(true);
+            }
+        };
+
         return (
             <div className="max-w-5xl mx-auto pb-12">
+                <MonthlyUpdateStepper
+                    activeStep={showConfirmPopup ? "publish" : "review"}
+                    enabledSteps={["connect", "draft", "review", "publish"]}
+                    onStepClick={handleReviewStepperClick}
+                    className="mt-6 mb-6"
+                />
+
                 {/* Header — back arrow top-left, title center-left, X on right */}
                 <div className="flex items-center gap-3 py-6 mb-4">
                     <button
@@ -2742,7 +2835,14 @@ export default function CreateUpdate() {
 
                         return (
                             <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-900/60 backdrop-blur-sm p-4">
-                                <div className="bg-white rounded-2xl shadow-xl max-w-sm w-full p-8 text-center relative overflow-hidden animate-in fade-in zoom-in duration-300">
+                                <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full p-8 text-center relative overflow-hidden animate-in fade-in zoom-in duration-300">
+                                    <MonthlyUpdateStepper
+                                        activeStep="publish"
+                                        enabledSteps={["connect", "draft", "review", "publish"]}
+                                        onStepClick={handleReviewStepperClick}
+                                        compact
+                                        className="mb-6 text-left"
+                                    />
                                     <h2 className="text-2xl font-black text-gray-900 mb-2 tracking-tight">Ready to send? 🚀</h2>
                                     <p className="text-gray-600 mb-6 text-sm leading-relaxed">
                                         Your update is about to go live on Vibe Raising. We will send it directly to <strong className="font-bold text-gray-900">{count} investors</strong> matching your criteria: {criteria.join(", ")}.
@@ -2866,6 +2966,13 @@ export default function CreateUpdate() {
     // 3. Create/Edit Form View
     return (
         <div className="max-w-3xl mx-auto pb-12">
+            <MonthlyUpdateStepper
+                activeStep="draft"
+                enabledSteps={isEdit ? ["draft"] : ["connect", "draft"]}
+                onStepClick={handleDraftStepperClick}
+                className="mt-6 mb-6"
+            />
+
             {/* Header */}
             <div className="sticky top-0 z-10 py-4 mb-6 flex items-center justify-between">
                 <h1 className="text-xl font-bold text-gray-900">
@@ -3088,6 +3195,35 @@ export default function CreateUpdate() {
                     {isEmailDraftBusy && (
                         <div className="absolute inset-0 z-10 cursor-wait rounded-2xl bg-white/30" aria-hidden />
                     )}
+                </div>
+
+                <div className="rounded-2xl border border-violet-100 bg-white p-5 shadow-sm">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <p className="text-sm font-bold text-gray-900">Selected inputs</p>
+                            <div className="mt-2 flex flex-wrap gap-2">
+                                {selectedInputSourceLabels.length > 0 ? (
+                                    selectedInputSourceLabels.map((label) => (
+                                        <span key={label} className="rounded-full bg-violet-50 px-3 py-1 text-xs font-bold text-violet-700 ring-1 ring-violet-100">
+                                            {label}
+                                        </span>
+                                    ))
+                                ) : (
+                                    <span className="rounded-full bg-gray-50 px-3 py-1 text-xs font-bold text-gray-500 ring-1 ring-gray-100">
+                                        Manual materials only
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                        {!isEdit && (
+                            <Link
+                                to="/vibe-raising/connect-data"
+                                className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-4 py-2 text-sm font-bold text-gray-600 transition hover:bg-gray-50"
+                            >
+                                Change inputs
+                            </Link>
+                        )}
+                    </div>
                 </div>
 
                 {emailDraftCardVisible ? (

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -20,18 +20,20 @@ import {
 } from "~/lib/vibe-raising";
 import {
   BuildingOffice2Icon,
+  CircleStackIcon,
   DocumentTextIcon,
   UsersIcon,
 } from "@heroicons/react/24/outline";
 
 const FOUNDER_NAVIGATION = [
-  { name: "My Updates", href: "/vibe-raising", icon: DocumentTextIcon },
+  { name: "My Updates", href: "/vibe-raising", icon: DocumentTextIcon, exact: true },
+  { name: "Data Sources", href: "/vibe-raising/connect-data", icon: CircleStackIcon },
   { name: "Discover Investors", href: "/vibe-raising/discover", icon: UsersIcon },
   { name: "Manage Companies", href: "/vibe-raising/companies", icon: BuildingOffice2Icon },
 ];
 
 const INVESTOR_NAVIGATION = [
-  { name: "Portfolio Updates", href: "/vibe-raising", icon: DocumentTextIcon },
+  { name: "Portfolio Updates", href: "/vibe-raising", icon: DocumentTextIcon, exact: true },
   { name: "Connections", href: "/vibe-raising/discover", icon: UsersIcon },
 ];
 

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -107,6 +107,45 @@ export interface VibeRaisingVideoCompressionMetadata {
   compressionRatio?: number | null;
 }
 
+export type VibeRaisingInputSourceKey =
+  | "gmail"
+  | "stripe"
+  | "xero"
+  | "bank_feed"
+  | "notion"
+  | "google_drive"
+  | "slack";
+
+export type VibeRaisingInputSourceStatus =
+  | "connected"
+  | "not_connected"
+  | "syncing"
+  | "error"
+  | "coming_soon"
+  | "unavailable";
+
+export type VibeRaisingInputSourceCapability =
+  | "metrics"
+  | "context"
+  | "cash_validation"
+  | "docs";
+
+export interface VibeRaisingInputSourceSummary {
+  key: VibeRaisingInputSourceKey;
+  label: string;
+  accountLabel?: string | null;
+  capabilities: VibeRaisingInputSourceCapability[];
+  selected: boolean;
+  status: VibeRaisingInputSourceStatus;
+  lastSyncedAt?: string | null;
+  warning?: string | null;
+}
+
+export interface VibeRaisingInputSourcesStatusResponse {
+  sources: VibeRaisingInputSourceSummary[];
+  financeUnavailable: boolean;
+}
+
 export type VibeRaisingStartupUpdateState =
   | "needs_domain"
   | "auth_required"


### PR DESCRIPTION
## Summary
- add a Connect Data step before Vibe Raising update drafting
- add selectable connector cards/status handling for Gmail, Stripe, Xero, and planned sources
- add a monthly update stepper with clickable flow navigation
- add local-dev backend fallbacks for auth/profile/monthly updates so preview pages do not crash when the backend is down

## Validation
- bun run typecheck
- browser smoke test for Connect Data copy and stepper navigation
- git diff --check