### PR TITLE
[codex] Show expanded Xero preview metrics

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -2428,6 +2428,28 @@ export async function getVibeRaisingXeroPreview(
     monthlyRecurringRevenue:
       asNullableString(payload.monthlyRecurringRevenue) ??
       asNullableString(payload.monthly_recurring_revenue),
+    revenue:
+      asNullableString(payload.revenue),
+    revenueGrowthRate:
+      asNullableString(payload.revenueGrowthRate) ??
+      asNullableString(payload.revenue_growth_rate),
+    burnRate:
+      asNullableString(payload.burnRate) ??
+      asNullableString(payload.burn_rate),
+    runway:
+      asNullableString(payload.runway),
+    invoiceRevenue:
+      asNullableString(payload.invoiceRevenue) ??
+      asNullableString(payload.invoice_revenue),
+    invoiceCount:
+      asNullableString(payload.invoiceCount) ??
+      asNullableString(payload.invoice_count),
+    customerCount:
+      asNullableString(payload.customerCount) ??
+      asNullableString(payload.customer_count),
+    recurringInvoiceCount:
+      asNullableString(payload.recurringInvoiceCount) ??
+      asNullableString(payload.recurring_invoice_count),
     cashCollected:
       asNullableString(payload.cashCollected) ??
       asNullableString(payload.cash_collected),

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -284,7 +284,7 @@ function capabilityLabel(capability: VibeRaisingInputSourceSummary["capabilities
 function formatMoney(value?: string | null, currency?: string | null) {
   if (!value) return "Balance unavailable";
   const amount = Number(value);
-  if (!Number.isFinite(amount)) return currency ? `${value} ${currency}` : value;
+  if (!Number.isFinite(amount)) return value;
   try {
     return new Intl.NumberFormat("en-AU", {
       style: "currency",
@@ -384,6 +384,19 @@ function XeroPreview({
   syncing: boolean;
   onSync: () => void;
 }) {
+  const previewMetrics = preview
+    ? [
+        { label: "P&L revenue", value: preview.revenue },
+        { label: "Revenue growth", value: preview.revenueGrowthRate },
+        { label: "Burn rate", value: preview.burnRate },
+        { label: "Runway", value: preview.runway },
+        { label: "Invoice revenue", value: preview.invoiceRevenue },
+        { label: "Invoice count", value: preview.invoiceCount },
+        { label: "Customers", value: preview.customerCount },
+        { label: "Recurring invoices", value: preview.recurringInvoiceCount },
+      ].filter((item) => item.value && item.value !== "0")
+    : [];
+
   return (
     <section className="rounded-xl border border-sky-100 bg-white p-6 shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -434,6 +447,17 @@ function XeroPreview({
               {formatMoney(preview.cashCollected, preview.currencies[0] || "AUD")}
             </p>
           </div>
+        </div>
+      ) : null}
+
+      {previewMetrics.length ? (
+        <div className="mt-3 grid gap-3 md:grid-cols-4">
+          {previewMetrics.map((metric) => (
+            <div key={metric.label} className="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+              <p className="text-xs font-bold uppercase tracking-wide text-slate-500">{metric.label}</p>
+              <p className="mt-2 text-sm font-black text-gray-950">{metric.value}</p>
+            </div>
+          ))}
         </div>
       ) : null}
 

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -350,6 +350,14 @@ export interface VibeRaisingXeroPreview {
   tenantId?: string | null;
   lastSyncedAt?: string | null;
   monthlyRecurringRevenue?: string | null;
+  revenue?: string | null;
+  revenueGrowthRate?: string | null;
+  burnRate?: string | null;
+  runway?: string | null;
+  invoiceRevenue?: string | null;
+  invoiceCount?: string | null;
+  customerCount?: string | null;
+  recurringInvoiceCount?: string | null;
   cashCollected?: string | null;
   currencies: string[];
   warnings: string[];


### PR DESCRIPTION
## Summary
- expand Xero preview API types for report-backed and operational metrics
- normalize new Xero preview fields in the frontend client
- display populated Xero accounting metrics in the connect-data preview

## Validation
- bunx tsc --noEmit --pretty false