### PR TITLE
Surface Xero report reconnect state

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -11,6 +11,8 @@ import type {
   VibeRaisingCompany,
   VibeRaisingDraftedContent,
   VibeRaisingEmailDraftMonth,
+  VibeRaisingFinancialSyncResponse,
+  VibeRaisingFinancialSyncRun,
   VibeRaisingGmailMessagePreview,
   VibeRaisingGmailPreview,
   VibeRaisingInputSourceKey,
@@ -326,6 +328,11 @@ function normalizePastMonthSummary(raw: unknown) {
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
     metrics: normalizeMetrics(payload.metrics),
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
@@ -387,6 +394,11 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
     metrics: normalizeMetrics(payload.metrics),
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
@@ -486,6 +498,11 @@ function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | nu
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
     metrics: normalizeMetrics(payload.metrics),
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
@@ -560,6 +577,11 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
   };
 }
 function normalizeStartupUpdateRun(raw: unknown): VibeRaisingStartupUpdateRunSummary | null {
@@ -989,11 +1011,18 @@ function normalizeFinancialSourceSummaries(raw: unknown): Partial<Record<"stripe
       asNullableString(connection.lastError) ??
       asNullableString(connection.last_error) ??
       asNullableString(connection.error);
+    const rawRequiredReportScopes = connection.requiredReportScopes ?? connection.required_report_scopes;
+    const requiredReportScopes = Array.isArray(rawRequiredReportScopes)
+      ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
+      : [];
 
     summaries[provider] = createInputSourceSummary(provider, status, {
       accountLabel,
       lastSyncedAt,
       warning,
+      hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
+      needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
+      requiredReportScopes,
     });
   }
 
@@ -1049,6 +1078,10 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
       typeof connection.selectedProjectCount === "number" && Number.isFinite(connection.selectedProjectCount)
         ? connection.selectedProjectCount
         : Number(connection.selectedProjectCount ?? connection.selected_project_count ?? 0) || 0;
+    const rawRequiredReportScopes = connection.requiredReportScopes ?? connection.required_report_scopes;
+    const requiredReportScopes = Array.isArray(rawRequiredReportScopes)
+      ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
+      : [];
 
     summaries[provider] = createInputSourceSummary(provider, status, {
       accountLabel,
@@ -1057,6 +1090,9 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
       selected,
       selectedChannelCount,
       selectedProjectCount,
+      hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
+      needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
+      requiredReportScopes,
     });
   }
 
@@ -1454,6 +1490,10 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
       "Sales cycle for enterprise is running 6-8 weeks longer than forecast. Hiring a second AE has stalled after two declined offers.",
     asks:
       "Intros to Sydney-based CTOs evaluating internal tooling, and warm leads to senior AEs open to pre-Series A equity.",
+    learnings:
+      "The strongest activation lift came from guided onboarding, not additional dashboard depth.",
+    next30Days:
+      "Convert two enterprise pilots to paid annual agreements. Restart AE hiring with a narrower candidate profile.",
   },
   {
     id: "update-2026-03",
@@ -1476,6 +1516,10 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
       "Churn ticked up to 4.1% as a large cohort from the Q4 promo ended their trial without converting.",
     asks:
       "Feedback on our pricing experiment - considering a usage-based tier for teams under 20 seats.",
+    learnings:
+      "Self-serve teams need clearer usage limits before pricing conversations become productive.",
+    next30Days:
+      "Finish pricing interviews and ship the retention prompts for the Q4 promo cohort.",
   },
   {
     id: "update-2026-02",
@@ -1497,6 +1541,10 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     challenges:
       "Infra costs rose 22% as we scaled the ML inference layer - investigating GPU spot instances.",
     asks: "Intros to AI infra investors who have conviction on vertical SaaS.",
+    learnings:
+      "Healthcare design partners want workflow ownership more than generic model accuracy claims.",
+    next30Days:
+      "Complete the healthcare workflow prototype and benchmark GPU spot savings.",
   },
 ];
 
