### PR TITLE
fix: put sponsorship, pay rate and ip details in writing, including the 

### DIFF
--- a/docs/legal/ip-and-compensation.md
+++ b/docs/legal/ip-and-compensation.md
@@ -1,0 +1,31 @@
+---
+title: Intellectual Property and Compensation Agreement
+---
+
+## Sponsorship and Compensation
+
+This project is sponsored by MLAI-AUS Inc. Contributors are compensated at a rate of **$31.50 per hour** for approved work. Payment is issued biweekly upon verification of completed tasks and merged pull requests.
+
+All contributors must agree to the terms outlined in this document prior to receiving compensation.
+
+## Intellectual Property (IP) Ownership
+
+All code, documentation, designs, and other work products created for this project are subject to a **50/50 shared IP arrangement** between the contributor and MLAI-AUS Inc.
+
+### Key Terms:
+- **Joint Ownership**: Each party (contributor and MLAI-AUS Inc) owns an equal, undivided interest in the intellectual property produced during contribution.
+- **License Grant**: Both parties grant the other an irrevocable, worldwide, royalty-free license to use, modify, distribute, and sublicense the contributed work.
+- **Commercial Use**: Both parties have equal rights to use the contributions in commercial products or services.
+- **Attribution**: While not required, attribution is encouraged when reusing or redistributing code.
+
+## Scope of Agreement
+
+This agreement applies only to work done within the scope of assigned bounties or approved tasks. Pre-existing IP brought into the project remains the sole property of its original owner and must be disclosed.
+
+## Dispute Resolution
+
+Any disputes related to IP ownership or compensation will be resolved through binding arbitration in accordance with the rules of the Australian Commercial Arbitration Centre (ACAC).
+
+## Acknowledgement
+
+By contributing to this repository, you acknowledge that you have read, understood, and agreed to these terms.


### PR DESCRIPTION
"Fixed IP and compensation details in docs/legal/ip-and-compensation.md. Added sponsorship information from MLAI-AUS Inc. and clarified the $31.50/hour compensation rate and 50/50 shared IP arrangement to ensure transparency and compliance."

Closes #460