### PR TITLE
[codex] Update Gmail verification legal pages

### DIFF
--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -1,11 +1,21 @@
 import type { MetaFunction } from "react-router";
 import { Container } from "~/components/ui/Container";
 
+const LAST_UPDATED = "4 May 2026";
+
 export const meta: MetaFunction = () => {
   return [
-    { title: "MLAI Privacy Policy | Data & Consent Guide" },
-    { name: "description", content: "MLAI Privacy Policy outlining the collection, use, and management of personal information for our AI community." },
-    { name: "keywords", content: "privacy policy, MLAI, machine learning, AI community, personal information, Australian Privacy Principles" },
+    { title: "MLAI Vibe Raising Privacy Policy | Google and Gmail Data Use" },
+    {
+      name: "description",
+      content:
+        "Privacy Policy for MLAI Vibe Raising, including Google OAuth, Gmail data access, AI-assisted monthly founder updates, retention, deletion, and Limited Use commitments.",
+    },
+    {
+      name: "keywords",
+      content:
+        "MLAI Vibe Raising privacy policy, Gmail integration, Google OAuth, Google user data, Limited Use, data deletion",
+    },
   ];
 };
 
@@ -16,19 +26,26 @@ export default function Privacy() {
         <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-1 lg:grid-rows-[auto_1fr] lg:gap-y-12">
           <div className="lg:order-first lg:row-span-2">
             <h1 className="text-4xl pt-12 font-bold tracking-tight text-[#3b82f6] sm:text-5xl dark:text-[#3b82f6]">
-              MLAI Privacy Policy
+              MLAI Vibe Raising Privacy Policy
             </h1>
             <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
               <h2 className="text-xl font-semibold leading-7 text-gray-900">
-                Last updated: {new Date().toLocaleDateString()}
+                Last updated: {LAST_UPDATED}
               </h2>
 
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                MLAI Aus Inc ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website or attend our events.
+                MLAI Aus Inc ("MLAI", "we", "our", or "us") provides MLAI
+                Vibe Raising, a founder tool that helps startups draft monthly
+                investor updates from information the founder chooses to provide
+                or connect. This Privacy Policy explains how we collect, use,
+                store, share, protect, retain, and delete information, including
+                Google user data and Gmail data.
               </p>
 
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                By accessing and using our website and services, you agree to the terms of this Privacy Policy.
+                By using MLAI websites, applications, and services, including
+                MLAI Vibe Raising, you acknowledge the practices described in
+                this Privacy Policy.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
@@ -36,143 +53,217 @@ export default function Privacy() {
               </h2>
 
               <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Personal Information
+                Account, Contact, and Support Information
               </h3>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We may collect personal information that you voluntarily provide to us when you:
+                We may collect information you provide when you create an
+                account, contact us, register for events, subscribe to updates,
+                request support, or otherwise interact with MLAI. This may
+                include your name, email address, company name, role, support
+                requests, and communication preferences.
+              </p>
+
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                Startup and Founder Update Information
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                MLAI Vibe Raising may process startup information that you enter,
+                upload, generate, or approve in the product. This may include
+                company profile information, goals, metrics, milestones,
+                customer conversations, investor asks, risks, blockers, draft
+                updates, final updates, notes, files, and other materials you
+                choose to use for monthly founder or investor updates.
+              </p>
+
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                Optional Connected Data Sources
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                You may choose to connect third-party services so MLAI Vibe
+                Raising can use relevant context for the update workflow.
+                Connected sources may include Google services such as Gmail and
+                Google Account profile information, as well as other data sources
+                that are available in the product from time to time. You should
+                only connect accounts and data that you own or are authorized to
+                use.
+              </p>
+
+              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
+                Google and Gmail Data We Access
+              </h3>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                If you choose to connect your Google account, Google will show
+                the exact permissions requested before you grant access. Depending
+                on the feature you enable, MLAI may access or process:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Register for events or workshops</li>
-                <li>Subscribe to our newsletter or mailing list</li>
-                <li>Contact us through our website or email</li>
-                <li>Apply to volunteer with our organization</li>
-                <li>Participate in surveys or feedback forms</li>
+                <li>Google account identifiers such as your email address and profile information.</li>
+                <li>OAuth access tokens and refresh tokens needed to maintain the connection.</li>
+                <li>Gmail message and thread identifiers, history identifiers, labels, headers, dates, and other metadata.</li>
+                <li>Email subjects, sender and recipient fields, snippets, body text, cleaned or extracted text, and previews.</li>
+                <li>Attachment metadata and attachment content when processed for the update workflow.</li>
+                <li>Derived artifacts such as relevance scores, summaries, extracted events, metrics, asks, risks, and generated drafts.</li>
               </ul>
 
               <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
                 Automatically Collected Information
               </h3>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                When you visit our website, we may automatically collect certain information about your device and browsing behavior, including:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>IP address</li>
-                <li>Browser type and version</li>
-                <li>Operating system</li>
-                <li>Pages visited and time spent on our site</li>
-                <li>Referring website</li>
-              </ul>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                How We Use Your Information
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We use the information we collect to:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Organize and manage events, workshops, and meetups</li>
-                <li>Send newsletters and updates about MLAI activities</li>
-                <li>Respond to your inquiries and provide customer support</li>
-                <li>Improve our website and services</li>
-                <li>Comply with legal obligations</li>
-                <li>Coordinate volunteer activities and opportunities</li>
-              </ul>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Email Communications and Newsletter
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you subscribe to our newsletter or mailing list, we will send you periodic updates about:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Upcoming events and workshops</li>
-                <li>Community news and announcements</li>
-                <li>Educational content related to AI and machine learning</li>
-                <li>Volunteer opportunities</li>
-              </ul>
-
-              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Unsubscribe Options
-              </h3>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                <strong>You can unsubscribe at any time by clicking the unsubscribe button</strong> included in every email we send. You may also:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Contact us directly at hi@mlai.au to request removal from our mailing list</li>
-                <li>Update your email preferences through the link provided in our emails</li>
-                <li>Opt out of specific types of communications while remaining subscribed to others</li>
-              </ul>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                Once you unsubscribe, we will process your request promptly and you will stop receiving marketing emails within 5-10 business days. Please note that you may still receive transactional emails related to events you have registered for or other essential communications.
+                When you use our website or services, we may collect technical
+                and usage information such as IP address, browser type, device
+                information, pages visited, referral source, timestamps, log
+                data, product events, and error diagnostics.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Information Sharing and Disclosure
+                How We Use Information
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We do not sell, trade, or otherwise transfer your personal information to third parties without your consent, except in the following circumstances:
+                We use information to provide, maintain, secure, and improve MLAI
+                services. For MLAI Vibe Raising, we use connected and provided
+                data to:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Event management platforms (e.g., Humanitix, Eventbrite) when you register for events</li>
-                <li>Service providers who assist us in operating our website and conducting our activities</li>
-                <li>When required by law or to protect our rights and safety</li>
+                <li>Generate monthly founder and investor update drafts requested by you.</li>
+                <li>Identify relevant update signals such as milestones, metrics, investor feedback, customer conversations, risks, asks, and follow-ups.</li>
+                <li>Show previews, summaries, source context, and derived outputs in the product.</li>
+                <li>Maintain your connected account status and refresh authorized data when needed for the requested workflow.</li>
+                <li>Provide support, troubleshoot issues, prevent abuse, protect security, and comply with legal obligations.</li>
+                <li>Send service, transactional, and account-related communications.</li>
+              </ul>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                AI Processing
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                MLAI Vibe Raising may use automated systems and AI models to
+                analyze founder-provided data and optional connected data,
+                including Gmail data, for the purpose of producing the
+                user-facing monthly update workflow you requested. We do not use
+                Google Workspace API data, including Gmail data, to create, train,
+                or improve generalized AI or machine learning models.
+              </p>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Google User Data and Limited Use Commitments
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                MLAI's use and transfer of information received from Google APIs
+                will adhere to the Google API Services User Data Policy,
+                including the Limited Use requirements. In particular:
+              </p>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>We use Google user data only to provide or improve user-facing features that are visible in MLAI Vibe Raising.</li>
+                <li>We do not sell Google user data or Gmail data.</li>
+                <li>We do not use Google user data for advertising, retargeting, personalized advertising, data broker services, credit-worthiness, or lending purposes.</li>
+                <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
+                <li>We do not transfer Google user data except as needed to provide or improve the user-facing feature with your consent, comply with law, protect security, or as otherwise permitted by Google policy.</li>
+                <li>We do not allow humans to read Google user data unless you have given explicit permission, it is necessary for security or legal compliance, or the data has been aggregated and anonymized for permitted internal operations.</li>
+              </ul>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Sharing and Disclosure
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                We do not sell your personal information, Google user data, or
+                Gmail data. We may disclose information only in the following
+                limited circumstances:
+              </p>
+              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
+                <li>To service providers that help us operate, host, secure, support, or provide MLAI services, subject to confidentiality and data protection obligations.</li>
+                <li>To AI infrastructure providers only as needed to provide the user-facing feature you requested, and not for generalized model training on Google Workspace API data.</li>
+                <li>When you direct us to share an output, send an update, invite a collaborator, or otherwise disclose information through the product.</li>
+                <li>When required by law, regulation, legal process, or to protect rights, safety, security, and prevent abuse.</li>
+                <li>In connection with a merger, acquisition, financing, reorganization, or sale of assets, subject to applicable law and required user consent where Google policy requires it.</li>
               </ul>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Data Security
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We implement appropriate technical and organizational security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction.
+                We use technical and organizational safeguards designed to protect
+                information from unauthorized access, alteration, disclosure, or
+                destruction. These safeguards include HTTPS for data transmitted
+                over external networks, encryption for stored sensitive data where
+                applicable, access controls, token protection, and internal
+                restrictions on who may access production systems. No system is
+                perfectly secure, but we work to maintain a secure operating
+                environment for user data and credentials.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Data Retention
+                Retention and Deletion
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We retain your personal information only as long as necessary to fulfill the purposes outlined in this Privacy Policy, unless a longer retention period is required by law.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Your Rights
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                Depending on your location, you may have certain rights regarding your personal information, including:
+                We retain information only for as long as needed to provide MLAI
+                services, comply with legal obligations, resolve disputes,
+                enforce agreements, maintain security, and support legitimate
+                business purposes. For MLAI Vibe Raising:
               </p>
               <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>The right to access your personal information</li>
-                <li>The right to correct or update your information</li>
-                <li>The right to delete your information</li>
-                <li>The right to restrict processing of your information</li>
-                <li>The right to data portability</li>
+                <li>OAuth tokens and connected account identifiers are retained while your Google connection is active.</li>
+                <li>Selected Gmail message and thread artifacts, extracted text, metadata, relevance signals, and derived outputs may be retained while needed to generate, display, troubleshoot, and improve the user-facing update workflow.</li>
+                <li>Generated drafts, monthly updates, summaries, metrics, and other derived outputs may be retained while your account is active or until you delete them or request deletion.</li>
+                <li>When you disconnect Google, revoke access, delete your account, or request deletion, we will delete or de-identify associated Google tokens, Gmail artifacts, and derived outputs within a reasonable time unless retention is required or permitted by law, security, or legitimate operational needs.</li>
               </ul>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Your Choices and Controls
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                You may choose not to connect Gmail. If you connect Gmail, you may
+                disconnect it in MLAI account settings where available, revoke
+                MLAI's access from your Google Account permissions page, or email
+                us at hi@mlai.au. You may also request access, correction,
+                deletion, export, or restriction of your personal information,
+                subject to applicable law and verification of your request.
+              </p>
+
+              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
+                Email Communications and Newsletter
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-600">
+                If you subscribe to MLAI emails, we may send updates about MLAI
+                activities, events, product information, and service notices. You
+                can unsubscribe from marketing emails by using the unsubscribe
+                link in those emails or by contacting hi@mlai.au. We may still
+                send transactional or account-related messages.
+              </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Children's Privacy
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                Our services are not directed to children under 13 years of age. We do not knowingly collect personal information from children under 13.
+                Our services are not directed to children under 13 years of age.
+                We do not knowingly collect personal information from children
+                under 13.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Changes to This Privacy Policy
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last updated" date.
+                We may update this Privacy Policy from time to time. If we change
+                how MLAI uses Google user data in a material way, we will update
+                this Privacy Policy and provide notice or seek consent where
+                required before using Google user data for the new purpose.
               </p>
 
               <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                 Contact Us
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you have any questions about this Privacy Policy or our privacy practices, please contact us at:
+                If you have questions about this Privacy Policy, our privacy
+                practices, or a deletion request, contact us at:
               </p>
 
               <div className="mt-4 bg-gray-50 p-6 rounded-lg">
-                <p className="mb-2 text-base leading-7 text-zinc-600"><strong>MLAI Aus Inc</strong></p>
+                <p className="mb-2 text-base leading-7 text-zinc-600">
+                  <strong>MLAI Aus Inc</strong>
+                </p>
                 <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
                 <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
               </div>
-
             </div>
           </div>
         </div>

--- a/app/routes/terms.tsx
+++ b/app/routes/terms.tsx
@@ -1,20 +1,20 @@
 import type { MetaFunction } from "react-router";
 import { Container } from "~/components/ui/Container";
 
-const LAST_UPDATED = "16 December 2025"; // Update this manually when you change the Terms
+const LAST_UPDATED = "4 May 2026";
 
 export const meta: MetaFunction = () => {
     return [
-        { title: "MLAI Terms of Service" },
+        { title: "MLAI Vibe Raising Terms of Service" },
         {
             name: "description",
             content:
-                "MLAI Terms of Service governing use of MLAI services, including Google/Gmail connections and AI-generated summaries.",
+                "Terms of Service for MLAI services, including MLAI Vibe Raising, Google/Gmail connections, AI-generated monthly updates, retention, and data deletion.",
         },
         {
             name: "keywords",
             content:
-                "terms of service, MLAI, Gmail integration, Google OAuth, AI summaries, retention, data deletion",
+                "terms of service, MLAI Vibe Raising, Gmail integration, Google OAuth, AI summaries, retention, data deletion",
         },
     ];
 };
@@ -26,7 +26,7 @@ export default function TermsOfService() {
                 <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-1 lg:grid-rows-[auto_1fr] lg:gap-y-12">
                     <div className="lg:order-first lg:row-span-2">
                         <h1 className="text-4xl pt-12 font-bold tracking-tight text-[#3b82f6] sm:text-5xl dark:text-[#3b82f6]">
-                            MLAI Terms of Service
+                            MLAI Vibe Raising Terms of Service
                         </h1>
 
                         <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
@@ -35,24 +35,28 @@ export default function TermsOfService() {
                             </h2>
 
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                These Terms of Service (“Terms”) govern your access to and use of the MLAI
-                                websites, applications, and services (collectively, the “Services”) provided
-                                by MLAI Aus Inc (“MLAI”, “we”, “our”, or “us”).
+                                These Terms of Service ("Terms") govern your access to and use
+                                of MLAI websites, applications, and services, including MLAI
+                                Vibe Raising (collectively, the "Services") provided by MLAI
+                                Aus Inc ("MLAI", "we", "our", or "us").
                             </p>
 
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                By accessing or using the Services, you agree to be bound by these Terms. If
-                                you do not agree, do not use the Services.
+                                By accessing or using the Services, you agree to be bound by
+                                these Terms. If you do not agree, do not use the Services.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 1. The Services
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                MLAI provides community, educational, and software-based tools, which may
-                                include AI-powered features. Some features allow you to connect third-party
-                                accounts (such as Google/Gmail) so that MLAI can process your data to
-                                deliver user-requested outputs, such as summaries and reports.
+                                MLAI provides community, educational, and software-based tools.
+                                MLAI Vibe Raising helps founders draft monthly startup and
+                                investor updates from information the founder chooses to enter,
+                                upload, generate, or connect. Some features allow you to
+                                connect third-party accounts, including Google and Gmail, so
+                                MLAI can process relevant context for user-requested summaries,
+                                drafts, metrics, asks, risks, and follow-ups.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
@@ -60,152 +64,101 @@ export default function TermsOfService() {
                             </h2>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                                 <li>You must be able to form a legally binding contract to use the Services.</li>
-                                <li>
-                                    You are responsible for maintaining the confidentiality of your account
-                                    credentials and for all activity under your account.
-                                </li>
-                                <li>
-                                    You agree to provide accurate, current, and complete information and keep
-                                    it updated.
-                                </li>
+                                <li>You are responsible for maintaining the confidentiality of your account credentials and for all activity under your account.</li>
+                                <li>You agree to provide accurate, current, and complete information and keep it updated.</li>
                             </ul>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 3. Google/Gmail Connection (OAuth) and Email Analysis
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you choose to connect your Google account, you authorize MLAI to access
-                                the Google data you explicitly grant through the Google consent screen (for
-                                example, Gmail data) for the purpose of providing the feature you requested
-                                (for example, generating a monthly update).
+                                Gmail connection is optional. If you choose to connect your
+                                Google account, you authorize MLAI to access the Google user
+                                data you explicitly grant through the Google consent screen for
+                                the purpose of providing the MLAI Vibe Raising feature you
+                                requested, such as drafting a monthly founder or investor
+                                update from relevant email context.
                             </p>
 
                             <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.1 What you are authorising
+                                3.1 What you are authorizing
                             </h3>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Depending on the feature you enable, MLAI may access Gmail data such as
-                                email metadata (e.g., sender, recipient, subject, date) and/or email content
-                                (e.g., body text). The exact permissions are shown on the Google consent
-                                screen at the time you connect.
+                                Depending on the feature you enable, MLAI may access Gmail data
+                                such as message and thread identifiers, labels, headers, dates,
+                                sender and recipient fields, subjects, snippets, body text,
+                                cleaned or extracted text, attachment metadata, and attachment
+                                content when processed for the requested update workflow. The
+                                exact permissions are shown on the Google consent screen before
+                                you grant access.
                             </p>
 
                             <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
                                 3.2 What we do with Gmail data
                             </h3>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    We use Gmail data to provide the user-facing feature you requested, such
-                                    as generating summaries, insights, and reports about your startup
-                                    activity.
-                                </li>
-                                <li>
-                                    We may process Gmail data using automated systems, including AI models, to
-                                    produce the requested outputs.
-                                </li>
-                                <li>
-                                    We may store tokens required to maintain your connection (including
-                                    refresh tokens) and may store limited derived outputs (e.g., a generated
-                                    monthly report) associated with your account.
-                                </li>
+                                <li>We use Gmail data only to provide or improve the user-facing MLAI Vibe Raising workflow you requested.</li>
+                                <li>We use Gmail context to identify relevant update signals such as investor feedback, customer conversations, milestones, risks, asks, metrics, and follow-ups.</li>
+                                <li>We may process Gmail data using automated systems and AI models to produce requested drafts, summaries, extracted facts, and related outputs.</li>
+                                <li>We may store OAuth tokens, connected account identifiers, selected message or thread artifacts, and derived outputs while needed to provide the Services.</li>
                             </ul>
 
                             <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
                                 3.3 Google API data use commitments
                             </h3>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                When you connect Google services, we will handle Google user data in
-                                accordance with our Privacy Policy and applicable Google requirements. In
-                                particular:
+                                MLAI's use and transfer of information received from Google
+                                APIs will adhere to the Google API Services User Data Policy,
+                                including the Limited Use requirements. In particular:
                             </p>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>We do not sell Gmail data.</li>
-                                <li>
-                                    We do not use Gmail data to train or improve generalized AI/ML models
-                                    (outside of providing the requested feature and personalizing your
-                                    experience).
-                                </li>
-                                <li>
-                                    We limit access to Gmail data to what is necessary to provide the feature
-                                    you request.
-                                </li>
+                                <li>We do not sell Google user data or Gmail data.</li>
+                                <li>We do not use Google user data or Gmail data for advertising, retargeting, credit-worthiness, lending, data broker, or information reseller purposes.</li>
+                                <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
+                                <li>We limit access, transfer, and human review of Google user data to what is permitted by our Privacy Policy, your consent, applicable law, security needs, and Google policy.</li>
                             </ul>
 
                             <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.4 What we store (email content vs derived summaries)
+                                3.4 What we store
                             </h3>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Our goal is to minimise the data we store.
+                                Our goal is to minimize the Google user data we store while
+                                still providing the MLAI Vibe Raising workflow you requested.
+                                We may store:
                             </p>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    <strong>Raw Gmail content:</strong> We do not permanently store your Gmail
-                                    email content (including message bodies). Any Gmail data accessed via your
-                                    connection is processed transiently for the requested feature and then
-                                    disposed of.
-                                </li>
-                                <li>
-                                    <strong>Derived outputs:</strong> We may store derived outputs (for example,
-                                    a monthly summary/report, insights, action items, or aggregated metrics)
-                                    associated with your account so you can view them later.
-                                </li>
-                                <li>
-                                    <strong>Connection data:</strong> We may store OAuth connection tokens
-                                    (including refresh tokens) and basic account identifiers (such as the email
-                                    address associated with the connected Google account) to keep the
-                                    integration working.
-                                </li>
+                                <li><strong>Connection data:</strong> OAuth tokens, refresh tokens, and basic account identifiers, such as the connected Google account email address, while your connection is active.</li>
+                                <li><strong>Selected Gmail artifacts:</strong> message and thread metadata, extracted or cleaned text, attachment information, relevance signals, and source context needed to generate, display, troubleshoot, and improve the requested update workflow.</li>
+                                <li><strong>Derived outputs:</strong> monthly update drafts, summaries, insights, events, metrics, asks, follow-ups, and other outputs associated with your account.</li>
                             </ul>
 
                             <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.5 Data retention (retention window)
+                                3.5 Data retention
                             </h3>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    <strong>Gmail data accessed via your connection:</strong> We do not store
-                                    your Gmail data and will dispose of any data gained from your Gmail
-                                    connection within <strong>24 hours</strong>.
-                                </li>
-                                <li>
-                                    <strong>Derived outputs (e.g., monthly reports):</strong> We retain derived
-                                    outputs only for as long as necessary to provide the Services to you (for
-                                    example, while your account remains active, or until you delete them).
-                                </li>
-                                <li>
-                                    <strong>OAuth tokens:</strong> We retain refresh tokens while your Gmail
-                                    connection is active so we can generate recurring updates. If you
-                                    disconnect Google/Gmail or delete your account, we will delete or
-                                    invalidate stored tokens within a reasonable time.
-                                </li>
+                                <li><strong>OAuth tokens:</strong> We retain tokens while your Gmail connection is active. If you disconnect Google/Gmail, revoke access, or delete your account, we will delete or invalidate stored tokens within a reasonable time.</li>
+                                <li><strong>Gmail artifacts and source context:</strong> We retain selected artifacts only while needed to provide, display, troubleshoot, secure, and improve the user-facing update workflow, unless you request deletion or a longer period is required or permitted by law.</li>
+                                <li><strong>Derived outputs:</strong> We retain generated drafts and reports while your account remains active or until you delete them or request deletion, subject to legal, security, and operational requirements.</li>
                             </ul>
 
                             <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
                                 3.6 Disconnecting, deleting data, and revoking access
                             </h3>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You can disconnect your Google account from MLAI in your account settings
-                                (if available) and you can also revoke MLAI’s access at any time in your
-                                Google Account permissions page. After you disconnect or revoke access,
-                                some features may stop working.
+                                You can disconnect your Google account from MLAI in account
+                                settings where available, revoke MLAI's access at any time in
+                                your Google Account permissions page, or email hi@mlai.au.
+                                After you disconnect or revoke access, Gmail-powered features
+                                may stop working.
                             </p>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you want MLAI to delete data associated with your Gmail connection or AI
-                                outputs, you can:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>
-                                    Use the <strong>Settings</strong> area (if available) to disconnect Google/Gmail
-                                    and/or delete your generated reports.
-                                </li>
-                                <li>
-                                    Email us at <strong>hi@mlai.au</strong> with your request (please include the
-                                    Google email address you connected, and your MLAI account email if
-                                    different).
-                                </li>
-                            </ul>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We will action deletion requests within a reasonable time and, where
-                                applicable, confirm once completed.
+                                If you want MLAI to delete data associated with your Gmail
+                                connection, generated updates, or AI outputs, you can use the
+                                settings area where available or email hi@mlai.au with your
+                                request. Please include the Google email address you connected
+                                and your MLAI account email if different. We will action
+                                deletion requests within a reasonable time and confirm where
+                                applicable.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
@@ -213,114 +166,122 @@ export default function TermsOfService() {
                             </h2>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                                 <li>You may only connect accounts and data that you own or are authorized to use.</li>
-                                <li>
-                                    You are responsible for ensuring that your use of the Services complies
-                                    with applicable laws, regulations, and contractual obligations (including
-                                    confidentiality obligations to third parties).
-                                </li>
-                                <li>You are responsible for reviewing outputs before relying on them for important decisions.</li>
+                                <li>You are responsible for ensuring that your use of the Services complies with applicable laws, regulations, confidentiality obligations, and contracts with third parties.</li>
+                                <li>You are responsible for reviewing any generated update, summary, metric, ask, or other output before relying on it or sharing it with investors or other recipients.</li>
                             </ul>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 5. Acceptable Use
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You agree not to misuse the Services. You must not, and must not attempt to:
+                                You agree not to misuse the Services. You must not, and must
+                                not attempt to:
                             </p>
                             <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
                                 <li>Access or use the Services in a way that violates any law or infringes the rights of others.</li>
+                                <li>Connect accounts, emails, files, or other data that you are not authorized to use.</li>
                                 <li>Attempt to gain unauthorized access to any accounts, systems, or networks.</li>
-                                <li>
-                                    Reverse engineer, decompile, or attempt to extract the source code of the
-                                    Services except to the extent permitted by law.
-                                </li>
+                                <li>Reverse engineer, decompile, or attempt to extract the source code of the Services except to the extent permitted by law.</li>
                                 <li>Upload or transmit malware or interfere with the operation or security of the Services.</li>
+                                <li>Use the Services to send spam, deceptive communications, unlawful content, or unsolicited commercial mail.</li>
                             </ul>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 6. AI Outputs and Disclaimers
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                The Services may produce outputs generated by AI. AI-generated outputs may
-                                be inaccurate, incomplete, or misleading and should not be treated as
-                                professional advice (including legal, financial, tax, medical, or security
-                                advice). You are solely responsible for how you use any outputs.
+                                The Services may produce outputs generated by automated systems
+                                or AI models. AI-generated outputs may be inaccurate,
+                                incomplete, outdated, or misleading. You must review outputs
+                                before relying on them. Outputs are not professional advice,
+                                including legal, financial, tax, investment, medical, or
+                                security advice.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 7. Intellectual Property
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We and our licensors own all rights, title, and interest in and to the
-                                Services, including all intellectual property rights. You retain ownership
-                                of your content. You grant MLAI a limited license to process your content
-                                solely to provide and operate the Services.
+                                We and our licensors own all rights, title, and interest in and
+                                to the Services, including all intellectual property rights. You
+                                retain ownership of your content. You grant MLAI a limited
+                                license to process your content solely to provide, operate,
+                                secure, support, and improve the Services in accordance with
+                                these Terms and our Privacy Policy.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 8. Third-Party Services
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                The Services may integrate with third-party services (such as Google).
-                                Third-party services are governed by their own terms and policies. MLAI is
-                                not responsible for third-party services.
+                                The Services may integrate with third-party services, including
+                                Google. Third-party services are governed by their own terms and
+                                policies. MLAI is not responsible for third-party services.
+                                Your use of Google services remains subject to Google's terms
+                                and policies.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 9. Suspension and Termination
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We may suspend or terminate your access to the Services if we reasonably
-                                believe you have violated these Terms, pose a risk to the Services, or where
-                                required by law. You may stop using the Services at any time and may revoke
-                                connected account access as described above.
+                                We may suspend or terminate your access to the Services if we
+                                reasonably believe you have violated these Terms, pose a risk to
+                                the Services, or where required by law. You may stop using the
+                                Services at any time and may revoke connected account access as
+                                described above.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 10. Disclaimer of Warranties
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                To the maximum extent permitted by law, the Services are provided on an “as
-                                is” and “as available” basis. We disclaim all warranties, express or
-                                implied, including implied warranties of merchantability, fitness for a
-                                particular purpose, and non-infringement.
+                                To the maximum extent permitted by law, the Services are
+                                provided on an "as is" and "as available" basis. We disclaim all
+                                warranties, express or implied, including implied warranties of
+                                merchantability, fitness for a particular purpose, and
+                                non-infringement.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 11. Limitation of Liability
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                To the maximum extent permitted by law, MLAI will not be liable for any
-                                indirect, incidental, special, consequential, or punitive damages, or any
-                                loss of profits, revenue, data, or goodwill arising from or related to your
-                                use of the Services.
+                                To the maximum extent permitted by law, MLAI will not be liable
+                                for any indirect, incidental, special, consequential, or punitive
+                                damages, or any loss of profits, revenue, data, goodwill, or
+                                business opportunity arising from or related to your use of the
+                                Services.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 12. Indemnity
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You agree to indemnify and hold harmless MLAI from and against any claims,
-                                liabilities, damages, losses, and expenses arising out of or related to
-                                your use of the Services, your content, or your violation of these Terms.
+                                You agree to indemnify and hold harmless MLAI from and against
+                                any claims, liabilities, damages, losses, and expenses arising
+                                out of or related to your use of the Services, your content,
+                                connected accounts or data, or your violation of these Terms.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 13. Privacy
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Our Privacy Policy explains how we collect, use, and protect personal
-                                information. By using the Services, you agree to our Privacy Policy.
+                                Our <a href="/privacy" className="font-semibold text-[#3b82f6] underline">Privacy Policy</a>{" "}
+                                explains how we collect, use, protect, retain, and delete
+                                personal information, including Google user data and Gmail data.
+                                By using the Services, you acknowledge our Privacy Policy.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
                                 14. Changes to These Terms
                             </h2>
                             <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We may update these Terms from time to time. We will post the updated Terms
-                                on this page and update the “Last updated” date. Your continued use of the
-                                Services after changes become effective constitutes acceptance of the
-                                updated Terms.
+                                We may update these Terms from time to time. We will post the
+                                updated Terms on this page and update the "Last updated" date.
+                                Your continued use of the Services after changes become
+                                effective constitutes acceptance of the updated Terms.
                             </p>
 
                             <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
@@ -337,7 +298,6 @@ export default function TermsOfService() {
                                 <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
                                 <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
                             </div>
-
                         </div>
                     </div>
                 </div>

--- a/app/routes/vibe-raising-landing.tsx
+++ b/app/routes/vibe-raising-landing.tsx
@@ -152,8 +152,8 @@ export default function VibeRaisingPage({}: Route.ComponentProps) {
                 "Gmail connection is optional and initiated by the founder.",
                 "Gmail data is used only to generate requested investor update drafts and summaries.",
                 "Gmail data is not sold and is not used to train generalized AI or machine learning models.",
-                "Raw Gmail content is processed transiently and deleted after processing.",
-                "Generated drafts and OAuth tokens may be retained only as needed to provide the service.",
+                "Gmail data is minimized and retained only as needed for the requested update workflow.",
+                "Generated drafts, selected artifacts, and OAuth tokens may be retained only as needed to provide the service.",
               ].map((item) => (
                 <li key={item} className="flex gap-3">
                   <DocumentTextIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--vr-color-primary)]" />


### PR DESCRIPTION
## Summary
- Rewrites the public privacy policy around MLAI Vibe Raising, Google OAuth, Gmail access, AI processing, Google user data, Limited Use, retention, deletion, and revoke controls.
- Aligns the Terms of Service with the Gmail verification posture and removes the unsupported blanket 24-hour Gmail deletion promise.
- Updates the Vibe Raising landing page Gmail commitments so the public homepage copy matches the legal pages and current backend behavior.

## Validation
- `bun run typecheck`
- `bun run build` (completed with the existing IndexNow 403 message from postbuild, but exited 0)
- Local route checks for `/privacy`, `/terms`, and `/vibe-raising` returned 200 in the earlier implementation worktree.