@@ -1538,6 +1586,8 @@ export async function saveVibeRaisingMonthlyUpdate(
     highlights: string;
     challenges: string;
     asks: string;
+    learnings: string;
+    next30Days: string;
     metrics: Record<string, string>;
     metricSuggestions?: VibeRaisingMetricSuggestion[];
     summary?: string | null;
@@ -1556,7 +1606,12 @@ export async function saveVibeRaisingMonthlyUpdate(
   } catch (error: any) {
     const status = error.response?.status;
     const hasOptionalFields = Boolean(
-      body.summary || body.sourceUrl || body.videoUrl || (body.metricSuggestions || []).length > 0,
+      body.summary ||
+        body.sourceUrl ||
+        body.videoUrl ||
+        body.learnings ||
+        body.next30Days ||
+        (body.metricSuggestions || []).length > 0,
     );
     if (!hasOptionalFields || (status !== 400 && status !== 422)) {
       throw error;
@@ -1568,6 +1623,8 @@ export async function saveVibeRaisingMonthlyUpdate(
       highlights: body.highlights,
       challenges: body.challenges,
       asks: body.asks,
+      learnings: body.learnings,
+      next30Days: body.next30Days,
       metrics: body.metrics,
     });
     return normalizeMonthlyUpdate(response.data?.update ?? response.data);
@@ -1784,8 +1841,8 @@ export function connectVibeRaisingInputSource(
 export async function syncVibeRaisingFinancialSources(
   backendBaseUrl: string,
   providers?: Array<Extract<VibeRaisingInputSourceKey, "stripe" | "xero" | "bank_feed">>,
-): Promise<Record<string, unknown>> {
-  return requestBrowserJson<Record<string, unknown>>(
+): Promise<VibeRaisingFinancialSyncResponse> {
+  const payload = await requestBrowserJson<Record<string, unknown>>(
     backendBaseUrl,
     FINANCIAL_SYNC_PATH,
     {
@@ -1793,6 +1850,40 @@ export async function syncVibeRaisingFinancialSources(
       body: providers?.length ? JSON.stringify({ providers }) : undefined,
     },
   );
+  const runs = collectRawList(payload, ["syncRuns", "sync_runs"])
+    .map(normalizeFinancialSyncRun)
+    .filter((run): run is VibeRaisingFinancialSyncRun => run !== null);
+  return {
+    status: asNullableString(payload.status) ?? "queued",
+    syncRuns: runs,
+  };
+}
+
+function normalizeFinancialSyncRun(raw: unknown): VibeRaisingFinancialSyncRun | null {
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const rawWarnings = payload.metricWarnings ?? payload.metric_warnings;
+  const rawMetricsPublishedCount = payload.metricsPublishedCount ?? payload.metrics_published_count;
+  const metricsPublishedCount =
+    typeof rawMetricsPublishedCount === "number" && Number.isFinite(rawMetricsPublishedCount)
+      ? rawMetricsPublishedCount
+      : Number(rawMetricsPublishedCount ?? 0) || 0;
+  return {
+    provider:
+      asNullableString(payload.provider) ??
+      asNullableString(payload.source) ??
+      "unknown",
+    status: asNullableString(payload.status) ?? "queued",
+    error:
+      asNullableString(payload.error) ??
+      asNullableString(payload.detail),
+    hasReportScope: asBoolean(payload.hasReportScope ?? payload.has_report_scope),
+    needsReportReconnect: asBoolean(payload.needsReportReconnect ?? payload.needs_report_reconnect),
+    metricsPublishedCount,
+    metricWarnings: Array.isArray(rawWarnings)
+      ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
+      : [],
+  };
 }
 
 export async function syncVibeRaisingInputSources(
@@ -2453,6 +2544,7 @@ export async function getVibeRaisingXeroPreview(
     .filter((value): value is VibeRaisingXeroRecord => value !== null);
   const rawCurrencies = payload.currencies;
   const rawWarnings = payload.warnings;
+  const rawRequiredReportScopes = payload.requiredReportScopes ?? payload.required_report_scopes;
   return {
     tenantLabel:
       asNullableString(payload.tenantLabel) ??
@@ -2505,6 +2597,11 @@ export async function getVibeRaisingXeroPreview(
       : [],
     warnings: Array.isArray(rawWarnings)
       ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
+      : [],
+    hasReportScope: asBoolean(payload.hasReportScope ?? payload.has_report_scope),
+    needsReportReconnect: asBoolean(payload.needsReportReconnect ?? payload.needs_report_reconnect),
+    requiredReportScopes: Array.isArray(rawRequiredReportScopes)
+      ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
       : [],
     recurringInvoices,
     recentInvoices,

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -377,12 +377,14 @@ function XeroPreview({
   error,
   syncing,
   onSync,
+  reconnectHref,
 }: {
   preview: VibeRaisingXeroPreview | null;
   loading: boolean;
   error: string | null;
   syncing: boolean;
   onSync: () => void;
+  reconnectHref?: string | null;
 }) {
   const previewMetrics = preview
     ? [
@@ -416,11 +418,25 @@ function XeroPreview({
               Loading
             </span>
           ) : null}
+          {preview?.needsReportReconnect && reconnectHref ? (
+            <a
+              href={reconnectHref}
+              className="inline-flex items-center gap-2 rounded-lg bg-sky-600 px-3 py-2 text-xs font-extrabold text-white transition hover:bg-sky-700"
+            >
+              <LinkIcon className="h-4 w-4" />
+              Reconnect Xero
+            </a>
+          ) : null}
           <button
             type="button"
             onClick={onSync}
             disabled={syncing}
-            className="inline-flex items-center gap-2 rounded-lg border border-sky-100 px-3 py-2 text-xs font-extrabold text-sky-700 transition hover:bg-sky-50 disabled:cursor-not-allowed disabled:opacity-60"
+            className={clsx(
+              "inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-extrabold transition disabled:cursor-not-allowed disabled:opacity-60",
+              preview?.needsReportReconnect
+                ? "border-gray-200 text-slate-600 hover:bg-gray-50"
+                : "border-sky-100 text-sky-700 hover:bg-sky-50",
+            )}
           >
             <ArrowPathIcon className={clsx("h-4 w-4", syncing && "animate-spin")} />
             {syncing ? "Syncing" : "Sync Xero"}
@@ -1767,8 +1783,33 @@ export default function ConnectData() {
     setSyncingFinance(true);
     setStatusMessage(null);
     try {
-      await syncVibeRaisingFinancialSources(backendBaseUrl, providers);
+      const response = await syncVibeRaisingFinancialSources(backendBaseUrl, providers);
       await refreshStatuses();
+      if (!providers?.length || providers.includes("xero")) {
+        setLoadingXeroPreview(true);
+        setXeroPreviewError(null);
+        try {
+          setXeroPreview(await getVibeRaisingXeroPreview(backendBaseUrl));
+        } catch (previewError) {
+          setXeroPreviewError(previewError instanceof Error ? previewError.message : "We couldn't load Xero preview.");
+        } finally {
+          setLoadingXeroPreview(false);
+        }
+      }
+      const xeroRun = response.syncRuns.find((run) => run.provider === "xero");
+      if (xeroRun?.needsReportReconnect) {
+        setStatusMessage("Xero invoices and payments synced. Reconnect Xero to allow Profit and Loss and Balance Sheet report metrics.");
+      } else if (xeroRun?.metricWarnings.length) {
+        setStatusMessage(xeroRun.metricWarnings[0]);
+      } else if (xeroRun?.status === "synced") {
+        setStatusMessage(
+          xeroRun.metricsPublishedCount && xeroRun.metricsPublishedCount > 0
+            ? "Xero synced, including Profit and Loss and Balance Sheet metrics."
+            : "Xero synced.",
+        );
+      } else if (response.status === "synced") {
+        setStatusMessage("Financial sources synced.");
+      }
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : "We couldn't start the financial sync.");
     } finally {
@@ -2281,6 +2322,7 @@ export default function ConnectData() {
           error={xeroPreviewError}
           syncing={syncingFinance}
           onSync={() => void handleSyncFinance(["xero"])}
+          reconnectHref={connectVibeRaisingInputSource(backendBaseUrl, "xero", currentReturnPath)}
         />
       ) : null}
 

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -226,6 +226,8 @@ export async function action({ request, context }: Route.ActionArgs) {
             highlights: String(formData.get("highlights") || ""),
             challenges: String(formData.get("challenges") || ""),
             asks: String(formData.get("asks") || ""),
+            learnings: String(formData.get("learnings") || ""),
+            next30Days: String(formData.get("next30Days") || ""),
             metrics,
             metricSuggestions,
         });

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -40,6 +40,8 @@ export interface VibeRaisingPastMonthSummary {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
   metrics?: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
 }
@@ -63,6 +65,8 @@ export interface VibeRaisingDraftedContent {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
   pastMonths: VibeRaisingPastMonthSummary[];
   metrics?: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
@@ -88,6 +92,8 @@ export interface VibeRaisingMonthlyUpdate {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
 }
 
 export interface VibeRaisingVideoUploadResponse {
@@ -152,6 +158,24 @@ export interface VibeRaisingInputSourceSummary {
   warning?: string | null;
   selectedChannelCount?: number;
   selectedProjectCount?: number;
+  hasReportScope?: boolean;
+  needsReportReconnect?: boolean;
+  requiredReportScopes?: string[];
+}
+
+export interface VibeRaisingFinancialSyncRun {
+  provider: string;
+  status: string;
+  error?: string | null;
+  hasReportScope?: boolean;
+  needsReportReconnect?: boolean;
+  metricsPublishedCount?: number;
+  metricWarnings: string[];
+}
+
+export interface VibeRaisingFinancialSyncResponse {
+  status: string;
+  syncRuns: VibeRaisingFinancialSyncRun[];
 }
 
 export interface VibeRaisingInputSourcesStatusResponse {
@@ -373,6 +397,9 @@ export interface VibeRaisingXeroPreview {
   cashCollected?: string | null;
   currencies: string[];
   warnings: string[];
+  hasReportScope: boolean;
+  needsReportReconnect: boolean;
+  requiredReportScopes: string[];
   recurringInvoices: VibeRaisingXeroRecord[];
   recentInvoices: VibeRaisingXeroRecord[];
 }
@@ -445,6 +472,8 @@ export interface VibeRaisingEmailDraftMonth {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
   metrics?: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
 }


### PR DESCRIPTION
## Summary\n- parse Xero report-scope state from connector status, sync, and preview responses\n- show Reconnect Xero as the primary CTA when report scope is missing\n- reload Xero preview after sync and surface meaningful sync warnings\n\n## Tests\n- bun run typecheck\n- bun run build