### PR TITLE
Handle optional Xero report scopes in UI

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1031,6 +1031,10 @@ function normalizeFinancialSourceSummaries(raw: unknown): Partial<Record<"stripe
       warning,
       hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
       needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
+      canRequestReportScopes: asBoolean(connection.canRequestReportScopes ?? connection.can_request_report_scopes),
+      needsReportScopeConfiguration: asBoolean(
+        connection.needsReportScopeConfiguration ?? connection.needs_report_scope_configuration,
+      ),
       requiredReportScopes,
     });
   }
@@ -1101,6 +1105,10 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
       selectedProjectCount,
       hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
       needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
+      canRequestReportScopes: asBoolean(connection.canRequestReportScopes ?? connection.can_request_report_scopes),
+      needsReportScopeConfiguration: asBoolean(
+        connection.needsReportScopeConfiguration ?? connection.needs_report_scope_configuration,
+      ),
       requiredReportScopes,
     });
   }
@@ -1907,6 +1915,10 @@ function normalizeFinancialSyncRun(raw: unknown): VibeRaisingFinancialSyncRun | 
       asNullableString(payload.detail),
     hasReportScope: asBoolean(payload.hasReportScope ?? payload.has_report_scope),
     needsReportReconnect: asBoolean(payload.needsReportReconnect ?? payload.needs_report_reconnect),
+    canRequestReportScopes: asBoolean(payload.canRequestReportScopes ?? payload.can_request_report_scopes),
+    needsReportScopeConfiguration: asBoolean(
+      payload.needsReportScopeConfiguration ?? payload.needs_report_scope_configuration,
+    ),
     metricsPublishedCount,
     metricWarnings: Array.isArray(rawWarnings)
       ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
@@ -2628,6 +2640,10 @@ export async function getVibeRaisingXeroPreview(
       : [],
     hasReportScope: asBoolean(payload.hasReportScope ?? payload.has_report_scope),
     needsReportReconnect: asBoolean(payload.needsReportReconnect ?? payload.needs_report_reconnect),
+    canRequestReportScopes: asBoolean(payload.canRequestReportScopes ?? payload.can_request_report_scopes),
+    needsReportScopeConfiguration: asBoolean(
+      payload.needsReportScopeConfiguration ?? payload.needs_report_scope_configuration,
+    ),
     requiredReportScopes: Array.isArray(rawRequiredReportScopes)
       ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
       : [],

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -401,6 +401,8 @@ function XeroPreview({
         { label: "Recurring invoices", value: preview.recurringInvoiceCount },
       ].filter((item) => item.value && item.value !== "0")
     : [];
+  const reportReconnectHref =
+    preview?.needsReportReconnect && preview.canRequestReportScopes ? reconnectHref || undefined : undefined;
 
   return (
     <section className="rounded-xl border border-sky-100 bg-white p-6 shadow-sm">
@@ -418,9 +420,9 @@ function XeroPreview({
               Loading
             </span>
           ) : null}
-          {preview?.needsReportReconnect && reconnectHref ? (
+          {reportReconnectHref ? (
             <a
-              href={reconnectHref}
+              href={reportReconnectHref}
               className="inline-flex items-center gap-2 rounded-lg bg-sky-600 px-3 py-2 text-xs font-extrabold text-white transition hover:bg-sky-700"
             >
               <LinkIcon className="h-4 w-4" />
@@ -433,7 +435,7 @@ function XeroPreview({
             disabled={syncing}
             className={clsx(
               "inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-extrabold transition disabled:cursor-not-allowed disabled:opacity-60",
-              preview?.needsReportReconnect
+              reportReconnectHref
                 ? "border-gray-200 text-slate-600 hover:bg-gray-50"
                 : "border-sky-100 text-sky-700 hover:bg-sky-50",
             )}
@@ -1797,7 +1799,9 @@ export default function ConnectData() {
         }
       }
       const xeroRun = response.syncRuns.find((run) => run.provider === "xero");
-      if (xeroRun?.needsReportReconnect) {
+      if (xeroRun?.needsReportScopeConfiguration) {
+        setStatusMessage("Xero invoices and payments synced. Report metrics are disabled until Profit and Loss and Balance Sheet report scopes are configured.");
+      } else if (xeroRun?.needsReportReconnect) {
         setStatusMessage("Xero invoices and payments synced. Reconnect Xero to allow Profit and Loss and Balance Sheet report metrics.");
       } else if (xeroRun?.metricWarnings.length) {
         setStatusMessage(xeroRun.metricWarnings[0]);

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -160,6 +160,8 @@ export interface VibeRaisingInputSourceSummary {
   selectedProjectCount?: number;
   hasReportScope?: boolean;
   needsReportReconnect?: boolean;
+  canRequestReportScopes?: boolean;
+  needsReportScopeConfiguration?: boolean;
   requiredReportScopes?: string[];
 }
 
@@ -169,6 +171,8 @@ export interface VibeRaisingFinancialSyncRun {
   error?: string | null;
   hasReportScope?: boolean;
   needsReportReconnect?: boolean;
+  canRequestReportScopes?: boolean;
+  needsReportScopeConfiguration?: boolean;
   metricsPublishedCount?: number;
   metricWarnings: string[];
 }
@@ -399,6 +403,8 @@ export interface VibeRaisingXeroPreview {
   warnings: string[];
   hasReportScope: boolean;
   needsReportReconnect: boolean;
+  canRequestReportScopes: boolean;
+  needsReportScopeConfiguration: boolean;
   requiredReportScopes: string[];
   recurringInvoices: VibeRaisingXeroRecord[];
   recentInvoices: VibeRaisingXeroRecord[];


### PR DESCRIPTION
## Summary
- parse backend Xero report-scope configuration flags in Vibe Raising API clients
- only show the Xero reconnect CTA when the backend can request report scopes
- surface the report-scope configuration warning after Xero sync instead of sending users through a reconnect loop

## Validation
- `bun run typecheck`
- `bun run build` (completed; existing IndexNow submission returned 403 after build output)
