### PR TITLE
[codex] Add selected month update generation UI

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -23,6 +23,7 @@ import type {
   VibeRaisingLinearProjectPreview,
   VibeRaisingLinearProjectsResponse,
   VibeRaisingLinearProjectUpdatePreview,
+  VibeRaisingMetricSuggestion,
   VibeRaisingMonthlyUpdate,
   VibeRaisingProfile,
   VibeRaisingRole,
@@ -287,6 +288,28 @@ function normalizeMetrics(raw: unknown): Record<string, string> {
   return metrics;
 }
 
+function normalizeMetricSuggestions(raw: unknown): VibeRaisingMetricSuggestion[] {
+  if (!Array.isArray(raw)) return [];
+
+  const suggestions: VibeRaisingMetricSuggestion[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const payload = item as Record<string, unknown>;
+    const metricKey =
+      asNullableString(payload.metricKey) ??
+      asNullableString(payload.metric_key);
+    if (!metricKey || seen.has(metricKey)) continue;
+    seen.add(metricKey);
+    suggestions.push({
+      metricKey,
+      label: asNullableString(payload.label) ?? metricKey,
+      reason: asNullableString(payload.reason) ?? undefined,
+    });
+  }
+  return suggestions;
+}
+
 function asNullableNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string" && value.trim()) {
@@ -304,6 +327,9 @@ function normalizePastMonthSummary(raw: unknown) {
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
     metrics: normalizeMetrics(payload.metrics),
+    metricSuggestions: normalizeMetricSuggestions(
+      payload.metricSuggestions ?? payload.metric_suggestions,
+    ),
   };
 }
 
@@ -362,6 +388,9 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
     metrics: normalizeMetrics(payload.metrics),
+    metricSuggestions: normalizeMetricSuggestions(
+      payload.metricSuggestions ?? payload.metric_suggestions,
+    ),
     pastMonths: Array.isArray(payload.pastMonths)
       ? payload.pastMonths.map(normalizePastMonthSummary)
       : [],
@@ -458,6 +487,9 @@ function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | nu
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
     metrics: normalizeMetrics(payload.metrics),
+    metricSuggestions: normalizeMetricSuggestions(
+      payload.metricSuggestions ?? payload.metric_suggestions,
+    ),
   };
 }
 
@@ -522,6 +554,9 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
       asNullableString(payload.videoOriginalFilename) ??
       asNullableString(payload.video_original_filename),
     metrics: normalizeMetrics(payload.metrics),
+    metricSuggestions: normalizeMetricSuggestions(
+      payload.metricSuggestions ?? payload.metric_suggestions,
+    ),
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
@@ -1504,6 +1539,7 @@ export async function saveVibeRaisingMonthlyUpdate(
     challenges: string;
     asks: string;
     metrics: Record<string, string>;
+    metricSuggestions?: VibeRaisingMetricSuggestion[];
     summary?: string | null;
     sourceUrl?: string | null;
     videoUrl?: string | null;
@@ -1519,7 +1555,9 @@ export async function saveVibeRaisingMonthlyUpdate(
     return normalizeMonthlyUpdate(response.data?.update ?? response.data);
   } catch (error: any) {
     const status = error.response?.status;
-    const hasOptionalFields = Boolean(body.summary || body.sourceUrl || body.videoUrl);
+    const hasOptionalFields = Boolean(
+      body.summary || body.sourceUrl || body.videoUrl || (body.metricSuggestions || []).length > 0,
+    );
     if (!hasOptionalFields || (status !== 400 && status !== 422)) {
       throw error;
     }

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -11,6 +11,8 @@ import type {
   VibeRaisingCompany,
   VibeRaisingDraftedContent,
   VibeRaisingEmailDraftMonth,
+  VibeRaisingFinancialSyncResponse,
+  VibeRaisingFinancialSyncRun,
   VibeRaisingGmailMessagePreview,
   VibeRaisingGmailPreview,
   VibeRaisingInputSourceKey,
@@ -326,6 +328,11 @@ function normalizePastMonthSummary(raw: unknown) {
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
     metrics: normalizeMetrics(payload.metrics),
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
@@ -387,6 +394,11 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
     metrics: normalizeMetrics(payload.metrics),
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
@@ -486,6 +498,11 @@ function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | nu
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
     metrics: normalizeMetrics(payload.metrics),
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
@@ -560,6 +577,11 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
+    learnings: asNullableString(payload.learnings) ?? "",
+    next30Days:
+      asNullableString(payload.next30Days) ??
+      asNullableString(payload.next_30_days) ??
+      "",
   };
 }
 function normalizeStartupUpdateRun(raw: unknown): VibeRaisingStartupUpdateRunSummary | null {
@@ -586,6 +608,10 @@ function normalizeStartupUpdateRun(raw: unknown): VibeRaisingStartupUpdateRunSum
     currentStep:
       asNullableString(payload.currentStep) ??
       asNullableString(payload.current_step),
+    targetMonth:
+      asNullableString(payload.targetMonth) ??
+      asNullableString(payload.target_month) ??
+      null,
     stepOrder: Array.isArray(payload.stepOrder ?? payload.step_order)
       ? ((payload.stepOrder ?? payload.step_order) as unknown[]).map((item: unknown) => String(item))
       : [],
@@ -788,6 +814,11 @@ function normalizeStartupUpdateProgress(
       payload.generatedDraftMonths ??
         payload.generated_draft_months,
     ),
+    targetMonth:
+      asNullableString(payload.targetMonth) ??
+      asNullableString(payload.target_month) ??
+      run?.targetMonth ??
+      null,
   };
 }
 
@@ -989,11 +1020,18 @@ function normalizeFinancialSourceSummaries(raw: unknown): Partial<Record<"stripe
       asNullableString(connection.lastError) ??
       asNullableString(connection.last_error) ??
       asNullableString(connection.error);
+    const rawRequiredReportScopes = connection.requiredReportScopes ?? connection.required_report_scopes;
+    const requiredReportScopes = Array.isArray(rawRequiredReportScopes)
+      ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
+      : [];
 
     summaries[provider] = createInputSourceSummary(provider, status, {
       accountLabel,
       lastSyncedAt,
       warning,
+      hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
+      needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
+      requiredReportScopes,
     });
   }
 
@@ -1049,6 +1087,10 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
       typeof connection.selectedProjectCount === "number" && Number.isFinite(connection.selectedProjectCount)
         ? connection.selectedProjectCount
         : Number(connection.selectedProjectCount ?? connection.selected_project_count ?? 0) || 0;
+    const rawRequiredReportScopes = connection.requiredReportScopes ?? connection.required_report_scopes;
+    const requiredReportScopes = Array.isArray(rawRequiredReportScopes)
+      ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
+      : [];
 
     summaries[provider] = createInputSourceSummary(provider, status, {
       accountLabel,
@@ -1057,6 +1099,9 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
       selected,
       selectedChannelCount,
       selectedProjectCount,
+      hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
+      needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
+      requiredReportScopes,
     });
   }
 
@@ -1177,6 +1222,24 @@ function normalizeStartupUpdateStatus(
         payload.generated_draft_months ??
         progress?.generatedDraftMonths ??
         [],
+    ),
+    targetMonth:
+      asNullableString(payload.targetMonth) ??
+      asNullableString(payload.target_month) ??
+      progress?.targetMonth ??
+      run?.targetMonth ??
+      null,
+    requestedTargetMonth:
+      asNullableString(payload.requestedTargetMonth) ??
+      asNullableString(payload.requested_target_month) ??
+      null,
+    activeTargetMonth:
+      asNullableString(payload.activeTargetMonth) ??
+      asNullableString(payload.active_target_month) ??
+      null,
+    targetMonthConflict: Boolean(
+      payload.targetMonthConflict ??
+        payload.target_month_conflict,
     ),
     reusedExistingRun: Boolean(
       payload.reusedExistingRun ??
@@ -1454,6 +1517,10 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
       "Sales cycle for enterprise is running 6-8 weeks longer than forecast. Hiring a second AE has stalled after two declined offers.",
     asks:
       "Intros to Sydney-based CTOs evaluating internal tooling, and warm leads to senior AEs open to pre-Series A equity.",
+    learnings:
+      "The strongest activation lift came from guided onboarding, not additional dashboard depth.",
+    next30Days:
+      "Convert two enterprise pilots to paid annual agreements. Restart AE hiring with a narrower candidate profile.",
   },
   {
     id: "update-2026-03",
@@ -1476,6 +1543,10 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
       "Churn ticked up to 4.1% as a large cohort from the Q4 promo ended their trial without converting.",
     asks:
       "Feedback on our pricing experiment - considering a usage-based tier for teams under 20 seats.",
+    learnings:
+      "Self-serve teams need clearer usage limits before pricing conversations become productive.",
+    next30Days:
+      "Finish pricing interviews and ship the retention prompts for the Q4 promo cohort.",
   },
   {
     id: "update-2026-02",
@@ -1497,6 +1568,10 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     challenges:
       "Infra costs rose 22% as we scaled the ML inference layer - investigating GPU spot instances.",
     asks: "Intros to AI infra investors who have conviction on vertical SaaS.",
+    learnings:
+      "Healthcare design partners want workflow ownership more than generic model accuracy claims.",
+    next30Days:
+      "Complete the healthcare workflow prototype and benchmark GPU spot savings.",
   },
 ];
 
