### PR TITLE
Update connector privacy and terms

### DIFF
--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -1,11 +1,21 @@
 import type { MetaFunction } from "react-router";
 import { Container } from "~/components/ui/Container";
 
+const LAST_UPDATED = "30 April 2026";
+
 export const meta: MetaFunction = () => {
   return [
     { title: "MLAI Privacy Policy | Data & Consent Guide" },
-    { name: "description", content: "MLAI Privacy Policy outlining the collection, use, and management of personal information for our AI community." },
-    { name: "keywords", content: "privacy policy, MLAI, machine learning, AI community, personal information, Australian Privacy Principles" },
+    {
+      name: "description",
+      content:
+        "MLAI Privacy Policy covering events, Founder Tools, connected accounts, Google API data, and AI-assisted monthly updates.",
+    },
+    {
+      name: "keywords",
+      content:
+        "privacy policy, MLAI, machine learning, AI community, personal information, Google API data, Founder Tools",
+    },
   ];
 };
 
@@ -20,15 +30,20 @@ export default function Privacy() {
             </h1>
             <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
               <h2 className="text-xl font-semibold leading-7 text-gray-900">
-                Last updated: {new Date().toLocaleDateString()}
+                Last updated: {LAST_UPDATED}
               </h2>
 
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                MLAI Aus Inc ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website or attend our events.
+                MLAI Aus Inc ("we", "our", or "us") is committed to protecting
+                your privacy. This Privacy Policy explains how we collect, use,
+                disclose, and safeguard information when you visit our websites,
+                attend our events, use our applications, or use MLAI Founder
+                Tools, including Vibe Raising monthly updates.
               </p>
 
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                By accessing and using our website and services, you agree to the terms of this Privacy Policy.
+                By accessing and using our website and services, you agree to the
+                terms of this Privacy Policy.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
@@ -39,21 +54,29 @@ export default function Privacy() {
                 Personal Information
               </h3>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We may collect personal information that you voluntarily provide to us when you:
+                We may collect personal information that you voluntarily provide
+                to us when you:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>Create or sign in to an MLAI account</li>
                 <li>Register for events or workshops</li>
                 <li>Subscribe to our newsletter or mailing list</li>
                 <li>Contact us through our website or email</li>
                 <li>Apply to volunteer with our organization</li>
                 <li>Participate in surveys or feedback forms</li>
+                <li>Provide startup, company, workspace, or team profile details</li>
+                <li>
+                  Upload or enter materials, URLs, notes, documents, or other
+                  content into our applications
+                </li>
               </ul>
 
               <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
                 Automatically Collected Information
               </h3>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                When you visit our website, we may automatically collect certain information about your device and browsing behavior, including:
+                When you visit our website, we may automatically collect certain
+                information about your device and browsing behavior, including:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                 <li>IP address</li>
@@ -61,6 +84,94 @@ export default function Privacy() {
                 <li>Operating system</li>
                 <li>Pages visited and time spent on our site</li>
                 <li>Referring website</li>
+              </ul>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Founder Tools and Connected Accounts
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                If you use Founder Tools, Vibe Raising, or related software
+                features, you may choose to connect third-party accounts or
+                provide source materials so MLAI can generate user-requested
+                outputs such as monthly updates, summaries, metrics, timelines,
+                and drafts.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Depending on the features you enable, the information we collect
+                and process may include:
+              </p>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>
+                  <strong>Google/Gmail:</strong> Gmail metadata, senders,
+                  recipients, subjects, dates, snippets, cleaned message or
+                  thread text, attachment metadata, and extracted attachment text
+                  where enabled and authorized by you.
+                </li>
+                <li>
+                  <strong>Slack:</strong> workspace and channel identifiers,
+                  selected channel names, public or private channel indicators,
+                  message text, thread context, timestamps, and related message
+                  metadata from channels you select or authorize.
+                </li>
+                <li>
+                  <strong>Xero:</strong> organization, tenant, invoice, payment,
+                  contact, account, report, profit and loss, balance sheet, and
+                  metric information permitted by the scopes granted to MLAI.
+                </li>
+                <li>
+                  <strong>Linear:</strong> workspace, project, issue, comment,
+                  status, assignee, cycle, label, and delivery context where a
+                  Linear integration is enabled.
+                </li>
+                <li>
+                  <strong>Notion and Google Drive:</strong> page, file, document,
+                  folder, metadata, and extracted text where these connectors are
+                  enabled and authorized.
+                </li>
+                <li>
+                  <strong>Manual materials:</strong> source URLs, short
+                  summaries, recorded notes, uploaded files, pasted text, and
+                  other materials you add directly.
+                </li>
+                <li>
+                  <strong>Startup profile and generated outputs:</strong> company
+                  profile details, monthly update drafts, generated sections,
+                  extracted events, metrics, evidence, recommendations, and
+                  review results.
+                </li>
+              </ul>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Google API Data and Limited Use
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                MLAI’s use and transfer of information received from Google APIs
+                will adhere to the Google API Services User Data Policy,
+                including the Limited Use requirements.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                For Google and Gmail data:
+              </p>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>We do not sell Google or Gmail data.</li>
+                <li>
+                  We do not use Google or Gmail data for advertising,
+                  retargeting, or creditworthiness decisions.
+                </li>
+                <li>
+                  We do not use Google or Gmail data to train generalized AI
+                  models or foundation models.
+                </li>
+                <li>
+                  We use Google and Gmail data only to provide, maintain, secure,
+                  and improve the user-requested features that depend on your
+                  connection.
+                </li>
+                <li>
+                  Human access is limited to cases such as security, abuse
+                  prevention, support you request, legal compliance, or where you
+                  have given explicit permission.
+                </li>
               </ul>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
@@ -73,16 +184,41 @@ export default function Privacy() {
                 <li>Organize and manage events, workshops, and meetups</li>
                 <li>Send newsletters and updates about MLAI activities</li>
                 <li>Respond to your inquiries and provide customer support</li>
+                <li>Authenticate users and operate MLAI accounts and workspaces</li>
+                <li>
+                  Provide Founder Tools features, including connector sync,
+                  monthly update generation, timelines, summaries, metrics,
+                  drafts, and evidence review
+                </li>
+                <li>
+                  Classify, extract, summarize, draft, and review user-requested
+                  outputs from connected sources and manual materials
+                </li>
                 <li>Improve our website and services</li>
                 <li>Comply with legal obligations</li>
                 <li>Coordinate volunteer activities and opportunities</li>
               </ul>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                AI Processing
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Some MLAI features use automated systems and AI service providers,
+                including Valley and model providers such as OpenAI, to classify,
+                extract, summarize, draft, and review outputs that you request.
+                We may send connected-source data, manual materials, generated
+                drafts, extracted metrics, and evidence to these providers only
+                as needed to provide the requested feature, maintain service
+                quality, and keep the service secure. We do not use Google or
+                Gmail data to train generalized AI models or foundation models.
+              </p>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Email Communications and Newsletter
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you subscribe to our newsletter or mailing list, we will send you periodic updates about:
+                If you subscribe to our newsletter or mailing list, we will send
+                you periodic updates about:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                 <li>Upcoming events and workshops</li>
@@ -95,7 +231,8 @@ export default function Privacy() {
                 Unsubscribe Options
               </h3>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                <strong>You can unsubscribe at any time by clicking the unsubscribe button</strong> included in every email we send. You may also:
+                <strong>You can unsubscribe at any time by clicking the unsubscribe button</strong>{" "}
+                included in every email we send. You may also:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                 <li>Contact us directly at hi@mlai.au to request removal from our mailing list</li>
@@ -103,18 +240,35 @@ export default function Privacy() {
                 <li>Opt out of specific types of communications while remaining subscribed to others</li>
               </ul>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                Once you unsubscribe, we will process your request promptly and you will stop receiving marketing emails within 5-10 business days. Please note that you may still receive transactional emails related to events you have registered for or other essential communications.
+                Once you unsubscribe, we will process your request promptly and
+                you will stop receiving marketing emails within 5-10 business
+                days. Please note that you may still receive transactional emails
+                related to events you have registered for or other essential
+                communications.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Information Sharing and Disclosure
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We do not sell, trade, or otherwise transfer your personal information to third parties without your consent, except in the following circumstances:
+                We do not sell your personal information. We do not share
+                connected account data for advertising or retargeting. We may
+                disclose information only as needed for the following purposes:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Event management platforms (e.g., Humanitix, Eventbrite) when you register for events</li>
-                <li>Service providers who assist us in operating our website and conducting our activities</li>
+                <li>
+                  Event management platforms (e.g., Humanitix, Eventbrite) when
+                  you register for events
+                </li>
+                <li>
+                  Service providers who assist us in operating our websites,
+                  applications, infrastructure, security, analytics, email,
+                  support, and AI processing
+                </li>
+                <li>
+                  Third-party services you choose to connect, as needed to
+                  complete the action you requested
+                </li>
                 <li>When required by law or to protect our rights and safety</li>
               </ul>
 
@@ -122,21 +276,63 @@ export default function Privacy() {
                 Data Security
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We implement appropriate technical and organizational security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction.
+                We implement appropriate technical and organizational security
+                measures to protect your personal information against unauthorized
+                access, alteration, disclosure, or destruction. These measures may
+                include access controls, logging, encrypted transport, and
+                protected storage for OAuth tokens and other sensitive connection
+                data where supported. No method of transmission or storage is
+                completely secure.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Data Retention
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We retain your personal information only as long as necessary to fulfill the purposes outlined in this Privacy Policy, unless a longer retention period is required by law.
+                We retain personal information only for as long as reasonably
+                necessary to provide the Services, maintain account history,
+                comply with legal obligations, resolve disputes, enforce
+                agreements, prevent abuse, and keep the Services secure.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                For connected accounts, we may retain OAuth tokens while your
+                connection is active. Source artifacts, extracted text, generated
+                drafts, metrics, timeline events, evidence, and review results
+                may be retained while your account or workspace is active, until
+                you delete them where product controls are available, or until you
+                request deletion. Deletion may be subject to legal, security,
+                audit, and backup retention requirements.
+              </p>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Disconnecting Accounts and Deleting Data
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                You can disconnect third-party accounts in the product where
+                controls are available, and you can also revoke access directly
+                through the third-party provider, such as your Google Account
+                permissions page. Disconnecting a connector stops future sync for
+                that connector but may not automatically remove historical
+                generated outputs, source artifacts, metrics, or evidence already
+                created from that connection.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                To request deletion of data associated with a connector, generated
+                monthly update, or MLAI account, email us at{" "}
+                <a className="text-[#3b82f6]" href="mailto:hi@mlai.au">
+                  hi@mlai.au
+                </a>
+                . Please include the email address associated with your MLAI
+                account and, where relevant, the third-party account you
+                connected.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Your Rights
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                Depending on your location, you may have certain rights regarding your personal information, including:
+                Depending on your location, you may have certain rights regarding
+                your personal information, including:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                 <li>The right to access your personal information</li>
@@ -150,29 +346,35 @@ export default function Privacy() {
                 Children's Privacy
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                Our services are not directed to children under 13 years of age. We do not knowingly collect personal information from children under 13.
+                Our services are not directed to children under 13 years of age.
+                We do not knowingly collect personal information from children
+                under 13.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Changes to This Privacy Policy
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last updated" date.
+                We may update this Privacy Policy from time to time. We will
+                notify you of any changes by posting the new Privacy Policy on
+                this page and updating the "Last updated" date.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Contact Us
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you have any questions about this Privacy Policy or our privacy practices, please contact us at:
+                If you have any questions about this Privacy Policy or our
+                privacy practices, please contact us at:
               </p>
 
               <div className="mt-4 bg-gray-50 p-6 rounded-lg">
-                <p className="mb-2 text-base leading-7 text-zinc-600"><strong>MLAI Aus Inc</strong></p>
+                <p className="mb-2 text-base leading-7 text-zinc-600">
+                  <strong>MLAI Aus Inc</strong>
+                </p>
                 <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
                 <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
               </div>
-
             </div>
           </div>
         </div>

--- a/app/routes/terms.tsx
+++ b/app/routes/terms.tsx
@@ -1,347 +1,372 @@
 import type { MetaFunction } from "react-router";
 import { Container } from "~/components/ui/Container";
 
-const LAST_UPDATED = "16 December 2025"; // Update this manually when you change the Terms
+const LAST_UPDATED = "30 April 2026";
 
 export const meta: MetaFunction = () => {
-    return [
-        { title: "MLAI Terms of Service" },
-        {
-            name: "description",
-            content:
-                "MLAI Terms of Service governing use of MLAI services, including Google/Gmail connections and AI-generated summaries.",
-        },
-        {
-            name: "keywords",
-            content:
-                "terms of service, MLAI, Gmail integration, Google OAuth, AI summaries, retention, data deletion",
-        },
-    ];
+  return [
+    { title: "MLAI Terms of Service" },
+    {
+      name: "description",
+      content:
+        "MLAI Terms of Service governing use of MLAI services, Founder Tools, connected accounts, and AI-assisted monthly updates.",
+    },
+    {
+      name: "keywords",
+      content:
+        "terms of service, MLAI, Founder Tools, Gmail integration, Slack integration, Xero integration, Google OAuth, AI summaries",
+    },
+  ];
 };
 
 export default function TermsOfService() {
-    return (
-        <>
-            <Container className="bg-white pt-32">
-                <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-1 lg:grid-rows-[auto_1fr] lg:gap-y-12">
-                    <div className="lg:order-first lg:row-span-2">
-                        <h1 className="text-4xl pt-12 font-bold tracking-tight text-[#3b82f6] sm:text-5xl dark:text-[#3b82f6]">
-                            MLAI Terms of Service
-                        </h1>
+  return (
+    <>
+      <Container className="bg-white pt-32">
+        <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-1 lg:grid-rows-[auto_1fr] lg:gap-y-12">
+          <div className="lg:order-first lg:row-span-2">
+            <h1 className="text-4xl pt-12 font-bold tracking-tight text-[#3b82f6] sm:text-5xl dark:text-[#3b82f6]">
+              MLAI Terms of Service
+            </h1>
 
-                        <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
-                            <h2 className="text-xl font-semibold leading-7 text-gray-900">
-                                Last updated: {LAST_UPDATED}
-                            </h2>
+            <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
+              <h2 className="text-xl font-semibold leading-7 text-gray-900">
+                Last updated: {LAST_UPDATED}
+              </h2>
 
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                These Terms of Service (“Terms”) govern your access to and use of the MLAI
-                                websites, applications, and services (collectively, the “Services”) provided
-                                by MLAI Aus Inc (“MLAI”, “we”, “our”, or “us”).
-                            </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                These Terms of Service ("Terms") govern your access to and use
+                of the MLAI websites, applications, and services (collectively,
+                the "Services") provided by MLAI Aus Inc ("MLAI", "we", "our",
+                or "us").
+              </p>
 
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                By accessing or using the Services, you agree to be bound by these Terms. If
-                                you do not agree, do not use the Services.
-                            </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                By accessing or using the Services, you agree to be bound by
+                these Terms. If you do not agree, do not use the Services.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                1. The Services
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                MLAI provides community, educational, and software-based tools, which may
-                                include AI-powered features. Some features allow you to connect third-party
-                                accounts (such as Google/Gmail) so that MLAI can process your data to
-                                deliver user-requested outputs, such as summaries and reports.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                1. The Services
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                MLAI provides community, educational, and software-based tools,
+                which may include AI-powered features. Some features, including
+                Founder Tools and Vibe Raising monthly updates, allow you to
+                connect third-party accounts or provide materials so MLAI can
+                process your data to deliver user-requested outputs such as
+                summaries, reports, metrics, timelines, and drafts.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Supported connectors may include Google/Gmail, Slack, Xero,
+                Linear, Notion, Google Drive, and other services where enabled.
+                You may also provide manual materials such as URLs, notes,
+                summaries, recordings, pasted text, or uploaded files.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                2. Eligibility and Accounts
-                            </h2>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>You must be able to form a legally binding contract to use the Services.</li>
-                                <li>
-                                    You are responsible for maintaining the confidentiality of your account
-                                    credentials and for all activity under your account.
-                                </li>
-                                <li>
-                                    You agree to provide accurate, current, and complete information and keep
-                                    it updated.
-                                </li>
-                            </ul>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                2. Eligibility and Accounts
+              </h2>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>You must be able to form a legally binding contract to use the Services.</li>
+                <li>
+                  You are responsible for maintaining the confidentiality of your
+                  account credentials and for all activity under your account.
+                </li>
+                <li>
+                  You agree to provide accurate, current, and complete
+                  information and keep it updated.
+                </li>
+              </ul>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                3. Google/Gmail Connection (OAuth) and Email Analysis
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you choose to connect your Google account, you authorize MLAI to access
-                                the Google data you explicitly grant through the Google consent screen (for
-                                example, Gmail data) for the purpose of providing the feature you requested
-                                (for example, generating a monthly update).
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                3. Connected Accounts, OAuth, and Founder Tools Data
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                If you choose to connect a third-party account or workspace, you
+                authorize MLAI to access and process the data you explicitly grant
+                through the relevant consent screen, API authorization, or in-app
+                selection flow for the purpose of providing the feature you
+                requested.
+              </p>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.1 What you are authorising
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Depending on the feature you enable, MLAI may access Gmail data such as
-                                email metadata (e.g., sender, recipient, subject, date) and/or email content
-                                (e.g., body text). The exact permissions are shown on the Google consent
-                                screen at the time you connect.
-                            </p>
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                3.1 What you are authorising
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Depending on the feature you enable, MLAI may access data from
+                connected services such as Gmail messages and attachments, Slack
+                channels and threads, Xero invoices, payments, contacts, accounts
+                and reports, Linear projects and issues, Notion pages, Google
+                Drive files, and related metadata. The exact permissions are
+                shown in the relevant consent screen or connector UI when you
+                connect or select sources.
+              </p>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.2 What we do with Gmail data
-                            </h3>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    We use Gmail data to provide the user-facing feature you requested, such
-                                    as generating summaries, insights, and reports about your startup
-                                    activity.
-                                </li>
-                                <li>
-                                    We may process Gmail data using automated systems, including AI models, to
-                                    produce the requested outputs.
-                                </li>
-                                <li>
-                                    We may store tokens required to maintain your connection (including
-                                    refresh tokens) and may store limited derived outputs (e.g., a generated
-                                    monthly report) associated with your account.
-                                </li>
-                            </ul>
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                3.2 What we do with connected-source data
+              </h3>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>
+                  We use connected-source data to provide the user-facing feature
+                  you requested, such as generating monthly updates, summaries,
+                  insights, metrics, timelines, evidence, and reports about your
+                  startup activity.
+                </li>
+                <li>
+                  We may process connected-source data using automated systems
+                  and AI service providers to classify, extract, summarize,
+                  draft, and review requested outputs.
+                </li>
+                <li>
+                  We may store tokens required to maintain your connection,
+                  including refresh tokens where provided, and may store source
+                  artifacts, extracted text, evidence, metrics, generated drafts,
+                  and other derived outputs associated with your account or
+                  workspace.
+                </li>
+              </ul>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.3 Google API data use commitments
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                When you connect Google services, we will handle Google user data in
-                                accordance with our Privacy Policy and applicable Google requirements. In
-                                particular:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>We do not sell Gmail data.</li>
-                                <li>
-                                    We do not use Gmail data to train or improve generalized AI/ML models
-                                    (outside of providing the requested feature and personalizing your
-                                    experience).
-                                </li>
-                                <li>
-                                    We limit access to Gmail data to what is necessary to provide the feature
-                                    you request.
-                                </li>
-                            </ul>
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                3.3 Google API data use commitments
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                MLAI’s use and transfer of information received from Google APIs
+                will adhere to the Google API Services User Data Policy,
+                including the Limited Use requirements.
+              </p>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>We do not sell Google or Gmail data.</li>
+                <li>
+                  We do not use Google or Gmail data for advertising,
+                  retargeting, or creditworthiness decisions.
+                </li>
+                <li>
+                  We do not use Google or Gmail data to train generalized AI
+                  models or foundation models.
+                </li>
+                <li>
+                  We limit access to Google and Gmail data to what is necessary
+                  to provide, maintain, secure, and support the feature you
+                  request, or as otherwise permitted by law and Google policy.
+                </li>
+              </ul>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.4 What we store (email content vs derived summaries)
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Our goal is to minimise the data we store.
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    <strong>Raw Gmail content:</strong> We do not permanently store your Gmail
-                                    email content (including message bodies). Any Gmail data accessed via your
-                                    connection is processed transiently for the requested feature and then
-                                    disposed of.
-                                </li>
-                                <li>
-                                    <strong>Derived outputs:</strong> We may store derived outputs (for example,
-                                    a monthly summary/report, insights, action items, or aggregated metrics)
-                                    associated with your account so you can view them later.
-                                </li>
-                                <li>
-                                    <strong>Connection data:</strong> We may store OAuth connection tokens
-                                    (including refresh tokens) and basic account identifiers (such as the email
-                                    address associated with the connected Google account) to keep the
-                                    integration working.
-                                </li>
-                            </ul>
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                3.4 Storage and retention
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Our goal is to store only what is reasonably needed to provide
+                and operate the Services. For connected accounts, we may store
+                OAuth connection tokens, account identifiers, selected source
+                settings, source artifacts, extracted text, evidence, metrics,
+                generated drafts, review results, and other outputs associated
+                with your account or workspace.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                We may retain this information while your account or workspace is
+                active, until you delete it where product controls are available,
+                or until you request deletion, subject to legal, security, audit,
+                and backup retention requirements. Disconnecting a connector
+                stops future sync for that connector but may not automatically
+                delete historical generated outputs, source artifacts, metrics,
+                or evidence already created from that connection.
+              </p>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.5 Data retention (retention window)
-                            </h3>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    <strong>Gmail data accessed via your connection:</strong> We do not store
-                                    your Gmail data and will dispose of any data gained from your Gmail
-                                    connection within <strong>24 hours</strong>.
-                                </li>
-                                <li>
-                                    <strong>Derived outputs (e.g., monthly reports):</strong> We retain derived
-                                    outputs only for as long as necessary to provide the Services to you (for
-                                    example, while your account remains active, or until you delete them).
-                                </li>
-                                <li>
-                                    <strong>OAuth tokens:</strong> We retain refresh tokens while your Gmail
-                                    connection is active so we can generate recurring updates. If you
-                                    disconnect Google/Gmail or delete your account, we will delete or
-                                    invalidate stored tokens within a reasonable time.
-                                </li>
-                            </ul>
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                3.5 Disconnecting, deleting data, and revoking access
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                You can disconnect connected accounts in the product where
+                controls are available, and you can also revoke MLAI access
+                directly through the relevant third-party provider. After you
+                disconnect or revoke access, some features may stop working.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                If you want MLAI to delete data associated with a connector,
+                generated monthly update, or AI output, use available product
+                controls or email us at <strong>hi@mlai.au</strong> with your
+                request. Please include the email address associated with your
+                MLAI account and, where relevant, the third-party account or
+                workspace you connected.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                We will action deletion requests within a reasonable time and,
+                where applicable, confirm once completed.
+              </p>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.6 Disconnecting, deleting data, and revoking access
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You can disconnect your Google account from MLAI in your account settings
-                                (if available) and you can also revoke MLAI’s access at any time in your
-                                Google Account permissions page. After you disconnect or revoke access,
-                                some features may stop working.
-                            </p>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you want MLAI to delete data associated with your Gmail connection or AI
-                                outputs, you can:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    Use the <strong>Settings</strong> area (if available) to disconnect Google/Gmail
-                                    and/or delete your generated reports.
-                                </li>
-                                <li>
-                                    Email us at <strong>hi@mlai.au</strong> with your request (please include the
-                                    Google email address you connected, and your MLAI account email if
-                                    different).
-                                </li>
-                            </ul>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We will action deletion requests within a reasonable time and, where
-                                applicable, confirm once completed.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                4. Your Responsibilities
+              </h2>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>
+                  You may only connect accounts, workspaces, channels, files, and
+                  data that you own, administer, or are authorized to use with the
+                  Services.
+                </li>
+                <li>
+                  You are responsible for ensuring that your use of the Services
+                  complies with applicable laws, regulations, third-party terms,
+                  privacy obligations, and contractual obligations, including
+                  confidentiality obligations to customers, employees, investors,
+                  and other third parties.
+                </li>
+                <li>
+                  You are responsible for reviewing generated drafts, metrics,
+                  evidence, summaries, and reports before relying on them,
+                  publishing them, or sharing them with investors, communities,
+                  customers, or other third parties.
+                </li>
+                <li>
+                  You must not share outputs that contain confidential,
+                  privileged, personal, or third-party information unless you are
+                  authorized to do so.
+                </li>
+              </ul>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                4. Your Responsibilities
-                            </h2>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>You may only connect accounts and data that you own or are authorized to use.</li>
-                                <li>
-                                    You are responsible for ensuring that your use of the Services complies
-                                    with applicable laws, regulations, and contractual obligations (including
-                                    confidentiality obligations to third parties).
-                                </li>
-                                <li>You are responsible for reviewing outputs before relying on them for important decisions.</li>
-                            </ul>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                5. Acceptable Use
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                You agree not to misuse the Services. You must not, and must not
+                attempt to:
+              </p>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>Access or use the Services in a way that violates any law or infringes the rights of others.</li>
+                <li>Attempt to gain unauthorized access to any accounts, systems, or networks.</li>
+                <li>
+                  Reverse engineer, decompile, or attempt to extract the source
+                  code of the Services except to the extent permitted by law.
+                </li>
+                <li>Upload or transmit malware or interfere with the operation or security of the Services.</li>
+              </ul>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                5. Acceptable Use
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You agree not to misuse the Services. You must not, and must not attempt to:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>Access or use the Services in a way that violates any law or infringes the rights of others.</li>
-                                <li>Attempt to gain unauthorized access to any accounts, systems, or networks.</li>
-                                <li>
-                                    Reverse engineer, decompile, or attempt to extract the source code of the
-                                    Services except to the extent permitted by law.
-                                </li>
-                                <li>Upload or transmit malware or interfere with the operation or security of the Services.</li>
-                            </ul>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                6. AI Outputs and Disclaimers
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                The Services may produce outputs generated or assisted by AI,
+                including monthly update drafts, summaries, metrics, evidence,
+                recommendations, and review results. AI-generated outputs may be
+                inaccurate, incomplete, stale, or misleading and should not be
+                treated as professional advice, including legal, financial, tax,
+                medical, security, or investment advice.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Outputs may include confidential, personal, or third-party
+                information from connected sources or materials you provide. You
+                are solely responsible for reviewing, editing, approving, and
+                deciding whether to publish, send, or otherwise use any output.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                6. AI Outputs and Disclaimers
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                The Services may produce outputs generated by AI. AI-generated outputs may
-                                be inaccurate, incomplete, or misleading and should not be treated as
-                                professional advice (including legal, financial, tax, medical, or security
-                                advice). You are solely responsible for how you use any outputs.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                7. Intellectual Property
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                We and our licensors own all rights, title, and interest in and
+                to the Services, including all intellectual property rights. You
+                retain ownership of your content. You grant MLAI a limited
+                license to process your content solely to provide, operate,
+                secure, and support the Services.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                7. Intellectual Property
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We and our licensors own all rights, title, and interest in and to the
-                                Services, including all intellectual property rights. You retain ownership
-                                of your content. You grant MLAI a limited license to process your content
-                                solely to provide and operate the Services.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                8. Third-Party Services
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                The Services may integrate with third-party services such as
+                Google, Gmail, Google Drive, Slack, Xero, Linear, Notion, OpenAI,
+                and other AI or infrastructure providers. Third-party services
+                are governed by their own terms and policies. MLAI is not
+                responsible for third-party services.
+              </p>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Connector features may be affected by third-party API outages,
+                rate limits, revoked scopes, expired or invalid tokens,
+                permission changes, product changes, policy changes, or account
+                restrictions. You may need to reconnect accounts or update
+                permissions for some features to work.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                8. Third-Party Services
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                The Services may integrate with third-party services (such as Google).
-                                Third-party services are governed by their own terms and policies. MLAI is
-                                not responsible for third-party services.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                9. Suspension and Termination
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                We may suspend or terminate your access to the Services if we
+                reasonably believe you have violated these Terms, pose a risk to
+                the Services, or where required by law. You may stop using the
+                Services at any time and may revoke connected account access as
+                described above.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                9. Suspension and Termination
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We may suspend or terminate your access to the Services if we reasonably
-                                believe you have violated these Terms, pose a risk to the Services, or where
-                                required by law. You may stop using the Services at any time and may revoke
-                                connected account access as described above.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                10. Disclaimer of Warranties
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                To the maximum extent permitted by law, the Services are provided
+                on an "as is" and "as available" basis. We disclaim all
+                warranties, express or implied, including implied warranties of
+                merchantability, fitness for a particular purpose, and
+                non-infringement.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                10. Disclaimer of Warranties
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                To the maximum extent permitted by law, the Services are provided on an “as
-                                is” and “as available” basis. We disclaim all warranties, express or
-                                implied, including implied warranties of merchantability, fitness for a
-                                particular purpose, and non-infringement.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                11. Limitation of Liability
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                To the maximum extent permitted by law, MLAI will not be liable
+                for any indirect, incidental, special, consequential, or punitive
+                damages, or any loss of profits, revenue, data, or goodwill
+                arising from or related to your use of the Services.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                11. Limitation of Liability
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                To the maximum extent permitted by law, MLAI will not be liable for any
-                                indirect, incidental, special, consequential, or punitive damages, or any
-                                loss of profits, revenue, data, or goodwill arising from or related to your
-                                use of the Services.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                12. Indemnity
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                You agree to indemnify and hold harmless MLAI from and against
+                any claims, liabilities, damages, losses, and expenses arising
+                out of or related to your use of the Services, your content, or
+                your violation of these Terms.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                12. Indemnity
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You agree to indemnify and hold harmless MLAI from and against any claims,
-                                liabilities, damages, losses, and expenses arising out of or related to
-                                your use of the Services, your content, or your violation of these Terms.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                13. Privacy
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                Our Privacy Policy explains how we collect, use, and protect
+                personal information. By using the Services, you agree to our
+                Privacy Policy.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                13. Privacy
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Our Privacy Policy explains how we collect, use, and protect personal
-                                information. By using the Services, you agree to our Privacy Policy.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                14. Changes to These Terms
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                We may update these Terms from time to time. We will post the
+                updated Terms on this page and update the "Last updated" date.
+                Your continued use of the Services after changes become
+                effective constitutes acceptance of the updated Terms.
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                14. Changes to These Terms
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We may update these Terms from time to time. We will post the updated Terms
-                                on this page and update the “Last updated” date. Your continued use of the
-                                Services after changes become effective constitutes acceptance of the
-                                updated Terms.
-                            </p>
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                15. Contact Us
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                If you have questions about these Terms, contact us at:
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                15. Contact Us
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you have questions about these Terms, contact us at:
-                            </p>
-
-                            <div className="mt-4 bg-gray-50 p-6 rounded-lg">
-                                <p className="mb-2 text-base leading-7 text-zinc-600">
-                                    <strong>MLAI Aus Inc</strong>
-                                </p>
-                                <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
-                                <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
-                            </div>
-
-                        </div>
-                    </div>
-                </div>
-            </Container>
-        </>
-    );
+              <div className="mt-4 bg-gray-50 p-6 rounded-lg">
+                <p className="mb-2 text-base leading-7 text-zinc-600">
+                  <strong>MLAI Aus Inc</strong>
+                </p>
+                <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
+                <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- Update the MLAI Privacy Policy with Founder Tools connector disclosures for Gmail, Slack, Xero, Linear, Notion/Google Drive, manual materials, generated drafts, retention, deletion, and AI processing.
- Update the MLAI Terms of Service to cover connected-account responsibilities, third-party service caveats, and monthly-update AI output review requirements.
- Add Google API Limited Use language and remove the outdated 24-hour Gmail retention claim.

## Validation
- `git diff --check -- app/routes/privacy.tsx app/routes/terms.tsx`
- `bun run typecheck`
- `bun run build`

Note: `bun run build` exits 0. It still emits the existing Vite reporter line `The build was canceled` and IndexNow returns 403, but the React Router build completes successfully.
