### PR TITLE
Normalize article delivery modes

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -8,6 +8,7 @@ import type {
   VibeMarketingComponentManifest,
   VibeMarketingComponentManifestItem,
   VibeMarketingContentPackage,
+  VibeMarketingDeliveryMode,
   VibeMarketingGuidedStep,
   VibeMarketingLivePreview,
   VibeMarketingPublishEvidence,
@@ -28,6 +29,14 @@ function asNullableString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
+}
+
+export function normalizeArticleDeliveryMode(
+  value: unknown,
+  fallback: VibeMarketingDeliveryMode = "publish_code",
+): VibeMarketingDeliveryMode {
+  const normalized = asNullableString(value);
+  return normalized === "publish_code" || normalized === "content_only" ? normalized : fallback;
 }
 
 function asStringList(value: unknown): string[] {
@@ -179,10 +188,9 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
     settings: {
       brandName: asNullableString(settings.brandName) ?? asNullableString(settings.brand_name),
       companyContext: asNullableString(settings.companyContext) ?? asNullableString(settings.company_context),
-      articleDeliveryMode:
-        asNullableString(settings.articleDeliveryMode) ??
-        asNullableString(settings.article_delivery_mode) ??
-        "publish_code",
+      articleDeliveryMode: normalizeArticleDeliveryMode(
+        settings.articleDeliveryMode ?? settings.article_delivery_mode,
+      ),
       githubRepo: asNullableString(settings.githubRepo) ?? asNullableString(settings.github_repo),
       dailyDiscoveryEnabled: Boolean(settings.dailyDiscoveryEnabled ?? settings.daily_discovery_enabled),
       dailyDiscoveryPriority: Number(settings.dailyDiscoveryPriority ?? 0) || 0,

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -26,6 +26,7 @@ import { getEnv } from "~/lib/env.server";
 import {
   connectVibeMarketingGithub,
   getVibeMarketingBootstrap,
+  normalizeArticleDeliveryMode,
   replayVibeMarketingDaily,
   refreshVibeMarketingBaselineGoogle,
   saveVibeMarketingSettings,
@@ -214,7 +215,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title ?? "",
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: stringFromForm(formData, "deliveryMode"),
+        deliveryMode: normalizeArticleDeliveryMode(stringFromForm(formData, "deliveryMode")),
         deliveryModeConfirmed: true,
         sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -24,6 +24,7 @@ import {
   deleteVibeMarketingComponentComment,
   getVibeMarketingBootstrap,
   getVibeMarketingRun,
+  normalizeArticleDeliveryMode,
   submitVibeMarketingComponentComments,
   startVibeMarketingLivePreview,
   startVibeMarketingArticle,
@@ -101,7 +102,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       }
     } else if (intent === "delivery-mode") {
       await controlVibeMarketingRun(env, request, runId, "delivery-mode", {
-        deliveryMode: String(formData.get("deliveryMode") ?? ""),
+        deliveryMode: normalizeArticleDeliveryMode(formData.get("deliveryMode"), "content_only"),
       });
     } else if (intent === "start-article") {
       const bootstrap = await getVibeMarketingBootstrap(env, request);
@@ -125,7 +126,10 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title || candidateTitle,
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: stringFromForm(formData, "deliveryMode") || bootstrap.settings.articleDeliveryMode,
+        deliveryMode: normalizeArticleDeliveryMode(
+          stringFromForm(formData, "deliveryMode") || bootstrap.settings.articleDeliveryMode,
+          "content_only",
+        ),
         deliveryModeConfirmed: true,
         sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceRunId") || runId,
       });

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -4,7 +4,11 @@ import { ArrowLeftIcon, ArrowPathIcon, CheckCircleIcon } from "@heroicons/react/
 
 import FounderStartupDetailsStep from "~/components/FounderStartupDetailsStep";
 import { getEnv } from "~/lib/env.server";
-import { getVibeMarketingBootstrap, saveVibeMarketingSettings } from "~/lib/vibe-marketing";
+import {
+  getVibeMarketingBootstrap,
+  normalizeArticleDeliveryMode,
+  saveVibeMarketingSettings,
+} from "~/lib/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
@@ -33,6 +37,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   const { appUser } = await requireVibeRaisingFounder(env, request);
   const activeCompany = getActiveVibeRaisingCompany(appUser);
   const formData = await request.formData();
+  const articleDeliveryMode = normalizeArticleDeliveryMode(stringFromForm(formData, "articleDeliveryMode"));
 
   try {
     await saveVibeRaisingCompany(env, request, {
@@ -49,7 +54,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       stage: stringFromForm(formData, "stage"),
       organizationKind: stringFromForm(formData, "organizationKind"),
       githubRepo: stringFromForm(formData, "githubRepo"),
-      articleDeliveryMode: stringFromForm(formData, "articleDeliveryMode"),
+      articleDeliveryMode,
       dailyDiscoveryEnabled: formData.get("dailyDiscoveryEnabled") === "on",
       defaultTimezone: stringFromForm(formData, "defaultTimezone"),
       registered: true,
@@ -62,7 +67,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       competitors: listFromForm(formData.get("competitors")),
       seedKeywords: listFromForm(formData.get("seedKeywords")),
       githubRepo: stringFromForm(formData, "githubRepo"),
-      articleDeliveryMode: stringFromForm(formData, "articleDeliveryMode"),
+      articleDeliveryMode,
       dailyDiscoveryEnabled: formData.get("dailyDiscoveryEnabled") === "on",
       defaultTimezone: stringFromForm(formData, "defaultTimezone"),
     });

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -12,6 +12,8 @@ export type VibeMarketingRunStatus =
   | "denied"
   | string;
 
+export type VibeMarketingDeliveryMode = "publish_code" | "content_only";
+
 export interface VibeMarketingStepState {
   key: string;
   name: string;
@@ -144,7 +146,7 @@ export interface VibeMarketingOrganization {
 export interface VibeMarketingSettings {
   brandName?: string | null;
   companyContext?: string | null;
-  articleDeliveryMode?: string | null;
+  articleDeliveryMode?: VibeMarketingDeliveryMode | null;
   githubRepo?: string | null;
   dailyDiscoveryEnabled: boolean;
   dailyDiscoveryPriority?: number | null;


### PR DESCRIPTION
## Summary
- adds a frontend whitelist for article delivery modes so only `publish_code` and `content_only` are normalized from backend settings
- sanitizes delivery mode submissions from create, run, and settings flows before posting to the backend
- keeps the existing UI options unchanged and leaves no Webflow delivery references in the frontend repo

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `rg -n "webflow|Webflow|WEBFLOW|publish_webflow|webflow_cms" . --glob '!node_modules/**' --glob '!dist/**' --glob '!build/**' --glob '!coverage/**' --glob '!**/.react-router/**' --glob '!**/.git/**'` -> no matches
- `git diff --check`