@@ -1538,6 +1613,8 @@ export async function saveVibeRaisingMonthlyUpdate(
     highlights: string;
     challenges: string;
     asks: string;
+    learnings: string;
+    next30Days: string;
     metrics: Record<string, string>;
     metricSuggestions?: VibeRaisingMetricSuggestion[];
     summary?: string | null;
@@ -1556,7 +1633,12 @@ export async function saveVibeRaisingMonthlyUpdate(
   } catch (error: any) {
     const status = error.response?.status;
     const hasOptionalFields = Boolean(
-      body.summary || body.sourceUrl || body.videoUrl || (body.metricSuggestions || []).length > 0,
+      body.summary ||
+        body.sourceUrl ||
+        body.videoUrl ||
+        body.learnings ||
+        body.next30Days ||
+        (body.metricSuggestions || []).length > 0,
     );
     if (!hasOptionalFields || (status !== 400 && status !== 422)) {
       throw error;
@@ -1568,6 +1650,8 @@ export async function saveVibeRaisingMonthlyUpdate(
       highlights: body.highlights,
       challenges: body.challenges,
       asks: body.asks,
+      learnings: body.learnings,
+      next30Days: body.next30Days,
       metrics: body.metrics,
     });
     return normalizeMonthlyUpdate(response.data?.update ?? response.data);
@@ -1784,8 +1868,8 @@ export function connectVibeRaisingInputSource(
 export async function syncVibeRaisingFinancialSources(
   backendBaseUrl: string,
   providers?: Array<Extract<VibeRaisingInputSourceKey, "stripe" | "xero" | "bank_feed">>,
-): Promise<Record<string, unknown>> {
-  return requestBrowserJson<Record<string, unknown>>(
+): Promise<VibeRaisingFinancialSyncResponse> {
+  const payload = await requestBrowserJson<Record<string, unknown>>(
     backendBaseUrl,
     FINANCIAL_SYNC_PATH,
     {
@@ -1793,6 +1877,40 @@ export async function syncVibeRaisingFinancialSources(
       body: providers?.length ? JSON.stringify({ providers }) : undefined,
     },
   );
+  const runs = collectRawList(payload, ["syncRuns", "sync_runs"])
+    .map(normalizeFinancialSyncRun)
+    .filter((run): run is VibeRaisingFinancialSyncRun => run !== null);
+  return {
+    status: asNullableString(payload.status) ?? "queued",
+    syncRuns: runs,
+  };
+}
+
+function normalizeFinancialSyncRun(raw: unknown): VibeRaisingFinancialSyncRun | null {
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const rawWarnings = payload.metricWarnings ?? payload.metric_warnings;
+  const rawMetricsPublishedCount = payload.metricsPublishedCount ?? payload.metrics_published_count;
+  const metricsPublishedCount =
+    typeof rawMetricsPublishedCount === "number" && Number.isFinite(rawMetricsPublishedCount)
+      ? rawMetricsPublishedCount
+      : Number(rawMetricsPublishedCount ?? 0) || 0;
+  return {
+    provider:
+      asNullableString(payload.provider) ??
+      asNullableString(payload.source) ??
+      "unknown",
+    status: asNullableString(payload.status) ?? "queued",
+    error:
+      asNullableString(payload.error) ??
+      asNullableString(payload.detail),
+    hasReportScope: asBoolean(payload.hasReportScope ?? payload.has_report_scope),
+    needsReportReconnect: asBoolean(payload.needsReportReconnect ?? payload.needs_report_reconnect),
+    metricsPublishedCount,
+    metricWarnings: Array.isArray(rawWarnings)
+      ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
+      : [],
+  };
 }
 
 export async function syncVibeRaisingInputSources(
@@ -2453,6 +2571,7 @@ export async function getVibeRaisingXeroPreview(
     .filter((value): value is VibeRaisingXeroRecord => value !== null);
   const rawCurrencies = payload.currencies;
   const rawWarnings = payload.warnings;
+  const rawRequiredReportScopes = payload.requiredReportScopes ?? payload.required_report_scopes;
   return {
     tenantLabel:
       asNullableString(payload.tenantLabel) ??
@@ -2506,6 +2625,11 @@ export async function getVibeRaisingXeroPreview(
     warnings: Array.isArray(rawWarnings)
       ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
       : [],
+    hasReportScope: asBoolean(payload.hasReportScope ?? payload.has_report_scope),
+    needsReportReconnect: asBoolean(payload.needsReportReconnect ?? payload.needs_report_reconnect),
+    requiredReportScopes: Array.isArray(rawRequiredReportScopes)
+      ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
+      : [],
     recurringInvoices,
     recentInvoices,
   };
@@ -2513,11 +2637,20 @@ export async function getVibeRaisingXeroPreview(
 
 export async function runVibeRaisingStartupUpdate(
   backendBaseUrl: string,
-  options?: { forceRegenerate?: boolean; inputSources?: VibeRaisingInputSourceKey[] },
+  options?: {
+    forceRegenerate?: boolean;
+    inputSources?: VibeRaisingInputSourceKey[];
+    targetMonth?: string | null;
+  },
 ): Promise<VibeRaisingStartupUpdateStatusResponse> {
   const body: Record<string, unknown> = {};
   if (options?.forceRegenerate) {
     body.forceRegenerate = true;
+  }
+  const targetMonth = String(options?.targetMonth || "").trim();
+  if (targetMonth) {
+    body.targetMonth = targetMonth;
+    body.target_month = targetMonth;
   }
   const inputSources = Array.from(new Set(options?.inputSources ?? []));
   if (inputSources.length > 0) {

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -111,6 +111,19 @@ function getMonthlyUpdateKey(month: string, year: number | string) {
     return `${parsedYear}-${String(monthIndex + 1).padStart(2, "0")}`;
 }
 
+function getMonthlyUpdateIsoMonth(month: string, year: number | string) {
+    const key = getMonthlyUpdateKey(month, year);
+    return key ? `${key}-01` : "";
+}
+
+function isFutureMonthlyUpdate(month: string, year: number | string) {
+    const monthIndex = VIBE_RAISING_MONTH_OPTIONS.findIndex((option) => option.name === month);
+    const parsedYear = Number(year);
+    if (monthIndex < 0 || !Number.isFinite(parsedYear)) return true;
+    const now = new Date();
+    return parsedYear > now.getFullYear() || (parsedYear === now.getFullYear() && monthIndex > now.getMonth());
+}
+
 function getMonthlyUpdateStorageKey(update: VibeRaisingMonthlyUpdate) {
     const isoMonth = String(update.isoMonth || "").trim();
     const isoMatch = isoMonth.match(/^(\d{4})-(\d{2})/);
@@ -152,7 +165,9 @@ export async function loader({ request, context }: Route.LoaderArgs) {
             activeUsers: "3420",
             highlights: "Closed 3 new enterprise deals with Fortune 500 companies totaling $75K ARR. Launched new dashboard feature which increased user engagement by 32%. Featured in TechCrunch - drove 1,200+ signups. Team grew to 8 people with new Head of Sales joining.",
             challenges: "Customer onboarding time is averaging 14 days vs target of 7 days. Need to streamline our implementation process. CAC increased to $850 this month due to increased competition in paid channels.",
-            asks: "Looking for introductions to VP of Customer Success at B2B SaaS companies to help optimize our onboarding process. Would appreciate feedback on our pricing strategy as we move upmarket."
+            asks: "Looking for introductions to VP of Customer Success at B2B SaaS companies to help optimize our onboarding process. Would appreciate feedback on our pricing strategy as we move upmarket.",
+            learnings: "Enterprise buyers care most about implementation speed once the security review is complete.",
+            next30Days: "Reduce onboarding time to 10 days and close two more enterprise pilots."
         };
     }
 
@@ -226,6 +241,8 @@ export async function action({ request, context }: Route.ActionArgs) {
             highlights: String(formData.get("highlights") || ""),
             challenges: String(formData.get("challenges") || ""),
             asks: String(formData.get("asks") || ""),
+            learnings: String(formData.get("learnings") || ""),
+            next30Days: String(formData.get("next30Days") || ""),
             metrics,
             metricSuggestions,
         });
@@ -964,6 +981,16 @@ const SECTION_HINTS: Record<string, string[]> = {
         "e.g. Churn rate increased from 3% to 5% this month.",
         "e.g. Struggling to close enterprise deals over $50K.",
     ],
+    learnings: [
+        "e.g. Enterprise buyers care most about security posture before pricing.",
+        "e.g. Founder-led demos convert better when the problem is framed by workflow.",
+        "e.g. Smaller customers need onboarding templates before they expand usage.",
+    ],
+    next30Days: [
+        "e.g. Convert two pilots into paid annual agreements.",
+        "e.g. Ship the onboarding checklist and measure activation lift.",
+        "e.g. Complete 12 customer interviews before pricing changes.",
+    ],
     asks: [
         "e.g. Intros to VP of Customer Success at B2B SaaS companies.",
         "e.g. Feedback on our pricing strategy for enterprise tier.",
@@ -1228,7 +1255,7 @@ function CollapsibleFeedback({ icon, headline, color, children }: { icon: React.
 }
 
 // Collapsible past month card for investor preview
-function PastMonthPreviewCard({ pm }: { pm: { month: string; highlights: string; challenges: string; asks: string; metrics: Record<string, string> } }) {
+function PastMonthPreviewCard({ pm }: { pm: { month: string; highlights: string; challenges: string; asks: string; learnings: string; next30Days: string; metrics: Record<string, string> } }) {
     const [open, setOpen] = useState(false);
     return (
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
@@ -1307,6 +1334,24 @@ function PastMonthPreviewCard({ pm }: { pm: { month: string; highlights: string;
                                 <BulletList text={pm.challenges} className="text-xs text-gray-600" />
                             </div>
                         )}
+                        {pm.learnings && (
+                            <div>
+                                <h5 className="text-[10px] font-bold text-gray-900 uppercase tracking-wide mb-1 flex items-center gap-1">
+                                    <LightBulbIcon className="w-3 h-3 text-amber-500" />
+                                    Learnings
+                                </h5>
+                                <BulletList text={pm.learnings} className="text-xs text-gray-600" />
+                            </div>
+                        )}
+                        {pm.next30Days && (
+                            <div>
+                                <h5 className="text-[10px] font-bold text-gray-900 uppercase tracking-wide mb-1 flex items-center gap-1">
+                                    <ArrowRightIcon className="w-3 h-3 text-blue-500" />
+                                    Next 30 Days
+                                </h5>
+                                <BulletList text={pm.next30Days} className="text-xs text-gray-600" />
+                            </div>
+                        )}
                         {pm.asks && (
                             <div>
                                 <h5 className="text-[10px] font-bold text-gray-900 uppercase tracking-wide mb-1 flex items-center gap-1">
@@ -1342,6 +1387,17 @@ interface ChartData {
     isCurrent?: boolean;
     isSelected?: boolean;
 }
+
+type EditorMonthCard = {
+    month: string;
+    expanded: boolean;
+    highlights: string;
+    challenges: string;
+    asks: string;
+    learnings: string;
+    next30Days: string;
+    metrics: Record<string, string>;
+};
 
 function parseRevenue(raw: string): number {
     return parseInt(String(raw).replace(/[$,\s]/g, "")) || 0;
@@ -1543,14 +1599,9 @@ export default function CreateUpdate() {
     const [highlights, setHighlights] = useState<string>(defaultData?.highlights || "");
     const [challenges, setChallenges] = useState<string>(defaultData?.challenges || "");
     const [asks, setAsks] = useState<string>(defaultData?.asks || "");
-    const [pastMonthCards, setPastMonthCards] = useState<Array<{
-        month: string;
-        expanded: boolean;
-        highlights: string;
-        challenges: string;
-        asks: string;
-        metrics: Record<string, string>;
-    }>>([]);
+    const [learnings, setLearnings] = useState<string>(defaultData?.learnings || "");
+    const [next30Days, setNext30Days] = useState<string>(defaultData?.next30Days || "");
+    const [pastMonthCards, setPastMonthCards] = useState<EditorMonthCard[]>([]);
     const [expandedCards, setExpandedCards] = useState<Set<number>>(new Set());
 
     const [selectedMonth, setSelectedMonth] = useState<string>(defaultData?.month || "February");
@@ -1558,6 +1609,8 @@ export default function CreateUpdate() {
     const [activePeriodKey, setActivePeriodKey] = useState("current");
     const selectedMonthTheme = getVibeRaisingMonthTheme(selectedMonth);
     const selectedMonthUpdateKey = getMonthlyUpdateKey(selectedMonth, selectedYear);
+    const targetMonthIso = getMonthlyUpdateIsoMonth(selectedMonth, selectedYear);
+    const isSelectedMonthInFuture = isFutureMonthlyUpdate(selectedMonth, selectedYear);
     const existingUpdateForSelectedMonth = existingMonthlyUpdates.find(
         (update) => getMonthlyUpdateStorageKey(update) === selectedMonthUpdateKey,
     );
@@ -1603,6 +1656,8 @@ export default function CreateUpdate() {
     const videoUploadAbortRef = useRef<AbortController | null>(null);
     const videoUploadSequenceRef = useRef(0);
     const videoPreviewObjectUrlRef = useRef<string | null>(null);
+    const loadedExistingUpdateKeyRef = useRef<string | null>(null);
+    const editorMonthKeyRef = useRef<string>(selectedMonthUpdateKey);
 
     const handleDraftComplete = (data: any) => {
         setActivePeriodKey("current");
@@ -1611,6 +1666,8 @@ export default function CreateUpdate() {
         setHighlights(data.highlights);
         setChallenges(data.challenges);
         setAsks(data.asks || "");
+        setLearnings(data.learnings || "");
+        setNext30Days(data.next30Days || "");
         setSummary(data.summary || "");
         setSourceUrl(data.sourceUrl || data.source_url || "");
         if (data.videoUrl || data.video_url) {
@@ -1630,9 +1687,12 @@ export default function CreateUpdate() {
         setPastMonthCards((data.pastMonths || []).map((pm: any) => ({
             ...pm,
             month: pm.month || "Unknown",
+            expanded: Boolean(pm.expanded),
             highlights: pm.highlights || "",
             challenges: pm.challenges || "",
             asks: pm.asks || "",
+            learnings: pm.learnings || "",
+            next30Days: pm.next30Days || "",
             metrics: {
                 ...Object.fromEntries(metricKeysFromSuggestions(pm.metricSuggestions).map((key) => [key, ""])),
                 ...(pm.metrics || {}),
@@ -1848,6 +1908,14 @@ export default function CreateUpdate() {
             persistEmailDraftRun(statusResponse);
         }
 
+        if (statusResponse.targetMonthConflict) {
+            startTransition(() => {
+                setEmailDraftStatus(statusResponse);
+                setEmailDraftUiError(statusResponse.error ?? "Another monthly update is already generating.");
+            });
+            return;
+        }
+
         if (statusResponse.state === "queued" || statusResponse.state === "running") {
             startTransition(() => {
                 setEmailDraftStatus(statusResponse);
@@ -1918,6 +1986,7 @@ export default function CreateUpdate() {
                 {
                     ...(shouldForceRegenerate ? { forceRegenerate: true } : {}),
                     inputSources: selectedInputSources,
+                    targetMonth: targetMonthIso,
                 },
             );
             emailDraftIgnoredRunIdRef.current = null;
@@ -1938,11 +2007,15 @@ export default function CreateUpdate() {
         } finally {
             setEmailDraftActionBusy(false);
         }
-    }, [backendBaseUrl, emailDraftForceRegenerateKey, selectedInputSources]);
+    }, [backendBaseUrl, emailDraftForceRegenerateKey, selectedInputSources, targetMonthIso]);
 
     const startDraftFromSelectedInputs = useCallback(async (options?: { forceRegenerate?: boolean }) => {
         if (!canGenerateDraftFromEmail) {
             navigate("/founder-tools/companies");
+            return;
+        }
+        if (isSelectedMonthInFuture || !targetMonthIso) {
+            setEmailDraftUiError("Choose the current month or a previous month before generating an update.");
             return;
         }
 
@@ -1967,7 +2040,15 @@ export default function CreateUpdate() {
         } finally {
             setEmailDraftActionBusy(false);
         }
-    }, [backendBaseUrl, canGenerateDraftFromEmail, navigate, selectedInputSources, startOrResumeEmailDraft]);
+    }, [
+        backendBaseUrl,
+        canGenerateDraftFromEmail,
+        isSelectedMonthInFuture,
+        navigate,
+        selectedInputSources,
+        startOrResumeEmailDraft,
+        targetMonthIso,
+    ]);
 
     const executeDraftRequest = useCallback((request?: { forceRegenerate?: boolean; clearPersistedRun?: boolean }) => {
         if (request?.clearPersistedRun) {
@@ -2126,6 +2207,55 @@ export default function CreateUpdate() {
     ]);
 
     const isEmailDraftBusy = isEmailDraftRunning(emailDraftStatus);
+    useEffect(() => {
+        if (isEmailDraftBusy) return;
+
+        if (!existingUpdateForSelectedMonth) {
+            loadedExistingUpdateKeyRef.current = null;
+            if (editorMonthKeyRef.current !== selectedMonthUpdateKey) {
+                editorMonthKeyRef.current = selectedMonthUpdateKey;
+                setSummary("");
+                setSourceUrl("");
+                resetVideoUpload();
+                setHighlights("");
+                setChallenges("");
+                setAsks("");
+                setLearnings("");
+                setNext30Days("");
+                setMetricValues({});
+                setSelectedMetrics(new Set());
+                setPastMonthCards([]);
+                setExpandedCards(new Set());
+                setActivePeriodKey("current");
+            }
+            return;
+        }
+        if (loadedExistingUpdateKeyRef.current === selectedMonthUpdateKey) return;
+        loadedExistingUpdateKeyRef.current = selectedMonthUpdateKey;
+        editorMonthKeyRef.current = selectedMonthUpdateKey;
+
+        setSummary(existingUpdateForSelectedMonth.summary || "");
+        setSourceUrl(existingUpdateForSelectedMonth.sourceUrl || "");
+        setUploadedVideoUrl(existingUpdateForSelectedMonth.videoUrl || "");
+        setVideoPreviewUrl(existingUpdateForSelectedMonth.videoUrl || null);
+        setVideoStoragePath(existingUpdateForSelectedMonth.videoStoragePath || "");
+        setVideoContentType(existingUpdateForSelectedMonth.videoContentType || "");
+        setVideoFileSizeBytes(existingUpdateForSelectedMonth.videoFileSizeBytes || null);
+        setVideoOriginalFilename(existingUpdateForSelectedMonth.videoOriginalFilename || "");
+        setPreviewMediaKind(existingUpdateForSelectedMonth.videoUrl ? "video" : null);
+        setVideoUploadStatus(existingUpdateForSelectedMonth.videoUrl ? "ready" : "idle");
+        setVideoUploadError(null);
+        setHighlights(existingUpdateForSelectedMonth.highlights || "");
+        setChallenges(existingUpdateForSelectedMonth.challenges || "");
+        setAsks(existingUpdateForSelectedMonth.asks || "");
+        setLearnings(existingUpdateForSelectedMonth.learnings || "");
+        setNext30Days(existingUpdateForSelectedMonth.next30Days || "");
+        const nextMetrics = existingUpdateForSelectedMonth.metrics || {};
+        setMetricValues(nextMetrics);
+        setSelectedMetrics(new Set(Object.keys(nextMetrics).filter((key) => METRIC_OPTION_MAP.has(key))));
+        setActivePeriodKey("current");
+    }, [existingUpdateForSelectedMonth, isEmailDraftBusy, resetVideoUpload, selectedMonthUpdateKey]);
+
     const emailDraftCardVisible =
         isEmailDraftBusy ||
         emailDraftStatus?.state === "failed" ||
@@ -2162,13 +2292,16 @@ export default function CreateUpdate() {
         isEmailDraftBusy && emailDraftStatus?.state !== "failed"
             ? emailDraftUiError
             : null;
+    const selectedMonthGenerationVerb = existingUpdateForSelectedMonth ? "Regenerate" : "Generate";
     const emailDraftButtonTitle = emailDraftActionBusy
-        ? "Checking selected inputs..."
-        : "Generate update from selected inputs";
+        ? `Generating ${selectedMonthLabel} update`
+        : `${selectedMonthGenerationVerb} ${selectedMonthLabel} update`;
     const emailDraftButtonDescription = emailDraftActionBusy
         ? "Contacting the MLAI backend and preparing the selected sources for drafting."
+        : isSelectedMonthInFuture
+            ? "Choose the current month or a previous month. Future monthly updates can be drafted once that month starts."
         : canGenerateDraftFromEmail
-            ? `Use ${selectedInputSourceDescription} to find key signals, metrics, wins, and asks, then turn them into a first draft.`
+            ? `Use ${selectedInputSourceDescription} to find key signals, metrics, wins, and asks for ${selectedMonthLabel}, then turn them into a first draft.`
             : "Add a company domain first so inputs can be matched to the right startup.";
     const isVideoUploadPending = videoUploadStatus === "validating" ||
         videoUploadStatus === "compressing" ||
@@ -2352,6 +2485,8 @@ export default function CreateUpdate() {
             setHighlights(draft.highlights || "");
             setChallenges(draft.challenges || "");
             setAsks(draft.asks || "");
+            setLearnings(draft.learnings || "");
+            setNext30Days(draft.next30Days || "");
 
             // Restore current month metrics
             const metrics: Record<string, string> = {};
@@ -2370,11 +2505,7 @@ export default function CreateUpdate() {
             setSelectedMetrics(newSelected);
 
             // Reconstruct past month cards from flat pastMonth_N_* fields
-            const restoredPastMonths: Array<{
-                month: string; expanded: boolean;
-                highlights: string; challenges: string; asks: string;
-                metrics: Record<string, string>;
-            }> = [];
+            const restoredPastMonths: EditorMonthCard[] = [];
             for (let i = 0; draft[`pastMonth_${i}_month`]; i++) {
                 const pmMetrics: Record<string, string> = {};
                 METRIC_OPTIONS.forEach(opt => {
@@ -2387,6 +2518,8 @@ export default function CreateUpdate() {
                     highlights: draft[`pastMonth_${i}_highlights`] || "",
                     challenges: draft[`pastMonth_${i}_challenges`] || "",
                     asks: draft[`pastMonth_${i}_asks`] || "",
+                    learnings: draft[`pastMonth_${i}_learnings`] || "",
+                    next30Days: draft[`pastMonth_${i}_next30Days`] || "",
                     metrics: pmMetrics,
                 });
             }
@@ -2453,6 +2586,8 @@ export default function CreateUpdate() {
     const activeHighlights = isViewingCurrentUpdate ? highlights : activePastCard?.highlights || "";
     const activeChallenges = isViewingCurrentUpdate ? challenges : activePastCard?.challenges || "";
     const activeAsks = isViewingCurrentUpdate ? asks : activePastCard?.asks || "";
+    const activeLearnings = isViewingCurrentUpdate ? learnings : activePastCard?.learnings || "";
+    const activeNext30Days = isViewingCurrentUpdate ? next30Days : activePastCard?.next30Days || "";
     const periodTabs = [
         { key: "current", month: selectedMonth, year: selectedYear },
         ...pastMonthCards.map((card, index) => {
@@ -2503,6 +2638,16 @@ export default function CreateUpdate() {
     const updateActiveAsks = (value: string) => {
         if (isViewingCurrentUpdate) setAsks(value);
         else if (activePastIndex >= 0) updatePastMonthField(activePastIndex, "asks", value);
+    };
+
+    const updateActiveLearnings = (value: string) => {
+        if (isViewingCurrentUpdate) setLearnings(value);
+        else if (activePastIndex >= 0) updatePastMonthField(activePastIndex, "learnings", value);
+    };
+
+    const updateActiveNext30Days = (value: string) => {
+        if (isViewingCurrentUpdate) setNext30Days(value);
+        else if (activePastIndex >= 0) updatePastMonthField(activePastIndex, "next30Days", value);
     };
 
     useEffect(() => {
@@ -2848,6 +2993,24 @@ export default function CreateUpdate() {
                                         <BulletList text={(data as any).challenges} />
                                     </div>
                                 )}
+                                {(data as any)?.learnings && (
+                                    <div>
+                                        <h4 className="text-xs font-bold text-gray-900 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
+                                            <LightBulbIcon className="w-3.5 h-3.5 text-amber-500" />
+                                            Learnings
+                                        </h4>
+                                        <BulletList text={(data as any).learnings} />
+                                    </div>
+                                )}
+                                {(data as any)?.next30Days && (
+                                    <div>
+                                        <h4 className="text-xs font-bold text-gray-900 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
+                                            <ArrowRightIcon className="w-3.5 h-3.5 text-blue-500" />
+                                            Next 30 Days
+                                        </h4>
+                                        <BulletList text={(data as any).next30Days} />
+                                    </div>
+                                )}
                                 {(data as any)?.asks && (
                                     <div>
                                         <h4 className="text-xs font-bold text-gray-900 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
@@ -2863,9 +3026,17 @@ export default function CreateUpdate() {
                         {/* Revenue + Active Users charts + Past month previews */}
                         {(() => {
                             const d = data as any;
-                            const pastMonths: Array<{ month: string; highlights: string; challenges: string; asks: string; metrics: Record<string, string> }> = [];
+                            const pastMonths: Array<{ month: string; highlights: string; challenges: string; asks: string; learnings: string; next30Days: string; metrics: Record<string, string> }> = [];
                             for (let i = 0; d?.[`pastMonth_${i}_month`]; i++) {
-                                const pm: any = { month: d[`pastMonth_${i}_month`], highlights: d[`pastMonth_${i}_highlights`] || "", challenges: d[`pastMonth_${i}_challenges`] || "", asks: d[`pastMonth_${i}_asks`] || "", metrics: {} };
+                                const pm: any = {
+                                    month: d[`pastMonth_${i}_month`],
+                                    highlights: d[`pastMonth_${i}_highlights`] || "",
+                                    challenges: d[`pastMonth_${i}_challenges`] || "",
+                                    asks: d[`pastMonth_${i}_asks`] || "",
+                                    learnings: d[`pastMonth_${i}_learnings`] || "",
+                                    next30Days: d[`pastMonth_${i}_next30Days`] || "",
+                                    metrics: {},
+                                };
                                 for (const m of METRIC_OPTIONS) {
                                     if (d[`pastMonth_${i}_${m.key}`]) pm.metrics[m.key] = d[`pastMonth_${i}_${m.key}`];
                                 }
@@ -2941,7 +3112,7 @@ export default function CreateUpdate() {
                         {/* Your Audience Block */}
                         {(() => {
                             const d = data as any;
-                            const text = [(d.highlights || ''), (d.challenges || ''), (d.asks || '')].join(" ").toLowerCase();
+                            const text = [(d.highlights || ''), (d.challenges || ''), (d.learnings || ''), (d.next30Days || ''), (d.asks || '')].join(" ").toLowerCase();
                             
                             const criteria = [];
                             if (text.includes("saas") || text.includes("software")) criteria.push("B2B SaaS");
@@ -3006,7 +3177,7 @@ export default function CreateUpdate() {
                     {/* Pre-Publish Confirmation Popup */}
                     {showConfirmPopup && (() => {
                         const d = data as any;
-                        const text = [(d.highlights || ''), (d.challenges || ''), (d.asks || '')].join(" ").toLowerCase();
+                        const text = [(d.highlights || ''), (d.challenges || ''), (d.learnings || ''), (d.next30Days || ''), (d.asks || '')].join(" ").toLowerCase();
                         
                         const criteria = [];
                         if (text.includes("saas") || text.includes("software")) criteria.push("B2B SaaS");
@@ -3234,7 +3405,7 @@ export default function CreateUpdate() {
                                 className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-2.5 text-sm font-bold text-white shadow-lg shadow-violet-600/20 transition hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-60"
                             >
                                 {emailDraftActionBusy ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : null}
-                                Draft again
+                                Regenerate {selectedMonthLabel}
                             </button>
                         </div>
                     </div>
@@ -3411,13 +3582,41 @@ export default function CreateUpdate() {
                     </div>
                 </div>
 
+                <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+                    <div className="mb-4 flex flex-col gap-1">
+                        <p className="text-sm font-bold text-gray-900">Selected update month</p>
+                        <p className="text-xs font-medium text-gray-500">
+                            AI generation and edits below apply to {selectedMonthLabel}.
+                        </p>
+                    </div>
+                    <MonthYearTabs
+                        month={selectedMonth}
+                        year={selectedYear}
+                        onMonthChange={setSelectedMonth}
+                        onYearChange={setSelectedYear}
+                        onPeriodChange={setActivePeriodKey}
+                        isDateEditable={!isEmailDraftBusy}
+                        statusLabel="Selected month"
+                    />
+                    {isSelectedMonthInFuture && (
+                        <p className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-700">
+                            Future monthly updates can be generated once that month starts.
+                        </p>
+                    )}
+                    {existingUpdateForSelectedMonth && !isSelectedMonthInFuture && (
+                        <p className="mt-3 rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-sm font-medium text-violet-700">
+                            An update already exists for {selectedMonthLabel}. Regenerating will refresh matching points and add new evidence-backed points.
+                        </p>
+                    )}
+                </section>
+
                 {emailDraftCardVisible ? (
                     <EmailDraftInProgressCard
                         status={emailDraftCardStatus}
                         displayStage={emailDraftCardDisplayStage}
                         completedSteps={emailDraftCardCompletedSteps}
                         totalSteps={emailDraftCardTotalSteps}
-                        sourceLabel="inputs"
+                        sourceLabel={`${selectedInputSourceDescription} for ${selectedMonthLabel}`}
                         error={emailDraftCardError}
                         notice={emailDraftCardNotice}
                         pollingDegraded={emailDraftPollingDegraded}
@@ -3432,39 +3631,35 @@ export default function CreateUpdate() {
                 ) : (
                     <button
                         type="button"
-                        disabled={emailDraftActionBusy}
+                        disabled={emailDraftActionBusy || isSelectedMonthInFuture}
                         onClick={() => {
                             void handleGenerateDraftFromEmailClick();
                         }}
                         className={clsx(
-                            "group relative w-full overflow-hidden rounded-2xl border border-black bg-black p-6 text-left shadow-[0_24px_70px_-50px_rgba(0,0,0,0.65)] transition-all hover:-translate-y-0.5 hover:shadow-[0_28px_80px_-50px_rgba(0,0,0,0.8)]",
-                            canGenerateDraftFromEmail
+                            "group flex w-full items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-white p-5 text-left shadow-sm transition hover:border-violet-200 hover:bg-violet-50/40 disabled:cursor-not-allowed disabled:opacity-60",
+                            canGenerateDraftFromEmail && !isSelectedMonthInFuture
                                 ? "cursor-pointer"
-                                : "cursor-pointer opacity-80",
-                            emailDraftActionBusy && "opacity-70",
+                                : "cursor-not-allowed",
                         )}
                     >
-                        <div className="relative z-10">
-                            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/10 text-white ring-1 ring-white/15">
+                        <div className="flex min-w-0 items-center gap-4">
+                            <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-violet-50 text-violet-700 ring-1 ring-violet-100">
                                 {emailDraftActionBusy ? (
-                                    <ArrowPathIcon className="h-7 w-7 animate-spin" />
+                                    <ArrowPathIcon className="h-5 w-5 animate-spin" />
                                 ) : (
-                                    <SparklesIcon className="h-7 w-7" />
+                                    <SparklesIcon className="h-5 w-5" />
                                 )}
                             </div>
-
-                            <div className="mt-4 flex items-center justify-between gap-4">
-                                <div>
-                                    <h2 className="text-xl font-bold text-white">
-                                        {emailDraftButtonTitle}
-                                    </h2>
-                                    <p className="mt-3 max-w-2xl text-sm leading-6 text-white/72">
-                                        {emailDraftButtonDescription}
-                                    </p>
-                                </div>
-                                <ArrowRightIcon className="h-5 w-5 flex-shrink-0 text-white/60 transition-transform group-hover:translate-x-1" />
+                            <div className="min-w-0">
+                                <h2 className="text-base font-bold text-gray-950">
+                                    {emailDraftButtonTitle}
+                                </h2>
+                                <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-600">
+                                    {emailDraftButtonDescription}
+                                </p>
                             </div>
                         </div>
+                        <ArrowRightIcon className="h-5 w-5 flex-shrink-0 text-gray-400 transition-transform group-hover:translate-x-1" />
                     </button>
                 )}
 
@@ -3601,6 +3796,14 @@ export default function CreateUpdate() {
                                             <BulletInput value={card.challenges} onChange={(v) => updatePastMonthField(index, "challenges", v)} placeholder="Challenge faced..." section="challenges" />
                                         </div>
                                         <div>
+                                            <label className="block text-xs font-medium text-gray-500 mb-1">Learnings</label>
+                                            <BulletInput value={card.learnings} onChange={(v) => updatePastMonthField(index, "learnings", v)} placeholder="Learning from this month..." section="learnings" />
+                                        </div>
+                                        <div>
+                                            <label className="block text-xs font-medium text-gray-500 mb-1">Next 30 Days</label>
+                                            <BulletInput value={card.next30Days} onChange={(v) => updatePastMonthField(index, "next30Days", v)} placeholder="Priority for the next month..." section="next30Days" />
+                                        </div>
+                                        <div>
                                             <label className="block text-xs font-medium text-gray-500 mb-1">Asks</label>
                                             <BulletInput value={card.asks} onChange={(v) => updatePastMonthField(index, "asks", v)} placeholder="Ask from investors..." section="asks" />
                                         </div>
@@ -3612,6 +3815,8 @@ export default function CreateUpdate() {
                                 <input type="hidden" name={`pastMonth_${index}_highlights`} value={card.highlights} />
                                 <input type="hidden" name={`pastMonth_${index}_challenges`} value={card.challenges} />
                                 <input type="hidden" name={`pastMonth_${index}_asks`} value={card.asks} />
+                                <input type="hidden" name={`pastMonth_${index}_learnings`} value={card.learnings} />
+                                <input type="hidden" name={`pastMonth_${index}_next30Days`} value={card.next30Days} />
                                 {Object.entries(card.metrics).map(([key, value]) => (
                                     <input key={key} type="hidden" name={`pastMonth_${index}_${key}`} value={value} />
                                 ))}
@@ -3627,19 +3832,14 @@ export default function CreateUpdate() {
 	                                activeMonthTheme.ringClass,
 	                            )}
 	                        >
-	                            <MonthYearTabs
-	                                month={activeDisplayMonth}
-	                                year={activeDisplayYear}
-	                                onMonthChange={setSelectedMonth}
-	                                onYearChange={setSelectedYear}
-	                                periodTabs={periodTabs}
-	                                activePeriodKey={activePeriodKey}
-	                                onPeriodChange={selectPeriod}
-	                                submitDateFields={isViewingCurrentUpdate}
-	                                isDateEditable={isViewingCurrentUpdate}
-	                                statusLabel={isViewingCurrentUpdate ? "Current Update" : "Previous Update"}
-	                                showInfoControl={pastMonthCards.length > 0}
-	                            />
+	                            <div className="flex flex-col gap-1">
+	                                <p className="text-xs font-bold uppercase tracking-wide text-gray-400">
+	                                    {isViewingCurrentUpdate ? "Generated update" : "Previous update"}
+	                                </p>
+	                                <h2 className="text-lg font-black text-gray-950">
+	                                    {activeDisplayMonth} {activeDisplayYear}
+	                                </h2>
+	                            </div>
 
 	                            {!isViewingCurrentUpdate && (
 	                                <>
@@ -3648,6 +3848,8 @@ export default function CreateUpdate() {
 	                                    <input type="hidden" name="highlights" value={highlights} />
 	                                    <input type="hidden" name="challenges" value={challenges} />
 	                                    <input type="hidden" name="asks" value={asks} />
+	                                    <input type="hidden" name="learnings" value={learnings} />
+	                                    <input type="hidden" name="next30Days" value={next30Days} />
 	                                    <input type="hidden" name="metricKeys" value={formMetricKeys.join(",")} />
 	                                    {getMetricOptionsForMetrics(metricValues).map((metric) => (
 	                                        <input key={metric.key} type="hidden" name={metric.key} value={metricValues[metric.key] || ""} />
@@ -3725,6 +3927,24 @@ export default function CreateUpdate() {
                                     icon={ExclamationCircleIcon}
                                 />
 	                                <SectionWithExample
+	                                    label="Learnings"
+	                                    name={isViewingCurrentUpdate ? "learnings" : `pastMonth_${activePastIndex}_learnings`}
+	                                    value={activeLearnings}
+	                                    onChange={updateActiveLearnings}
+                                    rows={3}
+                                    placeholder="What did you learn from customers, experiments, or execution this month?"
+                                    icon={LightBulbIcon}
+                                />
+	                                <SectionWithExample
+	                                    label="Next 30 Days"
+	                                    name={isViewingCurrentUpdate ? "next30Days" : `pastMonth_${activePastIndex}_next30Days`}
+	                                    value={activeNext30Days}
+	                                    onChange={updateActiveNext30Days}
+                                    rows={3}
+                                    placeholder="What are the highest priority actions, deadlines, or goals for the next month?"
+                                    icon={ArrowRightIcon}
+                                />
+	                                <SectionWithExample
 	                                    label="Ask from Investors"
 	                                    name={isViewingCurrentUpdate ? "asks" : `pastMonth_${activePastIndex}_asks`}
 	                                    value={activeAsks}
@@ -3747,13 +3967,10 @@ export default function CreateUpdate() {
                             selectedMonthTheme.ringClass,
                         )}
                     >
-	                        <MonthYearTabs
-	                            month={selectedMonth}
-	                            year={selectedYear}
-	                            onMonthChange={setSelectedMonth}
-	                            onYearChange={setSelectedYear}
-	                            statusLabel="Current Update"
-	                        />
+                        <div className="flex flex-col gap-1">
+                            <p className="text-xs font-bold uppercase tracking-wide text-gray-400">Update draft</p>
+                            <h2 className="text-lg font-black text-gray-950">{selectedMonthLabel}</h2>
+                        </div>
 
                         {/* Metrics — square boxes, click to activate */}
                         <div>
@@ -3821,6 +4038,22 @@ export default function CreateUpdate() {
                                 onChange={setChallenges}
                                 placeholder="What obstacles are you facing? Where do you need help?"
                                 icon={ExclamationCircleIcon}
+                            />
+                            <SectionWithExample
+                                label="Learnings"
+                                name="learnings"
+                                value={learnings}
+                                onChange={setLearnings}
+                                placeholder="What did you learn from customers, experiments, or execution this month?"
+                                icon={LightBulbIcon}
+                            />
+                            <SectionWithExample
+                                label="Next 30 Days"
+                                name="next30Days"
+                                value={next30Days}
+                                onChange={setNext30Days}
+                                placeholder="What are the highest priority actions, deadlines, or goals for the next month?"
+                                icon={ArrowRightIcon}
                             />
                             <SectionWithExample
                                 label="Ask from Investors"

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -44,6 +44,7 @@ import StartupRegionBadge from "~/components/StartupRegionBadge";
 import { getVibeRaisingMonthTheme, parseVibeRaisingMonthYear, VIBE_RAISING_MONTH_OPTIONS, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
 import type {
     VibeRaisingInputSourceKey,
+    VibeRaisingMetricSuggestion,
     VibeRaisingMonthlyUpdate,
     VibeRaisingStartupUpdateStatusResponse,
     VibeRaisingVideoCompressionMetadata,
@@ -200,13 +201,15 @@ export async function action({ request, context }: Route.ActionArgs) {
         const dynamicMetricKeys = String(formData.get("metricKeys") || "")
             .split(",")
             .map((key) => key.trim())
-            .filter(Boolean);
-        const metricKeys = Array.from(new Set([...METRIC_FORM_KEYS, ...dynamicMetricKeys]));
+            .filter((key) => key && METRIC_OPTION_MAP.has(key));
+        const selectedMetricKeys = Array.from(new Set(dynamicMetricKeys));
+        const metricKeys = Array.from(new Set([...METRIC_FORM_KEYS, ...selectedMetricKeys]));
         const metrics = Object.fromEntries(
             metricKeys
                 .map((key) => [key, String(formData.get(key) || "").trim()] as const)
                 .filter(([, value]) => value.length > 0),
         );
+        const metricSuggestions = metricSuggestionsFromKeys(selectedMetricKeys, metrics);
         const rawVideoUrl = String(formData.get("videoUrl") || "").trim();
         const rawVideoFileSizeBytes = Number(formData.get("videoFileSizeBytes") || 0);
 
@@ -224,6 +227,7 @@ export async function action({ request, context }: Route.ActionArgs) {
             challenges: String(formData.get("challenges") || ""),
             asks: String(formData.get("asks") || ""),
             metrics,
+            metricSuggestions,
         });
 
         return redirect("/founder-tools/updates");
@@ -254,55 +258,58 @@ const METRIC_OPTIONS: MetricOption[] = [
     { key: "revenueGrowthRate", label: "Revenue Growth", placeholder: "12%", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Month-on-month revenue or MRR growth when source data supports it." },
     { key: "customerCount", label: "Customers", placeholder: "24", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Number of active or paying customers when source data supports it." },
     { key: "churn", label: "Churn", placeholder: "2%", icon: <ArrowPathIcon className="w-4 h-4 text-gray-400" />, info: "Customer or revenue churn when source data supports it." },
-    { key: "invoiceCount", label: "Invoices", placeholder: "12", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Sales invoice count from accounting data." },
+    { key: "invoiceCount", label: "Invoices", placeholder: "12", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Sales invoice count or invoices sent this month." },
     { key: "recurringInvoiceCount", label: "Recurring Invoices", placeholder: "6", icon: <ArrowPathIcon className="w-4 h-4 text-gray-400" />, info: "Active recurring invoice count from accounting data." },
+    { key: "websiteVisitors", label: "Website Visitors", placeholder: "1,200", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Visitors to the company website this month." },
+    { key: "waitlistSignups", label: "Waitlist Signups", placeholder: "85", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "People who joined the waitlist this month." },
+    { key: "demoRequests", label: "Demo Requests", placeholder: "14", icon: <ArrowRightIcon className="w-4 h-4 text-gray-400" />, info: "Inbound requests to see or try the product." },
+    { key: "customerInterviews", label: "Customer Interviews", placeholder: "10", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Potential or current customers interviewed this month." },
+    { key: "experimentsRun", label: "Experiments Run", placeholder: "4", icon: <LightBulbIcon className="w-4 h-4 text-gray-400" />, info: "Validation, growth, product, or pricing experiments completed." },
+    { key: "pilotCount", label: "Pilots", placeholder: "3", icon: <SparklesIcon className="w-4 h-4 text-gray-400" />, info: "Active pilots, design partners, or trials." },
+    { key: "qualifiedPipeline", label: "Qualified Pipeline", placeholder: "250,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Qualified sales pipeline with customer intent." },
 ];
 
 const METRIC_OPTION_MAP = new Map(METRIC_OPTIONS.map((option) => [option.key, option]));
 const METRIC_FORM_KEYS = METRIC_OPTIONS.map((option) => option.key);
 
-function humanizeMetricKey(key: string) {
-    return key
-        .replace(/[_-]+/g, " ")
-        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-        .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function getMetricOption(key: string): MetricOption {
-    return METRIC_OPTION_MAP.get(key) ?? {
-        key,
-        label: humanizeMetricKey(key),
-        placeholder: "Value",
-        icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />,
-        info: "Source-backed metric.",
-    };
-}
-
 function getMetricOptionsForMetrics(metrics?: Record<string, string>) {
     const keys = Object.keys(metrics || {}).filter((key) => String(metrics?.[key] || "").trim());
-    const known = METRIC_OPTIONS.filter((option) => keys.includes(option.key));
-    const extra = keys
-        .filter((key) => !METRIC_OPTION_MAP.has(key))
-        .map((key) => getMetricOption(key));
-    return [...known, ...extra];
+    return METRIC_OPTIONS.filter((option) => keys.includes(option.key));
 }
 
 function getMetricOptionsForDisplay(metrics?: Record<string, string>) {
-    const extra = Object.keys(metrics || {})
-        .filter((key) => !METRIC_OPTION_MAP.has(key))
-        .map((key) => getMetricOption(key));
-    return [...METRIC_OPTIONS, ...extra];
+    return getMetricOptionsForMetrics(metrics);
 }
 
 function getEditableMetricOptions(metrics?: Record<string, string>, selected?: Set<string>) {
-    const keys = new Set<string>([
-        ...Object.keys(metrics || {}),
-        ...Array.from(selected || []),
-    ]);
-    const extra = Array.from(keys)
-        .filter((key) => !METRIC_OPTION_MAP.has(key))
-        .map((key) => getMetricOption(key));
-    return [...METRIC_OPTIONS, ...extra];
+    return METRIC_OPTIONS.filter((option) => {
+        const hasKnownValue = Object.prototype.hasOwnProperty.call(metrics || {}, option.key);
+        const isSelected = selected?.has(option.key) ?? false;
+        return hasKnownValue || isSelected || METRIC_OPTION_MAP.has(option.key);
+    });
+}
+
+function metricKeysFromSuggestions(suggestions?: VibeRaisingMetricSuggestion[]) {
+    return (suggestions || [])
+        .map((suggestion) => suggestion.metricKey)
+        .filter((key) => METRIC_OPTION_MAP.has(key));
+}
+
+function metricSuggestionsFromKeys(keys: string[], metrics: Record<string, string>) {
+    const suggestions: VibeRaisingMetricSuggestion[] = [];
+    const seen = new Set<string>();
+    keys.forEach((key) => {
+        if (seen.has(key) || !METRIC_OPTION_MAP.has(key) || String(metrics[key] || "").trim()) return;
+        seen.add(key);
+        const option = METRIC_OPTION_MAP.get(key);
+        suggestions.push({ metricKey: key, label: option?.label || key, reason: "" });
+    });
+    return suggestions;
+}
+
+function metricOptionsFromKeys(keys: string[]) {
+    const selected = new Set(keys.filter((key) => METRIC_OPTION_MAP.has(key)));
+    return METRIC_OPTIONS.filter((option) => selected.has(option.key));
 }
 
 function MetricInfoBadge({ info }: { info?: string }) {
@@ -1232,7 +1239,7 @@ function PastMonthPreviewCard({ pm }: { pm: { month: string; highlights: string;
             >
                 <div className="flex items-center gap-3">
                     <h4 className="text-sm font-bold text-gray-700">{pm.month}</h4>
-                    {!open && Object.keys(pm.metrics).length > 0 && (
+                    {!open && getMetricOptionsForMetrics(pm.metrics).length > 0 && (
                         <span className="flex items-center gap-2 text-xs text-gray-400">
                             {getMetricOptionsForMetrics(pm.metrics).map(m => (
                                 <span key={m.key} className="whitespace-nowrap">{m.label}: {m.prefix || ""}{pm.metrics[m.key]}</span>
@@ -1573,7 +1580,6 @@ export default function CreateUpdate() {
                 initial.add(opt.key);
             }
         });
-        if (initial.size === 0) initial.add("revenue");
         return initial;
     });
     const selectedInputSourceLabels = selectedInputSources.map((key) => INPUT_SOURCE_LABELS[key]);
@@ -1619,21 +1625,26 @@ export default function CreateUpdate() {
             setVideoUploadError(null);
             setPreviewMediaKind("video");
         }
-        setMetricValues(data.metrics || {});
+        const currentMetrics = data.metrics || {};
+        setMetricValues(currentMetrics);
         setPastMonthCards((data.pastMonths || []).map((pm: any) => ({
             ...pm,
             month: pm.month || "Unknown",
             highlights: pm.highlights || "",
             challenges: pm.challenges || "",
             asks: pm.asks || "",
-            metrics: pm.metrics || {}
+            metrics: {
+                ...Object.fromEntries(metricKeysFromSuggestions(pm.metricSuggestions).map((key) => [key, ""])),
+                ...(pm.metrics || {}),
+            }
         })));
         
         const newMetrics = new Set<string>();
-        Object.keys(data.metrics || {}).forEach(key => {
-            if (data.metrics[key]) newMetrics.add(key);
+        Object.keys(currentMetrics).forEach(key => {
+            if (METRIC_OPTION_MAP.has(key) && currentMetrics[key]) newMetrics.add(key);
         });
-        setSelectedMetrics(newMetrics.size > 0 ? newMetrics : new Set(["revenue"]));
+        metricKeysFromSuggestions(data.metricSuggestions).forEach((key) => newMetrics.add(key));
+        setSelectedMetrics(newMetrics);
     };
 
     const revokeVideoPreviewObjectUrl = useCallback(() => {
@@ -2348,8 +2359,14 @@ export default function CreateUpdate() {
                 if (draft[opt.key]) metrics[opt.key] = draft[opt.key];
             });
             setMetricValues(metrics);
-            const newSelected = new Set<string>(Object.keys(metrics).filter(k => metrics[k]));
-            if (newSelected.size === 0) newSelected.add("revenue");
+            const restoredMetricKeys = String(draft.metricKeys || "")
+                .split(",")
+                .map((key: string) => key.trim())
+                .filter((key: string) => METRIC_OPTION_MAP.has(key));
+            const newSelected = new Set<string>([
+                ...restoredMetricKeys,
+                ...Object.keys(metrics).filter(k => metrics[k]),
+            ]);
             setSelectedMetrics(newSelected);
 
             // Reconstruct past month cards from flat pastMonth_N_* fields
@@ -2389,15 +2406,23 @@ export default function CreateUpdate() {
     };
 
     const toggleMetric = (key: string) => {
+        const wasSelected = selectedMetrics.has(key);
         setSelectedMetrics(prev => {
             const next = new Set(prev);
             if (next.has(key)) {
-                if (next.size > 1) next.delete(key);
+                next.delete(key);
             } else {
                 next.add(key);
             }
             return next;
         });
+        if (wasSelected) {
+            setMetricValues(values => {
+                const updated = { ...values };
+                delete updated[key];
+                return updated;
+            });
+        }
     };
 
     const updatePastMonthField = (index: number, field: string, value: string) => {
@@ -2420,7 +2445,11 @@ export default function CreateUpdate() {
     const activeMetricValues = isViewingCurrentUpdate ? metricValues : activePastCard?.metrics || {};
     const activeSelectedMetrics = isViewingCurrentUpdate
         ? selectedMetrics
-        : new Set(Object.keys(activeMetricValues).filter((key) => activeMetricValues[key]));
+        : new Set(Object.keys(activeMetricValues).filter((key) => METRIC_OPTION_MAP.has(key)));
+    const formMetricKeys = Array.from(new Set([
+        ...Array.from(selectedMetrics),
+        ...Object.keys(metricValues),
+    ])).filter((key) => METRIC_OPTION_MAP.has(key));
     const activeHighlights = isViewingCurrentUpdate ? highlights : activePastCard?.highlights || "";
     const activeChallenges = isViewingCurrentUpdate ? challenges : activePastCard?.challenges || "";
     const activeAsks = isViewingCurrentUpdate ? asks : activePastCard?.asks || "";
@@ -2455,7 +2484,7 @@ export default function CreateUpdate() {
             const nextMetrics = { ...card.metrics };
             if (key in nextMetrics) {
                 delete nextMetrics[key];
-                return Object.keys(nextMetrics).length > 0 ? { ...card, metrics: nextMetrics } : card;
+                return { ...card, metrics: nextMetrics };
             }
             return { ...card, metrics: { ...nextMetrics, [key]: "" } };
         }));
@@ -2511,6 +2540,8 @@ export default function CreateUpdate() {
             isSelected: activePeriodKey === "current"
         }
     ];
+    const hasRevenueChart = chartData.some((item) => item.value > 0);
+    const hasActiveUsersChart = activeUsersChartData.some((item) => item.value > 0);
 
     // Chart click: always expand + scroll
     const expandCardFromChart = (index: number) => {
@@ -2733,7 +2764,16 @@ export default function CreateUpdate() {
                             {/* Metrics — square boxes */}
                             <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
                                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
-                                    {getMetricOptionsForDisplay(((data as any)?.metrics || data) as Record<string, string>).map(m => {
+                                    {(() => {
+                                        const metricRecord = (((data as any)?.metrics || data) as Record<string, string>) || {};
+                                        const selectedReviewKeys = String((data as any)?.metricKeys || "")
+                                            .split(",")
+                                            .map((key) => key.trim())
+                                            .filter(Boolean);
+                                        const options = selectedReviewKeys.length > 0
+                                            ? metricOptionsFromKeys(selectedReviewKeys)
+                                            : getMetricOptionsForDisplay(metricRecord);
+                                        return options.map(m => {
                                         const val = (data as any)?.[m.key] || (data as any)?.metrics?.[m.key];
                                         return (
                                             <div
@@ -2764,7 +2804,8 @@ export default function CreateUpdate() {
                                                 )}>{m.label}</p>
                                             </div>
                                         );
-                                    })}
+                                    });
+                                    })()}
                                 </div>
                             </div>
 
@@ -3205,7 +3246,7 @@ export default function CreateUpdate() {
                 <input
                     type="hidden"
                     name="metricKeys"
-                    value={Array.from(new Set([...Object.keys(metricValues), ...Object.keys(activeMetricValues)])).join(",")}
+                    value={formMetricKeys.join(",")}
                 />
                 <input type="hidden" name="summary" value={summary} />
                 <input type="hidden" name="sourceUrl" value={sourceUrl} />
@@ -3430,22 +3471,26 @@ export default function CreateUpdate() {
                 <div className="relative">
                     <fieldset disabled={isEmailDraftBusy} className={clsx(isEmailDraftBusy && "opacity-80")}>
 	                        {/* ─── Growth Charts ─── */}
-                        {pastMonthCards.length > 0 && (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <GrowthChart
-                                    data={chartData}
-                                    onSelect={expandCardFromChart}
-                                    title="Revenue"
-                                    subtitle="Monthly revenue with MoM growth"
-                                    formatter={formatCompact}
-                                />
-                                <GrowthChart
-                                    data={activeUsersChartData}
-                                    onSelect={expandCardFromChart}
-                                    title="Active Users"
-                                    subtitle="Monthly active users with MoM growth"
-                                    formatter={formatUsers}
-                                />
+                        {pastMonthCards.length > 0 && (hasRevenueChart || hasActiveUsersChart) && (
+                            <div className={clsx("grid gap-4", hasRevenueChart && hasActiveUsersChart ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1")}>
+                                {hasRevenueChart && (
+                                    <GrowthChart
+                                        data={chartData}
+                                        onSelect={expandCardFromChart}
+                                        title="Revenue"
+                                        subtitle="Monthly revenue with MoM growth"
+                                        formatter={formatCompact}
+                                    />
+                                )}
+                                {hasActiveUsersChart && (
+                                    <GrowthChart
+                                        data={activeUsersChartData}
+                                        onSelect={expandCardFromChart}
+                                        title="Active Users"
+                                        subtitle="Monthly active users with MoM growth"
+                                        formatter={formatUsers}
+                                    />
+                                )}
                             </div>
                         )}
 
@@ -3471,14 +3516,14 @@ export default function CreateUpdate() {
                                             <h4 className="text-sm font-bold text-gray-600">{card.month}</h4>
                                             {!expandedCards.has(index) && (
                                                 <>
-                                                    {Object.keys(card.metrics).length > 0 && (
+                                                    {getMetricOptionsForMetrics(card.metrics).length > 0 && (
                                                         <span className="flex items-center gap-2 text-xs text-gray-400">
                                                             {getMetricOptionsForMetrics(card.metrics).map(m => (
                                                                 <span key={m.key} className="whitespace-nowrap">{m.label}: {m.prefix || ""}{card.metrics[m.key]}</span>
                                                             ))}
                                                         </span>
                                                     )}
-                                                    {Object.keys(card.metrics).length === 0 && (
+                                                    {getMetricOptionsForMetrics(card.metrics).length === 0 && (
                                                         <span className="text-xs text-gray-400 truncate max-w-[300px]">{(card.highlights || "").slice(0, 80)}...</span>
                                                     )}
                                                 </>
@@ -3507,9 +3552,7 @@ export default function CreateUpdate() {
                                                                 if (active) {
                                                                     const updated = { ...card.metrics };
                                                                     delete updated[m.key];
-                                                                    if (Object.keys(updated).length > 0) {
-                                                                        setPastMonthCards(prev => prev.map((c, i) => i === index ? { ...c, metrics: updated } : c));
-                                                                    }
+                                                                    setPastMonthCards(prev => prev.map((c, i) => i === index ? { ...c, metrics: updated } : c));
                                                                 } else {
                                                                     updatePastMonthMetric(index, m.key, "");
                                                                 }
@@ -3605,7 +3648,7 @@ export default function CreateUpdate() {
 	                                    <input type="hidden" name="highlights" value={highlights} />
 	                                    <input type="hidden" name="challenges" value={challenges} />
 	                                    <input type="hidden" name="asks" value={asks} />
-	                                    <input type="hidden" name="metricKeys" value={Object.keys(metricValues).join(",")} />
+	                                    <input type="hidden" name="metricKeys" value={formMetricKeys.join(",")} />
 	                                    {getMetricOptionsForMetrics(metricValues).map((metric) => (
 	                                        <input key={metric.key} type="hidden" name={metric.key} value={metricValues[metric.key] || ""} />
 	                                    ))}

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -41,6 +41,13 @@ export interface VibeRaisingPastMonthSummary {
   challenges: string;
   asks: string;
   metrics?: Record<string, string>;
+  metricSuggestions?: VibeRaisingMetricSuggestion[];
+}
+
+export interface VibeRaisingMetricSuggestion {
+  metricKey: string;
+  label: string;
+  reason?: string;
 }
 
 export interface VibeRaisingDraftedContent {
@@ -58,6 +65,7 @@ export interface VibeRaisingDraftedContent {
   asks: string;
   pastMonths: VibeRaisingPastMonthSummary[];
   metrics?: Record<string, string>;
+  metricSuggestions?: VibeRaisingMetricSuggestion[];
 }
 
 export interface VibeRaisingMonthlyUpdate {
@@ -76,6 +84,7 @@ export interface VibeRaisingMonthlyUpdate {
   videoFileSizeBytes?: number | null;
   videoOriginalFilename?: string | null;
   metrics: Record<string, string>;
+  metricSuggestions?: VibeRaisingMetricSuggestion[];
   highlights: string;
   challenges: string;
   asks: string;
@@ -437,6 +446,7 @@ export interface VibeRaisingEmailDraftMonth {
   challenges: string;
   asks: string;
   metrics?: Record<string, string>;
+  metricSuggestions?: VibeRaisingMetricSuggestion[];
 }
 
 export interface VibeRaisingStartupUpdateBootstrapResponse {

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -40,6 +40,8 @@ export interface VibeRaisingPastMonthSummary {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
   metrics?: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
 }
@@ -63,6 +65,8 @@ export interface VibeRaisingDraftedContent {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
   pastMonths: VibeRaisingPastMonthSummary[];
   metrics?: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
@@ -88,6 +92,8 @@ export interface VibeRaisingMonthlyUpdate {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
 }
 
 export interface VibeRaisingVideoUploadResponse {
@@ -152,6 +158,24 @@ export interface VibeRaisingInputSourceSummary {
   warning?: string | null;
   selectedChannelCount?: number;
   selectedProjectCount?: number;
+  hasReportScope?: boolean;
+  needsReportReconnect?: boolean;
+  requiredReportScopes?: string[];
+}
+
+export interface VibeRaisingFinancialSyncRun {
+  provider: string;
+  status: string;
+  error?: string | null;
+  hasReportScope?: boolean;
+  needsReportReconnect?: boolean;
+  metricsPublishedCount?: number;
+  metricWarnings: string[];
+}
+
+export interface VibeRaisingFinancialSyncResponse {
+  status: string;
+  syncRuns: VibeRaisingFinancialSyncRun[];
 }
 
 export interface VibeRaisingInputSourcesStatusResponse {
@@ -373,6 +397,9 @@ export interface VibeRaisingXeroPreview {
   cashCollected?: string | null;
   currencies: string[];
   warnings: string[];
+  hasReportScope: boolean;
+  needsReportReconnect: boolean;
+  requiredReportScopes: string[];
   recurringInvoices: VibeRaisingXeroRecord[];
   recentInvoices: VibeRaisingXeroRecord[];
 }
@@ -412,6 +439,7 @@ export interface VibeRaisingStartupUpdateRunSummary {
   domain: string;
   status: string;
   currentStep?: string | null;
+  targetMonth?: string | null;
   stepOrder?: string[];
   stepStates?: Record<string, VibeRaisingStartupUpdateStepState>;
   createdAt?: string;
@@ -429,6 +457,7 @@ export interface VibeRaisingStartupUpdateRunProgress {
   canRetry: boolean;
   terminalState?: string | null;
   generatedDraftMonths: string[];
+  targetMonth?: string | null;
 }
 export interface VibeRaisingEmailDraftMonth {
   draftId?: number;
@@ -445,6 +474,8 @@ export interface VibeRaisingEmailDraftMonth {
   highlights: string;
   challenges: string;
   asks: string;
+  learnings: string;
+  next30Days: string;
   metrics?: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
 }
@@ -476,6 +507,10 @@ export interface VibeRaisingStartupUpdateStatusResponse {
   canRetry: boolean;
   terminalState?: string | null;
   generatedDraftMonths: string[];
+  targetMonth?: string | null;
+  requestedTargetMonth?: string | null;
+  activeTargetMonth?: string | null;
+  targetMonthConflict?: boolean;
   reusedExistingRun?: boolean;
   currentMonth?: VibeRaisingEmailDraftMonth | null;
   pastMonths: VibeRaisingEmailDraftMonth[];


### PR DESCRIPTION
## Summary
- Adds an explicit selected update month section above the monthly update editor.
- Sends the selected target month as YYYY-MM-01 through the startup update generation request.
- Replaces the ambiguous black generation card with a normal month-specific generation action and blocks future months.

## Validation
- bunx --yes react-router build
- bun run typecheck was attempted but still fails in unrelated existing marketing route typing in app/routes/founder-tools.marketing.run.tsx.