### PR TITLE
[codex] Refresh vibe marketing AI fill flow

### DIFF
--- a/app/components/ArticleRunStageProgress.tsx
+++ b/app/components/ArticleRunStageProgress.tsx
@@ -1,0 +1,297 @@
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  ExclamationTriangleIcon,
+} from "@heroicons/react/24/outline";
+import { clsx } from "clsx";
+
+import type { VibeMarketingRunSummary, VibeMarketingStepState } from "~/types/vibe-marketing";
+
+type StageId = "setup" | "research" | "write" | "preview";
+type StageStatus = "complete" | "running" | "up_next" | "attention";
+
+interface StageDefinition {
+  id: StageId;
+  label: string;
+  activeText: string;
+  completeText: string;
+  pendingText: string;
+}
+
+interface StageView extends StageDefinition {
+  status: StageStatus;
+  detail: string;
+}
+
+interface ArticleRunStageProgressProps {
+  run: VibeMarketingRunSummary;
+  pollingDegraded?: boolean;
+}
+
+const STAGES: StageDefinition[] = [
+  {
+    id: "setup",
+    label: "Checking website setup",
+    activeText: "Checking your repo, article system, and publish setup.",
+    completeText: "Website and repository setup are ready.",
+    pendingText: "Setup checks run before writing starts.",
+  },
+  {
+    id: "research",
+    label: "Researching topic",
+    activeText: "Collecting sources and shaping the article brief.",
+    completeText: "Topic research is ready.",
+    pendingText: "Research starts after setup checks pass.",
+  },
+  {
+    id: "write",
+    label: "Writing article",
+    activeText: "Planning, drafting, grounding, and assembling the article.",
+    completeText: "Draft content has been assembled.",
+    pendingText: "Writing starts after research is complete.",
+  },
+  {
+    id: "preview",
+    label: "Preparing preview",
+    activeText: "Rendering, packaging, and verifying the article preview.",
+    completeText: "The article package is ready to review.",
+    pendingText: "Preview preparation runs after the draft is assembled.",
+  },
+];
+
+const STAGE_INDEX = new Map(STAGES.map((stage, index) => [stage.id, index]));
+const COMPLETE_STEP_STATUSES = new Set(["completed", "skipped"]);
+const FAILED_STEP_STATUSES = new Set(["failed", "blocked", "cancelled", "blocked_verification", "denied"]);
+const RUNNING_STEP_STATUSES = new Set(["running", "retrying", "queued", "pending"]);
+const FAILED_RUN_STATUSES = new Set(["failed", "blocked", "blocked_verification", "denied", "cancelled"]);
+const RUNNING_RUN_STATUSES = new Set([
+  "queued",
+  "running",
+  "awaiting_confirmation",
+  "awaiting_delivery_mode",
+  "awaiting_approval",
+  "approval_required",
+]);
+
+function normalizedKey(step: VibeMarketingStepState | string | null | undefined) {
+  const key = typeof step === "string" ? step : step?.key;
+  return String(key ?? "").toLowerCase();
+}
+
+function fallbackStageForIndex(index: number, total: number): StageId {
+  const ratio = total > 0 ? index / total : 0;
+  if (ratio < 0.25) return "setup";
+  if (ratio < 0.45) return "research";
+  if (ratio < 0.75) return "write";
+  return "preview";
+}
+
+function stageForStep(step: VibeMarketingStepState | string | null | undefined, index = 0, total = 1): StageId {
+  const key = normalizedKey(step);
+
+  if (
+    key.includes("fetch_org_config") ||
+    key.includes("refresh_repo_auth") ||
+    key.includes("repo_auth") ||
+    key.includes("scan_repository") ||
+    key.includes("classify_repository") ||
+    key.includes("synthesize_repository") ||
+    key === "load_context"
+  ) {
+    return "setup";
+  }
+
+  if (
+    key.includes("discover_research") ||
+    key.includes("collect_research") ||
+    key.includes("research_sources") ||
+    key.includes("research_bundle") ||
+    key.includes("source_bundle") ||
+    key.includes("topic_explanation")
+  ) {
+    return "research";
+  }
+
+  if (
+    key.includes("plan_article") ||
+    key.includes("draft_section") ||
+    key.includes("ground_section") ||
+    key.includes("assemble_article") ||
+    key.includes("generate_content_images") ||
+    key === "finalize"
+  ) {
+    return "write";
+  }
+
+  if (
+    key.includes("render_article") ||
+    key.includes("package_content_delivery") ||
+    key.includes("validate_render") ||
+    key.includes("prove_publish") ||
+    key.includes("verify_") ||
+    key.includes("review_visual_style") ||
+    key.includes("preview") ||
+    key.includes("publish") ||
+    key.includes("repair_") ||
+    key.includes("archive_github")
+  ) {
+    return "preview";
+  }
+
+  return fallbackStageForIndex(index, total);
+}
+
+function formatStepName(value: string | null | undefined) {
+  return String(value ?? "")
+    .replace(/[:_]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function currentInternalStep(run: VibeMarketingRunSummary) {
+  const currentKey = normalizedKey(run.currentStep);
+  return (
+    run.steps.find((step) => normalizedKey(step) === currentKey) ??
+    run.steps.find((step) => RUNNING_STEP_STATUSES.has(step.status)) ??
+    run.steps.find((step) => !COMPLETE_STEP_STATUSES.has(step.status)) ??
+    [...run.steps].reverse().find((step) => COMPLETE_STEP_STATUSES.has(step.status)) ??
+    null
+  );
+}
+
+function stageStatusTone(status: StageStatus) {
+  if (status === "complete") return "border-emerald-200 bg-emerald-50 text-emerald-800";
+  if (status === "running") return "border-violet-200 bg-violet-50 text-violet-800";
+  if (status === "attention") return "border-red-200 bg-red-50 text-red-800";
+  return "border-gray-200 bg-white text-gray-500";
+}
+
+function stageStatusLabel(status: StageStatus) {
+  if (status === "complete") return "Complete";
+  if (status === "running") return "In progress";
+  if (status === "attention") return "Needs attention";
+  return "Up next";
+}
+
+function StageIcon({ status }: { status: StageStatus }) {
+  if (status === "complete") return <CheckCircleIcon className="h-5 w-5" />;
+  if (status === "running") return <ArrowPathIcon className="h-5 w-5 animate-spin" />;
+  if (status === "attention") return <ExclamationTriangleIcon className="h-5 w-5" />;
+  return <ClockIcon className="h-5 w-5" />;
+}
+
+function deriveStages(run: VibeMarketingRunSummary): StageView[] {
+  const total = Math.max(run.stepOrder.length, run.steps.length, 1);
+  const activeStep = currentInternalStep(run);
+  const activeStage = stageForStep(activeStep ?? run.currentStep, activeStep ? run.steps.indexOf(activeStep) : 0, total);
+  const failingStep = run.steps.find((step) => FAILED_STEP_STATUSES.has(step.status)) ?? null;
+  const failingStage = failingStep ? stageForStep(failingStep, run.steps.indexOf(failingStep), total) : null;
+  const runFailed = FAILED_RUN_STATUSES.has(run.status);
+  const runRunning = RUNNING_RUN_STATUSES.has(run.status);
+  const runComplete = run.status === "completed";
+  const activeStageIndex = STAGE_INDEX.get(activeStage) ?? 0;
+
+  return STAGES.map((stage) => {
+    const stageIndex = STAGE_INDEX.get(stage.id) ?? 0;
+    const stageSteps = run.steps.filter((step, index) => stageForStep(step, index, total) === stage.id);
+    const allStageStepsComplete =
+      stageSteps.length > 0 && stageSteps.every((step) => COMPLETE_STEP_STATUSES.has(step.status));
+    const attention = failingStage === stage.id || (runFailed && stage.id === activeStage);
+    const running = runRunning && stage.id === activeStage && !attention;
+    const complete = runComplete || allStageStepsComplete || (runRunning && stageIndex < activeStageIndex && !attention);
+    const status: StageStatus = attention ? "attention" : running ? "running" : complete ? "complete" : "up_next";
+
+    return {
+      ...stage,
+      status,
+      detail:
+        status === "complete"
+          ? stage.completeText
+          : status === "running"
+            ? stage.activeText
+            : status === "attention"
+              ? failingStep?.error || run.errors[0] || "Review the technical details before continuing."
+              : stage.pendingText,
+    };
+  });
+}
+
+export function articleRunTechnicalProgressLabel(run: VibeMarketingRunSummary) {
+  const total = Math.max(run.steps.length, run.stepOrder.length, 1);
+  const completed = run.steps.filter((step) => COMPLETE_STEP_STATUSES.has(step.status)).length;
+  return `${completed} of ${total} checks complete`;
+}
+
+export default function ArticleRunStageProgress({
+  run,
+  pollingDegraded = false,
+}: ArticleRunStageProgressProps) {
+  const stages = deriveStages(run);
+  const activeStage = stages.find((stage) => stage.status === "attention") ?? stages.find((stage) => stage.status === "running");
+  const activeStep = currentInternalStep(run);
+  const headline =
+    activeStage?.status === "attention"
+      ? "This article run needs attention"
+      : run.status === "completed"
+        ? "Article package ready"
+        : activeStage?.label ?? "Generating article";
+  const behindScenesStepName = activeStep?.name || formatStepName(activeStep?.key || run.currentStep || "Waiting");
+  const behindScenesMessage = activeStep?.message || activeStep?.error || "Waiting for the next update.";
+
+  return (
+    <section className="rounded-xl border border-violet-100 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-black uppercase tracking-wide text-violet-600">Generating article</p>
+          <h2 className="mt-1 text-xl font-black text-gray-950">{headline}</h2>
+          <p className="mt-2 max-w-2xl text-sm font-semibold leading-6 text-gray-600">
+            {activeStage?.detail ?? "We are preparing the generated article package."}
+          </p>
+        </div>
+        <span className="rounded-full bg-violet-50 px-3 py-1.5 text-xs font-black uppercase tracking-wide text-violet-700">
+          {run.status.replace(/_/g, " ")}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {stages.map((stage) => (
+          <div
+            key={stage.id}
+            className={clsx(
+              "rounded-xl border p-4 transition",
+              stage.status === "running" && "shadow-sm ring-2 ring-violet-100",
+              stageStatusTone(stage.status),
+            )}
+          >
+            <div className="flex items-center gap-3">
+              <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white/80">
+                <StageIcon status={stage.status} />
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-black text-gray-950">{stage.label}</p>
+                <p className="mt-0.5 text-xs font-black uppercase tracking-wide">{stageStatusLabel(stage.status)}</p>
+              </div>
+            </div>
+            <p className="mt-3 text-sm font-semibold leading-5 text-gray-600">{stage.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 rounded-xl bg-gray-50 px-4 py-3 text-xs font-semibold text-gray-500">
+        <span className="font-black text-gray-700">Behind the scenes:</span> {behindScenesStepName}
+        {behindScenesMessage ? ` - ${behindScenesMessage}` : ""}
+      </div>
+
+      {pollingDegraded ? (
+        <p className="mt-3 text-xs font-bold text-amber-700">Polling is retrying after a temporary connection problem.</p>
+      ) : null}
+      {run.errors.length > 0 ? (
+        <div className="mt-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
+          {run.errors[0]}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/components/FounderStartupDetailsStep.tsx
+++ b/app/components/FounderStartupDetailsStep.tsx
@@ -6,7 +6,6 @@ import {
   IdentificationIcon,
   LinkIcon,
   MapPinIcon,
-  SparklesIcon,
   TagIcon,
   UserGroupIcon,
 } from "@heroicons/react/24/outline";
@@ -59,7 +58,7 @@ function listDefault(value?: string[] | null) {
 }
 
 function FieldIcon({ children }: { children: ReactNode }) {
-  return <div className="pointer-events-none absolute left-3.5 top-3.5 h-5 w-5 text-[var(--vr-color-text-sub)]">{children}</div>;
+  return <div className="pointer-events-none absolute left-3.5 top-3.5 h-5 w-5 text-gray-400">{children}</div>;
 }
 
 const STARTUP_STAGE_OPTIONS = [
@@ -442,13 +441,13 @@ export default function FounderStartupDetailsStep({
         }
       : { defaultValue: fallback };
   const hint = (field: StartupDetailsField) =>
-    autofilled.has(field) ? <span className="ml-2 text-xs font-semibold text-[var(--vr-color-primary)]">Autofilled from website</span> : null;
+    autofilled.has(field) ? <span className="ml-2 text-xs font-semibold text-emerald-600">Autofilled from website</span> : null;
 
   return (
     <div className="space-y-6">
       <div className="grid gap-4 lg:grid-cols-2">
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Company name{hint("companyName")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Company name{hint("companyName")}</span>
           <div className="relative">
             <FieldIcon><BuildingOffice2Icon /></FieldIcon>
             <input
@@ -457,13 +456,13 @@ export default function FounderStartupDetailsStep({
               {...inputProps("companyName", defaults.companyName ?? "")}
               autoComplete="organization"
               placeholder="Acme AI"
-              className="w-full rounded-xl border border-[var(--vr-color-border)] py-3 pl-11 pr-4 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+              className="w-full rounded-xl border border-gray-200 py-3 pl-11 pr-4 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
             />
           </div>
         </label>
 
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Website domain{hint("domain")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Website domain{hint("domain")}</span>
           <div className="relative">
             <FieldIcon><GlobeAltIcon /></FieldIcon>
             <input
@@ -472,13 +471,13 @@ export default function FounderStartupDetailsStep({
               {...inputProps("domain", defaults.domain ?? "")}
               autoComplete="url"
               placeholder="example.com"
-              className="w-full rounded-xl border border-[var(--vr-color-border)] py-3 pl-11 pr-4 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+              className="w-full rounded-xl border border-gray-200 py-3 pl-11 pr-4 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
             />
           </div>
         </label>
 
         <label className="block lg:col-span-2">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Company LinkedIn URL{hint("companyLinkedInUrl")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Company LinkedIn URL{hint("companyLinkedInUrl")}</span>
           <div className="relative">
             <FieldIcon><LinkIcon /></FieldIcon>
             <input
@@ -486,13 +485,13 @@ export default function FounderStartupDetailsStep({
               {...inputProps("companyLinkedInUrl", defaults.companyLinkedInUrl ?? "")}
               autoComplete="url"
               placeholder="https://www.linkedin.com/company/acme"
-              className="w-full rounded-xl border border-[var(--vr-color-border)] py-3 pl-11 pr-4 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+              className="w-full rounded-xl border border-gray-200 py-3 pl-11 pr-4 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
             />
           </div>
         </label>
 
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Startup location{hint("location")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Startup location{hint("location")}</span>
           <LocationAutocompleteField
             value={isControlled ? textValue("location", defaults.location ?? "") : undefined}
             fallback={defaults.location ?? ""}
@@ -501,7 +500,7 @@ export default function FounderStartupDetailsStep({
         </label>
 
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">ABN{hint("abn")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">ABN{hint("abn")}</span>
           <AbnAutocompleteField
             value={isControlled ? textValue("abn", defaults.abn ?? "") : undefined}
             fallback={defaults.abn ?? ""}
@@ -511,29 +510,14 @@ export default function FounderStartupDetailsStep({
       </div>
 
       <label className="block">
-        <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Brand name{hint("brandName")}</span>
-        <div className="relative">
-          <FieldIcon><SparklesIcon /></FieldIcon>
-          <input
-            name="brandName"
-            {...inputProps("brandName", defaults.brandName ?? defaults.companyName ?? "")}
-            placeholder="Public-facing brand"
-            className="w-full rounded-xl border border-[var(--vr-color-border)] py-3 pl-11 pr-4 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
-          />
-        </div>
-      </label>
-
-      {afterBrandName}
-
-      <label className="block">
-        <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Company context{hint("companyContext")}</span>
+        <span className="mb-2 block text-sm font-bold text-gray-700">Company context{hint("companyContext")}</span>
         <textarea
           name="companyContext"
           required
           rows={compact ? 4 : 5}
           {...inputProps("companyContext", defaults.companyContext ?? defaults.notes ?? "")}
           placeholder="What you sell, who you help, why your product is different, and what buyers care about."
-          className="w-full resize-y rounded-xl border border-[var(--vr-color-border)] px-4 py-3 text-sm font-medium leading-6 text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+          className="w-full resize-y rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium leading-6 text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
         />
       </label>
 
@@ -541,7 +525,7 @@ export default function FounderStartupDetailsStep({
 
       <div className="grid gap-4 lg:grid-cols-2">
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Competitors{hint("competitors")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Competitors{hint("competitors")}</span>
           <div className="relative">
             <FieldIcon><UserGroupIcon /></FieldIcon>
             <textarea
@@ -549,13 +533,13 @@ export default function FounderStartupDetailsStep({
               rows={4}
               {...inputProps("competitors", listDefault(defaults.competitors))}
               placeholder="competitor.com&#10;another competitor"
-              className="w-full resize-y rounded-xl border border-[var(--vr-color-border)] py-3 pl-11 pr-4 text-sm font-medium leading-6 text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+              className="w-full resize-y rounded-xl border border-gray-200 py-3 pl-11 pr-4 text-sm font-medium leading-6 text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
             />
           </div>
         </label>
 
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Seed keywords{hint("seedKeywords")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Seed keywords{hint("seedKeywords")}</span>
           <div className="relative">
             <FieldIcon><TagIcon /></FieldIcon>
             <textarea
@@ -563,7 +547,7 @@ export default function FounderStartupDetailsStep({
               rows={4}
               {...inputProps("seedKeywords", listDefault(defaults.seedKeywords))}
               placeholder="investor updates&#10;startup reporting"
-              className="w-full resize-y rounded-xl border border-[var(--vr-color-border)] py-3 pl-11 pr-4 text-sm font-medium leading-6 text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+              className="w-full resize-y rounded-xl border border-gray-200 py-3 pl-11 pr-4 text-sm font-medium leading-6 text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
             />
           </div>
         </label>
@@ -571,17 +555,17 @@ export default function FounderStartupDetailsStep({
 
       <div className="grid gap-4 lg:grid-cols-[1fr_220px_220px]">
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Founder names{hint("founderNames")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Founder names{hint("founderNames")}</span>
           <input
             name="founderNames"
             {...inputProps("founderNames", (defaults.founderNames ?? []).join(", "))}
             placeholder="Sam Donegan, Alex Founder"
-            className="w-full rounded-xl border border-[var(--vr-color-border)] px-4 py-3 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+            className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
           />
         </label>
 
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Stage{hint("stage")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Stage{hint("stage")}</span>
           <select
             name="stage"
             {...(isControlled
@@ -590,7 +574,7 @@ export default function FounderStartupDetailsStep({
                   onChange: (event: ChangeEvent<HTMLSelectElement>) => onValueChange?.("stage", event.target.value),
                 }
               : { defaultValue: defaults.stage ?? "" })}
-            className="w-full rounded-xl border border-[var(--vr-color-border)] px-4 py-3 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+            className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
           >
             {STARTUP_STAGE_OPTIONS.map((option) => (
               <option key={option || "blank"} value={option}>
@@ -601,7 +585,7 @@ export default function FounderStartupDetailsStep({
         </label>
 
         <label className="block">
-          <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Organization type{hint("organizationKind")}</span>
+          <span className="mb-2 block text-sm font-bold text-gray-700">Organization type{hint("organizationKind")}</span>
           <select
             name="organizationKind"
             {...(isControlled
@@ -610,7 +594,7 @@ export default function FounderStartupDetailsStep({
                   onChange: (event: ChangeEvent<HTMLSelectElement>) => onValueChange?.("organizationKind", event.target.value),
                 }
               : { defaultValue: defaults.organizationKind ?? "" })}
-            className="w-full rounded-xl border border-[var(--vr-color-border)] px-4 py-3 text-sm font-medium text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+            className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
           >
             {ORGANIZATION_KIND_OPTIONS.map((option) => (
               <option key={option || "blank"} value={option}>
@@ -620,17 +604,6 @@ export default function FounderStartupDetailsStep({
           </select>
         </label>
       </div>
-
-      <label className="block">
-        <span className="mb-2 block text-sm font-bold text-[var(--vr-color-text-mid)]">Internal notes{hint("notes")}</span>
-        <textarea
-          name="notes"
-          rows={3}
-          {...inputProps("notes", defaults.notes ?? "")}
-          placeholder="Anything the monthly update and marketing agents should remember."
-          className="w-full resize-y rounded-xl border border-[var(--vr-color-border)] px-4 py-3 text-sm font-medium leading-6 text-[var(--vr-color-text)] outline-none transition focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
-        />
-      </label>
     </div>
   );
 }

--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -18,7 +18,9 @@ import type {
 
 interface MarketingWorkflowShellProps {
   progress?: VibeMarketingWorkflowProgress | null;
+  viewedStepId?: string | null;
   title?: string;
+  titleAs?: "h1" | "h2";
   subtitle?: string;
   isSubmitting?: boolean;
   primaryActionSlot?: ReactNode;
@@ -90,9 +92,18 @@ function stepKey(step: VibeMarketingWorkflowStep) {
   return `${step.id}-${step.order ?? step.label}`;
 }
 
+function viewingLabel(step: VibeMarketingWorkflowStep) {
+  if (step.id === "profile") return "Startup profile";
+  if (step.id === "repo") return "Repository setup";
+  if (step.id === "article_system") return "Article system setup";
+  return step.label;
+}
+
 export default function MarketingWorkflowShell({
   progress,
+  viewedStepId,
   title = "Article workflow",
+  titleAs = "h2",
   subtitle,
   isSubmitting = false,
   primaryActionSlot,
@@ -100,33 +111,61 @@ export default function MarketingWorkflowShell({
 }: MarketingWorkflowShellProps) {
   const steps = progress?.steps ?? [];
   if (!steps.length) return null;
-  const currentStep = steps.find((step) => step.id === progress?.currentStepId) ?? steps.find((step) => step.status !== "complete" && step.status !== "locked") ?? steps[0];
-  const currentIndex = Math.max(0, steps.findIndex((step) => step.id === currentStep.id));
+  const requiredStep = steps.find((step) => step.id === progress?.currentStepId) ?? steps.find((step) => step.status !== "complete" && step.status !== "locked") ?? steps[0];
+  const viewedStep = steps.find((step) => step.id === viewedStepId) ?? requiredStep;
+  const viewingRequiredStep = viewedStep.id === requiredStep.id;
+  const viewedIndex = Math.max(0, steps.findIndex((step) => step.id === viewedStep.id));
   const completeCount = steps.filter((step) => step.status === "complete").length;
   const percent = Math.max(4, Math.round((completeCount / steps.length) * 100));
   const phases = Array.from(new Set(steps.map((step) => step.phase)));
+  const headerLabel = viewingRequiredStep
+    ? `Next required step: ${requiredStep.label}`
+    : `Viewing: ${viewingLabel(viewedStep)} - ${statusLabel(viewedStep.status)}`;
+  const requiredStepUsesViewedSurface = Boolean(requiredStep.href && viewedStep.href && requiredStep.href === viewedStep.href);
+  const requiredNavigationAction =
+    requiredStep.primaryAction?.label
+      ? {
+          ...requiredStep.primaryAction,
+          href: requiredStep.primaryAction.href || requiredStep.href,
+          variant: requiredStep.primaryAction.variant ?? "secondary",
+        }
+      : { label: `Go to ${requiredStep.label}`, href: requiredStep.href, variant: "secondary" as const };
+  const HeadingTag = titleAs;
 
   return (
     <section className={clsx("rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5", className)}>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <p className="text-xs font-extrabold uppercase tracking-wide text-violet-600">
-            Step {currentIndex + 1} of {steps.length}
+            Step {viewedIndex + 1} of {steps.length}
           </p>
-          <h2 className="mt-1 text-xl font-black text-gray-950">{title}</h2>
+          <HeadingTag className={clsx("mt-1 font-black text-gray-950", titleAs === "h1" ? "text-2xl" : "text-xl")}>
+            {title}
+          </HeadingTag>
           <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className={clsx("inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-black", statusTone(currentStep.status))}>
-              <StepStatusIcon status={currentStep.status} />
-              {statusLabel(currentStep.status)}
+            <span className={clsx("inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-black", statusTone(viewedStep.status))}>
+              <StepStatusIcon status={viewedStep.status} />
+              {statusLabel(viewedStep.status)}
             </span>
-            <span className="text-sm font-bold text-gray-700">{currentStep.label}</span>
+            <span className="text-sm font-bold text-gray-700">{headerLabel}</span>
+            {!viewingRequiredStep ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-2.5 py-1 text-xs font-black text-violet-700">
+                Next required step: {requiredStep.label}
+              </span>
+            ) : null}
           </div>
           <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-500">
-            {subtitle ?? currentStep.summary}
+            {subtitle ?? viewedStep.summary}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          {primaryActionSlot ?? <ActionButton action={currentStep.primaryAction} disabled={isSubmitting} />}
+          {viewingRequiredStep ? (
+            primaryActionSlot ?? <ActionButton action={requiredStep.primaryAction} disabled={isSubmitting} />
+          ) : requiredStepUsesViewedSurface && primaryActionSlot ? (
+            primaryActionSlot
+          ) : (
+            <ActionButton action={requiredNavigationAction} disabled={isSubmitting} />
+          )}
         </div>
       </div>
 
@@ -138,7 +177,7 @@ export default function MarketingWorkflowShell({
         {phases.map((phase) => {
           const phaseSteps = steps.filter((step) => step.phase === phase);
           const phaseComplete = phaseSteps.every((step) => step.status === "complete");
-          const phaseActive = phaseSteps.some((step) => step.id === currentStep.id);
+          const phaseActive = phaseSteps.some((step) => step.id === viewedStep.id);
           return (
             <span
               key={phase}
@@ -157,7 +196,8 @@ export default function MarketingWorkflowShell({
 
       <ol className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
         {steps.map((step, index) => {
-          const active = step.id === currentStep.id;
+          const active = step.id === viewedStep.id;
+          const nextRequired = step.id === requiredStep.id;
           const locked = step.status === "locked";
           const content = (
             <>
@@ -166,13 +206,21 @@ export default function MarketingWorkflowShell({
               </span>
               <span className="min-w-0">
                 <span className={clsx("block truncate text-sm font-black", active ? "text-violet-800" : "text-gray-900")}>{step.label}</span>
-                <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{statusLabel(step.status)}</span>
+                <span className="mt-0.5 flex flex-wrap items-center gap-1 text-xs font-semibold text-gray-500">
+                  <span className="truncate">{statusLabel(step.status)}</span>
+                  {nextRequired && !active ? (
+                    <span className="rounded-full bg-violet-100 px-1.5 py-0.5 text-[10px] font-black uppercase text-violet-700">
+                      Next required
+                    </span>
+                  ) : null}
+                </span>
               </span>
             </>
           );
           const itemClass = clsx(
             "flex min-h-[64px] items-center gap-3 rounded-xl border px-3 py-2 text-left transition",
             active ? "border-violet-200 bg-violet-50 shadow-sm" : "border-gray-100 bg-gray-50/70",
+            nextRequired && !active && "border-violet-100 bg-white",
             !locked && "hover:border-violet-200 hover:bg-white",
             locked && "opacity-70",
           );

--- a/app/components/TopicDecisionCard.tsx
+++ b/app/components/TopicDecisionCard.tsx
@@ -1,0 +1,203 @@
+import { clsx } from "clsx";
+
+import type { VibeMarketingTopicCandidate } from "~/types/vibe-marketing";
+
+function numericValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/,/g, "").trim();
+    if (!cleaned) return undefined;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-AU", { maximumFractionDigits: value >= 100 ? 0 : 1 }).format(value);
+}
+
+function titleCase(value: string) {
+  return value
+    .replace(/[_-]/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function competitionPhrase(candidate: VibeMarketingTopicCandidate) {
+  const explicit = stringValue(candidate.competition);
+  if (explicit) return explicit.toLowerCase().includes("competition") ? explicit : `${explicit} competition`;
+  const difficulty = numericValue(candidate.difficulty);
+  if (difficulty === undefined) return null;
+  const tier = difficulty <= 35 ? "low" : difficulty <= 65 ? "moderate" : "high";
+  return `${tier} competition at ${formatNumber(difficulty)}/100`;
+}
+
+function audienceFromCandidate(candidate: VibeMarketingTopicCandidate) {
+  const explicit = stringValue(candidate.audience);
+  if (explicit) return explicit;
+
+  const intentRecord = recordValue(candidate.intent);
+  const recordAudience =
+    stringValue(intentRecord?.audience) ||
+    stringValue(intentRecord?.target_audience) ||
+    stringValue(intentRecord?.targetAudience) ||
+    stringValue(intentRecord?.segment);
+  if (recordAudience) return recordAudience;
+
+  const intentText = stringValue(candidate.intent);
+  if (intentText) return `${titleCase(intentText)} searchers looking for practical guidance.`;
+
+  const keyword = candidate.keyword.toLowerCase();
+  if (keyword.startsWith("what is") || keyword.startsWith("what are")) {
+    return "Beginners searching for a plain-English explanation.";
+  }
+  if (keyword.startsWith("how to") || keyword.includes("guide")) {
+    return "Readers looking for step-by-step guidance.";
+  }
+  return `Readers searching for practical guidance on ${candidate.keyword}.`;
+}
+
+function whyTopic(candidate: VibeMarketingTopicCandidate) {
+  const parts: string[] = [];
+  const volume = numericValue(candidate.volume);
+  if (volume !== undefined) parts.push(`${formatNumber(volume)} monthly searches`);
+  const competition = competitionPhrase(candidate);
+  if (competition) parts.push(competition);
+  const trend = stringValue(candidate.trend) || stringValue(candidate.interest);
+  if (trend) parts.push(`${trend.toLowerCase().includes("interest") ? trend : `${trend} interest`}`);
+  const aiSearches = numericValue(candidate.aiSearches);
+  if (aiSearches !== undefined) parts.push(`${formatNumber(aiSearches)} AI searches/mo`);
+
+  const metrics = parts.length ? parts.join(", ") : null;
+  const reason = stringValue(candidate.reason);
+  if (metrics && reason) return `${metrics}. ${reason}`;
+  return metrics || reason || "Recommended from the latest topic discovery.";
+}
+
+function confidenceForCandidate(candidate: VibeMarketingTopicCandidate) {
+  const explicit = stringValue(candidate.confidence);
+  if (explicit) return titleCase(explicit);
+  const score = numericValue(candidate.opportunityScore);
+  if (score === undefined) return "Exploratory";
+  if (score >= 150) return "High";
+  if (score >= 50) return "Medium";
+  return "Exploratory";
+}
+
+function opportunityText(candidate: VibeMarketingTopicCandidate) {
+  const score = numericValue(candidate.opportunityScore);
+  return score === undefined ? null : `Opportunity score ${formatNumber(score)}`;
+}
+
+export function TopicDecisionCard({
+  candidate,
+  checked,
+  onChange,
+  name = "topicCandidateId",
+}: {
+  candidate: VibeMarketingTopicCandidate;
+  checked: boolean;
+  onChange: () => void;
+  name?: string;
+}) {
+  const opportunity = opportunityText(candidate);
+  return (
+    <label
+      className={clsx(
+        "block cursor-pointer rounded-xl border p-4 transition",
+        checked
+          ? "border-violet-400 bg-violet-50/70 shadow-sm ring-2 ring-violet-100"
+          : "border-gray-200 bg-white hover:border-violet-200 hover:bg-violet-50/30",
+      )}
+    >
+      <div className="flex gap-3">
+        <input
+          type="radio"
+          name={name}
+          value={candidate.id}
+          checked={checked}
+          onChange={onChange}
+          className="mt-1 h-4 w-4 flex-none text-violet-600"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">What will we write?</p>
+              <h3 className="mt-1 text-base font-black leading-6 text-gray-950">{candidate.title}</h3>
+              <p className="mt-1 text-xs font-bold text-gray-500">Keyword: {candidate.keyword}</p>
+            </div>
+            <div className="flex flex-none flex-wrap items-center gap-2">
+              <span className="rounded-full bg-white px-3 py-1 text-xs font-black text-violet-700 ring-1 ring-violet-100">
+                Confidence: {confidenceForCandidate(candidate)}
+              </span>
+              {opportunity ? (
+                <span className="rounded-full bg-gray-50 px-3 py-1 text-xs font-bold text-gray-600 ring-1 ring-gray-100">
+                  {opportunity}
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            <div className="rounded-lg bg-gray-50 px-3 py-2">
+              <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Who is it for?</p>
+              <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{audienceFromCandidate(candidate)}</p>
+            </div>
+            <div className="rounded-lg bg-gray-50 px-3 py-2">
+              <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Why this topic?</p>
+              <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{whyTopic(candidate)}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </label>
+  );
+}
+
+export function CustomTopicDecisionCard({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: () => void;
+}) {
+  return (
+    <label
+      className={clsx(
+        "block cursor-pointer rounded-xl border p-4 transition",
+        checked
+          ? "border-violet-400 bg-violet-50/70 shadow-sm ring-2 ring-violet-100"
+          : "border-gray-200 bg-white hover:border-violet-200 hover:bg-violet-50/30",
+      )}
+    >
+      <div className="flex gap-3">
+        <input
+          type="radio"
+          name="topicCandidateId"
+          value="__custom__"
+          checked={checked}
+          onChange={onChange}
+          className="mt-1 h-4 w-4 flex-none text-violet-600"
+        />
+        <div>
+          <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">What will we write?</p>
+          <h3 className="mt-1 text-base font-black text-gray-950">Custom article</h3>
+          <p className="mt-1 text-sm font-semibold text-gray-600">Use the keyword, title, and context fields below to define the article brief.</p>
+        </div>
+      </div>
+    </label>
+  );
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1,4 +1,4 @@
-import { createApiClient, shouldUseDevAuthBypass, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
+import { createApiClient, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
 import type {
   VibeMarketingBootstrap,
   VibeMarketingComponentFeedback,
@@ -8,7 +8,6 @@ import type {
   VibeMarketingComponentManifest,
   VibeMarketingComponentManifestItem,
   VibeMarketingContentPackage,
-  VibeMarketingDeliveryMode,
   VibeMarketingGuidedStep,
   VibeMarketingLivePreview,
   VibeMarketingPublishEvidence,
@@ -30,14 +29,6 @@ function asNullableString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
-}
-
-export function normalizeArticleDeliveryMode(
-  value: unknown,
-  fallback: VibeMarketingDeliveryMode = "publish_code",
-): VibeMarketingDeliveryMode {
-  const normalized = asNullableString(value);
-  return normalized === "publish_code" || normalized === "content_only" ? normalized : fallback;
 }
 
 function asStringList(value: unknown): string[] {
@@ -189,9 +180,10 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
     settings: {
       brandName: asNullableString(settings.brandName) ?? asNullableString(settings.brand_name),
       companyContext: asNullableString(settings.companyContext) ?? asNullableString(settings.company_context),
-      articleDeliveryMode: normalizeArticleDeliveryMode(
-        settings.articleDeliveryMode ?? settings.article_delivery_mode,
-      ),
+      articleDeliveryMode:
+        asNullableString(settings.articleDeliveryMode) ??
+        asNullableString(settings.article_delivery_mode) ??
+        "publish_code",
       githubRepo: asNullableString(settings.githubRepo) ?? asNullableString(settings.github_repo),
       dailyDiscoveryEnabled: Boolean(settings.dailyDiscoveryEnabled ?? settings.daily_discovery_enabled),
       dailyDiscoveryPriority: Number(settings.dailyDiscoveryPriority ?? 0) || 0,
@@ -613,67 +605,134 @@ const DEV_BOOTSTRAP: VibeMarketingBootstrap = {
   hasCompletedArticleFlow: false,
   startPageMode: "first_article_setup",
   workflowProgress: {
-    currentStepId: "profile",
-    nextStepId: "baseline",
+    currentStepId: "choose_topic",
+    nextStepId: "generate",
     steps: [
       {
         id: "profile",
         label: "Startup profile",
         phase: "Setup",
-        status: "needs_action",
+        status: "complete",
         href: "/founder-tools/marketing/create?step=startupDetails",
         summary: "Company, audience, competitors, and seed keywords.",
-        primaryAction: { label: "Save startup profile", href: "/founder-tools/marketing/create?step=startupDetails" },
+        primaryAction: null,
         order: 1,
+      },
+      {
+        id: "baseline",
+        label: "Website baseline",
+        phase: "Setup",
+        status: "complete",
+        href: "/founder-tools/marketing/create?step=baseline",
+        summary: "Capture website health before article work starts.",
+        primaryAction: null,
+        order: 2,
+      },
+      {
+        id: "repo",
+        label: "Repository",
+        phase: "Setup",
+        status: "complete",
+        href: "/founder-tools/marketing/create?step=github",
+        summary: "Connect the repository used for exact article previews and publishing.",
+        primaryAction: null,
+        order: 3,
+      },
+      {
+        id: "article_system",
+        label: "Article system",
+        phase: "Setup",
+        status: "complete",
+        href: "/founder-tools/marketing/create?step=articleSystem",
+        summary: "Detect or prepare the article route, registry, and publish target.",
+        primaryAction: null,
+        order: 4,
+      },
+      {
+        id: "research",
+        label: "Research topics",
+        phase: "Plan",
+        status: "complete",
+        href: "/founder-tools/marketing/create?step=research",
+        summary: "Find article candidates from the company context.",
+        primaryAction: null,
+        order: 5,
+      },
+      {
+        id: "choose_topic",
+        label: "Choose topic",
+        phase: "Plan",
+        status: "needs_action",
+        href: "/founder-tools/marketing/create?step=chooseArticle",
+        summary: "Pick a discovered topic or enter a custom article brief.",
+        primaryAction: { label: "Choose article topic", href: "/founder-tools/marketing/create?step=chooseArticle" },
+        order: 6,
+      },
+      {
+        id: "generate",
+        label: "Generate article",
+        phase: "Create",
+        status: "locked",
+        href: "/founder-tools/marketing/create?step=writeCheck",
+        summary: "Generate the article and package its content artifacts.",
+        primaryAction: null,
+        order: 7,
+      },
+      {
+        id: "review",
+        label: "Review article",
+        phase: "Create",
+        status: "locked",
+        href: "/founder-tools/marketing/create?step=editArticle",
+        summary: "Review the exact live article preview and leave component comments.",
+        primaryAction: null,
+        order: 8,
+      },
+      {
+        id: "revise",
+        label: "Revise article",
+        phase: "Create",
+        status: "locked",
+        href: "/founder-tools/marketing/create?step=editArticle",
+        summary: "Send component comments for AI revision and accept the result.",
+        primaryAction: null,
+        order: 9,
+      },
+      {
+        id: "package",
+        label: "Package ready",
+        phase: "Publish",
+        status: "locked",
+        href: "/founder-tools/marketing/create?step=reviewPublish",
+        summary: "Content-only delivery artifacts are ready to inspect or promote.",
+        primaryAction: null,
+        order: 10,
+      },
+      {
+        id: "publish",
+        label: "Publish to site",
+        phase: "Publish",
+        status: "locked",
+        href: "/founder-tools/marketing/create?step=reviewPublish",
+        summary: "Promote the package into a PR, preview URL, or CMS publish flow.",
+        primaryAction: null,
+        order: 11,
+      },
+      {
+        id: "automation",
+        label: "Daily automation",
+        phase: "Automate",
+        status: "complete",
+        href: "/founder-tools/marketing/create?step=dailyAutomation",
+        summary: "Enable recurring topic discovery with human review.",
+        primaryAction: null,
+        order: 12,
       },
     ],
   },
 };
 
 const DEV_RUN_SNAPSHOTS = new Map<string, Record<string, unknown>>();
-
-function shouldUseVibeMarketingDevPreview(error?: unknown) {
-  const maybeError = error as { response?: { status?: number } } | null | undefined;
-  const status = maybeError?.response?.status;
-  if (status === 401 && shouldUseDevAuthBypass()) {
-    return true;
-  }
-  if (!maybeError?.response && shouldUseDevAuthBypass()) {
-    return true;
-  }
-  return shouldUseDevBackendFallback(error);
-}
-
-function createDevMarketingRunTicket(path: string, body: Record<string, unknown>) {
-  const runId = `dev-${path.replace(/[^a-z0-9]+/gi, "-")}-${Date.now().toString(36)}`;
-  DEV_RUN_SNAPSHOTS.set(runId, { ...body });
-  return { runId, status: "queued" as const };
-}
-
-function getDevMarketingRunPreview(runId: string) {
-  if (runId.includes("autofill")) {
-    return devAutofillResultFromSnapshot(runId, DEV_RUN_SNAPSHOTS.get(runId));
-  }
-  return normalizeMarketingRun({
-    runId,
-    workflow: runId.includes("baseline") ? "website_baseline" : "article_generation",
-    domain: DEV_BOOTSTRAP.organization.domain,
-    status: "completed",
-    currentStep: "finalize",
-    stepOrder: runId.includes("baseline")
-      ? ["crawl_technical_health", "measure_lighthouse", "measure_search_visibility", "finalize"]
-      : ["queued", "finalize"],
-    steps: runId.includes("baseline")
-      ? [
-          { key: "crawl_technical_health", status: "completed", attempts: 1, artifacts: [] },
-          { key: "measure_lighthouse", status: "completed", attempts: 1, artifacts: [] },
-          { key: "measure_search_visibility", status: "completed", attempts: 1, artifacts: [] },
-          { key: "finalize", status: "completed", attempts: 1, artifacts: [] },
-        ]
-      : [],
-    result: runId.includes("baseline") ? { baseline: DEV_BOOTSTRAP.websiteBaseline } : {},
-  });
-}
 
 function primaryBodyString(body: Record<string, unknown>, ...keys: string[]) {
   for (const key of keys) {
@@ -844,10 +903,7 @@ export async function getVibeMarketingBootstrap(env: Env, request: Request, comp
     const response = await client.get(`${BASE_PATH}/bootstrap/${query}`);
     return normalizeBootstrap(response.data);
   } catch (error) {
-    if (shouldUseVibeMarketingDevPreview(error)) {
-      console.warn("Vibe Marketing bootstrap unavailable in local dev; using preview bootstrap.");
-      return DEV_BOOTSTRAP;
-    }
+    if (shouldUseDevBackendFallback(error)) return DEV_BOOTSTRAP;
     throw error;
   }
 }
@@ -966,20 +1022,23 @@ export async function connectVibeMarketingGithub(env: Env, request: Request, bod
 
 async function startMarketingRun(env: Env, request: Request, path: string, body: Record<string, unknown>) {
   if (shouldUseDevBackendStub()) {
-    return createDevMarketingRunTicket(path, body);
+    const runId = `dev-${path.replace(/[^a-z0-9]+/gi, "-")}-${Date.now().toString(36)}`;
+    DEV_RUN_SNAPSHOTS.set(runId, { ...body });
+    return { runId, status: "queued", error: null, errors: [] };
   }
-  try {
-    const client = createApiClient(env, request);
-    const response = await client.post(`${BASE_PATH}/${path}`, body);
-    const runId = asNullableString(response.data?.runId) ?? asNullableString(response.data?.run_id);
-    return { runId, status: asNullableString(response.data?.status) ?? "queued" };
-  } catch (error) {
-    if (shouldUseVibeMarketingDevPreview(error)) {
-      console.warn(`Vibe Marketing ${path} run unavailable in local dev; using preview run.`);
-      return createDevMarketingRunTicket(path, body);
-    }
-    throw error;
-  }
+  const client = createApiClient(env, request);
+  const response = await client.post(`${BASE_PATH}/${path}`, body);
+  const runId = asNullableString(response.data?.runId) ?? asNullableString(response.data?.run_id);
+  const error =
+    asNullableString(response.data?.error) ??
+    asNullableString(response.data?.detail) ??
+    asNullableString(response.data?.message);
+  return {
+    runId,
+    status: asNullableString(response.data?.status) ?? "queued",
+    error,
+    errors: asStringList(response.data?.errors ?? (error ? [error] : [])),
+  };
 }
 
 export function startVibeMarketingScan(env: Env, request: Request, body: Record<string, unknown>) {
@@ -1088,20 +1147,33 @@ export function replayVibeMarketingDaily(env: Env, request: Request, body: Recor
 
 export async function getVibeMarketingRun(env: Env, request: Request, runId: string, companyId?: string | null) {
   if (shouldUseDevBackendStub()) {
-    return getDevMarketingRunPreview(runId);
-  }
-  try {
-    const client = createApiClient(env, request);
-    const query = companyId ? `?company_id=${encodeURIComponent(companyId)}` : "";
-    const response = await client.get(`${BASE_PATH}/runs/${encodeURIComponent(runId)}${query}`);
-    return normalizeMarketingRun(response.data);
-  } catch (error) {
-    if (shouldUseVibeMarketingDevPreview(error)) {
-      console.warn("Vibe Marketing run unavailable in local dev; using preview run.");
-      return getDevMarketingRunPreview(runId);
+    if (runId.includes("autofill")) {
+      return devAutofillResultFromSnapshot(runId, DEV_RUN_SNAPSHOTS.get(runId));
     }
-    throw error;
+    return normalizeMarketingRun({
+      runId,
+      workflow: runId.includes("baseline") ? "website_baseline" : "article_generation",
+      domain: DEV_BOOTSTRAP.organization.domain,
+      status: "completed",
+      currentStep: "finalize",
+      stepOrder: runId.includes("baseline")
+        ? ["crawl_technical_health", "measure_lighthouse", "measure_search_visibility", "finalize"]
+        : ["queued", "finalize"],
+      steps: runId.includes("baseline")
+        ? [
+            { key: "crawl_technical_health", status: "completed", attempts: 1, artifacts: [] },
+            { key: "measure_lighthouse", status: "completed", attempts: 1, artifacts: [] },
+            { key: "measure_search_visibility", status: "completed", attempts: 1, artifacts: [] },
+            { key: "finalize", status: "completed", attempts: 1, artifacts: [] },
+          ]
+        : [],
+      result: runId.includes("baseline") ? { baseline: DEV_BOOTSTRAP.websiteBaseline } : {},
+    });
   }
+  const client = createApiClient(env, request);
+  const query = companyId ? `?company_id=${encodeURIComponent(companyId)}` : "";
+  const response = await client.get(`${BASE_PATH}/runs/${encodeURIComponent(runId)}${query}`);
+  return normalizeMarketingRun(response.data);
 }
 
 export async function controlVibeMarketingRun(

--- a/app/routes/founder-tools.marketing.autofill-run.tsx
+++ b/app/routes/founder-tools.marketing.autofill-run.tsx
@@ -3,10 +3,58 @@ import type { Route } from "./+types/founder-tools.marketing.autofill-run";
 import { getEnv } from "~/lib/env.server";
 import { getVibeMarketingRun } from "~/lib/vibe-marketing";
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
+import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
+
+function runLoaderErrorMessage(error: unknown) {
+  if (error && typeof error === "object") {
+    const payload = error as {
+      message?: unknown;
+      response?: { data?: { detail?: unknown; error?: unknown; message?: unknown } };
+    };
+    const detail = payload.response?.data?.detail ?? payload.response?.data?.error ?? payload.response?.data?.message ?? payload.message;
+    if (typeof detail === "string" && detail.trim()) return detail;
+  }
+  return "Company profile research status is unavailable. We will keep trying, but you can retry the research if this continues.";
+}
+
+function blockedRunPayload(runId: string, error: unknown): VibeMarketingRunSummary {
+  const message = runLoaderErrorMessage(error);
+  return {
+    runId,
+    workflow: "startup_autofill",
+    domain: "",
+    githubRepo: null,
+    status: "blocked",
+    currentStep: "status_check_failed",
+    approvalState: null,
+    resumeAvailable: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: [message],
+    artifacts: [],
+    previewUrl: null,
+    prUrl: null,
+    routePath: null,
+    diagnostics: { statusLoaderError: message },
+    contentPackage: null,
+    componentManifest: null,
+    livePreview: null,
+    componentFeedback: null,
+    workflowProgress: null,
+    result: { error: message, errors: [message], diagnostics: { statusLoaderError: message } },
+  };
+}
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
-  return getVibeMarketingRun(env, request, runId);
+  try {
+    return await getVibeMarketingRun(env, request, runId);
+  } catch (error) {
+    return blockedRunPayload(runId, error);
+  }
 }

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -19,14 +19,13 @@ import FounderStartupDetailsStep, {
   type StartupDetailsField,
   type StartupDetailsFormValues,
 } from "~/components/FounderStartupDetailsStep";
-import MarketingEvidencePanel from "~/components/MarketingEvidencePanel";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
+import { CustomTopicDecisionCard, TopicDecisionCard } from "~/components/TopicDecisionCard";
 import { type VibeMarketingStepKey } from "~/components/VibeMarketingStepper";
 import { getEnv } from "~/lib/env.server";
 import {
   connectVibeMarketingGithub,
   getVibeMarketingBootstrap,
-  normalizeArticleDeliveryMode,
   replayVibeMarketingDaily,
   refreshVibeMarketingBaselineGoogle,
   saveVibeMarketingSettings,
@@ -66,6 +65,92 @@ const STEP_KEYS: VibeMarketingStepKey[] = [
   "dailyAutomation",
 ];
 
+const WORKFLOW_STEP_ID_BY_CREATE_STEP: Record<VibeMarketingStepKey, string> = {
+  startupDetails: "profile",
+  baseline: "baseline",
+  github: "repo",
+  scan: "article_system",
+  articleSystem: "article_system",
+  research: "research",
+  chooseArticle: "choose_topic",
+  writeCheck: "generate",
+  editArticle: "review",
+  reviewPublish: "package",
+  dailyAutomation: "automation",
+};
+
+const CREATE_STEP_BY_WORKFLOW_STEP_ID: Record<string, VibeMarketingStepKey> = {
+  profile: "startupDetails",
+  baseline: "baseline",
+  repo: "github",
+  article_system: "articleSystem",
+  research: "research",
+  choose_topic: "chooseArticle",
+  generate: "writeCheck",
+  review: "editArticle",
+  revise: "editArticle",
+  package: "reviewPublish",
+  publish: "reviewPublish",
+  automation: "dailyAutomation",
+};
+
+type StepExplainer = {
+  why: string;
+  next: string;
+  safety?: string;
+};
+
+const STEP_EXPLAINERS: Record<VibeMarketingStepKey, StepExplainer> = {
+  startupDetails: {
+    why: "Company details anchor the article tone, audience, proof points, and topic relevance.",
+    next: "Save the profile, then capture a baseline or continue through setup.",
+  },
+  baseline: {
+    why: "The baseline records current site health, search visibility, and traffic before content changes.",
+    next: "Run it or skip it for now, then connect the repository used for previews and publishing.",
+  },
+  github: {
+    why: "Repository access lets us find the article system and prepare reviewable preview branches or PRs.",
+    next: "Choose the repo, review the permissions on GitHub, then return here to scan the article setup.",
+    safety: "Generated changes stay reviewable before publishing.",
+  },
+  scan: {
+    why: "We inspect the repo so generated articles land in the right files and preview safely.",
+    next: "The scan records framework, routes, build commands, article components, and publish targets.",
+    safety: "The scan does not publish changes.",
+  },
+  articleSystem: {
+    why: "The article system contract tells Content Factory how this website renders articles.",
+    next: "Once the contract is ready, topic research and generation can use the correct route and components.",
+    safety: "Preparation stays in setup until you explicitly generate or publish.",
+  },
+  research: {
+    why: "Research turns company context, competitors, seed keywords, and topic history into article candidates.",
+    next: "Choose a pending topic or run new research if the current candidates have already been used.",
+  },
+  chooseArticle: {
+    why: "The selected topic becomes the article brief, including the title angle and target keyword.",
+    next: "Content Factory generates the article, images, and content package for review.",
+  },
+  writeCheck: {
+    why: "Generation creates the article and validates the files before you review the result.",
+    next: "When the run completes, open the exact live preview and inspect the article.",
+  },
+  editArticle: {
+    why: "Review shows the article as it will render in the target app, with component comments for changes.",
+    next: "Leave comments, send one AI revision batch, or continue once the draft is acceptable.",
+  },
+  reviewPublish: {
+    why: "The package is the handoff point between reviewed content and an explicit publish action.",
+    next: "Publish to the website when ready, or inspect PR and preview evidence first.",
+    safety: "Package completion does not publish automatically.",
+  },
+  dailyAutomation: {
+    why: "Automation keeps new topic candidates flowing without removing human review.",
+    next: "Daily candidates still need selection, review, revision, and publish approval.",
+  },
+};
+
 function listFromForm(value: FormDataEntryValue | null) {
   return String(value ?? "")
     .split(/[,\n]/)
@@ -82,12 +167,31 @@ function normalizeStep(value: string | null | undefined, fallback: string | null
   return STEP_KEYS.includes(candidate as VibeMarketingStepKey) ? (candidate as VibeMarketingStepKey) : "startupDetails";
 }
 
+function createStepForWorkflowStep(stepId: string | null | undefined): VibeMarketingStepKey | null {
+  return stepId ? CREATE_STEP_BY_WORKFLOW_STEP_ID[stepId] ?? null : null;
+}
+
+function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMarketingBootstrap): VibeMarketingStepKey {
+  const requiredStep =
+    createStepForWorkflowStep(bootstrap.workflowProgress?.currentStepId) ??
+    normalizeStep(bootstrap.currentGuidedStep, "startupDetails");
+  const requested = normalizeStep(value, requiredStep);
+  const requestedWorkflowStepId = WORKFLOW_STEP_ID_BY_CREATE_STEP[requested];
+  const requestedWorkflowStep = bootstrap.workflowProgress?.steps?.find((step) => step.id === requestedWorkflowStepId);
+
+  if (requestedWorkflowStep?.status === "locked") {
+    return requiredStep;
+  }
+
+  return requested;
+}
+
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   await requireVibeRaisingFounder(env, request);
   const bootstrap = await getVibeMarketingBootstrap(env, request);
   const url = new URL(request.url);
-  const activeStep = normalizeStep(url.searchParams.get("step"), bootstrap.currentGuidedStep);
+  const activeStep = resolveActiveStep(url.searchParams.get("step"), bootstrap);
   return { bootstrap, activeStep, shouldRefreshGoogleBaseline: url.searchParams.get("googleBaseline") === "refresh" };
 }
 
@@ -198,6 +302,18 @@ export async function action({ request, context }: Route.ActionArgs) {
         topicCandidateId && topicCandidateId !== "__custom__"
           ? bootstrap.topicCandidates.find((candidate) => candidate.id === topicCandidateId) ?? null
           : null;
+      if (topicCandidateId && topicCandidateId !== "__custom__" && !selectedCandidate) {
+        return {
+          intent,
+          error: "That topic is no longer available. Choose a pending topic or enter a custom article.",
+        };
+      }
+      if (selectedCandidate?.alreadyWritten) {
+        return {
+          intent,
+          error: "That topic has already been written. Choose a pending topic or enter a custom article.",
+        };
+      }
       const customKeyword = stringFromForm(formData, "targetKeyword");
       const customTitle = stringFromForm(formData, "customTitle") || stringFromForm(formData, "titleAngle");
       const topic = customTitle || selectedCandidate?.title || customKeyword || selectedCandidate?.keyword || "";
@@ -215,7 +331,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title ?? "",
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: normalizeArticleDeliveryMode(stringFromForm(formData, "deliveryMode")),
+        deliveryMode: stringFromForm(formData, "deliveryMode"),
         deliveryModeConfirmed: true,
         sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
@@ -276,7 +392,7 @@ function actionDataError(data: unknown): string | null {
   return typeof error === "string" ? error : null;
 }
 
-function StatusBadge({ passed }: { passed: boolean }) {
+function StatusBadge({ passed, label }: { passed: boolean; label?: string }) {
   return (
     <span
       className={clsx(
@@ -284,19 +400,51 @@ function StatusBadge({ passed }: { passed: boolean }) {
         passed ? "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100" : "bg-amber-50 text-amber-700 ring-1 ring-amber-100",
       )}
     >
-      {passed ? "Ready" : "Needs setup"}
+      {label ?? (passed ? "Ready" : "Needs setup")}
     </span>
   );
 }
 
-function PanelHeader({ title, description, passed }: { title: string; description: string; passed: boolean }) {
+function PanelHeader({
+  title,
+  description,
+  passed,
+  statusLabel,
+  explainer,
+}: {
+  title: string;
+  description: string;
+  passed: boolean;
+  statusLabel?: string;
+  explainer?: StepExplainer;
+}) {
   return (
-    <div className="mb-6 flex flex-col gap-3 border-b border-gray-100 pb-5 lg:flex-row lg:items-start lg:justify-between">
-      <div>
-        <h1 className="text-2xl font-black tracking-tight text-gray-950">{title}</h1>
-        <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-600">{description}</p>
+    <div className="mb-6 border-b border-gray-100 pb-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-black tracking-tight text-gray-950">{title}</h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-600">{description}</p>
+        </div>
+        <StatusBadge passed={passed} label={statusLabel} />
       </div>
-      <StatusBadge passed={passed} />
+      {explainer ? (
+        <div className="mt-4 grid gap-3 border-l-4 border-violet-200 bg-violet-50/50 py-3 pl-4 pr-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">Why we need this</p>
+            <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{explainer.why}</p>
+          </div>
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">What happens next</p>
+            <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{explainer.next}</p>
+          </div>
+          {explainer.safety ? (
+            <div className="sm:col-span-2 lg:col-span-1">
+              <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">Safety</p>
+              <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{explainer.safety}</p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -1217,6 +1365,36 @@ export default function FounderToolsMarketingCreate() {
   const latestArticle = bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article"].includes(run.workflow));
   const latestContentPackage = latestArticle?.contentPackage ?? bootstrap.publishEvidence?.contentPackage ?? null;
   const contentPackageReady = Boolean(latestContentPackage?.contentPackaged);
+  const selectableTopicCandidates = useMemo(
+    () => bootstrap.topicCandidates.filter((candidate) => !candidate.alreadyWritten).slice(0, 5),
+    [bootstrap.topicCandidates],
+  );
+  const alreadyWrittenCandidates = useMemo(() => {
+    const candidates = [...bootstrap.hiddenTopicCandidates, ...bootstrap.topicCandidates].filter(
+      (candidate) => candidate.alreadyWritten,
+    );
+    const seen = new Set<string>();
+    return candidates.filter((candidate) => {
+      const key = `${candidate.keyword.toLowerCase()}::${candidate.title.toLowerCase()}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [bootstrap.hiddenTopicCandidates, bootstrap.topicCandidates]);
+  const chooseArticleStatusLabel = !bootstrap.checks.baseline?.passed
+    ? "Needs baseline"
+    : selectableTopicCandidates.length > 0
+      ? "Ready"
+      : alreadyWrittenCandidates.length > 0
+        ? "Topics written"
+        : "No pending topics";
+  const defaultTopicCandidateId = selectableTopicCandidates[0]?.id ?? "__custom__";
+  const [selectedTopicCandidateId, setSelectedTopicCandidateId] = useState(defaultTopicCandidateId);
+  const selectedTopicCandidate = useMemo(
+    () => selectableTopicCandidates.find((candidate) => candidate.id === selectedTopicCandidateId) ?? null,
+    [selectableTopicCandidates, selectedTopicCandidateId],
+  );
+  const selectedTopicLabel = selectedTopicCandidate?.title ?? "Custom article";
   const latestBaselineRun = bootstrap.latestRuns.find((run) => run.workflow === "website_baseline");
   const autofillStartData = autofillStartFetcher.data;
   const autofillRun = autofillRunFetcher.data as VibeMarketingRunSummary | undefined;
@@ -1297,6 +1475,15 @@ export default function FounderToolsMarketingCreate() {
     setAppliedAutofillRunId(null);
     googleAutoRefreshSubmittedRef.current = false;
   }, [activeCompanyKey, startupDefaults, startupDefaultsSignature]);
+
+  useEffect(() => {
+    const selectionStillValid =
+      selectedTopicCandidateId === "__custom__" ||
+      selectableTopicCandidates.some((candidate) => candidate.id === selectedTopicCandidateId);
+    if (!selectionStillValid) {
+      setSelectedTopicCandidateId(defaultTopicCandidateId);
+    }
+  }, [defaultTopicCandidateId, selectableTopicCandidates, selectedTopicCandidateId]);
 
   useEffect(() => {
     if (autofillStartData?.autofillRunId) {
@@ -1383,6 +1570,7 @@ export default function FounderToolsMarketingCreate() {
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
       <MarketingWorkflowShell
         progress={bootstrap.workflowProgress}
+        viewedStepId={WORKFLOW_STEP_ID_BY_CREATE_STEP[activeStep]}
         title="Create and publish article"
         isSubmitting={isSubmitting}
       />
@@ -1393,14 +1581,14 @@ export default function FounderToolsMarketingCreate() {
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
-        <main className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
-          {activeStep === "startupDetails" ? (
-            <>
+      <main className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
+        {activeStep === "startupDetails" ? (
+          <>
               <PanelHeader
                 title="Startup details"
                 description="This is the shared company profile used by Vibe Raising monthly updates and Vibe Marketing article generation."
                 passed={Boolean(bootstrap.checks.websiteProfile?.passed)}
+                explainer={STEP_EXPLAINERS.startupDetails}
               />
               <Form method="POST" className="space-y-6">
                 <FounderStartupDetailsStep
@@ -1463,6 +1651,7 @@ export default function FounderToolsMarketingCreate() {
                 title="Website baseline"
                 description="Capture the current website health, performance, search visibility, authority, AI visibility, and traffic data before article generation starts."
                 passed={Boolean(bootstrap.checks.baseline?.passed || effectiveBaseline.passed)}
+                explainer={STEP_EXPLAINERS.baseline}
               />
 
               <div className="space-y-5">
@@ -1603,6 +1792,7 @@ export default function FounderToolsMarketingCreate() {
                 title="Connect GitHub"
                 description="Vibe Marketing needs repository access to detect your article system and open previewable article PRs."
                 passed={Boolean(bootstrap.checks.github?.passed)}
+                explainer={STEP_EXPLAINERS.github}
               />
               <Form method="POST" className="space-y-5">
                 <input type="hidden" name="intent" value="connect-github" />
@@ -1634,6 +1824,7 @@ export default function FounderToolsMarketingCreate() {
                 title={activeStep === "scan" ? "Scan repository" : "Prepare article system"}
                 description="The scan detects your framework, build commands, article directories, registries, components, and safe publish targets."
                 passed={activeStep === "scan" ? Boolean(bootstrap.checks.scan?.passed) : Boolean(bootstrap.checks.scaffold?.passed)}
+                explainer={STEP_EXPLAINERS[activeStep]}
               />
               {latestScan ? (
                 <div className="mb-5 rounded-xl border border-gray-100 bg-gray-50 p-4">
@@ -1661,6 +1852,7 @@ export default function FounderToolsMarketingCreate() {
                 title="Research topics"
                 description="Discovery uses your company context, competitors, and seed keywords to find article candidates."
                 passed={Boolean(bootstrap.checks.research?.passed)}
+                explainer={STEP_EXPLAINERS.research}
               />
               <div className="mb-5 grid gap-3 lg:grid-cols-2">
                 <div className="rounded-xl bg-gray-50 p-4">
@@ -1688,7 +1880,9 @@ export default function FounderToolsMarketingCreate() {
               <PanelHeader
                 title="Choose article"
                 description="Pick a discovered topic or enter a known keyword and title angle."
-                passed={Boolean(latestArticle)}
+                passed={Boolean(latestArticle || selectableTopicCandidates.length > 0)}
+                statusLabel={chooseArticleStatusLabel}
+                explainer={STEP_EXPLAINERS.chooseArticle}
               />
               {!bootstrap.checks.baseline?.passed ? (
                 <div className="mb-5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-800">
@@ -1702,24 +1896,57 @@ export default function FounderToolsMarketingCreate() {
                 <input type="hidden" name="intent" value="start-article" />
                 <input type="hidden" name="sourceDiscoveryRunId" value={latestDiscovery?.runId ?? ""} />
                 <div className="grid gap-3">
-                  {bootstrap.topicCandidates.slice(0, 5).map((candidate, index) => (
-                    <label key={candidate.id} className="flex cursor-pointer gap-3 rounded-xl border border-gray-200 p-4 transition hover:bg-violet-50/60">
-                      <input type="radio" name="topicCandidateId" value={candidate.id} defaultChecked={index === 0} className="mt-1 h-4 w-4 text-violet-600" />
-                      <span>
-                        <span className="block text-sm font-black text-gray-950">{candidate.title}</span>
-                        <span className="mt-1 block text-xs font-semibold text-gray-500">{candidate.keyword}</span>
-                        {candidate.reason ? <span className="mt-2 block text-sm text-gray-600">{candidate.reason}</span> : null}
-                      </span>
-                    </label>
+                  {selectableTopicCandidates.length === 0 ? (
+                    <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900">
+                      {alreadyWrittenCandidates.length > 0
+                        ? "All discovered topics have already been written. Run new research or enter a custom article."
+                        : "No pending discovered topics are available yet. Run topic research or enter a custom article."}
+                    </div>
+                  ) : null}
+                  {selectableTopicCandidates.map((candidate) => (
+                    <TopicDecisionCard
+                      key={candidate.id}
+                      candidate={candidate}
+                      checked={selectedTopicCandidateId === candidate.id}
+                      onChange={() => setSelectedTopicCandidateId(candidate.id)}
+                    />
                   ))}
-                  <label className="flex cursor-pointer gap-3 rounded-xl border border-gray-200 p-4 transition hover:bg-violet-50/60">
-                    <input type="radio" name="topicCandidateId" value="__custom__" defaultChecked={bootstrap.topicCandidates.length === 0} className="mt-1 h-4 w-4 text-violet-600" />
-                    <span>
-                      <span className="block text-sm font-black text-gray-950">Custom article</span>
-                      <span className="mt-1 block text-xs font-semibold text-gray-500">Use the keyword and title fields below.</span>
-                    </span>
-                  </label>
+                  <CustomTopicDecisionCard
+                    checked={selectedTopicCandidateId === "__custom__"}
+                    onChange={() => setSelectedTopicCandidateId("__custom__")}
+                  />
                 </div>
+                {alreadyWrittenCandidates.length > 0 ? (
+                  <details className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                    <summary className="cursor-pointer text-sm font-black text-gray-800">Already written from this discovery</summary>
+                    <div className="mt-3 grid gap-2">
+                      {alreadyWrittenCandidates.slice(0, 8).map((candidate) => (
+                        <div key={`${candidate.id}:${candidate.keyword}`} className="rounded-lg bg-white px-3 py-2 text-sm">
+                          <div className="font-bold text-gray-900">{candidate.writtenArticle?.title || candidate.title}</div>
+                          <div className="mt-1 text-xs font-semibold text-gray-500">{candidate.keyword}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </details>
+                ) : null}
+                {bootstrap.writtenTopics.length > 0 ? (
+                  <div className="rounded-xl border border-gray-200 p-4">
+                    <div className="text-sm font-black text-gray-900">Recent written topics</div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-2">
+                      {bootstrap.writtenTopics.slice(0, 6).map((topic) => (
+                        <div key={topic.id ?? `${topic.slug}:${topic.keyword}`} className="rounded-lg bg-gray-50 px-3 py-2 text-sm">
+                          <div className="font-bold text-gray-900">{topic.title}</div>
+                          <div className="mt-1 text-xs font-semibold text-gray-500">{topic.keyword}</div>
+                          {topic.articleUrl || topic.prUrl ? (
+                            <a href={topic.articleUrl || topic.prUrl || "#"} className="mt-2 inline-flex text-xs font-black text-violet-700 underline">
+                              Open evidence
+                            </a>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
                 <div className="grid gap-4 lg:grid-cols-2">
                   <label className="block">
                     <span className="mb-2 block text-sm font-bold text-gray-700">Custom keyword</span>
@@ -1743,10 +1970,18 @@ export default function FounderToolsMarketingCreate() {
                   <span className="mb-2 block text-sm font-bold text-gray-700">Article context</span>
                   <textarea name="articleContext" rows={4} placeholder="Add any angle, product detail, proof point, or audience note." className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium leading-6 outline-none focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10" />
                 </label>
-                <button type="submit" disabled={isSubmitting || !bootstrap.checks.baseline?.passed} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                  Generate article
-                </button>
+                <div className="sticky bottom-4 z-10 rounded-xl border border-gray-200 bg-white/95 p-3 shadow-lg backdrop-blur">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Selected topic</p>
+                      <p className="mt-1 max-w-2xl text-sm font-black leading-5 text-gray-950">{selectedTopicLabel}</p>
+                    </div>
+                    <button type="submit" disabled={isSubmitting || !bootstrap.checks.baseline?.passed} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
+                      {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
+                      Generate draft article
+                    </button>
+                  </div>
+                </div>
               </Form>
             </>
           ) : null}
@@ -1761,6 +1996,7 @@ export default function FounderToolsMarketingCreate() {
                     ? Boolean(bootstrap.checks.publish?.passed || bootstrap.checks.contentPackage?.passed || contentPackageReady)
                     : Boolean(bootstrap.checks.write?.passed)
                 }
+                explainer={STEP_EXPLAINERS[activeStep]}
               />
               {latestArticle ? (
                 <div className="space-y-4">
@@ -1791,6 +2027,7 @@ export default function FounderToolsMarketingCreate() {
                 title="Daily automation"
                 description="Daily generation creates candidates and keeps human approval before final publish by default."
                 passed={Boolean(bootstrap.checks.dailyAutomation?.passed)}
+                explainer={STEP_EXPLAINERS.dailyAutomation}
               />
               <Form method="POST" className="space-y-5">
                 <label className="flex items-start gap-3 rounded-xl border border-gray-200 p-4">
@@ -1814,26 +2051,8 @@ export default function FounderToolsMarketingCreate() {
                 </div>
               </Form>
             </>
-          ) : null}
-        </main>
-
-        <div className="space-y-4">
-          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <p className="text-xs font-bold uppercase tracking-wide text-gray-400">Current company</p>
-            <p className="mt-2 text-lg font-black text-gray-950">{bootstrap.company.name}</p>
-            <p className="mt-1 text-sm font-semibold text-gray-500">{bootstrap.organization.domain || "No domain saved"}</p>
-            <div className="mt-4 space-y-2">
-              {Object.entries(bootstrap.checks).map(([key, check]) => (
-                <div key={key} className="flex items-center justify-between gap-3 text-sm">
-                  <span className="font-semibold text-gray-600">{key.replace(/[A-Z]/g, " $&")}</span>
-                  <span className={clsx("h-2.5 w-2.5 rounded-full", check.passed ? "bg-emerald-500" : "bg-gray-300")} />
-                </div>
-              ))}
-            </div>
-          </div>
-          <MarketingEvidencePanel run={latestArticle ?? latestScan ?? null} evidence={bootstrap.publishEvidence} />
-        </div>
-      </div>
+        ) : null}
+      </main>
     </div>
   );
 }

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -13,9 +13,10 @@ import {
 } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 
-import MarketingEvidencePanel from "~/components/MarketingEvidencePanel";
+import ArticleRunStageProgress, { articleRunTechnicalProgressLabel } from "~/components/ArticleRunStageProgress";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
+import { TopicDecisionCard } from "~/components/TopicDecisionCard";
 import { getEnv } from "~/lib/env.server";
 import {
   controlVibeMarketingRun,
@@ -24,7 +25,6 @@ import {
   deleteVibeMarketingComponentComment,
   getVibeMarketingBootstrap,
   getVibeMarketingRun,
-  normalizeArticleDeliveryMode,
   submitVibeMarketingComponentComments,
   startVibeMarketingLivePreview,
   startVibeMarketingArticle,
@@ -48,6 +48,12 @@ const POLLING_STATUSES = new Set([
   "awaiting_approval",
   "approval_required",
 ]);
+
+const DISCOVERY_WORKFLOWS = new Set(["auto_discovery", "content_factory_discovery", "daily_discovery"]);
+const SCAN_WORKFLOWS = new Set(["repo_scan", "content_factory_scan"]);
+const ARTICLE_WORKFLOWS = new Set(["article_generation", "content_factory_article", "article_revision"]);
+const RESUMABLE_ATTENTION_STATUSES = new Set(["blocked", "blocked_verification", "failed"]);
+const APPROVAL_GATE_STATUSES = new Set(["awaiting_approval", "approval_required"]);
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
@@ -102,7 +108,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       }
     } else if (intent === "delivery-mode") {
       await controlVibeMarketingRun(env, request, runId, "delivery-mode", {
-        deliveryMode: normalizeArticleDeliveryMode(formData.get("deliveryMode"), "content_only"),
+        deliveryMode: String(formData.get("deliveryMode") ?? ""),
       });
     } else if (intent === "start-article") {
       const bootstrap = await getVibeMarketingBootstrap(env, request);
@@ -126,10 +132,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title || candidateTitle,
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: normalizeArticleDeliveryMode(
-          stringFromForm(formData, "deliveryMode") || bootstrap.settings.articleDeliveryMode,
-          "content_only",
-        ),
+        deliveryMode: stringFromForm(formData, "deliveryMode") || bootstrap.settings.articleDeliveryMode,
         deliveryModeConfirmed: true,
         sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceRunId") || runId,
       });
@@ -243,6 +246,12 @@ function topicCandidatesFromRun(run: { result?: Record<string, unknown>; runId: 
         keyword: keyword || title,
         title: title || keyword,
         reason: asString(payload.reason) || asString(payload.selection_reason) || asString(payload.rationale),
+        audience: asString(payload.audience) || asString(payload.target_audience) || asString(payload.targetAudience),
+        confidence: asString(payload.confidence),
+        trend: payload.trend ?? payload.search_trend,
+        interest: payload.interest ?? payload.interest_trend,
+        competition: payload.competition ?? payload.competition_level,
+        aiSearches: payload.aiSearches ?? payload.ai_searches ?? payload.ai_search_volume,
         source: asString(payload.source) || "discovery",
         sourceRunId: asString(payload.source_run_id) || asString(payload.sourceRunId) || run.runId,
         intent: payload.intent,
@@ -266,6 +275,173 @@ function StepStatusDot({ status }: { status: string }) {
         !isComplete && !isFailed && "bg-violet-300",
       )}
     />
+  );
+}
+
+function RunStepTimeline({ run, framed = true }: { run: VibeMarketingRunSummary; framed?: boolean }) {
+  return (
+    <section className={framed ? "rounded-xl border border-gray-200 bg-white p-5 shadow-sm" : ""}>
+      <h2 className="text-lg font-black text-gray-950">Step timeline</h2>
+      {run.steps.length > 0 ? (
+        <ol className="mt-5 space-y-4">
+          {run.steps.map((step) => (
+            <li key={step.key} className="flex gap-3">
+              <StepStatusDot status={step.status} />
+              <div className="min-w-0 flex-1 border-b border-gray-100 pb-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm font-black text-gray-950">{step.name}</p>
+                  <span className="rounded-full bg-gray-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-gray-500">
+                    {step.status.replace(/_/g, " ")}
+                  </span>
+                </div>
+                {step.message ? <p className="mt-1 text-sm text-gray-600">{step.message}</p> : null}
+                {step.error ? <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{step.error}</p> : null}
+                {step.artifacts.length > 0 ? (
+                  <p className="mt-2 text-xs font-semibold text-gray-500">{step.artifacts.length} artifacts</p>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="mt-4 rounded-xl bg-gray-50 px-4 py-8 text-center text-sm font-semibold text-gray-500">
+          No step details have been reported yet.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function RunApprovalActions({
+  isSubmitting,
+  approveLabel = "Approve",
+  denyLabel = "Deny",
+}: {
+  isSubmitting: boolean;
+  approveLabel?: string;
+  denyLabel?: string;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Form method="POST">
+        <button
+          type="submit"
+          name="intent"
+          value="deny"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50"
+        >
+          <XCircleIcon className="h-4 w-4" />
+          {denyLabel}
+        </button>
+      </Form>
+      <Form method="POST">
+        <button
+          type="submit"
+          name="intent"
+          value="approve"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
+        >
+          <CheckCircleIcon className="h-4 w-4" />
+          {approveLabel}
+        </button>
+      </Form>
+    </div>
+  );
+}
+
+function RunDiagnosticsDetails({ run }: { run: VibeMarketingRunSummary }) {
+  return (
+    <details className="rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm shadow-sm">
+      <summary className="cursor-pointer text-sm font-black text-gray-700">Run diagnostics</summary>
+      <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <dt className="font-black uppercase tracking-wide text-gray-400">Run ID</dt>
+          <dd className="mt-1 break-all font-mono text-gray-600">{run.runId}</dd>
+        </div>
+        <div>
+          <dt className="font-black uppercase tracking-wide text-gray-400">Workflow</dt>
+          <dd className="mt-1 font-semibold text-gray-700">{run.workflow || "Not reported"}</dd>
+        </div>
+        <div>
+          <dt className="font-black uppercase tracking-wide text-gray-400">Status</dt>
+          <dd className="mt-1 font-semibold text-gray-700">{run.status || "Not reported"}</dd>
+        </div>
+        <div>
+          <dt className="font-black uppercase tracking-wide text-gray-400">Current step</dt>
+          <dd className="mt-1 font-semibold text-gray-700">{run.currentStep || "Not reported"}</dd>
+        </div>
+      </dl>
+    </details>
+  );
+}
+
+function PublishApprovalPanel({
+  run,
+  isSubmitting,
+}: {
+  run: VibeMarketingRunSummary;
+  isSubmitting: boolean;
+}) {
+  const previewUrl = run.previewUrl || stringResultValue(run, "preview_url", "previewUrl", "article_url", "articleUrl");
+  const prUrl = run.prUrl || stringResultValue(run, "pr_url", "prUrl", "pull_request_url", "pullRequestUrl");
+
+  return (
+    <section className="rounded-xl border border-emerald-200 bg-emerald-50 p-5 text-sm text-emerald-900">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-black text-emerald-950">Publish approval</h2>
+          <p className="mt-2 font-semibold">
+            Review the preview or PR evidence, then approve publication or deny this run.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {previewUrl ? (
+              <a
+                href={previewUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-xl border border-emerald-200 bg-white px-3 py-2 text-xs font-black text-emerald-800 transition hover:bg-emerald-100"
+              >
+                Open preview
+              </a>
+            ) : null}
+            {prUrl ? (
+              <a
+                href={prUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-xl border border-emerald-200 bg-white px-3 py-2 text-xs font-black text-emerald-800 transition hover:bg-emerald-100"
+              >
+                Open PR
+              </a>
+            ) : null}
+          </div>
+        </div>
+        <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve publish" denyLabel="Deny publish" />
+      </div>
+    </section>
+  );
+}
+
+function TechnicalRunDetails({ run, defaultOpen = false }: { run: VibeMarketingRunSummary; defaultOpen?: boolean }) {
+  return (
+    <details className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm" open={defaultOpen}>
+      <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 text-left">
+        <span>
+          <span className="block text-lg font-black text-gray-950">Technical run details</span>
+          <span className="mt-1 block text-sm font-semibold text-gray-500">
+            Internal pipeline checks are available for debugging.
+          </span>
+        </span>
+        <span className="rounded-full bg-gray-50 px-3 py-1.5 text-xs font-black uppercase tracking-wide text-gray-500">
+          {articleRunTechnicalProgressLabel(run)}
+        </span>
+      </summary>
+      <div className="mt-5 border-t border-gray-100 pt-5">
+        <RunStepTimeline run={run} framed={false} />
+      </div>
+    </details>
   );
 }
 
@@ -1124,6 +1300,8 @@ function ArticleWorkflowPrimaryAction({
   const publishUrl = run.previewUrl || run.prUrl || (typeof run.result?.["preview_url"] === "string" ? run.result["preview_url"] : "") || (typeof run.result?.["pr_url"] === "string" ? run.result["pr_url"] : "");
   const buttonClass = "inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-black shadow-sm transition disabled:opacity-50";
 
+  if (isPublishApprovalGate(run)) return null;
+
   if (canAcceptRevision) {
     return (
       <Form method="POST">
@@ -1183,6 +1361,64 @@ function ArticleWorkflowPrimaryAction({
   return null;
 }
 
+function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
+  for (const key of keys) {
+    const value = run.result?.[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    const nestedResult = run.result?.["result"];
+    if (nestedResult && typeof nestedResult === "object") {
+      const nestedValue = (nestedResult as Record<string, unknown>)[key];
+      if (typeof nestedValue === "string" && nestedValue.trim()) return nestedValue.trim();
+    }
+  }
+  return "";
+}
+
+function hasReviewTarget(run: VibeMarketingRunSummary) {
+  return Boolean(run.previewUrl || run.prUrl || stringResultValue(run, "preview_url", "previewUrl", "pr_url", "prUrl"));
+}
+
+function isRunApprovalRequired(run: VibeMarketingRunSummary) {
+  return run.approvalState === "approval_required" || APPROVAL_GATE_STATUSES.has(run.status);
+}
+
+function isScaffoldApprovalGate(run: VibeMarketingRunSummary) {
+  const workflow = String(run.workflow ?? "");
+  if (!SCAN_WORKFLOWS.has(workflow)) return false;
+  const requestedAction = stringResultValue(run, "requested_action");
+  const scaffoldStatus = stringResultValue(run, "scaffold_status");
+  return (
+    isRunApprovalRequired(run) ||
+    (run.status === "awaiting_confirmation" &&
+      (requestedAction === "scaffold_publish_route" || scaffoldStatus === "approval_required"))
+  );
+}
+
+function isPublishApprovalGate(run: VibeMarketingRunSummary) {
+  const workflow = String(run.workflow ?? "");
+  return ARTICLE_WORKFLOWS.has(workflow) && isRunApprovalRequired(run) && hasReviewTarget(run);
+}
+
+function viewedWorkflowStepIdForRun(run: VibeMarketingRunSummary) {
+  const workflow = String(run.workflow ?? "");
+  if (DISCOVERY_WORKFLOWS.has(workflow)) {
+    return run.status === "awaiting_confirmation" ? "choose_topic" : "research";
+  }
+  if (SCAN_WORKFLOWS.has(workflow)) return "article_system";
+  if (workflow === "website_baseline") return "baseline";
+  if (workflow === "article_revision") return "revise";
+  if (ARTICLE_WORKFLOWS.has(workflow)) {
+    const publishUrl = run.previewUrl || run.prUrl || stringResultValue(run, "preview_url", "previewUrl", "pr_url", "prUrl");
+    const isPublishRun = run.workflowProgress?.currentStepId === "publish" && (POLLING_STATUSES.has(run.status) || Boolean(publishUrl));
+    if (isPublishRun) return "publish";
+    if (POLLING_STATUSES.has(run.status)) return "generate";
+    if (run.contentPackage?.contentPackaged) return "package";
+    if (run.componentManifest) return "review";
+    return "generate";
+  }
+  return run.workflowProgress?.currentStepId ?? null;
+}
+
 export default function FounderToolsMarketingRun() {
   const { run, bootstrap } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
@@ -1193,7 +1429,9 @@ export default function FounderToolsMarketingRun() {
   const shouldPoll = POLLING_STATUSES.has(run.status);
   const workflow = String(run.workflow ?? "");
   const isArticleWorkflow = ["article_generation", "content_factory_article", "article_revision"].includes(workflow);
+  const isArticleGenerationWorkflow = ["article_generation", "content_factory_article"].includes(workflow);
   const contentPackage = run.contentPackage;
+  const runNeedsAttention = ["blocked", "failed", "blocked_verification", "denied", "cancelled"].includes(run.status);
   const hasArticlePreview =
     ["article_generation", "content_factory_article", "article_revision"].includes(workflow) &&
     Boolean(contentPackage?.contentPackaged || run.componentManifest);
@@ -1202,13 +1440,31 @@ export default function FounderToolsMarketingRun() {
   const isDiscoveryConfirmation =
     ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(workflow) &&
     run.status === "awaiting_confirmation";
-  const isScaffoldApproval =
-    ["repo_scan", "content_factory_scan"].includes(workflow) &&
-    ["awaiting_confirmation", "awaiting_approval", "approval_required"].includes(run.status);
-  const hasPublishApprovalTarget = Boolean(run.previewUrl || run.prUrl || run.result?.["preview_url"] || run.result?.["pr_url"]);
-  const canApprove = isScaffoldApproval || hasPublishApprovalTarget;
-  const canDeny = isScaffoldApproval || hasPublishApprovalTarget;
-  const discoveryCandidates = isDiscoveryConfirmation ? topicCandidatesFromRun(run) : [];
+  const isScaffoldApproval = isScaffoldApprovalGate(run);
+  const isPublishApproval = isPublishApprovalGate(run);
+  const showRunAttentionBanner = RESUMABLE_ATTENTION_STATUSES.has(run.status);
+  const canResume = Boolean(run.resumeAvailable && RESUMABLE_ATTENTION_STATUSES.has(run.status));
+  const discoveryCandidates = useMemo(
+    () => (isDiscoveryConfirmation ? topicCandidatesFromRun(run) : []),
+    [isDiscoveryConfirmation, run],
+  );
+  const [selectedDiscoveryCandidateId, setSelectedDiscoveryCandidateId] = useState(discoveryCandidates[0]?.id ?? "");
+  const selectedDiscoveryCandidate = useMemo(
+    () => discoveryCandidates.find((candidate) => candidate.id === selectedDiscoveryCandidateId) ?? discoveryCandidates[0] ?? null,
+    [discoveryCandidates, selectedDiscoveryCandidateId],
+  );
+  const viewedWorkflowStepId = viewedWorkflowStepIdForRun(run);
+  const workflowProgress = run.workflowProgress ?? bootstrap.workflowProgress;
+
+  useEffect(() => {
+    if (!isDiscoveryConfirmation) return;
+    const firstCandidateId = discoveryCandidates[0]?.id ?? "";
+    const selectionStillValid = discoveryCandidates.some((candidate) => candidate.id === selectedDiscoveryCandidateId);
+    if (!selectionStillValid && selectedDiscoveryCandidateId !== firstCandidateId) {
+      setSelectedDiscoveryCandidateId(firstCandidateId);
+    }
+  }, [discoveryCandidates, isDiscoveryConfirmation, selectedDiscoveryCandidateId]);
+
   useEffect(() => {
     if (!shouldPoll) return;
     const timer = window.setInterval(() => {
@@ -1219,38 +1475,12 @@ export default function FounderToolsMarketingRun() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
-      <div className="flex flex-col gap-4 border-b border-gray-200 pb-5">
-        <div>
-          <Link to="/founder-tools/marketing" className="mb-3 inline-flex items-center gap-2 text-sm font-bold text-gray-500 hover:text-gray-800">
-            <ArrowLeftIcon className="h-4 w-4" />
-            Back to marketing
-          </Link>
-          <h1 className="text-2xl font-black text-gray-950">Marketing run</h1>
-          <p className="mt-2 break-all font-mono text-xs text-gray-500">{run.runId}</p>
-        </div>
-        {!isArticleWorkflow ? (
-          <div className="flex flex-wrap gap-3">
-            <Form method="POST">
-              <button type="submit" name="intent" value="resume" disabled={isSubmitting || !run.resumeAvailable} className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-50">
-                <PlayIcon className="h-4 w-4" />
-                Resume
-              </button>
-            </Form>
-            <Form method="POST">
-              <button type="submit" name="intent" value="deny" disabled={isSubmitting || !canDeny} className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50">
-                <XCircleIcon className="h-4 w-4" />
-                Deny
-              </button>
-            </Form>
-            <Form method="POST">
-              <button type="submit" name="intent" value="approve" disabled={isSubmitting || !canApprove} className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50">
-                <CheckCircleIcon className="h-4 w-4" />
-                Approve
-              </button>
-            </Form>
-          </div>
-        ) : null}
-      </div>
+      <nav className="border-b border-gray-200 pb-4" aria-label="Breadcrumb">
+        <Link to="/founder-tools/marketing" className="inline-flex items-center gap-2 text-sm font-bold text-gray-500 hover:text-gray-800">
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to marketing
+        </Link>
+      </nav>
 
       {actionData?.error ? (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
@@ -1259,8 +1489,10 @@ export default function FounderToolsMarketingRun() {
       ) : null}
 
       <MarketingWorkflowShell
-        progress={run.workflowProgress ?? bootstrap.workflowProgress}
+        progress={workflowProgress}
+        viewedStepId={viewedWorkflowStepId}
         title="Create and publish article"
+        titleAs="h1"
         isSubmitting={isSubmitting}
         primaryActionSlot={isArticleWorkflow ? <ArticleWorkflowPrimaryAction run={run} isSubmitting={isSubmitting} /> : undefined}
       />
@@ -1274,54 +1506,68 @@ export default function FounderToolsMarketingRun() {
         />
       ) : null}
 
+      {isPublishApproval ? <PublishApprovalPanel run={run} isSubmitting={isSubmitting} /> : null}
+
       {!isCompletedArticleReviewPage ? (
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
-          <main className="space-y-6">
+        <main className="space-y-6">
+          {isArticleGenerationWorkflow ? (
+            <ArticleRunStageProgress run={run} pollingDegraded={revalidator.state === "loading"} />
+          ) : (
             <MarketingRunProgressCard run={run} pollingDegraded={revalidator.state === "loading"} />
+          )}
 
           {isDiscoveryConfirmation ? (
             <section className="rounded-xl border border-violet-100 bg-white p-5 shadow-sm">
               <h2 className="text-lg font-black text-gray-950">Discovery confirmation</h2>
-              <div className="mt-4 space-y-3">
-                {discoveryCandidates.length > 0 ? (
-                  discoveryCandidates.slice(0, 5).map((candidate, index) => (
-                    <div key={`${candidate.id}-${index}`} className="rounded-xl border border-gray-200 p-4">
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                        <div>
-                          <p className="text-sm font-black text-gray-950">{candidate.title}</p>
-                          <p className="mt-1 text-xs font-semibold text-gray-500">{candidate.keyword}</p>
-                          {candidate.reason ? <p className="mt-2 text-sm text-gray-600">{candidate.reason}</p> : null}
-                        </div>
-                        <Form method="POST">
-                          <input type="hidden" name="intent" value="start-article" />
-                          <input type="hidden" name="topicCandidateId" value={candidate.id} />
-                          <input type="hidden" name="candidateTitle" value={candidate.title} />
-                          <input type="hidden" name="candidateKeyword" value={candidate.keyword} />
-                          <input type="hidden" name="sourceRunId" value={candidate.sourceRunId ?? run.runId} />
-                          <input type="hidden" name="deliveryMode" value={bootstrap.settings.articleDeliveryMode ?? "content_only"} />
-                          <button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50">
-                            <CheckCircleIcon className="h-4 w-4" />
-                            Generate article from this topic
-                          </button>
-                        </Form>
+              {discoveryCandidates.length > 0 && selectedDiscoveryCandidate ? (
+                <Form method="POST" className="mt-4 space-y-4">
+                  <input type="hidden" name="intent" value="start-article" />
+                  <input type="hidden" name="candidateTitle" value={selectedDiscoveryCandidate.title} />
+                  <input type="hidden" name="candidateKeyword" value={selectedDiscoveryCandidate.keyword} />
+                  <input type="hidden" name="sourceRunId" value={selectedDiscoveryCandidate.sourceRunId ?? run.runId} />
+                  <input type="hidden" name="deliveryMode" value={bootstrap.settings.articleDeliveryMode ?? "content_only"} />
+                  <div className="grid gap-3">
+                    {discoveryCandidates.slice(0, 5).map((candidate) => (
+                      <TopicDecisionCard
+                        key={candidate.id}
+                        candidate={candidate}
+                        checked={selectedDiscoveryCandidate.id === candidate.id}
+                        onChange={() => setSelectedDiscoveryCandidateId(candidate.id)}
+                      />
+                    ))}
+                  </div>
+                  <div className="sticky bottom-4 z-10 rounded-xl border border-gray-200 bg-white/95 p-3 shadow-lg backdrop-blur">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Selected topic</p>
+                        <p className="mt-1 max-w-2xl text-sm font-black leading-5 text-gray-950">{selectedDiscoveryCandidate.title}</p>
                       </div>
+                      <button type="submit" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50">
+                        <CheckCircleIcon className="h-4 w-4" />
+                        Generate draft article
+                      </button>
                     </div>
-                  ))
-                ) : (
-                  <p className="rounded-xl bg-gray-50 px-4 py-5 text-sm font-semibold text-gray-500">
-                    No topic candidates were included in this discovery result.
-                  </p>
-                )}
-              </div>
+                  </div>
+                </Form>
+              ) : (
+                <p className="mt-4 rounded-xl bg-gray-50 px-4 py-5 text-sm font-semibold text-gray-500">
+                  No topic candidates were included in this discovery result.
+                </p>
+              )}
             </section>
           ) : null}
 
           {isScaffoldApproval ? (
             <section className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-900">
-              <h2 className="text-lg font-black text-amber-950">Scaffold approval</h2>
-              <p className="mt-2 font-semibold">
-                Review the scan result and use Approve or Deny above to continue the article system setup.
-              </p>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-black text-amber-950">Scaffold approval</h2>
+                  <p className="mt-2 font-semibold">
+                    Review the scan result, then approve setup or deny the scaffold request.
+                  </p>
+                </div>
+                <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve setup" denyLabel="Deny setup" />
+              </div>
               {run.result?.["route_path"] || run.result?.["path"] ? (
                 <p className="mt-3 break-all rounded-lg bg-white px-3 py-2 font-mono text-xs text-amber-900">
                   {String(run.result?.["route_path"] ?? run.result?.["path"])}
@@ -1356,56 +1602,48 @@ export default function FounderToolsMarketingRun() {
             </section>
           ) : null}
 
-          {run.status === "blocked" || run.status === "failed" ? (
+          {showRunAttentionBanner ? (
             <div className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-800">
-              <div className="flex items-start gap-3">
-                <ExclamationTriangleIcon className="h-5 w-5 flex-shrink-0" />
-                <div>
-                  <p className="font-black">This run needs attention</p>
-                  <p className="mt-1">{run.errors[0] ?? "Review the failed step and resume when ready."}</p>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex items-start gap-3">
+                  <ExclamationTriangleIcon className="h-5 w-5 flex-shrink-0" />
+                  <div>
+                    <p className="font-black">This run needs attention</p>
+                    <p className="mt-1">{run.errors[0] ?? "Review the failed step and resume when ready."}</p>
+                  </div>
                 </div>
+                {canResume ? (
+                  <Form method="POST">
+                    <button
+                      type="submit"
+                      name="intent"
+                      value="resume"
+                      disabled={isSubmitting}
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm font-bold text-amber-900 shadow-sm transition hover:bg-amber-100 disabled:opacity-50 sm:w-auto"
+                    >
+                      <PlayIcon className="h-4 w-4" />
+                      Resume run
+                    </button>
+                  </Form>
+                ) : null}
               </div>
             </div>
           ) : null}
 
-          <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <h2 className="text-lg font-black text-gray-950">Step timeline</h2>
-            {run.steps.length > 0 ? (
-              <ol className="mt-5 space-y-4">
-                {run.steps.map((step) => (
-                  <li key={step.key} className="flex gap-3">
-                    <StepStatusDot status={step.status} />
-                    <div className="min-w-0 flex-1 border-b border-gray-100 pb-4">
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <p className="text-sm font-black text-gray-950">{step.name}</p>
-                        <span className="rounded-full bg-gray-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-gray-500">
-                          {step.status.replace(/_/g, " ")}
-                        </span>
-                      </div>
-                      {step.message ? <p className="mt-1 text-sm text-gray-600">{step.message}</p> : null}
-                      {step.error ? <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{step.error}</p> : null}
-                      {step.artifacts.length > 0 ? (
-                        <p className="mt-2 text-xs font-semibold text-gray-500">{step.artifacts.length} artifacts</p>
-                      ) : null}
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            ) : (
-              <p className="mt-4 rounded-xl bg-gray-50 px-4 py-8 text-center text-sm font-semibold text-gray-500">
-                No step details have been reported yet.
-              </p>
-            )}
-          </section>
+          {isArticleGenerationWorkflow ? (
+            <TechnicalRunDetails run={run} defaultOpen={runNeedsAttention} />
+          ) : (
+            <RunStepTimeline run={run} />
+          )}
+
+          <RunDiagnosticsDetails run={run} />
 
           {contentPackage?.contentPackaged || run.componentManifest ? (
             <ComponentCommentsPanel run={run} selectedComponent={selectedComponent} isSubmitting={isSubmitting} />
           ) : null}
-          </main>
-
-          <MarketingEvidencePanel run={run} />
-        </div>
+        </main>
       ) : null}
+      {isCompletedArticleReviewPage ? <RunDiagnosticsDetails run={run} /> : null}
     </div>
   );
 }

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -4,11 +4,7 @@ import { ArrowLeftIcon, ArrowPathIcon, CheckCircleIcon } from "@heroicons/react/
 
 import FounderStartupDetailsStep from "~/components/FounderStartupDetailsStep";
 import { getEnv } from "~/lib/env.server";
-import {
-  getVibeMarketingBootstrap,
-  normalizeArticleDeliveryMode,
-  saveVibeMarketingSettings,
-} from "~/lib/vibe-marketing";
+import { getVibeMarketingBootstrap, saveVibeMarketingSettings } from "~/lib/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
@@ -37,7 +33,6 @@ export async function action({ request, context }: Route.ActionArgs) {
   const { appUser } = await requireVibeRaisingFounder(env, request);
   const activeCompany = getActiveVibeRaisingCompany(appUser);
   const formData = await request.formData();
-  const articleDeliveryMode = normalizeArticleDeliveryMode(stringFromForm(formData, "articleDeliveryMode"));
 
   try {
     await saveVibeRaisingCompany(env, request, {
@@ -54,7 +49,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       stage: stringFromForm(formData, "stage"),
       organizationKind: stringFromForm(formData, "organizationKind"),
       githubRepo: stringFromForm(formData, "githubRepo"),
-      articleDeliveryMode,
+      articleDeliveryMode: stringFromForm(formData, "articleDeliveryMode"),
       dailyDiscoveryEnabled: formData.get("dailyDiscoveryEnabled") === "on",
       defaultTimezone: stringFromForm(formData, "defaultTimezone"),
       registered: true,
@@ -67,7 +62,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       competitors: listFromForm(formData.get("competitors")),
       seedKeywords: listFromForm(formData.get("seedKeywords")),
       githubRepo: stringFromForm(formData, "githubRepo"),
-      articleDeliveryMode,
+      articleDeliveryMode: stringFromForm(formData, "articleDeliveryMode"),
       dailyDiscoveryEnabled: formData.get("dailyDiscoveryEnabled") === "on",
       defaultTimezone: stringFromForm(formData, "defaultTimezone"),
     });

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -1,14 +1,17 @@
 import type { Route } from "./+types/founder-tools.marketing";
-import { Form, Link, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useNavigation } from "react-router";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  AlertTriangle,
   ArrowRight,
   BarChart3,
   CheckCircle2,
   ChevronDown,
+  ExternalLink,
   FileText,
   Flame,
+  Loader2,
   PenLine,
   Rocket,
   Save,
@@ -25,7 +28,11 @@ import { getEnv } from "~/lib/env.server";
 import {
   getVibeMarketingBootstrap,
   replayVibeMarketingDaily,
+  refreshVibeMarketingBaselineGoogle,
+  skipVibeMarketingBaseline,
   startVibeMarketingArticle,
+  startVibeMarketingAutofill,
+  startVibeMarketingBaseline,
   startVibeMarketingDiscovery,
   startVibeMarketingScan,
 } from "~/lib/vibe-marketing";
@@ -38,8 +45,13 @@ import {
   setVibeRaisingActiveCompany,
 } from "~/lib/vibe-raising";
 import type {
+  VibeMarketingAutofillCompetitor,
+  VibeMarketingAutofillResult,
   VibeMarketingBootstrap,
+  VibeMarketingRunSummary,
   VibeMarketingTopicCandidate,
+  VibeMarketingWebsiteBaseline,
+  VibeMarketingWebsiteBaselineMetric,
   VibeMarketingWrittenTopic,
 } from "~/types/vibe-marketing";
 import type { VibeRaisingProfile } from "~/types/vibe-raising";
@@ -197,7 +209,9 @@ export async function action({ request, context }: Route.ActionArgs) {
       const shortDescription = stringFromForm(formData, "shortDescription") || stringFromForm(formData, "companyContext");
       const problemSolved = stringFromForm(formData, "problemSolved");
       const targetAudience = stringFromForm(formData, "targetAudience");
-      const companyContext = combineCompanyContext({ shortDescription, problemSolved, targetAudience });
+      const companyContext =
+        stringFromForm(formData, "companyContext") ||
+        combineCompanyContext({ shortDescription, problemSolved, targetAudience });
 
       if (!name) {
         return { intent, error: "Add your startup or company name before continuing." };
@@ -219,6 +233,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         location: stringFromForm(formData, "location"),
         abn: stringFromForm(formData, "abn"),
         companyContext,
+        competitors: listFromForm(formData.get("competitors")),
         seedKeywords: listFromForm(formData.get("seedKeywords")),
         founderNames: listFromForm(formData.get("founderNames")),
         stage: stringFromForm(formData, "stage"),
@@ -238,8 +253,68 @@ export async function action({ request, context }: Route.ActionArgs) {
       return redirect("/founder-tools/marketing/create?step=baseline");
     }
 
+    if (intent === "start-autofill") {
+      if (!vibeContext.profile || !vibeContext.appUser) {
+        await saveVibeRaisingProfile(env, request, {
+          role: "founder",
+          organizationName: null,
+        });
+      }
+
+      const result = await startVibeMarketingAutofill(env, request, {
+        companyName: stringFromForm(formData, "companyName"),
+        company_name: stringFromForm(formData, "companyName"),
+        domain: stringFromForm(formData, "domain"),
+        companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
+        company_linkedin_url: stringFromForm(formData, "companyLinkedInUrl"),
+        location: stringFromForm(formData, "location"),
+        abn: stringFromForm(formData, "abn"),
+        organizationKind: stringFromForm(formData, "organizationKind"),
+        organization_kind: stringFromForm(formData, "organizationKind"),
+        existingFields: {
+          companyContext:
+            stringFromForm(formData, "companyContext") ||
+            combineCompanyContext({
+              shortDescription: stringFromForm(formData, "shortDescription"),
+              problemSolved: stringFromForm(formData, "problemSolved"),
+              targetAudience: stringFromForm(formData, "targetAudience"),
+            }),
+          competitors: listFromForm(formData.get("competitors")),
+          seedKeywords: listFromForm(formData.get("seedKeywords")),
+          companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
+        },
+        companyContext:
+          stringFromForm(formData, "companyContext") ||
+          combineCompanyContext({
+            shortDescription: stringFromForm(formData, "shortDescription"),
+            problemSolved: stringFromForm(formData, "problemSolved"),
+            targetAudience: stringFromForm(formData, "targetAudience"),
+          }),
+        competitors: listFromForm(formData.get("competitors")),
+        seedKeywords: listFromForm(formData.get("seedKeywords")),
+      });
+      return { intent, autofillRunId: result.runId, status: result.status, error: result.error, errors: result.errors };
+    }
+
     if (!vibeContext.appUser) {
       return { intent, error: "Save your startup details before starting article research." };
+    }
+
+    if (intent === "start-baseline") {
+      const result = await startVibeMarketingBaseline(env, request, {});
+      return { intent, baselineRunId: result.runId, status: result.status };
+    }
+
+    if (intent === "refresh-baseline-google") {
+      const websiteBaseline = await refreshVibeMarketingBaselineGoogle(env, request, {});
+      return { intent, websiteBaseline };
+    }
+
+    if (intent === "skip-baseline") {
+      await skipVibeMarketingBaseline(env, request, {
+        reason: stringFromForm(formData, "reason") || "Skipped during marketing setup",
+      });
+      return redirect("/founder-tools/marketing/create?step=github");
     }
 
     if (intent === "scan") {
@@ -439,6 +514,678 @@ function FormField({
   );
 }
 
+const STARTUP_STAGE_OPTIONS = [
+  "",
+  "Idea",
+  "Pre-seed",
+  "Seed",
+  "Series A",
+  "Series B",
+  "Series C+",
+  "Growth",
+  "Bootstrapped",
+  "Not fundraising",
+  "Other",
+];
+
+const ORGANIZATION_KIND_OPTIONS = ["", "For-profit", "Not-for-profit"];
+
+type StartupSetupField =
+  | "companyName"
+  | "domain"
+  | "companyLinkedInUrl"
+  | "location"
+  | "abn"
+  | "shortDescription"
+  | "problemSolved"
+  | "targetAudience"
+  | "competitors"
+  | "seedKeywords"
+  | "founderNames"
+  | "stage"
+  | "organizationKind";
+
+type StartupSetupValues = Record<StartupSetupField, string>;
+
+function splitCompanyContext(context: string | null | undefined, fallbackTargetAudience: string | null | undefined) {
+  const raw = String(context ?? "").trim();
+  if (!raw) {
+    return { shortDescription: "", problemSolved: "", targetAudience: String(fallbackTargetAudience ?? "").trim() };
+  }
+
+  const problemMatch = raw.match(/(?:^|\n+)Problem solved:\s*([\s\S]*?)(?=\n+Target audience:|$)/i);
+  const audienceMatch = raw.match(/(?:^|\n+)Target audience:\s*([\s\S]*?)$/i);
+  const shortDescription = raw
+    .replace(/(?:^|\n+)Problem solved:\s*[\s\S]*?(?=\n+Target audience:|$)/i, "")
+    .replace(/(?:^|\n+)Target audience:\s*[\s\S]*$/i, "")
+    .trim();
+
+  return {
+    shortDescription: shortDescription || raw,
+    problemSolved: problemMatch?.[1]?.trim() ?? "",
+    targetAudience: audienceMatch?.[1]?.trim() || String(fallbackTargetAudience ?? "").trim(),
+  };
+}
+
+function startupSetupDefaultsFromBootstrap(bootstrap: VibeMarketingBootstrap): StartupSetupValues {
+  const splitContext = splitCompanyContext(bootstrap.settings.companyContext, bootstrap.startupProfile.notes);
+  const companyName = bootstrap.company.name === "Company" ? "" : bootstrap.company.name ?? "";
+  return {
+    companyName,
+    domain: bootstrap.company.domain ?? bootstrap.organization.domain ?? "",
+    companyLinkedInUrl: bootstrap.organization.companyLinkedInUrl ?? bootstrap.company.companyLinkedInUrl ?? "",
+    location: bootstrap.company.location ?? "",
+    abn: bootstrap.company.abn ?? "",
+    shortDescription: splitContext.shortDescription,
+    problemSolved: splitContext.problemSolved,
+    targetAudience: splitContext.targetAudience,
+    competitors: (bootstrap.organization.competitors ?? []).join("\n"),
+    seedKeywords: (bootstrap.organization.seedKeywords ?? []).join(", "),
+    founderNames: (bootstrap.startupProfile.founderNames ?? []).join(", "),
+    stage: bootstrap.startupProfile.stage ?? "",
+    organizationKind: bootstrap.startupProfile.organizationKind ?? "",
+  };
+}
+
+function companyContextFromSetup(values: StartupSetupValues) {
+  return combineCompanyContext({
+    shortDescription: values.shortDescription,
+    problemSolved: values.problemSolved,
+    targetAudience: values.targetAudience,
+  });
+}
+
+function listFromUnknown(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+  if (typeof value === "string") return listFromForm(value);
+  return [];
+}
+
+function plainObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function objectArray(value: unknown): Record<string, unknown>[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === "object" && !Array.isArray(item)))
+    : undefined;
+}
+
+function competitorSuggestion(value: unknown): VibeMarketingAutofillCompetitor | null {
+  if (!value || typeof value !== "object") {
+    const text = String(value ?? "").trim();
+    return text ? { name: text, domain: text } : null;
+  }
+  const payload = value as Record<string, unknown>;
+  const name = String(payload.name ?? payload.company ?? payload.title ?? "").trim();
+  const domain = String(payload.domain ?? "").trim();
+  if (!name && !domain) return null;
+  const rawScore = numericValue(payload.score);
+  return {
+    name: name || domain,
+    domain,
+    linkedinUrl: payload.linkedinUrl ? String(payload.linkedinUrl) : payload.linkedin_url ? String(payload.linkedin_url) : undefined,
+    type: payload.type ? String(payload.type) : undefined,
+    score: rawScore,
+    reason: payload.reason ? String(payload.reason) : undefined,
+    source: payload.source ? String(payload.source) : undefined,
+    evidence: Array.isArray(payload.evidence) ? payload.evidence.map(String).filter(Boolean) : undefined,
+    confidence: payload.confidence ? String(payload.confidence) : undefined,
+  };
+}
+
+function competitorList(value: unknown): VibeMarketingAutofillCompetitor[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(competitorSuggestion).filter((competitor): competitor is VibeMarketingAutofillCompetitor => Boolean(competitor));
+}
+
+function keywordGroups(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((group): group is Record<string, unknown> => Boolean(group && typeof group === "object"))
+    .map((group) => ({
+      group: group.group ? String(group.group) : group.name ? String(group.name) : undefined,
+      intent: group.intent ? String(group.intent) : undefined,
+      keywords: listFromUnknown(group.keywords),
+    }))
+    .filter((group) => group.keywords.length);
+}
+
+function researchDepth(value: unknown): Record<string, number> | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const result: Record<string, number> = {};
+  for (const [key, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    const numberValue = numericValue(rawValue);
+    if (numberValue !== null) result[key] = numberValue;
+  }
+  return Object.keys(result).length ? result : undefined;
+}
+
+function autofillSources(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((source): source is Record<string, unknown> => Boolean(source && typeof source === "object"))
+    .map((source) => ({
+      url: String(source.url ?? ""),
+      title: source.title ? String(source.title) : undefined,
+      type: source.type ? String(source.type) : undefined,
+      query: source.query ? String(source.query) : undefined,
+      description: source.description ? String(source.description) : undefined,
+      source: source.source ? String(source.source) : undefined,
+    }))
+    .filter((source) => source.url);
+}
+
+function extractAutofill(run: VibeMarketingRunSummary | null | undefined): VibeMarketingAutofillResult | null {
+  const raw = run?.result?.autofill;
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const groupsPayload = plainObject(payload.competitorGroups) ?? {};
+  const directCompetitors = competitorList(payload.directCompetitors ?? payload.direct_competitors ?? groupsPayload.directCompetitors);
+  const seoCompetitors = competitorList(payload.seoCompetitors ?? payload.seo_competitors ?? groupsPayload.seoCompetitors);
+  const adjacentOrganizations = competitorList(
+    payload.adjacentOrganizations ?? payload.adjacent_organizations ?? groupsPayload.adjacentOrganizations,
+  );
+  const competitorCandidates = Array.isArray(payload.competitors)
+    ? payload.competitors
+    : Array.isArray(payload.competitorCandidates)
+      ? payload.competitorCandidates
+      : [];
+  const competitorSuggestions = [
+    ...directCompetitors,
+    ...seoCompetitors,
+    ...adjacentOrganizations,
+    ...competitorCandidates.map(competitorSuggestion).filter((item): item is VibeMarketingAutofillCompetitor => Boolean(item)),
+  ];
+  const competitorStrings = [
+    ...directCompetitors.map((competitor) => competitor.domain || competitor.name),
+    ...competitorCandidates
+      .map((competitor) => competitorSuggestion(competitor))
+      .map((competitor) => competitor?.domain || competitor?.name || ""),
+    ...listFromUnknown(payload.competitorDomains),
+    ...listFromUnknown(payload.competitorStrings),
+  ].filter(Boolean);
+  const groups = keywordGroups(payload.keywordGroups ?? payload.keyword_groups);
+  const seedKeywords = [
+    ...listFromUnknown(payload.seedKeywords),
+    ...listFromUnknown(payload.seed_keywords),
+    ...groups.flatMap((group) => group.keywords),
+  ];
+  return {
+    brandName: typeof payload.brandName === "string" ? payload.brandName : typeof payload.brand_name === "string" ? payload.brand_name : null,
+    companyLinkedInUrl:
+      typeof payload.companyLinkedInUrl === "string"
+        ? payload.companyLinkedInUrl
+        : typeof payload.company_linkedin_url === "string"
+          ? payload.company_linkedin_url
+          : null,
+    companyContext:
+      typeof payload.companyContext === "string"
+        ? payload.companyContext
+        : typeof payload.company_context === "string"
+          ? payload.company_context
+          : null,
+    competitors: Array.from(new Set(competitorStrings.map((competitor) => competitor.trim()).filter(Boolean))),
+    competitorSuggestions,
+    directCompetitors,
+    seoCompetitors,
+    adjacentOrganizations,
+    competitorGroups: { directCompetitors, seoCompetitors, adjacentOrganizations },
+    seedKeywords: Array.from(new Set(seedKeywords.map((keyword) => keyword.trim()).filter(Boolean))),
+    keywordGroups: groups,
+    sources: autofillSources(payload.sources),
+    linkedinProfile:
+      payload.linkedinProfile && typeof payload.linkedinProfile === "object"
+        ? {
+            url: String((payload.linkedinProfile as Record<string, unknown>).url ?? ""),
+            title: (payload.linkedinProfile as Record<string, unknown>).title
+              ? String((payload.linkedinProfile as Record<string, unknown>).title)
+              : undefined,
+            description: (payload.linkedinProfile as Record<string, unknown>).description
+              ? String((payload.linkedinProfile as Record<string, unknown>).description)
+              : undefined,
+            vanityName: (payload.linkedinProfile as Record<string, unknown>).vanityName
+              ? String((payload.linkedinProfile as Record<string, unknown>).vanityName)
+              : undefined,
+            blocked: Boolean((payload.linkedinProfile as Record<string, unknown>).blocked),
+          }
+        : undefined,
+    linkedinSimilarSignals: autofillSources(payload.linkedinSimilarSignals ?? payload.linkedin_similar_signals),
+    sourceCount: numericValue(payload.sourceCount ?? payload.source_count) ?? undefined,
+    competitorCount: numericValue(payload.competitorCount ?? payload.competitor_count) ?? undefined,
+    seedKeywordCount: numericValue(payload.seedKeywordCount ?? payload.seed_keyword_count) ?? undefined,
+    researchSummary:
+      typeof payload.researchSummary === "string"
+        ? payload.researchSummary
+        : typeof payload.research_summary === "string"
+          ? payload.research_summary
+          : null,
+    researchDepth: researchDepth(payload.researchDepth ?? payload.research_depth),
+    researchQuality: plainObject(payload.researchQuality ?? payload.research_quality),
+    modelTrace: objectArray(payload.modelTrace ?? payload.model_trace),
+    queryLog: objectArray(payload.queryLog ?? payload.query_log),
+    evidenceMap: plainObject(payload.evidenceMap ?? payload.evidence_map),
+    stepDurations: researchDepth(payload.stepDurations ?? payload.step_durations),
+    warnings: listFromUnknown(payload.warnings),
+  };
+}
+
+function competitorStringsFromAutofill(autofill: VibeMarketingAutofillResult) {
+  const candidates = autofill.competitors?.length
+    ? autofill.competitors
+    : [
+        ...(autofill.directCompetitors ?? []),
+        ...(autofill.seoCompetitors ?? []),
+        ...(autofill.adjacentOrganizations ?? []),
+        ...(autofill.competitorSuggestions ?? []),
+      ].map((competitor) => competitor.domain || competitor.name);
+  const seen = new Set<string>();
+  return candidates
+    .map((competitor) => String(competitor ?? "").trim())
+    .filter((competitor) => {
+      if (!competitor) return false;
+      const key = competitor.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running"]);
+const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "cancelled", "denied"]);
+const RESEARCH_DONE_STATUSES = new Set(["completed", ...RESEARCH_FAILED_STATUSES]);
+
+const PROFILE_RESEARCH_STEPS = [
+  {
+    id: "identity",
+    label: "Resolving company identity",
+    keys: ["queued", "resolve_company_identity", "profile_resolution"],
+  },
+  {
+    id: "website",
+    label: "Crawling owned website",
+    keys: ["crawl_owned_web", "crawl_website", "scrape_website"],
+  },
+  {
+    id: "public_web",
+    label: "Researching public web",
+    keys: ["research_public_web"],
+  },
+  {
+    id: "linkedin",
+    label: "Checking public LinkedIn signals",
+    keys: ["research_linkedin_public"],
+  },
+  {
+    id: "competitors",
+    label: "Finding competitor candidates",
+    keys: ["discover_competitor_candidates", "identify_competitors", "rank_competitors"],
+  },
+  {
+    id: "keywords",
+    label: "Generating keywords",
+    keys: ["generate_keyword_landscape", "generate_seed_keywords"],
+  },
+  {
+    id: "profile",
+    label: "Writing company profile",
+    keys: ["synthesize_company_profile", "synthesize_company_context"],
+  },
+  {
+    id: "finalize",
+    label: "Applying research results",
+    keys: ["finalize"],
+  },
+] as const;
+
+function normalizeResearchStepKey(step?: string | null) {
+  return String(step ?? "").trim().toLowerCase();
+}
+
+function autofillStepLabel(step?: string | null) {
+  const stepKey = normalizeResearchStepKey(step);
+  const configuredStep = PROFILE_RESEARCH_STEPS.find((item) => item.keys.some((key) => key === stepKey));
+  if (configuredStep) return configuredStep.label;
+  return stepKey ? stepKey.replace(/_/g, " ") : "Researching company profile";
+}
+
+function researchStepIndex(step?: string | null) {
+  const stepKey = normalizeResearchStepKey(step);
+  return PROFILE_RESEARCH_STEPS.findIndex((item) => item.keys.some((key) => key === stepKey));
+}
+
+function isResearchFailedStatus(status?: string | null) {
+  return RESEARCH_FAILED_STATUSES.has(normalizeResearchStepKey(status));
+}
+
+function isResearchTerminalStatus(status?: string | null) {
+  return RESEARCH_DONE_STATUSES.has(normalizeResearchStepKey(status));
+}
+
+function isResearchRunningStatus(status?: string | null) {
+  return RESEARCH_RUNNING_STATUSES.has(normalizeResearchStepKey(status));
+}
+
+function completedResearchStepCount(run?: VibeMarketingRunSummary | null, pending = false) {
+  const totalSteps = PROFILE_RESEARCH_STEPS.length;
+  if (pending || !run) return 0;
+  if (run.status === "completed") return totalSteps;
+
+  const stepStates = Array.isArray(run.steps) ? run.steps : [];
+  if (stepStates.length) {
+    return Math.min(
+      totalSteps,
+      stepStates.filter((step) => ["completed", "skipped"].includes(normalizeResearchStepKey(step.status))).length,
+    );
+  }
+
+  const index = researchStepIndex(run.currentStep);
+  if (index >= 0) return Math.min(index, totalSteps);
+  return 0;
+}
+
+function researchProgressSignature(run?: VibeMarketingRunSummary | null) {
+  if (!run) return "no-run";
+  const steps = (run.steps ?? [])
+    .map((step) => `${step.key}:${step.status}:${step.completedAt ?? ""}:${step.error ?? ""}`)
+    .join("|");
+  return [run.status, run.currentStep ?? "", run.updatedAt ?? "", run.errors?.join("|") ?? "", steps].join("::");
+}
+
+function ProfileResearchSegments({
+  completedSteps,
+  totalSteps,
+  failed,
+}: {
+  completedSteps: number;
+  totalSteps: number;
+  failed: boolean;
+}) {
+  const segmentCount = Math.max(totalSteps, 1);
+  const safeCompleted = Math.min(Math.max(completedSteps, 0), segmentCount);
+
+  return (
+    <div className="grid grid-cols-8 gap-2">
+      {Array.from({ length: segmentCount }).map((_, index) => {
+        const isComplete = index < safeCompleted;
+        const isActive = !failed && index === safeCompleted && safeCompleted < segmentCount;
+        return (
+          <div
+            key={index}
+            className={clsx(
+              "h-2 rounded-full transition-all",
+              failed && "bg-rose-200",
+              !failed && isComplete && "bg-purple-500",
+              !failed && isActive && "animate-pulse bg-purple-300",
+              !failed && !isComplete && !isActive && "bg-white/75",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ProfileResearchProgressCard({
+  run,
+  runId,
+  pending,
+  startStatus,
+  startError,
+  stalled,
+  unavailable,
+  onRetry,
+  retryDisabled,
+}: {
+  run?: VibeMarketingRunSummary | null;
+  runId?: string | null;
+  pending: boolean;
+  startStatus?: string | null;
+  startError?: string | null;
+  stalled: boolean;
+  unavailable: boolean;
+  onRetry: () => void;
+  retryDisabled: boolean;
+}) {
+  if (!runId && !pending) return null;
+  const autofill = extractAutofill(run);
+  const effectiveStatus = run?.status ?? startStatus ?? (pending ? "queued" : null);
+  const active = pending || (!isResearchTerminalStatus(effectiveStatus) && (!run || isResearchRunningStatus(run.status)));
+  const failed = isResearchFailedStatus(effectiveStatus) || unavailable;
+  const completedSteps = completedResearchStepCount(run, pending);
+  const totalSteps = PROFILE_RESEARCH_STEPS.length;
+  const progressLabel = `${Math.min(completedSteps, totalSteps)} of ${totalSteps} research steps complete`;
+  const label = pending
+    ? "Starting AI fill"
+    : run?.status === "completed"
+      ? "AI suggestions added"
+      : failed
+        ? "AI fill needs attention"
+        : autofillStepLabel(run?.currentStep);
+  const sourceCount = autofill?.sourceCount ?? autofill?.sources?.length ?? 0;
+  const competitorCount = autofill?.competitorCount ?? autofill?.competitorSuggestions?.length ?? autofill?.competitors?.length ?? 0;
+  const seedKeywordCount = autofill?.seedKeywordCount ?? autofill?.seedKeywords?.length ?? 0;
+  const errorMessage =
+    startError ||
+    run?.errors?.[0] ||
+    (failed ? "AI fill is unavailable. Check the Content Factory backend and try again." : null);
+  const notice = unavailable
+    ? "We have not received a fresh status update for more than 2 minutes. You can retry now, or keep this page open while polling continues."
+    : stalled
+      ? "This is taking longer than expected. We will keep checking for progress in the background."
+      : null;
+
+  return (
+    <div
+      className={clsx(
+        "relative overflow-hidden rounded-2xl border p-5 text-sm shadow-sm",
+        failed ? "border-rose-200 bg-rose-50 text-rose-900" : "border-purple-100 bg-gradient-to-br from-purple-50 via-violet-50 to-indigo-50 text-violet-950",
+      )}
+    >
+      <div
+        className={clsx(
+          "absolute right-0 top-0 -mr-10 -mt-10 h-36 w-36 rounded-full blur-3xl",
+          failed ? "bg-rose-200/30" : "bg-purple-200/30",
+        )}
+      />
+      <div className="relative z-10 flex gap-4">
+        <div className={clsx("flex h-12 w-12 shrink-0 items-center justify-center rounded-xl", failed ? "bg-rose-100" : "bg-purple-100")}>
+          {failed ? (
+            <AlertTriangle className="h-6 w-6 text-rose-600" />
+          ) : run?.status === "completed" ? (
+            <CheckCircle2 className="h-6 w-6 text-emerald-600" />
+          ) : (
+            <Sparkles className="h-6 w-6 text-purple-600" />
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-base font-black text-slate-950">{label}</p>
+            <span
+              className={clsx(
+                "rounded-full px-2.5 py-1 text-[11px] font-black uppercase tracking-wide",
+                failed ? "bg-white/80 text-rose-700" : "bg-white/80 text-purple-700",
+              )}
+            >
+              {failed ? "Retry available" : progressLabel}
+            </span>
+          </div>
+
+          <p className="mt-1 text-sm font-semibold text-slate-700">
+            {pending ? "Contacting the AI fill service" : run?.status === "completed" ? "AI suggestions have been applied to the form." : autofillStepLabel(run?.currentStep)}
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-500">
+            {active
+              ? "Usually takes 1-3 minutes. Refreshing the page is safe."
+              : failed
+                ? "The form is unlocked so you can retry or fill the fields manually."
+                : "Review the populated fields before continuing."}
+          </p>
+
+          {!failed ? (
+            <div className="mt-4 space-y-2">
+              <ProfileResearchSegments completedSteps={completedSteps} totalSteps={totalSteps} failed={false} />
+              <p className="text-xs font-semibold text-slate-500">
+                We&apos;ll keep checking until the fields below are ready to review.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-4 space-y-3">
+              <ProfileResearchSegments completedSteps={completedSteps} totalSteps={totalSteps} failed />
+              <p className="rounded-xl border border-rose-200 bg-white/80 px-4 py-3 text-sm font-semibold text-rose-700">
+                {errorMessage}
+              </p>
+              <button
+                type="button"
+                onClick={onRetry}
+                disabled={retryDisabled}
+                className="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-white px-4 py-2 text-sm font-black text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <Sparkles className="h-4 w-4" />
+                Retry research
+              </button>
+            </div>
+          )}
+
+          {notice && !failed ? (
+            <p className="mt-3 rounded-xl border border-amber-200 bg-white/80 px-4 py-3 text-sm font-semibold text-amber-700">
+              {notice}
+            </p>
+          ) : null}
+
+          {autofill ? (
+            <div className="mt-4 flex flex-wrap gap-2 text-xs font-black text-violet-800">
+              <span>{sourceCount} sources reviewed</span>
+              <span>{competitorCount} competitors found</span>
+              <span>{seedKeywordCount} seed keywords generated</span>
+            </div>
+          ) : null}
+          {autofill?.sources?.length ? (
+            <p className="mt-2 truncate text-xs font-semibold text-violet-700">
+              Sources: {autofill.sources.slice(0, 3).map((source) => source.title || source.url).join(", ")}
+            </p>
+          ) : null}
+          {autofill?.warnings?.length ? <p className="mt-2 text-xs font-semibold text-amber-700">{autofill.warnings[0]}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function baselineFromRun(run: VibeMarketingRunSummary | null | undefined): VibeMarketingWebsiteBaseline | null {
+  const raw = run?.result?.baseline;
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  return {
+    runId: run?.runId,
+    domain: typeof payload.domain === "string" ? payload.domain : run?.domain,
+    status: typeof payload.status === "string" ? payload.status : run?.status,
+    passed: run?.status === "completed",
+    collectedAt:
+      typeof payload.collectedAt === "string"
+        ? payload.collectedAt
+        : typeof payload.collected_at === "string"
+          ? payload.collected_at
+          : run?.updatedAt,
+    overallScore:
+      typeof payload.overallScore === "number"
+        ? payload.overallScore
+        : typeof payload.overall_score === "number"
+          ? payload.overall_score
+          : null,
+    summary:
+      typeof payload.summary === "string" || (payload.summary && typeof payload.summary === "object")
+        ? (payload.summary as VibeMarketingWebsiteBaseline["summary"])
+        : null,
+    metrics: payload.metrics && typeof payload.metrics === "object" ? (payload.metrics as VibeMarketingWebsiteBaseline["metrics"]) : {},
+    sourceStatus: payload.sourceStatus && typeof payload.sourceStatus === "object" ? (payload.sourceStatus as Record<string, string>) : {},
+    recommendations: Array.isArray(payload.recommendations) ? (payload.recommendations as Array<Record<string, unknown>>) : [],
+  };
+}
+
+function baselineSummaryText(summary: VibeMarketingWebsiteBaseline["summary"]) {
+  if (typeof summary === "string") return summary;
+  if (summary && typeof summary === "object" && typeof summary.text === "string") return summary.text;
+  return "Run a baseline to capture website health, search visibility, authority, AI visibility, and traffic before article generation starts.";
+}
+
+function metricStatus(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
+  const message = typeof metric?.message === "string" ? metric.message : "";
+  if (label === "Lighthouse" && /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message)) {
+    return "unavailable";
+  }
+  return metric?.status;
+}
+
+function metricScore(metric: VibeMarketingWebsiteBaselineMetric | undefined, status?: string | null) {
+  return status === "measured" && typeof metric?.score === "number" ? Math.round(metric.score) : null;
+}
+
+function metricMessage(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
+  const message = typeof metric?.message === "string" ? metric.message : null;
+  if (label === "Lighthouse" && message && /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message)) {
+    return "PageSpeed Insights is temporarily rate limited. Try again later.";
+  }
+  return message;
+}
+
+function sourceStatusLabel(status?: string | null) {
+  if (status === "measured") return "Verified";
+  if (status === "needs_connection") return "Needs connection";
+  if (status === "error") return "Error";
+  return "Unavailable";
+}
+
+function SourceStatusBadge({ status }: { status?: string | null }) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex rounded-full px-2 py-0.5 text-[11px] font-black",
+        status === "measured" && "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100",
+        status === "needs_connection" && "bg-amber-50 text-amber-700 ring-1 ring-amber-100",
+        status === "error" && "bg-rose-50 text-rose-700 ring-1 ring-rose-100",
+        !["measured", "needs_connection", "error"].includes(String(status)) && "bg-slate-50 text-slate-600 ring-1 ring-slate-100",
+      )}
+    >
+      {sourceStatusLabel(status)}
+    </span>
+  );
+}
+
+function BaselineMetricCard({
+  label,
+  metric,
+}: {
+  label: string;
+  metric?: VibeMarketingWebsiteBaselineMetric;
+}) {
+  const status = metricStatus(label, metric);
+  const score = metricScore(metric, status);
+  const message = metricMessage(label, metric);
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-black text-slate-950">{label}</p>
+        <SourceStatusBadge status={status} />
+      </div>
+      <p className="mt-3 text-2xl font-black text-slate-950">{score === null ? "—" : score}</p>
+      {message ? <p className="mt-2 line-clamp-4 break-words text-xs font-semibold text-slate-500">{message}</p> : null}
+    </div>
+  );
+}
+
+function GoogleIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09A6.6 6.6 0 0 1 5.49 12c0-.73.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.78.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
 function FirstArticleSetupPage({
   bootstrap,
   error,
@@ -446,8 +1193,255 @@ function FirstArticleSetupPage({
   bootstrap: VibeMarketingBootstrap;
   error: string | null;
 }) {
-  const context = bootstrap.settings.companyContext ?? "";
-  const companyName = bootstrap.company.name === "Company" ? "" : bootstrap.company.name;
+  const navigation = useNavigation();
+  const autofillStartFetcher = useFetcher<{
+    intent?: string;
+    autofillRunId?: string | null;
+    status?: string;
+    error?: string;
+    errors?: string[];
+  }>();
+  const autofillRunFetcher = useFetcher<VibeMarketingRunSummary>();
+  const baselineStartFetcher = useFetcher<{ intent?: string; baselineRunId?: string | null; status?: string; error?: string }>();
+  const baselineRunFetcher = useFetcher<VibeMarketingRunSummary>();
+  const googleBaselineFetcher = useFetcher<{ intent?: string; websiteBaseline?: VibeMarketingWebsiteBaseline; error?: string }>();
+  const skipBaselineFetcher = useFetcher<{ intent?: string; error?: string }>();
+  const startupDefaults = useMemo(() => startupSetupDefaultsFromBootstrap(bootstrap), [bootstrap]);
+  const startupDefaultsSignature = useMemo(() => JSON.stringify(startupDefaults), [startupDefaults]);
+  const activeCompanyKey = String(
+    bootstrap.company.id ||
+      bootstrap.company.organizationId ||
+      bootstrap.organization.id ||
+      bootstrap.organization.domain ||
+      bootstrap.company.domain ||
+      "no-company",
+  );
+  const activeCompanyKeyRef = useRef(activeCompanyKey);
+  const autofillPollStateRef = useRef(autofillRunFetcher.state);
+  const baselinePollStateRef = useRef(baselineRunFetcher.state);
+  const [startupValues, setStartupValues] = useState<StartupSetupValues>(startupDefaults);
+  const [autofillRunId, setAutofillRunId] = useState<string | null>(null);
+  const [appliedAutofillRunId, setAppliedAutofillRunId] = useState<string | null>(null);
+  const [baselineRunId, setBaselineRunId] = useState<string | null>(null);
+  const [googleBaseline, setGoogleBaseline] = useState<VibeMarketingWebsiteBaseline | null>(null);
+  const [autofillStartedAt, setAutofillStartedAt] = useState<number | null>(null);
+  const [autofillLastProgressAt, setAutofillLastProgressAt] = useState<number | null>(null);
+  const [autofillLastPollAt, setAutofillLastPollAt] = useState<number | null>(null);
+  const [autofillProgressSignature, setAutofillProgressSignature] = useState("");
+  const [autofillClock, setAutofillClock] = useState(() => Date.now());
+
+  const autofillStartData = autofillStartFetcher.data;
+  const autofillRun = autofillRunFetcher.data as VibeMarketingRunSummary | undefined;
+  const autofillStartStatus =
+    autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
+      ? autofillStartData.status
+      : null;
+  const autofillStartError =
+    autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
+      ? autofillStartData.error ?? autofillStartData.errors?.[0] ?? null
+      : null;
+  const baselineStartData = baselineStartFetcher.data;
+  const baselineRun = baselineRunFetcher.data as VibeMarketingRunSummary | undefined;
+  const latestBaselineRun = bootstrap.latestRuns.find((run) => run.workflow === "website_baseline");
+  const effectiveBaseline = googleBaseline ?? baselineFromRun(baselineRun) ?? baselineFromRun(latestBaselineRun) ?? bootstrap.websiteBaseline;
+  const baselineMetrics = effectiveBaseline.metrics ?? {};
+  const trafficMetric = baselineMetrics.traffic;
+  const trafficStatus = metricStatus("Traffic/users", trafficMetric);
+  const hasGoogleBaselineScopes = Boolean(bootstrap.googleBaselineConnection?.hasBaselineScopes);
+  const isSubmitting = navigation.state === "submitting";
+  const autofillPending = autofillStartFetcher.state !== "idle";
+  const baselinePending = baselineStartFetcher.state !== "idle";
+  const googleBaselinePending = googleBaselineFetcher.state !== "idle";
+  const skipBaselinePending = skipBaselineFetcher.state !== "idle";
+  const autofillPolling = Boolean(
+    autofillRunId &&
+      !isResearchTerminalStatus(autofillStartStatus) &&
+      (!autofillRun || isResearchRunningStatus(autofillRun.status)),
+  );
+  const baselinePolling = Boolean(baselineRunId && (!baselineRun || ["queued", "running"].includes(baselineRun.status)));
+  const autofillStatusAgeMs = autofillStartedAt ? autofillClock - (autofillLastPollAt ?? autofillStartedAt) : 0;
+  const autofillProgressAgeMs = autofillStartedAt ? autofillClock - (autofillLastProgressAt ?? autofillStartedAt) : 0;
+  const autofillStalled = Boolean(autofillPolling && autofillProgressAgeMs > 60_000);
+  const autofillUnavailable = Boolean(autofillPolling && (autofillStatusAgeMs > 120_000 || autofillProgressAgeMs > 120_000));
+  const researchLocked = autofillPending || (autofillPolling && !autofillUnavailable);
+  const canStartAutofill =
+    Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) &&
+    !autofillPending &&
+    (!autofillPolling || autofillUnavailable);
+  const canRetryAutofill = Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) && !autofillPending;
+  const canStartBaseline = Boolean((bootstrap.organization.domain || bootstrap.company.domain || startupValues.domain).trim()) && !baselinePending && !baselinePolling;
+  const canRefreshGoogleBaseline = hasGoogleBaselineScopes && effectiveBaseline.status !== "missing" && !googleBaselinePending;
+  const companyContext = companyContextFromSetup(startupValues);
+  const searchConsole = plainObject(trafficMetric?.googleSearchConsole);
+  const searchConsoleSummary = plainObject(searchConsole?.last28Days);
+
+  const updateValue = (field: StartupSetupField, value: string) => {
+    setStartupValues((current) => ({ ...current, [field]: value }));
+  };
+
+  const startAutofill = () => {
+    const snapshot = { ...startupValues };
+    const now = Date.now();
+    setAutofillRunId(null);
+    setAppliedAutofillRunId(null);
+    setAutofillStartedAt(now);
+    setAutofillLastProgressAt(now);
+    setAutofillLastPollAt(null);
+    setAutofillProgressSignature("");
+    setAutofillClock(now);
+    const formData = new FormData();
+    formData.set("intent", "start-autofill");
+    formData.set("companyContext", companyContextFromSetup(snapshot));
+    for (const [field, value] of Object.entries(snapshot)) {
+      formData.set(field, value);
+    }
+    autofillStartFetcher.submit(formData, { method: "POST" });
+  };
+
+  const startBaseline = () => {
+    setGoogleBaseline(null);
+    const formData = new FormData();
+    formData.set("intent", "start-baseline");
+    baselineStartFetcher.submit(formData, { method: "POST" });
+  };
+
+  const refreshGoogleBaseline = () => {
+    const formData = new FormData();
+    formData.set("intent", "refresh-baseline-google");
+    googleBaselineFetcher.submit(formData, { method: "POST" });
+  };
+
+  const skipBaseline = () => {
+    const formData = new FormData();
+    formData.set("intent", "skip-baseline");
+    formData.set("reason", "Skipped during marketing setup");
+    skipBaselineFetcher.submit(formData, { method: "POST" });
+  };
+
+  useEffect(() => {
+    autofillPollStateRef.current = autofillRunFetcher.state;
+  }, [autofillRunFetcher.state]);
+
+  useEffect(() => {
+    baselinePollStateRef.current = baselineRunFetcher.state;
+  }, [baselineRunFetcher.state]);
+
+  useEffect(() => {
+    if (activeCompanyKeyRef.current === activeCompanyKey) return;
+    activeCompanyKeyRef.current = activeCompanyKey;
+    setStartupValues(startupDefaults);
+    setAutofillRunId(null);
+    setBaselineRunId(null);
+    setGoogleBaseline(null);
+    setAppliedAutofillRunId(null);
+    setAutofillStartedAt(null);
+    setAutofillLastProgressAt(null);
+    setAutofillLastPollAt(null);
+    setAutofillProgressSignature("");
+  }, [activeCompanyKey, startupDefaults, startupDefaultsSignature]);
+
+  useEffect(() => {
+    if (autofillStartData?.autofillRunId) {
+      const now = Date.now();
+      setAutofillRunId(autofillStartData.autofillRunId);
+      setAppliedAutofillRunId(null);
+      setAutofillStartedAt((current) => current ?? now);
+      setAutofillLastProgressAt((current) => current ?? now);
+      setAutofillClock(now);
+    }
+  }, [autofillStartData?.autofillRunId]);
+
+  useEffect(() => {
+    if (baselineStartData?.baselineRunId) {
+      setBaselineRunId(baselineStartData.baselineRunId);
+      setGoogleBaseline(null);
+    }
+  }, [baselineStartData?.baselineRunId]);
+
+  useEffect(() => {
+    if (googleBaselineFetcher.data?.websiteBaseline) {
+      setGoogleBaseline(googleBaselineFetcher.data.websiteBaseline);
+    }
+  }, [googleBaselineFetcher.data?.websiteBaseline]);
+
+  useEffect(() => {
+    if (!autofillPending && !autofillPolling) return;
+    setAutofillClock(Date.now());
+    const timer = window.setInterval(() => {
+      setAutofillClock(Date.now());
+    }, 5000);
+    return () => window.clearInterval(timer);
+  }, [autofillPending, autofillPolling]);
+
+  useEffect(() => {
+    if (!autofillRunId || !autofillRun) return;
+    const now = Date.now();
+    const signature = researchProgressSignature(autofillRun);
+    setAutofillLastPollAt(now);
+    if (signature !== autofillProgressSignature) {
+      setAutofillProgressSignature(signature);
+      setAutofillLastProgressAt(now);
+    }
+  }, [autofillProgressSignature, autofillRun, autofillRunId]);
+
+  useEffect(() => {
+    if (!autofillRunId) return;
+    if (autofillRun && !isResearchRunningStatus(autofillRun.status)) return;
+    if (isResearchTerminalStatus(autofillStartStatus)) return;
+    const href = `/founder-tools/marketing/autofill-runs/${encodeURIComponent(autofillRunId)}`;
+    const loadIfIdle = () => {
+      if (autofillPollStateRef.current !== "idle") return;
+      autofillPollStateRef.current = "loading";
+      autofillRunFetcher.load(href);
+    };
+    loadIfIdle();
+    const timer = window.setInterval(() => {
+      loadIfIdle();
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [autofillRunId, autofillRun?.status, autofillStartStatus]);
+
+  useEffect(() => {
+    if (!baselineRunId) return;
+    if (baselineRun && !["queued", "running"].includes(baselineRun.status)) return;
+    const href = `/founder-tools/marketing/autofill-runs/${encodeURIComponent(baselineRunId)}`;
+    const loadIfIdle = () => {
+      if (baselinePollStateRef.current !== "idle") return;
+      baselinePollStateRef.current = "loading";
+      baselineRunFetcher.load(href);
+    };
+    loadIfIdle();
+    const timer = window.setInterval(() => {
+      loadIfIdle();
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [baselineRunId, baselineRun?.status]);
+
+  useEffect(() => {
+    if (!autofillRunId || appliedAutofillRunId === autofillRunId || autofillRun?.status !== "completed") return;
+    const autofill = extractAutofill(autofillRun);
+    if (!autofill) return;
+    const splitContext = splitCompanyContext(autofill.companyContext, startupValues.targetAudience);
+    const competitors = competitorStringsFromAutofill(autofill);
+
+    setStartupValues((current) => {
+      const updates: Partial<StartupSetupValues> = {
+        companyLinkedInUrl: autofill.companyLinkedInUrl || current.companyLinkedInUrl,
+        shortDescription: splitContext.shortDescription || current.shortDescription,
+        problemSolved: splitContext.problemSolved || current.problemSolved,
+        targetAudience: splitContext.targetAudience || current.targetAudience,
+        competitors: competitors.length ? competitors.join("\n") : current.competitors,
+        seedKeywords: autofill.seedKeywords?.length ? autofill.seedKeywords.join(", ") : current.seedKeywords,
+      };
+      return Object.keys(updates).length ? { ...current, ...updates } : current;
+    });
+    setAppliedAutofillRunId(autofillRunId);
+  }, [appliedAutofillRunId, autofillRun, autofillRunId, startupValues.targetAudience]);
+
+  const inputClass =
+    "h-12 w-full rounded-lg border border-slate-200 px-4 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500";
+  const textareaClass =
+    "w-full resize-none rounded-lg border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500";
 
   return (
     <div className="mx-auto max-w-[1580px] px-4 py-8 sm:px-6 lg:px-10">
@@ -475,6 +1469,7 @@ function FirstArticleSetupPage({
 
       <Form method="POST" className="mt-10 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <input type="hidden" name="intent" value="save-startup-details" />
+        <input type="hidden" name="companyContext" value={companyContext} />
         {error ? (
           <div className="border-b border-rose-100 bg-rose-50 px-6 py-4 text-sm font-bold text-rose-700">
             {error}
@@ -489,67 +1484,191 @@ function FirstArticleSetupPage({
               This helps us understand your business, audience, and what makes you unique.
             </p>
 
-            <div className="mt-8 grid gap-8 lg:grid-cols-2">
-              <div className="space-y-7">
-                <FormField label="Startup or Company Name" help="This will be used as the author for your articles.">
-                  <input
-                    name="companyName"
-                    defaultValue={companyName}
-                    placeholder="e.g. Your Startup Inc."
-                    className="h-12 w-full rounded-lg border border-slate-200 px-4 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
-                  />
-                </FormField>
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
+              <FormField label="Startup or Company Name" help="This will be used as the author for your articles.">
+                <input
+                  name="companyName"
+                  value={startupValues.companyName}
+                  onChange={(event) => updateValue("companyName", event.target.value)}
+                  disabled={researchLocked}
+                  placeholder="e.g. Your Startup Inc."
+                  className={inputClass}
+                />
+              </FormField>
 
-                <FormField label="Website domain" help="Connect this company to its website and article system.">
-                  <input
-                    name="domain"
-                    defaultValue={bootstrap.company.domain ?? bootstrap.organization.domain ?? ""}
-                    placeholder="e.g. yourstartup.com"
-                    className="h-12 w-full rounded-lg border border-slate-200 px-4 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
-                  />
-                </FormField>
-
-                <FormField label="Short description" help="In 1-2 sentences, what does your startup do?">
-                  <textarea
-                    name="shortDescription"
-                    defaultValue={context}
-                    placeholder="e.g. We help SaaS companies automate customer onboarding..."
-                    rows={5}
-                    maxLength={600}
-                    className="w-full resize-none rounded-lg border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
-                  />
-                </FormField>
-              </div>
-
-              <div className="space-y-7">
-                <FormField label="What problem do you solve?" help="What's the main problem you help your customers solve?">
-                  <textarea
-                    name="problemSolved"
-                    placeholder="e.g. SaaS teams waste time on manual processes..."
-                    rows={5}
-                    maxLength={400}
-                    className="w-full resize-none rounded-lg border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
-                  />
-                </FormField>
-
-                <FormField label="Who is your target audience?" help="Who do you serve?">
-                  <input
-                    name="targetAudience"
-                    placeholder="e.g. SaaS founders, marketing teams, eCommerce brands"
-                    className="h-12 w-full rounded-lg border border-slate-200 px-4 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
-                  />
-                </FormField>
-
-                <FormField label="Seed keywords" help="Optional starting keywords, separated by commas.">
-                  <input
-                    name="seedKeywords"
-                    defaultValue={bootstrap.organization.seedKeywords.join(", ")}
-                    placeholder="e.g. onboarding automation, product analytics"
-                    className="h-12 w-full rounded-lg border border-slate-200 px-4 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
-                  />
-                </FormField>
-              </div>
+              <FormField label="Website domain" help="Connect this company to its website and article system.">
+                <input
+                  name="domain"
+                  value={startupValues.domain}
+                  onChange={(event) => updateValue("domain", event.target.value)}
+                  disabled={researchLocked}
+                  placeholder="e.g. yourstartup.com"
+                  className={inputClass}
+                />
+              </FormField>
             </div>
+
+            <div className="mt-8 space-y-3 rounded-xl border border-violet-200 bg-violet-50/70 p-4 shadow-sm shadow-violet-100/70">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm font-black text-slate-950">Use AI to fill the details</p>
+                  <p className="mt-1 text-sm font-semibold leading-6 text-slate-600">
+                    Use the website and public company info to fill the fields below. You can edit everything before continuing.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={startAutofill}
+                  disabled={!canStartAutofill}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-700 px-5 py-3 text-sm font-black text-white shadow-lg shadow-violet-200 transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {autofillPending || autofillPolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                  {autofillPending || autofillPolling ? "Generating..." : "Generate with AI"}
+                </button>
+              </div>
+              {!canStartAutofill && !autofillPending && !autofillPolling ? (
+                <p className="text-xs font-bold text-slate-500">Add a company name and website domain before generating with AI.</p>
+              ) : null}
+              {autofillStartData?.error && !autofillStartData?.autofillRunId ? (
+                <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+                  {autofillStartData.error}
+                </div>
+              ) : null}
+              <ProfileResearchProgressCard
+                run={autofillRun}
+                runId={autofillRunId}
+                pending={autofillPending}
+                startStatus={autofillStartStatus}
+                startError={autofillStartError}
+                stalled={autofillStalled}
+                unavailable={autofillUnavailable}
+                onRetry={startAutofill}
+                retryDisabled={!canRetryAutofill}
+              />
+            </div>
+
+            <div
+              className={clsx(
+                "mt-8 rounded-xl border border-slate-200 bg-white p-4",
+                researchLocked && "bg-slate-50/80",
+              )}
+            >
+                  <div className="grid gap-7 lg:grid-cols-2">
+                    <FormField label="Short description" help="In 1-2 sentences, what does your startup do?">
+                      <textarea
+                        name="shortDescription"
+                        value={startupValues.shortDescription}
+                        onChange={(event) => updateValue("shortDescription", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="e.g. We help SaaS companies automate customer onboarding..."
+                        rows={5}
+                        maxLength={600}
+                        className={textareaClass}
+                      />
+                    </FormField>
+
+                    <FormField label="What problem do you solve?" help="What's the main problem you help your customers solve?">
+                      <textarea
+                        name="problemSolved"
+                        value={startupValues.problemSolved}
+                        onChange={(event) => updateValue("problemSolved", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="e.g. SaaS teams waste time on manual processes..."
+                        rows={5}
+                        maxLength={400}
+                        className={textareaClass}
+                      />
+                    </FormField>
+
+                    <FormField label="Who is your target audience?" help="Who do you serve?">
+                      <input
+                        name="targetAudience"
+                        value={startupValues.targetAudience}
+                        onChange={(event) => updateValue("targetAudience", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="e.g. SaaS founders, marketing teams, eCommerce brands"
+                        className={inputClass}
+                      />
+                    </FormField>
+
+                  </div>
+            </div>
+
+            <details className="mt-8 rounded-xl border border-slate-200 bg-slate-50/60 p-4">
+                  <summary className="cursor-pointer text-sm font-black text-slate-950">Advanced startup details</summary>
+                  <div className="mt-5 grid gap-6 lg:grid-cols-2">
+                    <FormField label="Company LinkedIn URL">
+                      <input
+                        name="companyLinkedInUrl"
+                        value={startupValues.companyLinkedInUrl}
+                        onChange={(event) => updateValue("companyLinkedInUrl", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="https://www.linkedin.com/company/yourstartup"
+                        className={inputClass}
+                      />
+                    </FormField>
+                    <FormField label="Location">
+                      <input
+                        name="location"
+                        value={startupValues.location}
+                        onChange={(event) => updateValue("location", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="Melbourne, Australia"
+                        className={inputClass}
+                      />
+                    </FormField>
+                    <FormField label="ABN">
+                      <input
+                        name="abn"
+                        value={startupValues.abn}
+                        onChange={(event) => updateValue("abn", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="Search ABN or business name"
+                        className={inputClass}
+                      />
+                    </FormField>
+                    <FormField label="Founder names">
+                      <input
+                        name="founderNames"
+                        value={startupValues.founderNames}
+                        onChange={(event) => updateValue("founderNames", event.target.value)}
+                        disabled={researchLocked}
+                        placeholder="Sam Donegan, Alex Founder"
+                        className={inputClass}
+                      />
+                    </FormField>
+                    <FormField label="Stage">
+                      <select
+                        name="stage"
+                        value={startupValues.stage}
+                        onChange={(event) => updateValue("stage", event.target.value)}
+                        disabled={researchLocked}
+                        className={inputClass}
+                      >
+                        {STARTUP_STAGE_OPTIONS.map((option) => (
+                          <option key={option || "blank"} value={option}>
+                            {option || "Select stage"}
+                          </option>
+                        ))}
+                      </select>
+                    </FormField>
+                    <FormField label="Organization type">
+                      <select
+                        name="organizationKind"
+                        value={startupValues.organizationKind}
+                        onChange={(event) => updateValue("organizationKind", event.target.value)}
+                        disabled={researchLocked}
+                        className={inputClass}
+                      >
+                        {ORGANIZATION_KIND_OPTIONS.map((option) => (
+                          <option key={option || "blank"} value={option}>
+                            {option || "Select type"}
+                          </option>
+                        ))}
+                      </select>
+                    </FormField>
+                  </div>
+            </details>
           </div>
 
           <aside className="self-start rounded-xl border border-slate-200 bg-white p-6">
@@ -568,8 +1687,200 @@ function FirstArticleSetupPage({
                 </li>
               ))}
             </ul>
+            <div className="mt-7 space-y-6 border-t border-slate-100 pt-6">
+              <FormField label="Seed keywords" help="Optional starting keywords, separated by commas.">
+                <input
+                  name="seedKeywords"
+                  value={startupValues.seedKeywords}
+                  onChange={(event) => updateValue("seedKeywords", event.target.value)}
+                  disabled={researchLocked}
+                  placeholder="e.g. onboarding automation, product analytics"
+                  className={inputClass}
+                />
+              </FormField>
+
+              <FormField label="Competitors" help="One competitor domain or company per line.">
+                <textarea
+                  name="competitors"
+                  value={startupValues.competitors}
+                  onChange={(event) => updateValue("competitors", event.target.value)}
+                  disabled={researchLocked}
+                  rows={5}
+                  placeholder="competitor.com&#10;another competitor"
+                  className={textareaClass}
+                />
+              </FormField>
+            </div>
           </aside>
         </div>
+
+        <section className="border-t border-slate-100 bg-white px-6 py-8 lg:px-8">
+          <div>
+            <p className="text-sm font-black text-violet-700">Optional baseline</p>
+            <h2 className="mt-3 text-2xl font-black tracking-normal text-slate-950">Measure where the website starts</h2>
+            <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-slate-600">
+              Connect Google Search Console first if you want search traffic included. Then generate a baseline snapshot for technical health, SEO,
+              authority, AI visibility, and traffic before the first article goes live.
+            </p>
+          </div>
+
+          <div className="mt-7 grid gap-4 lg:grid-cols-2">
+            <div className="rounded-xl border border-slate-200 bg-slate-50/60 p-4">
+              <div className="flex items-start gap-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">
+                  1
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm font-black text-slate-950">Connect Google Search Console</p>
+                  <p className="mt-1 text-sm font-semibold leading-6 text-slate-600">
+                    Optional. Connect it to include clicks, impressions, and search query data in the baseline.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                {hasGoogleBaselineScopes ? (
+                  <>
+                    <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-black text-emerald-700">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Search Console connected
+                    </span>
+                    <button
+                      type="button"
+                      onClick={refreshGoogleBaseline}
+                      disabled={!canRefreshGoogleBaseline}
+                      className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-black text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {googleBaselinePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <GoogleIcon />}
+                      {trafficStatus === "measured" ? "Refresh Search Console" : "Load Search Console"}
+                    </button>
+                  </>
+                ) : bootstrap.googleBaselineConnection?.connectUrl ? (
+                  <a
+                    href={bootstrap.googleBaselineConnection.connectUrl}
+                    className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-black text-slate-800 shadow-sm transition hover:bg-slate-50"
+                  >
+                    <GoogleIcon />
+                    Connect Google Search Console
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                ) : (
+                  <span className="rounded-full bg-white px-3 py-1.5 text-xs font-black text-slate-500 ring-1 ring-slate-200">
+                    Search Console can be skipped
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-slate-200 bg-slate-50/60 p-4">
+              <div className="flex items-start gap-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">
+                  2
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm font-black text-slate-950">Generate baseline snapshot</p>
+                  <p className="mt-1 text-sm font-semibold leading-6 text-slate-600">
+                    This can run without Search Console. Use it to compare future article growth against today&apos;s website state.
+                  </p>
+                  <p className="mt-3 text-sm font-black text-slate-950">{effectiveBaseline.domain || startupValues.domain || "No domain saved yet"}</p>
+                  <p className="mt-1 text-sm font-semibold text-slate-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
+                  {effectiveBaseline.collectedAt ? (
+                    <p className="mt-1 text-xs font-semibold text-slate-500">
+                      Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
+                      {effectiveBaseline.stale ? " · stale" : ""}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={startBaseline}
+                  disabled={!canStartBaseline}
+                  className="inline-flex items-center gap-2 rounded-lg bg-violet-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <BarChart3 className="h-4 w-4" />}
+                  {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Generate baseline" : "Rerun baseline"}
+                </button>
+                <button
+                  type="button"
+                  onClick={skipBaseline}
+                  disabled={skipBaselinePending}
+                  className="inline-flex items-center gap-2 rounded-lg border border-transparent bg-transparent px-4 py-2.5 text-sm font-black text-slate-600 transition hover:bg-white disabled:opacity-50"
+                >
+                  Skip for now
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {(baselineStartData?.error || googleBaselineFetcher.data?.error || skipBaselineFetcher.data?.error) ? (
+            <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+              {baselineStartData?.error ?? googleBaselineFetcher.data?.error ?? skipBaselineFetcher.data?.error}
+            </div>
+          ) : null}
+
+          {baselineRunId ? (
+            <div className="mt-4 rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-sm text-violet-900">
+              <div className="flex items-center gap-2 font-black">
+                {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                <span>
+                  {baselineRun?.status === "completed"
+                    ? "Baseline ready"
+                    : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
+                      ? "Baseline needs attention"
+                      : "Collecting baseline"}
+                </span>
+              </div>
+              {baselineRun?.errors?.length ? <p className="mt-2 font-semibold text-rose-700">{baselineRun.errors[0]}</p> : null}
+            </div>
+          ) : null}
+
+          <div className="mt-5 grid gap-3 rounded-xl border border-slate-100 bg-slate-50/50 p-4 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-sm font-black text-slate-950">Overall</p>
+                <SourceStatusBadge status={effectiveBaseline.status === "completed" ? "measured" : effectiveBaseline.status} />
+              </div>
+              <p className="mt-3 text-3xl font-black text-slate-950">
+                {typeof effectiveBaseline.overallScore === "number" ? effectiveBaseline.overallScore : "—"}
+              </p>
+            </div>
+            <BaselineMetricCard label="Technical health" metric={baselineMetrics.technicalHealth} />
+            <BaselineMetricCard label="Lighthouse" metric={baselineMetrics.lighthouse} />
+            <BaselineMetricCard label="Organic search" metric={baselineMetrics.organicSearch} />
+            <BaselineMetricCard label="AI visibility" metric={baselineMetrics.aiVisibility} />
+            <BaselineMetricCard label="Authority" metric={baselineMetrics.authority} />
+            <BaselineMetricCard label="Traffic/users" metric={trafficMetric} />
+            {searchConsole?.status === "measured" && searchConsoleSummary ? (
+              <div className="rounded-xl border border-slate-200 bg-white p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-sm font-black text-slate-950">Search Console</p>
+                  <GoogleIcon />
+                </div>
+                <p className="mt-3 text-2xl font-black text-slate-950">
+                  {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.clicks) ?? 0))}
+                </p>
+                <p className="mt-1 text-xs font-semibold text-slate-500">
+                  clicks from {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.impressions) ?? 0))} impressions
+                </p>
+              </div>
+            ) : null}
+          </div>
+
+          {effectiveBaseline.recommendations?.length ? (
+            <div className="mt-5 rounded-xl border border-slate-100 bg-white p-4">
+              <p className="text-sm font-black text-slate-950">Recommended fixes</p>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                {effectiveBaseline.recommendations.slice(0, 4).map((recommendation, index) => (
+                  <div key={`${recommendation.title ?? recommendation.source ?? index}`} className="rounded-xl bg-slate-50 px-4 py-3">
+                    <p className="text-sm font-black text-slate-950">{String(recommendation.title ?? "Review baseline recommendation")}</p>
+                    {recommendation.detail ? <p className="mt-1 text-xs font-semibold text-slate-600">{String(recommendation.detail)}</p> : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </section>
 
         <div className="flex flex-col gap-4 border-t border-slate-100 bg-slate-50/70 px-6 py-5 sm:flex-row sm:items-center sm:justify-between lg:px-8">
           <p className="flex items-center gap-3 text-sm font-bold text-slate-500">
@@ -581,7 +1892,8 @@ function FirstArticleSetupPage({
               type="submit"
               name="nextAction"
               value="save-exit"
-              className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-5 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:bg-slate-50"
+              disabled={isSubmitting || researchLocked}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-5 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Save className="h-4 w-4" />
               Save and exit
@@ -590,10 +1902,11 @@ function FirstArticleSetupPage({
               type="submit"
               name="nextAction"
               value="continue"
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800"
+              disabled={isSubmitting || researchLocked}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
             >
+              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
               Continue to website
-              <ArrowRight className="h-4 w-4" />
             </button>
           </div>
         </div>

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -12,8 +12,6 @@ export type VibeMarketingRunStatus =
   | "denied"
   | string;
 
-export type VibeMarketingDeliveryMode = "publish_code" | "content_only";
-
 export interface VibeMarketingStepState {
   key: string;
   name: string;
@@ -146,7 +144,7 @@ export interface VibeMarketingOrganization {
 export interface VibeMarketingSettings {
   brandName?: string | null;
   companyContext?: string | null;
-  articleDeliveryMode?: VibeMarketingDeliveryMode | null;
+  articleDeliveryMode?: string | null;
   githubRepo?: string | null;
   dailyDiscoveryEnabled: boolean;
   dailyDiscoveryPriority?: number | null;


### PR DESCRIPTION
## Summary
- refresh the Vibe Marketing start page and article workflow surfaces
- simplify the startup setup AI action to `Generate with AI` while keeping target fields visible and locked during generation
- add richer progress, retry, and error handling around company profile autofill

## Validation
- `bun run typecheck`
- in-app browser check for `/founder-tools/marketing`