### PR TITLE
[codex] Consolidate vibe marketing setup flow

### DIFF
--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -3,10 +3,15 @@ import { Form, Link } from "react-router";
 import {
   ArrowPathIcon,
   ArrowRightIcon,
+  CodeBracketIcon,
   CheckCircleIcon,
   ClockIcon,
   ExclamationTriangleIcon,
   LockClosedIcon,
+  MagnifyingGlassIcon,
+  PencilSquareIcon,
+  RocketLaunchIcon,
+  UserCircleIcon,
 } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 
@@ -24,8 +29,83 @@ interface MarketingWorkflowShellProps {
   subtitle?: string;
   isSubmitting?: boolean;
   primaryActionSlot?: ReactNode;
+  showPrimaryAction?: boolean;
   className?: string;
 }
+
+const ACTIONABLE_STATUSES = new Set(["blocked", "needs_action", "running", "ready"]);
+
+type WorkflowDisplayGroupId =
+  | "profile_baseline"
+  | "research_topic"
+  | "repo_article_system"
+  | "article_creation"
+  | "publish_automation";
+
+interface WorkflowDisplayGroupDefinition {
+  id: WorkflowDisplayGroupId;
+  label: string;
+  summary: string;
+  stepIds: string[];
+  completionStepId: string;
+  icon: typeof UserCircleIcon;
+}
+
+interface WorkflowDisplayGroup {
+  id: WorkflowDisplayGroupId;
+  label: string;
+  summary: string;
+  status: string;
+  href: string;
+  primaryAction?: VibeMarketingWorkflowAction | null;
+  sourceStep?: VibeMarketingWorkflowStep;
+  actionStep?: VibeMarketingWorkflowStep;
+  childSteps: VibeMarketingWorkflowStep[];
+  icon: typeof UserCircleIcon;
+}
+
+const WORKFLOW_DISPLAY_GROUPS: WorkflowDisplayGroupDefinition[] = [
+  {
+    id: "profile_baseline",
+    label: "Startup profile & baseline",
+    summary: "Company details, competitors, seed keywords, and the starting website baseline.",
+    stepIds: ["profile", "baseline"],
+    completionStepId: "baseline",
+    icon: UserCircleIcon,
+  },
+  {
+    id: "research_topic",
+    label: "Research & choose topic",
+    summary: "Find topic opportunities and choose the article brief.",
+    stepIds: ["research", "choose_topic"],
+    completionStepId: "choose_topic",
+    icon: MagnifyingGlassIcon,
+  },
+  {
+    id: "repo_article_system",
+    label: "Connect repo & article system",
+    summary: "Connect GitHub, scan the repository, and prepare the article system.",
+    stepIds: ["repo", "article_system"],
+    completionStepId: "article_system",
+    icon: CodeBracketIcon,
+  },
+  {
+    id: "article_creation",
+    label: "Generate, review & revise",
+    summary: "Generate the article, review the live preview, and revise with comments.",
+    stepIds: ["generate", "review", "revise"],
+    completionStepId: "review",
+    icon: PencilSquareIcon,
+  },
+  {
+    id: "publish_automation",
+    label: "Publish & automate",
+    summary: "Review the package, publish to the site, and enable daily automation.",
+    stepIds: ["package", "publish", "automation"],
+    completionStepId: "automation",
+    icon: RocketLaunchIcon,
+  },
+];
 
 function statusLabel(status: string) {
   if (status === "needs_action") return "Needs action";
@@ -88,15 +168,34 @@ function ActionButton({
   return null;
 }
 
-function stepKey(step: VibeMarketingWorkflowStep) {
-  return `${step.id}-${step.order ?? step.label}`;
+function groupForStepId(stepId: string | null | undefined, groups: WorkflowDisplayGroup[]) {
+  return groups.find((group) => group.childSteps.some((step) => step.id === stepId));
 }
 
-function viewingLabel(step: VibeMarketingWorkflowStep) {
-  if (step.id === "profile") return "Startup profile";
-  if (step.id === "repo") return "Repository setup";
-  if (step.id === "article_system") return "Article system setup";
-  return step.label;
+function buildWorkflowDisplayGroups(steps: VibeMarketingWorkflowStep[]): WorkflowDisplayGroup[] {
+  const stepById = new Map(steps.map((step) => [step.id, step]));
+  return WORKFLOW_DISPLAY_GROUPS.map((definition) => {
+    const childSteps = definition.stepIds.map((stepId) => stepById.get(stepId)).filter((step): step is VibeMarketingWorkflowStep => Boolean(step));
+    const actionableStep = childSteps.find((step) => ACTIONABLE_STATUSES.has(step.status));
+    const completionStep = stepById.get(definition.completionStepId) ?? childSteps[childSteps.length - 1] ?? childSteps[0];
+    const fallbackStep = childSteps[0];
+    const sourceStep = actionableStep ?? (completionStep?.status === "complete" ? completionStep : fallbackStep);
+    const status = actionableStep?.status ?? (completionStep?.status === "complete" ? "complete" : "locked");
+    const hrefStep = actionableStep ?? completionStep ?? fallbackStep;
+
+    return {
+      id: definition.id,
+      label: definition.label,
+      summary: sourceStep?.summary ?? definition.summary,
+      status,
+      href: actionableStep?.primaryAction?.href || hrefStep?.href || fallbackStep?.href || "/founder-tools/marketing/create",
+      primaryAction: actionableStep?.primaryAction ?? null,
+      sourceStep,
+      actionStep: actionableStep,
+      childSteps,
+      icon: definition.icon,
+    };
+  });
 }
 
 export default function MarketingWorkflowShell({
@@ -107,29 +206,31 @@ export default function MarketingWorkflowShell({
   subtitle,
   isSubmitting = false,
   primaryActionSlot,
+  showPrimaryAction = true,
   className,
 }: MarketingWorkflowShellProps) {
   const steps = progress?.steps ?? [];
   if (!steps.length) return null;
   const requiredStep = steps.find((step) => step.id === progress?.currentStepId) ?? steps.find((step) => step.status !== "complete" && step.status !== "locked") ?? steps[0];
   const viewedStep = steps.find((step) => step.id === viewedStepId) ?? requiredStep;
-  const viewingRequiredStep = viewedStep.id === requiredStep.id;
-  const viewedIndex = Math.max(0, steps.findIndex((step) => step.id === viewedStep.id));
-  const completeCount = steps.filter((step) => step.status === "complete").length;
-  const percent = Math.max(4, Math.round((completeCount / steps.length) * 100));
-  const phases = Array.from(new Set(steps.map((step) => step.phase)));
-  const headerLabel = viewingRequiredStep
-    ? `Next required step: ${requiredStep.label}`
-    : `Viewing: ${viewingLabel(viewedStep)} - ${statusLabel(viewedStep.status)}`;
-  const requiredStepUsesViewedSurface = Boolean(requiredStep.href && viewedStep.href && requiredStep.href === viewedStep.href);
+  const displayGroups = buildWorkflowDisplayGroups(steps);
+  const requiredGroup = groupForStepId(requiredStep.id, displayGroups) ?? displayGroups[0];
+  const viewedGroup = groupForStepId(viewedStep.id, displayGroups) ?? requiredGroup;
+  const viewingRequiredGroup = viewedGroup.id === requiredGroup.id;
+  const viewedIndex = Math.max(0, displayGroups.findIndex((group) => group.id === viewedGroup.id));
+  const completeCount = displayGroups.filter((group) => group.status === "complete").length;
+  const percent = Math.max(4, Math.round((completeCount / displayGroups.length) * 100));
+  const headerLabel = viewingRequiredGroup
+    ? `Next required step: ${requiredGroup.label}`
+    : `Viewing: ${viewedGroup.label} - ${statusLabel(viewedGroup.status)}`;
   const requiredNavigationAction =
-    requiredStep.primaryAction?.label
+    requiredGroup.primaryAction?.label
       ? {
-          ...requiredStep.primaryAction,
-          href: requiredStep.primaryAction.href || requiredStep.href,
-          variant: requiredStep.primaryAction.variant ?? "secondary",
+          ...requiredGroup.primaryAction,
+          href: requiredGroup.primaryAction.href || requiredGroup.href,
+          variant: requiredGroup.primaryAction.variant ?? "secondary",
         }
-      : { label: `Go to ${requiredStep.label}`, href: requiredStep.href, variant: "secondary" as const };
+      : { label: `Go to ${requiredGroup.label}`, href: requiredGroup.href, variant: "secondary" as const };
   const HeadingTag = titleAs;
 
   return (
@@ -137,99 +238,98 @@ export default function MarketingWorkflowShell({
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <p className="text-xs font-extrabold uppercase tracking-wide text-violet-600">
-            Step {viewedIndex + 1} of {steps.length}
+            Step {viewedIndex + 1} of {displayGroups.length}
           </p>
           <HeadingTag className={clsx("mt-1 font-black text-gray-950", titleAs === "h1" ? "text-2xl" : "text-xl")}>
             {title}
           </HeadingTag>
           <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className={clsx("inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-black", statusTone(viewedStep.status))}>
-              <StepStatusIcon status={viewedStep.status} />
-              {statusLabel(viewedStep.status)}
+            <span className={clsx("inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-black", statusTone(viewedGroup.status))}>
+              <StepStatusIcon status={viewedGroup.status} />
+              {statusLabel(viewedGroup.status)}
             </span>
             <span className="text-sm font-bold text-gray-700">{headerLabel}</span>
-            {!viewingRequiredStep ? (
+            {!viewingRequiredGroup ? (
               <span className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-2.5 py-1 text-xs font-black text-violet-700">
-                Next required step: {requiredStep.label}
+                Next required step: {requiredGroup.label}
               </span>
             ) : null}
           </div>
           <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-500">
-            {subtitle ?? viewedStep.summary}
+            {subtitle ?? viewedGroup.summary}
           </p>
         </div>
-        <div className="flex flex-wrap gap-2">
-          {viewingRequiredStep ? (
-            primaryActionSlot ?? <ActionButton action={requiredStep.primaryAction} disabled={isSubmitting} />
-          ) : requiredStepUsesViewedSurface && primaryActionSlot ? (
-            primaryActionSlot
-          ) : (
-            <ActionButton action={requiredNavigationAction} disabled={isSubmitting} />
-          )}
-        </div>
+        {showPrimaryAction ? (
+          <div className="flex flex-wrap gap-2">
+            {primaryActionSlot && viewedGroup.status !== "locked" ? (
+              primaryActionSlot
+            ) : viewingRequiredGroup ? (
+              <ActionButton action={viewedGroup.primaryAction} disabled={isSubmitting} />
+            ) : (
+              <ActionButton action={requiredNavigationAction} disabled={isSubmitting} />
+            )}
+          </div>
+        ) : null}
       </div>
 
       <div className="mt-5 h-1.5 overflow-hidden rounded-full bg-gray-100" aria-hidden>
         <div className="h-full rounded-full bg-violet-600 transition-all" style={{ width: `${percent}%` }} />
       </div>
 
-      <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
-        {phases.map((phase) => {
-          const phaseSteps = steps.filter((step) => step.phase === phase);
-          const phaseComplete = phaseSteps.every((step) => step.status === "complete");
-          const phaseActive = phaseSteps.some((step) => step.id === viewedStep.id);
-          return (
-            <span
-              key={phase}
-              className={clsx(
-                "min-w-fit rounded-full px-3 py-1.5 text-xs font-black ring-1",
-                phaseActive && "bg-violet-50 text-violet-700 ring-violet-100",
-                !phaseActive && phaseComplete && "bg-emerald-50 text-emerald-700 ring-emerald-100",
-                !phaseActive && !phaseComplete && "bg-gray-50 text-gray-500 ring-gray-100",
-              )}
-            >
-              {phase}
-            </span>
-          );
-        })}
-      </div>
-
-      <ol className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
-        {steps.map((step, index) => {
-          const active = step.id === viewedStep.id;
-          const nextRequired = step.id === requiredStep.id;
-          const locked = step.status === "locked";
+      <ol className="mt-5 grid gap-4 rounded-2xl border border-violet-100 bg-violet-50/60 p-4 shadow-sm shadow-violet-100/60 sm:grid-cols-2 lg:grid-cols-5 lg:p-5">
+        {displayGroups.map((group, index) => {
+          const active = group.id === viewedGroup.id;
+          const nextRequired = group.id === requiredGroup.id;
+          const locked = group.status === "locked";
+          const Icon = group.icon;
           const content = (
-            <>
-              <span className={clsx("flex h-8 w-8 items-center justify-center rounded-full border text-xs font-black", statusTone(step.status))}>
-                {step.status === "complete" ? <CheckCircleIcon className="h-4 w-4" /> : index + 1}
+            <div className="relative flex h-full flex-col items-center gap-3 text-center">
+              <span
+                className={clsx(
+                  "flex h-14 w-14 items-center justify-center rounded-full border transition",
+                  active && "border-violet-200 bg-violet-200 text-violet-700 shadow-sm",
+                  !active && group.status === "complete" && "border-emerald-200 bg-white text-emerald-600",
+                  !active && group.status === "running" && "border-violet-100 bg-white text-violet-600",
+                  !active && (group.status === "needs_action" || group.status === "ready") && "border-amber-200 bg-white text-amber-600",
+                  !active && group.status === "blocked" && "border-red-200 bg-white text-red-600",
+                  !active && locked && "border-gray-100 bg-white/70 text-gray-400",
+                )}
+              >
+                {group.status === "complete" ? (
+                  <CheckCircleIcon className="h-6 w-6" />
+                ) : group.status === "running" ? (
+                  <ArrowPathIcon className="h-6 w-6 animate-spin" />
+                ) : (
+                  <Icon className="h-6 w-6" />
+                )}
               </span>
-              <span className="min-w-0">
-                <span className={clsx("block truncate text-sm font-black", active ? "text-violet-800" : "text-gray-900")}>{step.label}</span>
-                <span className="mt-0.5 flex flex-wrap items-center gap-1 text-xs font-semibold text-gray-500">
-                  <span className="truncate">{statusLabel(step.status)}</span>
-                  {nextRequired && !active ? (
-                    <span className="rounded-full bg-violet-100 px-1.5 py-0.5 text-[10px] font-black uppercase text-violet-700">
-                      Next required
-                    </span>
-                  ) : null}
+              <span className="max-w-[180px] text-sm font-black leading-5 text-gray-950">{group.label}</span>
+              <span className={clsx("text-xs font-bold", active ? "text-violet-700" : locked ? "text-gray-400" : "text-gray-500")}>
+                {statusLabel(group.status)}
+              </span>
+              {nextRequired && !active ? (
+                <span className="rounded-full bg-violet-100 px-2 py-1 text-[10px] font-black uppercase text-violet-700">
+                  Next required
                 </span>
-              </span>
-            </>
-          );
-          const itemClass = clsx(
-            "flex min-h-[64px] items-center gap-3 rounded-xl border px-3 py-2 text-left transition",
-            active ? "border-violet-200 bg-violet-50 shadow-sm" : "border-gray-100 bg-gray-50/70",
-            nextRequired && !active && "border-violet-100 bg-white",
-            !locked && "hover:border-violet-200 hover:bg-white",
-            locked && "opacity-70",
+              ) : null}
+              {index < displayGroups.length - 1 ? (
+                <ArrowRightIcon className="absolute -right-5 top-5 hidden h-5 w-5 text-gray-400 lg:block" />
+              ) : null}
+            </div>
           );
           return (
-            <li key={stepKey(step)}>
+            <li key={group.id} className="min-h-[156px]">
               {locked ? (
-                <div className={itemClass}>{content}</div>
+                <div className="h-full rounded-xl px-3 py-4 opacity-70">{content}</div>
               ) : (
-                <Link to={step.href} className={itemClass}>
+                <Link
+                  to={group.href}
+                  aria-current={active ? "step" : undefined}
+                  className={clsx(
+                    "block h-full rounded-xl px-3 py-4 transition",
+                    active ? "bg-white shadow-sm ring-1 ring-violet-200" : "hover:bg-white/80",
+                  )}
+                >
                   {content}
                 </Link>
               )}

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -1,0 +1,1478 @@
+import { Form, Link, useFetcher, useNavigation } from "react-router";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  BadgeInfo,
+  BarChart3,
+  Building2,
+  CheckCircle2,
+  ExternalLink,
+  Globe2,
+  Link2,
+  Loader2,
+  MapPin,
+  PenLine,
+  Rocket,
+  Save,
+  Search,
+  Send,
+  ShieldCheck,
+  Sparkles,
+  Tags,
+  TrendingUp,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { clsx } from "clsx";
+
+import {
+  companyContextFromSetup,
+  ORGANIZATION_KIND_OPTIONS,
+  STARTUP_STAGE_OPTIONS,
+  startupSetupDefaultsFromBootstrap,
+  type StartupSetupField,
+  type StartupSetupValues,
+} from "~/lib/vibe-marketing-startup-setup";
+import type {
+  VibeMarketingAutofillCompetitor,
+  VibeMarketingAutofillResult,
+  VibeMarketingBootstrap,
+  VibeMarketingRunSummary,
+  VibeMarketingWebsiteBaseline,
+  VibeMarketingWebsiteBaselineMetric,
+} from "~/types/vibe-marketing";
+
+const FLOW_STEPS = [
+  { label: "You tell us about your startup", icon: Users },
+  { label: "We research your market", icon: Search },
+  { label: "We write your SEO article", icon: PenLine },
+  { label: "You review & publish", icon: Send },
+  { label: "Drive more traffic & grow", icon: BarChart3 },
+] as const;
+
+const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running"]);
+const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "cancelled", "denied"]);
+const RESEARCH_DONE_STATUSES = new Set(["completed", ...RESEARCH_FAILED_STATUSES]);
+
+const PROFILE_RESEARCH_STEPS = [
+  { id: "identity", label: "Resolving company identity", keys: ["queued", "resolve_company_identity", "profile_resolution"] },
+  { id: "website", label: "Crawling owned website", keys: ["crawl_owned_web", "crawl_website", "scrape_website"] },
+  { id: "public_web", label: "Researching public web", keys: ["research_public_web"] },
+  { id: "linkedin", label: "Checking public LinkedIn signals", keys: ["research_linkedin_public"] },
+  { id: "competitors", label: "Finding competitors", keys: ["discover_competitor_candidates", "identify_competitors", "rank_competitors"] },
+  { id: "keywords", label: "Generating keywords", keys: ["generate_keyword_landscape", "generate_seed_keywords"] },
+  { id: "profile", label: "Writing company profile", keys: ["synthesize_company_profile", "synthesize_company_context"] },
+  { id: "finalize", label: "Applying research results", keys: ["finalize"] },
+] as const;
+
+type SetupVariant = "landing" | "workflow";
+
+type VibeMarketingStartupBaselineSetupProps = {
+  bootstrap: VibeMarketingBootstrap;
+  error?: string | null;
+  variant?: SetupVariant;
+  focusSection?: "profile" | "baseline";
+  autoRefreshGoogleBaseline?: boolean;
+};
+
+function listFromText(value: unknown): string[] {
+  return String(value ?? "")
+    .split(/[,\n]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function numericValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function plainObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function objectArray(value: unknown): Record<string, unknown>[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === "object" && !Array.isArray(item)))
+    : undefined;
+}
+
+function listFromUnknown(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+  if (typeof value === "string") return listFromText(value);
+  return [];
+}
+
+function competitorSuggestion(value: unknown): VibeMarketingAutofillCompetitor | null {
+  if (!value || typeof value !== "object") {
+    const text = String(value ?? "").trim();
+    return text ? { name: text, domain: text } : null;
+  }
+  const payload = value as Record<string, unknown>;
+  const name = String(payload.name ?? payload.company ?? payload.title ?? "").trim();
+  const domain = String(payload.domain ?? "").trim();
+  if (!name && !domain) return null;
+  return {
+    name: name || domain,
+    domain,
+    linkedinUrl: payload.linkedinUrl ? String(payload.linkedinUrl) : payload.linkedin_url ? String(payload.linkedin_url) : undefined,
+    type: payload.type ? String(payload.type) : undefined,
+    score: numericValue(payload.score),
+    reason: payload.reason ? String(payload.reason) : undefined,
+    source: payload.source ? String(payload.source) : undefined,
+    evidence: Array.isArray(payload.evidence) ? payload.evidence.map(String).filter(Boolean) : undefined,
+    confidence: payload.confidence ? String(payload.confidence) : undefined,
+  };
+}
+
+function competitorList(value: unknown): VibeMarketingAutofillCompetitor[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(competitorSuggestion).filter((competitor): competitor is VibeMarketingAutofillCompetitor => Boolean(competitor));
+}
+
+function keywordGroups(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((group): group is Record<string, unknown> => Boolean(group && typeof group === "object"))
+    .map((group) => ({
+      group: group.group ? String(group.group) : group.name ? String(group.name) : undefined,
+      intent: group.intent ? String(group.intent) : undefined,
+      keywords: listFromUnknown(group.keywords),
+    }))
+    .filter((group) => group.keywords.length);
+}
+
+function researchDepth(value: unknown): Record<string, number> | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const result: Record<string, number> = {};
+  for (const [key, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    const numberValue = numericValue(rawValue);
+    if (numberValue !== null) result[key] = numberValue;
+  }
+  return Object.keys(result).length ? result : undefined;
+}
+
+function autofillSources(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((source): source is Record<string, unknown> => Boolean(source && typeof source === "object"))
+    .map((source) => ({
+      url: String(source.url ?? ""),
+      title: source.title ? String(source.title) : undefined,
+      type: source.type ? String(source.type) : undefined,
+      query: source.query ? String(source.query) : undefined,
+      description: source.description ? String(source.description) : undefined,
+      source: source.source ? String(source.source) : undefined,
+    }))
+    .filter((source) => source.url);
+}
+
+function extractAutofill(run: VibeMarketingRunSummary | null | undefined): VibeMarketingAutofillResult | null {
+  const raw = run?.result?.autofill;
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const groupsPayload = plainObject(payload.competitorGroups) ?? {};
+  const directCompetitors = competitorList(payload.directCompetitors ?? payload.direct_competitors ?? groupsPayload.directCompetitors);
+  const seoCompetitors = competitorList(payload.seoCompetitors ?? payload.seo_competitors ?? groupsPayload.seoCompetitors);
+  const adjacentOrganizations = competitorList(
+    payload.adjacentOrganizations ?? payload.adjacent_organizations ?? groupsPayload.adjacentOrganizations,
+  );
+  const competitorCandidates = Array.isArray(payload.competitors)
+    ? payload.competitors
+    : Array.isArray(payload.competitorCandidates)
+      ? payload.competitorCandidates
+      : [];
+  const competitorSuggestions = [
+    ...directCompetitors,
+    ...seoCompetitors,
+    ...adjacentOrganizations,
+    ...competitorCandidates.map(competitorSuggestion).filter((item): item is VibeMarketingAutofillCompetitor => Boolean(item)),
+  ];
+  const competitorStrings = [
+    ...directCompetitors.map((competitor) => competitor.domain || competitor.name),
+    ...competitorCandidates
+      .map((competitor) => competitorSuggestion(competitor))
+      .map((competitor) => competitor?.domain || competitor?.name || ""),
+    ...listFromUnknown(payload.competitorDomains),
+    ...listFromUnknown(payload.competitorStrings),
+  ].filter(Boolean);
+  const groups = keywordGroups(payload.keywordGroups ?? payload.keyword_groups);
+  const seedKeywords = [
+    ...listFromUnknown(payload.seedKeywords),
+    ...listFromUnknown(payload.seed_keywords),
+    ...groups.flatMap((group) => group.keywords),
+  ];
+  return {
+    brandName: typeof payload.brandName === "string" ? payload.brandName : typeof payload.brand_name === "string" ? payload.brand_name : null,
+    companyLinkedInUrl:
+      typeof payload.companyLinkedInUrl === "string"
+        ? payload.companyLinkedInUrl
+        : typeof payload.company_linkedin_url === "string"
+          ? payload.company_linkedin_url
+          : null,
+    companyContext:
+      typeof payload.companyContext === "string"
+        ? payload.companyContext
+        : typeof payload.company_context === "string"
+          ? payload.company_context
+          : null,
+    competitors: Array.from(new Set(competitorStrings.map((competitor) => competitor.trim()).filter(Boolean))),
+    competitorSuggestions,
+    directCompetitors,
+    seoCompetitors,
+    adjacentOrganizations,
+    competitorGroups: { directCompetitors, seoCompetitors, adjacentOrganizations },
+    seedKeywords: Array.from(new Set(seedKeywords.map((keyword) => keyword.trim()).filter(Boolean))),
+    keywordGroups: groups,
+    sources: autofillSources(payload.sources),
+    linkedinProfile:
+      payload.linkedinProfile && typeof payload.linkedinProfile === "object"
+        ? {
+            url: String((payload.linkedinProfile as Record<string, unknown>).url ?? ""),
+            title: (payload.linkedinProfile as Record<string, unknown>).title
+              ? String((payload.linkedinProfile as Record<string, unknown>).title)
+              : undefined,
+            description: (payload.linkedinProfile as Record<string, unknown>).description
+              ? String((payload.linkedinProfile as Record<string, unknown>).description)
+              : undefined,
+            vanityName: (payload.linkedinProfile as Record<string, unknown>).vanityName
+              ? String((payload.linkedinProfile as Record<string, unknown>).vanityName)
+              : undefined,
+            blocked: Boolean((payload.linkedinProfile as Record<string, unknown>).blocked),
+          }
+        : undefined,
+    linkedinSimilarSignals: autofillSources(payload.linkedinSimilarSignals ?? payload.linkedin_similar_signals),
+    sourceCount: numericValue(payload.sourceCount ?? payload.source_count) ?? undefined,
+    competitorCount: numericValue(payload.competitorCount ?? payload.competitor_count) ?? undefined,
+    seedKeywordCount: numericValue(payload.seedKeywordCount ?? payload.seed_keyword_count) ?? undefined,
+    researchSummary:
+      typeof payload.researchSummary === "string"
+        ? payload.researchSummary
+        : typeof payload.research_summary === "string"
+          ? payload.research_summary
+          : null,
+    researchDepth: researchDepth(payload.researchDepth ?? payload.research_depth),
+    researchQuality: plainObject(payload.researchQuality ?? payload.research_quality),
+    modelTrace: objectArray(payload.modelTrace ?? payload.model_trace),
+    queryLog: objectArray(payload.queryLog ?? payload.query_log),
+    evidenceMap: plainObject(payload.evidenceMap ?? payload.evidence_map),
+    stepDurations: researchDepth(payload.stepDurations ?? payload.step_durations),
+    warnings: listFromUnknown(payload.warnings),
+  };
+}
+
+function competitorStringsFromAutofill(autofill: VibeMarketingAutofillResult) {
+  const candidates = autofill.competitors?.length
+    ? autofill.competitors
+    : [
+        ...(autofill.directCompetitors ?? []),
+        ...(autofill.seoCompetitors ?? []),
+        ...(autofill.adjacentOrganizations ?? []),
+        ...(autofill.competitorSuggestions ?? []),
+      ].map((competitor) => competitor.domain || competitor.name);
+  const seen = new Set<string>();
+  return candidates
+    .map((competitor) => String(competitor ?? "").trim())
+    .filter((competitor) => {
+      if (!competitor) return false;
+      const key = competitor.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+function splitCompanyContext(context: string | null | undefined, fallbackTargetAudience: string | null | undefined) {
+  const raw = String(context ?? "").trim();
+  if (!raw) {
+    return { shortDescription: "", problemSolved: "", targetAudience: String(fallbackTargetAudience ?? "").trim() };
+  }
+
+  const problemMatch = raw.match(/(?:^|\n+)Problem solved:\s*([\s\S]*?)(?=\n+Target audience:|$)/i);
+  const audienceMatch = raw.match(/(?:^|\n+)Target audience:\s*([\s\S]*?)$/i);
+  const shortDescription = raw
+    .replace(/(?:^|\n+)Problem solved:\s*[\s\S]*?(?=\n+Target audience:|$)/i, "")
+    .replace(/(?:^|\n+)Target audience:\s*[\s\S]*$/i, "")
+    .trim();
+
+  return {
+    shortDescription: shortDescription || raw,
+    problemSolved: problemMatch?.[1]?.trim() ?? "",
+    targetAudience: audienceMatch?.[1]?.trim() || String(fallbackTargetAudience ?? "").trim(),
+  };
+}
+
+function normalizeResearchStepKey(step?: string | null) {
+  return String(step ?? "").trim().toLowerCase();
+}
+
+function isResearchFailedStatus(status?: string | null) {
+  return RESEARCH_FAILED_STATUSES.has(normalizeResearchStepKey(status));
+}
+
+function isResearchTerminalStatus(status?: string | null) {
+  return RESEARCH_DONE_STATUSES.has(normalizeResearchStepKey(status));
+}
+
+function isResearchRunningStatus(status?: string | null) {
+  return RESEARCH_RUNNING_STATUSES.has(normalizeResearchStepKey(status));
+}
+
+function researchStepIndex(step?: string | null) {
+  const stepKey = normalizeResearchStepKey(step);
+  return PROFILE_RESEARCH_STEPS.findIndex((item) => item.keys.some((key) => key === stepKey));
+}
+
+function autofillStepLabel(step?: string | null) {
+  const stepKey = normalizeResearchStepKey(step);
+  const configuredStep = PROFILE_RESEARCH_STEPS.find((item) => item.keys.some((key) => key === stepKey));
+  if (configuredStep) return configuredStep.label;
+  return stepKey ? stepKey.replace(/_/g, " ") : "Filling profile with AI";
+}
+
+function completedResearchStepCount(run?: VibeMarketingRunSummary | null, pending = false) {
+  const totalSteps = PROFILE_RESEARCH_STEPS.length;
+  if (pending || !run) return 0;
+  if (run.status === "completed") return totalSteps;
+
+  const stepStates = Array.isArray(run.steps) ? run.steps : [];
+  if (stepStates.length) {
+    return Math.min(
+      totalSteps,
+      stepStates.filter((step) => ["completed", "skipped"].includes(normalizeResearchStepKey(step.status))).length,
+    );
+  }
+
+  const index = researchStepIndex(run.currentStep);
+  if (index >= 0) return Math.min(index, totalSteps);
+  return 0;
+}
+
+function researchProgressSignature(run?: VibeMarketingRunSummary | null) {
+  if (!run) return "no-run";
+  const steps = (run.steps ?? [])
+    .map((step) => `${step.key}:${step.status}:${step.completedAt ?? ""}:${step.error ?? ""}`)
+    .join("|");
+  return [run.status, run.currentStep ?? "", run.updatedAt ?? "", run.errors?.join("|") ?? "", steps].join("::");
+}
+
+function baselineFromRun(run: VibeMarketingRunSummary | null | undefined): VibeMarketingWebsiteBaseline | null {
+  const raw = run?.result?.baseline;
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  return {
+    runId: run?.runId,
+    domain: typeof payload.domain === "string" ? payload.domain : run?.domain,
+    status: typeof payload.status === "string" ? payload.status : run?.status,
+    passed: run?.status === "completed",
+    collectedAt:
+      typeof payload.collectedAt === "string"
+        ? payload.collectedAt
+        : typeof payload.collected_at === "string"
+          ? payload.collected_at
+          : run?.updatedAt,
+    overallScore:
+      typeof payload.overallScore === "number"
+        ? payload.overallScore
+        : typeof payload.overall_score === "number"
+          ? payload.overall_score
+          : null,
+    summary:
+      typeof payload.summary === "string" || (payload.summary && typeof payload.summary === "object")
+        ? (payload.summary as VibeMarketingWebsiteBaseline["summary"])
+        : null,
+    metrics: payload.metrics && typeof payload.metrics === "object" ? (payload.metrics as VibeMarketingWebsiteBaseline["metrics"]) : {},
+    sourceStatus: payload.sourceStatus && typeof payload.sourceStatus === "object" ? (payload.sourceStatus as Record<string, string>) : {},
+    recommendations: Array.isArray(payload.recommendations) ? (payload.recommendations as Array<Record<string, unknown>>) : [],
+  };
+}
+
+function baselineSummaryText(summary: VibeMarketingWebsiteBaseline["summary"]) {
+  if (typeof summary === "string") return summary;
+  if (summary && typeof summary === "object" && typeof summary.text === "string") return summary.text;
+  return "Run a baseline to capture website health, search visibility, authority, AI visibility, and traffic before article generation starts.";
+}
+
+function metricStatus(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
+  const message = typeof metric?.message === "string" ? metric.message : "";
+  if (label === "Lighthouse" && /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message)) {
+    return "unavailable";
+  }
+  return metric?.status;
+}
+
+function metricScore(metric: VibeMarketingWebsiteBaselineMetric | undefined, status?: string | null) {
+  return status === "measured" && typeof metric?.score === "number" ? Math.round(metric.score) : null;
+}
+
+function metricMessage(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
+  const message = typeof metric?.message === "string" ? metric.message : null;
+  if (label === "Lighthouse" && message && /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message)) {
+    return "PageSpeed Insights is temporarily rate limited. Try again later.";
+  }
+  return message;
+}
+
+function sourceStatusLabel(status?: string | null) {
+  if (status === "measured") return "Verified";
+  if (status === "needs_connection") return "Needs connection";
+  if (status === "error") return "Error";
+  return "Unavailable";
+}
+
+function FirstArticleProgressPanel() {
+  return (
+    <div className="min-w-0 rounded-2xl border border-violet-100 bg-violet-50/70 px-5 py-6 shadow-sm shadow-violet-100/60 lg:px-8">
+      <p className="text-center text-sm font-black text-slate-600">What happens next?</p>
+      <div className="mt-5 grid grid-cols-2 gap-4 lg:grid-cols-5">
+        {FLOW_STEPS.map((step, index) => {
+          const Icon = step.icon;
+          return (
+            <div key={step.label} className="relative flex flex-col items-center gap-3 text-center">
+              <div
+                className={clsx(
+                  "flex h-12 w-12 items-center justify-center rounded-full",
+                  index === 0 ? "bg-violet-200 text-violet-700" : "bg-white/70 text-slate-500",
+                )}
+              >
+                <Icon className="h-5 w-5" />
+              </div>
+              <p className="max-w-[120px] text-xs font-black leading-5 text-slate-900">{step.label}</p>
+              {index < FLOW_STEPS.length - 1 ? (
+                <ArrowRight className="absolute right-[-18px] top-4 hidden h-4 w-4 text-slate-400 lg:block" />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FormField({
+  label,
+  help,
+  children,
+}: {
+  label: string;
+  help?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-sm font-bold text-gray-700">{label}</span>
+      {help ? <span className="mb-2 block text-sm font-semibold text-gray-500">{help}</span> : null}
+      {children}
+    </label>
+  );
+}
+
+function ControlIcon({ icon: Icon }: { icon: LucideIcon }) {
+  return (
+    <div className="pointer-events-none absolute left-3.5 top-3.5 h-5 w-5 text-gray-400">
+      <Icon className="h-5 w-5" />
+    </div>
+  );
+}
+
+function SourceStatusBadge({ status }: { status?: string | null }) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex rounded-full px-2 py-0.5 text-[11px] font-black",
+        status === "measured" && "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100",
+        status === "needs_connection" && "bg-amber-50 text-amber-700 ring-1 ring-amber-100",
+        status === "error" && "bg-rose-50 text-rose-700 ring-1 ring-rose-100",
+        !["measured", "needs_connection", "error"].includes(String(status)) && "bg-slate-50 text-slate-600 ring-1 ring-slate-100",
+      )}
+    >
+      {sourceStatusLabel(status)}
+    </span>
+  );
+}
+
+function BaselineMetricCard({
+  label,
+  metric,
+}: {
+  label: string;
+  metric?: VibeMarketingWebsiteBaselineMetric;
+}) {
+  const status = metricStatus(label, metric);
+  const score = metricScore(metric, status);
+  const message = metricMessage(label, metric);
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-black text-gray-950">{label}</p>
+        <SourceStatusBadge status={status} />
+      </div>
+      <p className="mt-3 text-2xl font-black text-gray-950">{score === null ? "-" : score}</p>
+      {message ? <p className="mt-2 line-clamp-4 break-words text-xs font-semibold text-gray-500">{message}</p> : null}
+    </div>
+  );
+}
+
+function GoogleIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09A6.6 6.6 0 0 1 5.49 12c0-.73.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.78.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+function ProfileResearchSegments({
+  completedSteps,
+  totalSteps,
+  failed,
+}: {
+  completedSteps: number;
+  totalSteps: number;
+  failed: boolean;
+}) {
+  const segmentCount = Math.max(totalSteps, 1);
+  const safeCompleted = Math.min(Math.max(completedSteps, 0), segmentCount);
+
+  return (
+    <div className="grid grid-cols-8 gap-2">
+      {Array.from({ length: segmentCount }).map((_, index) => {
+        const isComplete = index < safeCompleted;
+        const isActive = !failed && index === safeCompleted && safeCompleted < segmentCount;
+        return (
+          <div
+            key={index}
+            className={clsx(
+              "h-2 rounded-full transition-all",
+              failed && "bg-rose-200",
+              !failed && isComplete && "bg-purple-500",
+              !failed && isActive && "animate-pulse bg-purple-300",
+              !failed && !isComplete && !isActive && "bg-white/75",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ProfileResearchProgressCard({
+  run,
+  runId,
+  pending,
+  startStatus,
+  startError,
+  stalled,
+  unavailable,
+  onRetry,
+  retryDisabled,
+}: {
+  run?: VibeMarketingRunSummary | null;
+  runId?: string | null;
+  pending: boolean;
+  startStatus?: string | null;
+  startError?: string | null;
+  stalled: boolean;
+  unavailable: boolean;
+  onRetry: () => void;
+  retryDisabled: boolean;
+}) {
+  if (!runId && !pending) return null;
+  const autofill = extractAutofill(run);
+  const effectiveStatus = run?.status ?? startStatus ?? (pending ? "queued" : null);
+  const active = pending || (!isResearchTerminalStatus(effectiveStatus) && (!run || isResearchRunningStatus(run.status)));
+  const failed = isResearchFailedStatus(effectiveStatus) || unavailable;
+  const completedSteps = completedResearchStepCount(run, pending);
+  const totalSteps = PROFILE_RESEARCH_STEPS.length;
+  const progressLabel = `${Math.min(completedSteps, totalSteps)} of ${totalSteps} steps`;
+  const label = pending
+    ? "Starting AI fill"
+    : run?.status === "completed"
+      ? "AI suggestions added"
+      : failed
+        ? "AI fill needs attention"
+        : autofillStepLabel(run?.currentStep);
+  const sourceCount = autofill?.sourceCount ?? autofill?.sources?.length ?? 0;
+  const competitorCount = autofill?.competitorCount ?? autofill?.competitorSuggestions?.length ?? autofill?.competitors?.length ?? 0;
+  const seedKeywordCount = autofill?.seedKeywordCount ?? autofill?.seedKeywords?.length ?? 0;
+  const errorMessage =
+    startError ||
+    run?.errors?.[0] ||
+    (failed ? "AI fill is unavailable. Check the Content Factory backend and try again." : null);
+  const notice = unavailable
+    ? "We have not received a fresh status update for more than 2 minutes. You can retry now, or keep this page open while polling continues."
+    : stalled
+      ? "This is taking longer than expected. We will keep checking for progress in the background."
+      : null;
+
+  return (
+    <div
+      className={clsx(
+        "relative overflow-hidden rounded-2xl border p-5 text-sm shadow-sm",
+        failed ? "border-rose-200 bg-rose-50 text-rose-900" : "border-purple-100 bg-gradient-to-br from-purple-50 via-violet-50 to-indigo-50 text-violet-950",
+      )}
+    >
+      <div
+        className={clsx(
+          "absolute right-0 top-0 -mr-10 -mt-10 h-36 w-36 rounded-full blur-3xl",
+          failed ? "bg-rose-200/30" : "bg-purple-200/30",
+        )}
+      />
+      <div className="relative z-10 flex gap-4">
+        <div className={clsx("flex h-12 w-12 shrink-0 items-center justify-center rounded-xl", failed ? "bg-rose-100" : "bg-purple-100")}>
+          {failed ? (
+            <AlertTriangle className="h-6 w-6 text-rose-600" />
+          ) : run?.status === "completed" ? (
+            <CheckCircle2 className="h-6 w-6 text-emerald-600" />
+          ) : (
+            <Sparkles className="h-6 w-6 text-purple-600" />
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-base font-black text-gray-950">{label}</p>
+            <span className={clsx("rounded-full px-2.5 py-1 text-[11px] font-black uppercase tracking-wide", failed ? "bg-white/80 text-rose-700" : "bg-white/80 text-purple-700")}>
+              {failed ? "Retry available" : progressLabel}
+            </span>
+          </div>
+
+          <p className="mt-1 text-sm font-semibold text-gray-700">
+            {pending ? "Contacting the AI fill service" : run?.status === "completed" ? "AI suggestions have been applied to the form." : autofillStepLabel(run?.currentStep)}
+          </p>
+          <p className="mt-1 text-sm font-medium text-gray-500">
+            {active ? "Usually takes 1-3 minutes. Refreshing the page is safe." : failed ? "The form is unlocked so you can retry or fill the fields manually." : "Review the populated fields before continuing."}
+          </p>
+
+          {!failed ? (
+            <div className="mt-4 space-y-2">
+              <ProfileResearchSegments completedSteps={completedSteps} totalSteps={totalSteps} failed={false} />
+              <p className="text-xs font-semibold text-gray-500">We will keep checking until the fields below are ready to review.</p>
+            </div>
+          ) : (
+            <div className="mt-4 space-y-3">
+              <ProfileResearchSegments completedSteps={completedSteps} totalSteps={totalSteps} failed />
+              <p className="rounded-xl border border-rose-200 bg-white/80 px-4 py-3 text-sm font-semibold text-rose-700">{errorMessage}</p>
+              <button
+                type="button"
+                onClick={onRetry}
+                disabled={retryDisabled}
+                className="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-white px-4 py-2 text-sm font-black text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <Sparkles className="h-4 w-4" />
+                Retry AI fill
+              </button>
+            </div>
+          )}
+
+          {notice && !failed ? (
+            <p className="mt-3 rounded-xl border border-amber-200 bg-white/80 px-4 py-3 text-sm font-semibold text-amber-700">{notice}</p>
+          ) : null}
+
+          {autofill ? (
+            <div className="mt-4 flex flex-wrap gap-2 text-xs font-black text-violet-800">
+              <span>{sourceCount} sources reviewed</span>
+              <span>{competitorCount} competitors found</span>
+              <span>{seedKeywordCount} keywords generated</span>
+            </div>
+          ) : null}
+          {autofill?.warnings?.length ? <p className="mt-2 text-xs font-semibold text-amber-700">{autofill.warnings[0]}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VibeMarketingStartupBaselineSetup({
+  bootstrap,
+  error,
+  variant = "landing",
+  focusSection = "profile",
+  autoRefreshGoogleBaseline = false,
+}: VibeMarketingStartupBaselineSetupProps) {
+  const navigation = useNavigation();
+  const autofillStartFetcher = useFetcher<{
+    intent?: string;
+    autofillRunId?: string | null;
+    status?: string;
+    error?: string;
+    errors?: string[];
+  }>();
+  const autofillRunFetcher = useFetcher<VibeMarketingRunSummary>();
+  const baselineStartFetcher = useFetcher<{ intent?: string; baselineRunId?: string | null; status?: string; error?: string }>();
+  const baselineRunFetcher = useFetcher<VibeMarketingRunSummary>();
+  const googleBaselineFetcher = useFetcher<{ intent?: string; websiteBaseline?: VibeMarketingWebsiteBaseline; error?: string }>();
+  const skipBaselineFetcher = useFetcher<{ intent?: string; error?: string }>();
+  const baselineRef = useRef<HTMLElement | null>(null);
+  const googleAutoRefreshSubmittedRef = useRef(false);
+  const startupDefaults = useMemo(() => startupSetupDefaultsFromBootstrap(bootstrap), [bootstrap]);
+  const startupDefaultsSignature = useMemo(() => JSON.stringify(startupDefaults), [startupDefaults]);
+  const activeCompanyKey = String(
+    bootstrap.company.id ||
+      bootstrap.company.organizationId ||
+      bootstrap.organization.id ||
+      bootstrap.organization.domain ||
+      bootstrap.company.domain ||
+      "no-company",
+  );
+  const activeCompanyKeyRef = useRef(activeCompanyKey);
+  const autofillPollStateRef = useRef(autofillRunFetcher.state);
+  const baselinePollStateRef = useRef(baselineRunFetcher.state);
+  const [startupValues, setStartupValues] = useState<StartupSetupValues>(startupDefaults);
+  const [autofillRunId, setAutofillRunId] = useState<string | null>(null);
+  const [appliedAutofillRunId, setAppliedAutofillRunId] = useState<string | null>(null);
+  const [baselineRunId, setBaselineRunId] = useState<string | null>(null);
+  const [googleBaseline, setGoogleBaseline] = useState<VibeMarketingWebsiteBaseline | null>(null);
+  const [autofillStartedAt, setAutofillStartedAt] = useState<number | null>(null);
+  const [autofillLastProgressAt, setAutofillLastProgressAt] = useState<number | null>(null);
+  const [autofillLastPollAt, setAutofillLastPollAt] = useState<number | null>(null);
+  const [autofillProgressSignature, setAutofillProgressSignature] = useState("");
+  const [autofillClock, setAutofillClock] = useState(() => Date.now());
+
+  const autofillStartData = autofillStartFetcher.data;
+  const autofillRun = autofillRunFetcher.data as VibeMarketingRunSummary | undefined;
+  const autofillStartStatus =
+    autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
+      ? autofillStartData.status
+      : null;
+  const autofillStartError =
+    autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
+      ? autofillStartData.error ?? autofillStartData.errors?.[0] ?? null
+      : null;
+  const baselineStartData = baselineStartFetcher.data;
+  const baselineRun = baselineRunFetcher.data as VibeMarketingRunSummary | undefined;
+  const latestBaselineRun = bootstrap.latestRuns.find((run) => run.workflow === "website_baseline");
+  const effectiveBaseline = googleBaseline ?? baselineFromRun(baselineRun) ?? baselineFromRun(latestBaselineRun) ?? bootstrap.websiteBaseline;
+  const baselineMetrics = effectiveBaseline.metrics ?? {};
+  const trafficMetric = baselineMetrics.traffic;
+  const trafficStatus = metricStatus("Traffic/users", trafficMetric);
+  const hasGoogleBaselineScopes = Boolean(bootstrap.googleBaselineConnection?.hasBaselineScopes);
+  const isSubmitting = navigation.state === "submitting";
+  const autofillPending = autofillStartFetcher.state !== "idle";
+  const baselinePending = baselineStartFetcher.state !== "idle";
+  const googleBaselinePending = googleBaselineFetcher.state !== "idle";
+  const skipBaselinePending = skipBaselineFetcher.state !== "idle";
+  const autofillPolling = Boolean(
+    autofillRunId &&
+      !isResearchTerminalStatus(autofillStartStatus) &&
+      (!autofillRun || isResearchRunningStatus(autofillRun.status)),
+  );
+  const baselinePolling = Boolean(baselineRunId && (!baselineRun || ["queued", "running"].includes(baselineRun.status)));
+  const autofillStatusAgeMs = autofillStartedAt ? autofillClock - (autofillLastPollAt ?? autofillStartedAt) : 0;
+  const autofillProgressAgeMs = autofillStartedAt ? autofillClock - (autofillLastProgressAt ?? autofillStartedAt) : 0;
+  const autofillStalled = Boolean(autofillPolling && autofillProgressAgeMs > 60_000);
+  const autofillUnavailable = Boolean(autofillPolling && (autofillStatusAgeMs > 120_000 || autofillProgressAgeMs > 120_000));
+  const researchLocked = autofillPending || (autofillPolling && !autofillUnavailable);
+  const canStartAutofill =
+    Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) &&
+    !autofillPending &&
+    (!autofillPolling || autofillUnavailable);
+  const canRetryAutofill = Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) && !autofillPending;
+  const canStartBaseline = Boolean((bootstrap.organization.domain || bootstrap.company.domain || startupValues.domain).trim()) && !baselinePending && !baselinePolling;
+  const canRefreshGoogleBaseline = hasGoogleBaselineScopes && effectiveBaseline.status !== "missing" && !googleBaselinePending;
+  const companyContext = companyContextFromSetup(startupValues);
+  const searchConsole = plainObject(trafficMetric?.googleSearchConsole);
+  const searchConsoleSummary = plainObject(searchConsole?.last28Days);
+  const embedded = variant === "workflow";
+
+  const inputClass =
+    "w-full rounded-xl border border-gray-200 py-3 pr-4 text-sm font-medium text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500";
+  const inputWithIconClass = `${inputClass} pl-11`;
+  const textareaClass =
+    "w-full resize-y rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium leading-6 text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500";
+  const textareaWithIconClass =
+    "w-full resize-y rounded-xl border border-gray-200 py-3 pl-11 pr-4 text-sm font-medium leading-6 text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500";
+
+  const updateValue = (field: StartupSetupField, value: string) => {
+    setStartupValues((current) => ({ ...current, [field]: value }));
+  };
+
+  const startAutofill = () => {
+    const snapshot = { ...startupValues };
+    const now = Date.now();
+    setAutofillRunId(null);
+    setAppliedAutofillRunId(null);
+    setAutofillStartedAt(now);
+    setAutofillLastProgressAt(now);
+    setAutofillLastPollAt(null);
+    setAutofillProgressSignature("");
+    setAutofillClock(now);
+    const formData = new FormData();
+    formData.set("intent", "start-autofill");
+    formData.set("companyContext", companyContextFromSetup(snapshot));
+    for (const [field, value] of Object.entries(snapshot)) {
+      formData.set(field, value);
+    }
+    autofillStartFetcher.submit(formData, { method: "POST" });
+  };
+
+  const startBaseline = () => {
+    setGoogleBaseline(null);
+    const formData = new FormData();
+    formData.set("intent", "start-baseline");
+    baselineStartFetcher.submit(formData, { method: "POST" });
+  };
+
+  const refreshGoogleBaseline = () => {
+    const formData = new FormData();
+    formData.set("intent", "refresh-baseline-google");
+    googleBaselineFetcher.submit(formData, { method: "POST" });
+  };
+
+  const skipBaseline = () => {
+    const formData = new FormData();
+    formData.set("intent", "skip-baseline");
+    formData.set("reason", "Skipped during marketing setup");
+    skipBaselineFetcher.submit(formData, { method: "POST" });
+  };
+
+  useEffect(() => {
+    autofillPollStateRef.current = autofillRunFetcher.state;
+  }, [autofillRunFetcher.state]);
+
+  useEffect(() => {
+    baselinePollStateRef.current = baselineRunFetcher.state;
+  }, [baselineRunFetcher.state]);
+
+  useEffect(() => {
+    if (activeCompanyKeyRef.current === activeCompanyKey) return;
+    activeCompanyKeyRef.current = activeCompanyKey;
+    setStartupValues(startupDefaults);
+    setAutofillRunId(null);
+    setBaselineRunId(null);
+    setGoogleBaseline(null);
+    setAppliedAutofillRunId(null);
+    setAutofillStartedAt(null);
+    setAutofillLastProgressAt(null);
+    setAutofillLastPollAt(null);
+    setAutofillProgressSignature("");
+    googleAutoRefreshSubmittedRef.current = false;
+  }, [activeCompanyKey, startupDefaults, startupDefaultsSignature]);
+
+  useEffect(() => {
+    if (focusSection !== "baseline") return;
+    window.setTimeout(() => baselineRef.current?.scrollIntoView({ block: "start", behavior: "smooth" }), 100);
+  }, [focusSection]);
+
+  useEffect(() => {
+    if (!autoRefreshGoogleBaseline || googleAutoRefreshSubmittedRef.current) return;
+    if (focusSection !== "baseline" || !hasGoogleBaselineScopes || googleBaselinePending) return;
+    googleAutoRefreshSubmittedRef.current = true;
+    refreshGoogleBaseline();
+  }, [autoRefreshGoogleBaseline, focusSection, googleBaselinePending, hasGoogleBaselineScopes]);
+
+  useEffect(() => {
+    if (autofillStartData?.autofillRunId) {
+      const now = Date.now();
+      setAutofillRunId(autofillStartData.autofillRunId);
+      setAppliedAutofillRunId(null);
+      setAutofillStartedAt((current) => current ?? now);
+      setAutofillLastProgressAt((current) => current ?? now);
+      setAutofillClock(now);
+    }
+  }, [autofillStartData?.autofillRunId]);
+
+  useEffect(() => {
+    if (baselineStartData?.baselineRunId) {
+      setBaselineRunId(baselineStartData.baselineRunId);
+      setGoogleBaseline(null);
+    }
+  }, [baselineStartData?.baselineRunId]);
+
+  useEffect(() => {
+    if (googleBaselineFetcher.data?.websiteBaseline) {
+      setGoogleBaseline(googleBaselineFetcher.data.websiteBaseline);
+    }
+  }, [googleBaselineFetcher.data?.websiteBaseline]);
+
+  useEffect(() => {
+    if (!autofillPending && !autofillPolling) return;
+    setAutofillClock(Date.now());
+    const timer = window.setInterval(() => {
+      setAutofillClock(Date.now());
+    }, 5000);
+    return () => window.clearInterval(timer);
+  }, [autofillPending, autofillPolling]);
+
+  useEffect(() => {
+    if (!autofillRunId || !autofillRun) return;
+    const now = Date.now();
+    const signature = researchProgressSignature(autofillRun);
+    setAutofillLastPollAt(now);
+    if (signature !== autofillProgressSignature) {
+      setAutofillProgressSignature(signature);
+      setAutofillLastProgressAt(now);
+    }
+  }, [autofillProgressSignature, autofillRun, autofillRunId]);
+
+  useEffect(() => {
+    if (!autofillRunId) return;
+    if (autofillRun && !isResearchRunningStatus(autofillRun.status)) return;
+    if (isResearchTerminalStatus(autofillStartStatus)) return;
+    const href = `/founder-tools/marketing/autofill-runs/${encodeURIComponent(autofillRunId)}`;
+    const loadIfIdle = () => {
+      if (autofillPollStateRef.current !== "idle") return;
+      autofillPollStateRef.current = "loading";
+      autofillRunFetcher.load(href);
+    };
+    loadIfIdle();
+    const timer = window.setInterval(loadIfIdle, 2500);
+    return () => window.clearInterval(timer);
+  }, [autofillRunId, autofillRun?.status, autofillStartStatus]);
+
+  useEffect(() => {
+    if (!baselineRunId) return;
+    if (baselineRun && !["queued", "running"].includes(baselineRun.status)) return;
+    const href = `/founder-tools/marketing/autofill-runs/${encodeURIComponent(baselineRunId)}`;
+    const loadIfIdle = () => {
+      if (baselinePollStateRef.current !== "idle") return;
+      baselinePollStateRef.current = "loading";
+      baselineRunFetcher.load(href);
+    };
+    loadIfIdle();
+    const timer = window.setInterval(loadIfIdle, 2500);
+    return () => window.clearInterval(timer);
+  }, [baselineRunId, baselineRun?.status]);
+
+  useEffect(() => {
+    if (!autofillRunId || appliedAutofillRunId === autofillRunId || autofillRun?.status !== "completed") return;
+    const autofill = extractAutofill(autofillRun);
+    if (!autofill) return;
+    const splitContext = splitCompanyContext(autofill.companyContext, startupValues.targetAudience);
+    const competitors = competitorStringsFromAutofill(autofill);
+
+    setStartupValues((current) => ({
+      ...current,
+      companyLinkedInUrl: autofill.companyLinkedInUrl || current.companyLinkedInUrl,
+      shortDescription: splitContext.shortDescription || current.shortDescription,
+      problemSolved: splitContext.problemSolved || current.problemSolved,
+      targetAudience: splitContext.targetAudience || current.targetAudience,
+      competitors: competitors.length ? competitors.join("\n") : current.competitors,
+      seedKeywords: autofill.seedKeywords?.length ? autofill.seedKeywords.join(", ") : current.seedKeywords,
+    }));
+    setAppliedAutofillRunId(autofillRunId);
+  }, [appliedAutofillRunId, autofillRun, autofillRunId, startupValues.targetAudience]);
+
+  const form = (
+    <Form
+      method="POST"
+      className={clsx(
+        "bg-white",
+        embedded ? "space-y-0" : "mt-10 overflow-hidden rounded-2xl border border-gray-200 shadow-sm",
+      )}
+    >
+      <input type="hidden" name="intent" value="save-startup-details" />
+      <input type="hidden" name="companyContext" value={companyContext} />
+      {error ? (
+        <div className="border-b border-rose-100 bg-rose-50 px-6 py-4 text-sm font-bold text-rose-700">{error}</div>
+      ) : null}
+
+      <div className={clsx("grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px] xl:gap-12", embedded ? "" : "p-6 lg:p-8")}>
+        <div>
+          <p className="text-sm font-black text-violet-700">Step 1 of 5</p>
+          <h2 className="mt-3 text-2xl font-black tracking-normal text-gray-950">Tell us about your startup</h2>
+          <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
+            This helps us understand your business, audience, and what makes you unique.
+          </p>
+
+          <div className="mt-8 grid gap-4 lg:grid-cols-2">
+            <FormField label="Company name" help="This will be used as the author for your articles.">
+              <div className="relative">
+                <ControlIcon icon={Building2} />
+                <input
+                  name="companyName"
+                  value={startupValues.companyName}
+                  onChange={(event) => updateValue("companyName", event.target.value)}
+                  disabled={researchLocked}
+                  required
+                  autoComplete="organization"
+                  placeholder="Acme AI"
+                  className={inputWithIconClass}
+                />
+              </div>
+            </FormField>
+
+            <FormField label="Website domain" help="Connect this company to its website and article system.">
+              <div className="relative">
+                <ControlIcon icon={Globe2} />
+                <input
+                  name="domain"
+                  value={startupValues.domain}
+                  onChange={(event) => updateValue("domain", event.target.value)}
+                  disabled={researchLocked}
+                  required
+                  autoComplete="url"
+                  placeholder="example.com"
+                  className={inputWithIconClass}
+                />
+              </div>
+            </FormField>
+          </div>
+
+          <div className="mt-7 space-y-3 rounded-2xl border border-violet-200 bg-gradient-to-br from-violet-50 via-white to-indigo-50 p-5 shadow-sm shadow-violet-100/60">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-black text-gray-950">Fill in with AI</p>
+                <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+                  Use the website and public company info to fill the profile fields below.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={startAutofill}
+                disabled={!canStartAutofill}
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-700 px-5 py-3 text-sm font-black text-white shadow-lg shadow-violet-200 transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {autofillPending || autofillPolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                {autofillPending || autofillPolling ? "Generating..." : "Generate with AI"}
+              </button>
+            </div>
+            {!canStartAutofill && !autofillPending && !autofillPolling ? (
+              <p className="text-xs font-bold text-gray-500">Add a company name and website domain before generating with AI.</p>
+            ) : null}
+            {autofillStartData?.error && !autofillStartData?.autofillRunId ? (
+              <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">{autofillStartData.error}</div>
+            ) : null}
+            <ProfileResearchProgressCard
+              run={autofillRun}
+              runId={autofillRunId}
+              pending={autofillPending}
+              startStatus={autofillStartStatus}
+              startError={autofillStartError}
+              stalled={autofillStalled}
+              unavailable={autofillUnavailable}
+              onRetry={startAutofill}
+              retryDisabled={!canRetryAutofill}
+            />
+          </div>
+
+          <div className={clsx("mt-8 rounded-2xl border border-gray-200 bg-white p-5", researchLocked && "bg-gray-50/80")}>
+            <div className="grid gap-5 lg:grid-cols-2">
+              <FormField label="Short description" help="In 1-2 sentences, what does your startup do?">
+                <textarea
+                  name="shortDescription"
+                  value={startupValues.shortDescription}
+                  onChange={(event) => updateValue("shortDescription", event.target.value)}
+                  disabled={researchLocked}
+                  placeholder="e.g. We help SaaS companies automate customer onboarding..."
+                  rows={5}
+                  maxLength={600}
+                  className={textareaClass}
+                />
+              </FormField>
+
+              <FormField label="What problem do you solve?" help="What's the main problem you help your customers solve?">
+                <textarea
+                  name="problemSolved"
+                  value={startupValues.problemSolved}
+                  onChange={(event) => updateValue("problemSolved", event.target.value)}
+                  disabled={researchLocked}
+                  placeholder="e.g. SaaS teams waste time on manual processes..."
+                  rows={5}
+                  maxLength={400}
+                  className={textareaClass}
+                />
+              </FormField>
+
+              <FormField label="Who is your target audience?" help="Who do you serve?">
+                <div className="relative">
+                  <ControlIcon icon={Users} />
+                  <input
+                    name="targetAudience"
+                    value={startupValues.targetAudience}
+                    onChange={(event) => updateValue("targetAudience", event.target.value)}
+                    disabled={researchLocked}
+                    placeholder="e.g. SaaS founders, marketing teams, eCommerce brands"
+                    className={inputWithIconClass}
+                  />
+                </div>
+              </FormField>
+            </div>
+          </div>
+
+          <details className="mt-8 rounded-2xl border border-gray-200 bg-gray-50/70 p-5" open={Boolean(startupValues.companyLinkedInUrl || startupValues.location || startupValues.abn || startupValues.founderNames || startupValues.stage || startupValues.organizationKind)}>
+            <summary className="cursor-pointer text-sm font-black text-gray-950">Advanced startup details</summary>
+            <div className="mt-5 grid gap-5 lg:grid-cols-2">
+              <FormField label="Company LinkedIn URL">
+                <div className="relative">
+                  <ControlIcon icon={Link2} />
+                  <input
+                    name="companyLinkedInUrl"
+                    value={startupValues.companyLinkedInUrl}
+                    onChange={(event) => updateValue("companyLinkedInUrl", event.target.value)}
+                    disabled={researchLocked}
+                    placeholder="https://www.linkedin.com/company/acme"
+                    className={inputWithIconClass}
+                  />
+                </div>
+              </FormField>
+              <FormField label="Startup location">
+                <div className="relative">
+                  <ControlIcon icon={MapPin} />
+                  <input
+                    name="location"
+                    value={startupValues.location}
+                    onChange={(event) => updateValue("location", event.target.value)}
+                    disabled={researchLocked}
+                    placeholder="Melbourne, Australia"
+                    className={inputWithIconClass}
+                  />
+                </div>
+              </FormField>
+              <FormField label="ABN">
+                <div className="relative">
+                  <ControlIcon icon={BadgeInfo} />
+                  <input
+                    name="abn"
+                    value={startupValues.abn}
+                    onChange={(event) => updateValue("abn", event.target.value)}
+                    disabled={researchLocked}
+                    placeholder="Search ABN or business name"
+                    className={inputWithIconClass}
+                  />
+                </div>
+              </FormField>
+              <FormField label="Founder names">
+                <input
+                  name="founderNames"
+                  value={startupValues.founderNames}
+                  onChange={(event) => updateValue("founderNames", event.target.value)}
+                  disabled={researchLocked}
+                  placeholder="Sam Donegan, Alex Founder"
+                  className={`${inputClass} px-4`}
+                />
+              </FormField>
+              <FormField label="Stage">
+                <select
+                  name="stage"
+                  value={startupValues.stage}
+                  onChange={(event) => updateValue("stage", event.target.value)}
+                  disabled={researchLocked}
+                  className={`${inputClass} px-4`}
+                >
+                  {STARTUP_STAGE_OPTIONS.map((option) => (
+                    <option key={option || "blank"} value={option}>
+                      {option || "Select stage"}
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+              <FormField label="Organization type">
+                <select
+                  name="organizationKind"
+                  value={startupValues.organizationKind}
+                  onChange={(event) => updateValue("organizationKind", event.target.value)}
+                  disabled={researchLocked}
+                  className={`${inputClass} px-4`}
+                >
+                  {ORGANIZATION_KIND_OPTIONS.map((option) => (
+                    <option key={option || "blank"} value={option}>
+                      {option || "Select type"}
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+            </div>
+          </details>
+        </div>
+
+        <aside className="self-start rounded-2xl border border-gray-200 bg-white p-6">
+          <h3 className="flex items-center gap-2 text-sm font-black text-gray-950">
+            Why we ask this <CheckCircle2 className="h-4 w-4 text-gray-400" />
+          </h3>
+          <p className="mt-5 text-sm font-semibold leading-7 text-gray-600">
+            The more details you provide, the better we can research and write high-performing articles that rank and convert.
+          </p>
+          <p className="mt-7 text-sm font-black text-gray-950">Tips</p>
+          <ul className="mt-4 space-y-4 text-sm font-semibold text-gray-600">
+            {["Be specific about what you do", "Focus on the value you deliver", "Think about your ideal customer", "You can always update this later"].map((tip) => (
+              <li key={tip} className="flex gap-3">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-violet-600" />
+                <span>{tip}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-7 space-y-6 border-t border-gray-100 pt-6">
+            <FormField label="Seed keywords" help="Optional starting keywords, separated by commas.">
+              <div className="relative">
+                <ControlIcon icon={Tags} />
+                <textarea
+                  name="seedKeywords"
+                  value={startupValues.seedKeywords}
+                  onChange={(event) => updateValue("seedKeywords", event.target.value)}
+                  disabled={researchLocked}
+                  rows={4}
+                  placeholder="onboarding automation, product analytics"
+                  className={textareaWithIconClass}
+                />
+              </div>
+            </FormField>
+
+            <FormField label="Competitors" help="One competitor domain or company per line.">
+              <div className="relative">
+                <ControlIcon icon={Users} />
+                <textarea
+                  name="competitors"
+                  value={startupValues.competitors}
+                  onChange={(event) => updateValue("competitors", event.target.value)}
+                  disabled={researchLocked}
+                  rows={5}
+                  placeholder="competitor.com&#10;another competitor"
+                  className={textareaWithIconClass}
+                />
+              </div>
+            </FormField>
+          </div>
+        </aside>
+      </div>
+
+      <section
+        ref={baselineRef}
+        className={clsx(
+          "border-t border-gray-100 bg-white py-8",
+          embedded ? "" : "px-6 lg:px-8",
+          focusSection === "baseline" && "scroll-mt-6",
+        )}
+      >
+        <div>
+          <p className="text-sm font-black text-violet-700">Optional baseline</p>
+          <h2 className="mt-3 text-2xl font-black tracking-normal text-gray-950">Measure where the website starts</h2>
+          <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
+            Connect Google Search Console first if you want search traffic included. Then generate a baseline snapshot for technical health, SEO,
+            authority, AI visibility, and traffic before the first article goes live.
+          </p>
+        </div>
+
+        <div className="mt-7 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
+            <div className="flex items-start gap-3">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">1</span>
+              <div className="min-w-0">
+                <p className="text-sm font-black text-gray-950">Connect Google Search Console</p>
+                <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+                  Optional. Connect it to include clicks, impressions, and search query data in the baseline.
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              {hasGoogleBaselineScopes ? (
+                <>
+                  <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-black text-emerald-700">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    Search Console connected
+                  </span>
+                  <button
+                    type="button"
+                    onClick={refreshGoogleBaseline}
+                    disabled={!canRefreshGoogleBaseline}
+                    className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {googleBaselinePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <GoogleIcon />}
+                    {trafficStatus === "measured" ? "Refresh Search Console" : "Load Search Console"}
+                  </button>
+                </>
+              ) : bootstrap.googleBaselineConnection?.connectUrl ? (
+                <a
+                  href={bootstrap.googleBaselineConnection.connectUrl}
+                  className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50"
+                >
+                  <GoogleIcon />
+                  Connect Google Search Console
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              ) : (
+                <span className="rounded-full bg-white px-3 py-1.5 text-xs font-black text-gray-500 ring-1 ring-gray-200">
+                  Search Console can be skipped
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
+            <div className="flex items-start gap-3">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">2</span>
+              <div className="min-w-0">
+                <p className="text-sm font-black text-gray-950">Generate baseline snapshot</p>
+                <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+                  This can run without Search Console. Use it to compare future article growth against today&apos;s website state.
+                </p>
+                <p className="mt-3 text-sm font-black text-gray-950">{effectiveBaseline.domain || startupValues.domain || "No domain saved yet"}</p>
+                <p className="mt-1 text-sm font-semibold text-gray-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
+                {effectiveBaseline.collectedAt ? (
+                  <p className="mt-1 text-xs font-semibold text-gray-500">
+                    Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
+                    {effectiveBaseline.stale ? " · stale" : ""}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={startBaseline}
+                disabled={!canStartBaseline}
+                className="inline-flex items-center gap-2 rounded-xl bg-violet-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <BarChart3 className="h-4 w-4" />}
+                {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Generate baseline" : "Rerun baseline"}
+              </button>
+              <button
+                type="button"
+                onClick={skipBaseline}
+                disabled={skipBaselinePending}
+                className="inline-flex items-center gap-2 rounded-xl border border-transparent bg-transparent px-4 py-2.5 text-sm font-black text-gray-600 transition hover:bg-white disabled:opacity-50"
+              >
+                Skip for now
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {baselineStartData?.error || googleBaselineFetcher.data?.error || skipBaselineFetcher.data?.error ? (
+          <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+            {baselineStartData?.error ?? googleBaselineFetcher.data?.error ?? skipBaselineFetcher.data?.error}
+          </div>
+        ) : null}
+
+        {baselineRunId ? (
+          <div className="mt-4 rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-sm text-violet-900">
+            <div className="flex items-center gap-2 font-black">
+              {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+              <span>
+                {baselineRun?.status === "completed"
+                  ? "Baseline ready"
+                  : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
+                    ? "Baseline needs attention"
+                    : "Collecting baseline"}
+              </span>
+            </div>
+            {baselineRun?.errors?.length ? <p className="mt-2 font-semibold text-rose-700">{baselineRun.errors[0]}</p> : null}
+          </div>
+        ) : null}
+
+        <div className="mt-5 grid gap-3 rounded-2xl border border-gray-100 bg-gray-50/50 p-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-xl border border-gray-200 bg-white p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm font-black text-gray-950">Overall</p>
+              <SourceStatusBadge status={effectiveBaseline.status === "completed" ? "measured" : effectiveBaseline.status} />
+            </div>
+            <p className="mt-3 text-3xl font-black text-gray-950">
+              {typeof effectiveBaseline.overallScore === "number" ? effectiveBaseline.overallScore : "-"}
+            </p>
+          </div>
+          <BaselineMetricCard label="Technical health" metric={baselineMetrics.technicalHealth} />
+          <BaselineMetricCard label="Lighthouse" metric={baselineMetrics.lighthouse} />
+          <BaselineMetricCard label="Organic search" metric={baselineMetrics.organicSearch} />
+          <BaselineMetricCard label="AI visibility" metric={baselineMetrics.aiVisibility} />
+          <BaselineMetricCard label="Authority" metric={baselineMetrics.authority} />
+          <BaselineMetricCard label="Traffic/users" metric={trafficMetric} />
+          {searchConsole?.status === "measured" && searchConsoleSummary ? (
+            <div className="rounded-xl border border-gray-200 bg-white p-4">
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-sm font-black text-gray-950">Search Console</p>
+                <GoogleIcon />
+              </div>
+              <p className="mt-3 text-2xl font-black text-gray-950">
+                {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.clicks) ?? 0))}
+              </p>
+              <p className="mt-1 text-xs font-semibold text-gray-500">
+                clicks from {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.impressions) ?? 0))} impressions
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        {effectiveBaseline.recommendations?.length ? (
+          <div className="mt-5 rounded-xl border border-gray-100 bg-white p-4">
+            <p className="text-sm font-black text-gray-950">Recommended fixes</p>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              {effectiveBaseline.recommendations.slice(0, 4).map((recommendation, index) => (
+                <div key={`${recommendation.title ?? recommendation.source ?? index}`} className="rounded-xl bg-gray-50 px-4 py-3">
+                  <p className="text-sm font-black text-gray-950">{String(recommendation.title ?? "Review baseline recommendation")}</p>
+                  {recommendation.detail ? <p className="mt-1 text-xs font-semibold text-gray-600">{String(recommendation.detail)}</p> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <div className={clsx("flex flex-col gap-4 border-t border-gray-100 bg-gray-50/70 py-5 sm:flex-row sm:items-center sm:justify-between", embedded ? "" : "px-6 lg:px-8")}>
+        <p className="flex items-center gap-3 text-sm font-bold text-gray-500">
+          <ShieldCheck className="h-5 w-5 text-gray-400" />
+          Your data is secure and never shared.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          {embedded && focusSection === "baseline" ? (
+            <Link
+              to="/founder-tools/marketing/create?step=github"
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+            >
+              Continue to GitHub
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          ) : null}
+          {!embedded ? (
+            <button
+              type="submit"
+              name="nextAction"
+              value="save-exit"
+              disabled={isSubmitting || researchLocked}
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Save className="h-4 w-4" />
+              Save and exit
+            </button>
+          ) : null}
+          <button
+            type="submit"
+            name="nextAction"
+            value="continue"
+            disabled={isSubmitting || researchLocked}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+            {embedded ? (focusSection === "baseline" ? "Save startup profile" : "Save and continue") : "Continue to website"}
+          </button>
+        </div>
+      </div>
+    </Form>
+  );
+
+  if (embedded) return form;
+
+  return (
+    <div className="mx-auto max-w-[1580px] px-4 py-8 sm:px-6 lg:px-10">
+      <Link to="/founder-tools/updates" className="inline-flex items-center gap-2 text-xs font-bold text-violet-300">
+        <ArrowRight className="h-3.5 w-3.5 rotate-180" />
+        Back to home
+      </Link>
+
+      <div className="mt-8 grid gap-8 2xl:grid-cols-[minmax(0,0.85fr)_minmax(520px,1.15fr)] 2xl:items-start">
+        <div>
+          <h1 className="max-w-xl text-4xl font-black leading-tight tracking-normal text-gray-950 sm:text-5xl">
+            Let&apos;s create your{" "}
+            <span className="bg-gradient-to-r from-violet-700 to-blue-500 bg-clip-text text-transparent">
+              first SEO article
+            </span>{" "}
+            <Rocket className="inline h-9 w-9 translate-y-1 text-orange-500" />
+          </h1>
+          <p className="mt-5 max-w-xl text-lg font-semibold leading-8 text-gray-600">
+            We just need a bit of info about your startup and website to get started.
+          </p>
+        </div>
+
+        <FirstArticleProgressPanel />
+      </div>
+
+      {form}
+    </div>
+  );
+}

--- a/app/lib/vibe-marketing-startup-setup.ts
+++ b/app/lib/vibe-marketing-startup-setup.ts
@@ -1,0 +1,100 @@
+import type { VibeMarketingBootstrap } from "~/types/vibe-marketing";
+
+export const STARTUP_STAGE_OPTIONS = [
+  "",
+  "Idea",
+  "Pre-seed",
+  "Seed",
+  "Series A",
+  "Series B",
+  "Series C+",
+  "Growth",
+  "Bootstrapped",
+  "Not fundraising",
+  "Other",
+];
+
+export const ORGANIZATION_KIND_OPTIONS = ["", "For-profit", "Not-for-profit"];
+
+export type StartupSetupField =
+  | "companyName"
+  | "domain"
+  | "companyLinkedInUrl"
+  | "location"
+  | "abn"
+  | "shortDescription"
+  | "problemSolved"
+  | "targetAudience"
+  | "competitors"
+  | "seedKeywords"
+  | "founderNames"
+  | "stage"
+  | "organizationKind";
+
+export type StartupSetupValues = Record<StartupSetupField, string>;
+
+export function combineCompanyContext({
+  shortDescription,
+  problemSolved,
+  targetAudience,
+}: {
+  shortDescription: string;
+  problemSolved: string;
+  targetAudience: string;
+}) {
+  return [
+    shortDescription,
+    problemSolved ? `Problem solved: ${problemSolved}` : "",
+    targetAudience ? `Target audience: ${targetAudience}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+export function splitCompanyContext(context: string | null | undefined, fallbackTargetAudience: string | null | undefined) {
+  const raw = String(context ?? "").trim();
+  if (!raw) {
+    return { shortDescription: "", problemSolved: "", targetAudience: String(fallbackTargetAudience ?? "").trim() };
+  }
+
+  const problemMatch = raw.match(/(?:^|\n+)Problem solved:\s*([\s\S]*?)(?=\n+Target audience:|$)/i);
+  const audienceMatch = raw.match(/(?:^|\n+)Target audience:\s*([\s\S]*?)$/i);
+  const shortDescription = raw
+    .replace(/(?:^|\n+)Problem solved:\s*[\s\S]*?(?=\n+Target audience:|$)/i, "")
+    .replace(/(?:^|\n+)Target audience:\s*[\s\S]*$/i, "")
+    .trim();
+
+  return {
+    shortDescription: shortDescription || raw,
+    problemSolved: problemMatch?.[1]?.trim() ?? "",
+    targetAudience: audienceMatch?.[1]?.trim() || String(fallbackTargetAudience ?? "").trim(),
+  };
+}
+
+export function startupSetupDefaultsFromBootstrap(bootstrap: VibeMarketingBootstrap): StartupSetupValues {
+  const splitContext = splitCompanyContext(bootstrap.settings.companyContext, bootstrap.startupProfile.notes);
+  const companyName = bootstrap.company.name === "Company" ? "" : bootstrap.company.name ?? "";
+  return {
+    companyName,
+    domain: bootstrap.company.domain ?? bootstrap.organization.domain ?? "",
+    companyLinkedInUrl: bootstrap.organization.companyLinkedInUrl ?? bootstrap.company.companyLinkedInUrl ?? "",
+    location: bootstrap.company.location ?? "",
+    abn: bootstrap.company.abn ?? "",
+    shortDescription: splitContext.shortDescription,
+    problemSolved: splitContext.problemSolved,
+    targetAudience: splitContext.targetAudience,
+    competitors: (bootstrap.organization.competitors ?? []).join("\n"),
+    seedKeywords: (bootstrap.organization.seedKeywords ?? []).join(", "),
+    founderNames: (bootstrap.startupProfile.founderNames ?? []).join(", "),
+    stage: bootstrap.startupProfile.stage ?? "",
+    organizationKind: bootstrap.startupProfile.organizationKind ?? "",
+  };
+}
+
+export function companyContextFromSetup(values: StartupSetupValues) {
+  return combineCompanyContext({
+    shortDescription: values.shortDescription,
+    problemSolved: values.problemSolved,
+    targetAudience: values.targetAudience,
+  });
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,28 +1,24 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useNavigation } from "react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Form, Link, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
+import { useEffect, useMemo, useState } from "react";
 import {
+  ArrowLeftIcon,
   ArrowPathIcon,
   ArrowRightIcon,
-  ChartBarIcon,
   CheckCircleIcon,
   CodeBracketIcon,
-  GlobeAltIcon,
   MagnifyingGlassIcon,
   PlayIcon,
   RocketLaunchIcon,
-  SparklesIcon,
 } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 
-import FounderStartupDetailsStep, {
-  type StartupDetailsField,
-  type StartupDetailsFormValues,
-} from "~/components/FounderStartupDetailsStep";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { CustomTopicDecisionCard, TopicDecisionCard } from "~/components/TopicDecisionCard";
+import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { type VibeMarketingStepKey } from "~/components/VibeMarketingStepper";
 import { getEnv } from "~/lib/env.server";
+import { combineCompanyContext as combineStartupCompanyContext } from "~/lib/vibe-marketing-startup-setup";
 import {
   connectVibeMarketingGithub,
   getVibeMarketingBootstrap,
@@ -36,14 +32,7 @@ import {
   startVibeMarketingDiscovery,
   startVibeMarketingScan,
 } from "~/lib/vibe-marketing";
-import type {
-  VibeMarketingAutofillCompetitor,
-  VibeMarketingAutofillResult,
-  VibeMarketingBootstrap,
-  VibeMarketingRunSummary,
-  VibeMarketingWebsiteBaseline,
-  VibeMarketingWebsiteBaselineMetric,
-} from "~/types/vibe-marketing";
+import type { VibeMarketingBootstrap } from "~/types/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
@@ -192,7 +181,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const bootstrap = await getVibeMarketingBootstrap(env, request);
   const url = new URL(request.url);
   const activeStep = resolveActiveStep(url.searchParams.get("step"), bootstrap);
-  return { bootstrap, activeStep, shouldRefreshGoogleBaseline: url.searchParams.get("googleBaseline") === "refresh" };
+  const requestedStep = normalizeStep(url.searchParams.get("step"), activeStep);
+  return { bootstrap, activeStep, requestedStep, shouldRefreshGoogleBaseline: url.searchParams.get("googleBaseline") === "refresh" };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -204,6 +194,13 @@ export async function action({ request, context }: Route.ActionArgs) {
 
   try {
     if (intent === "save-startup-details") {
+      const companyContext =
+        stringFromForm(formData, "companyContext") ||
+        combineStartupCompanyContext({
+          shortDescription: stringFromForm(formData, "shortDescription"),
+          problemSolved: stringFromForm(formData, "problemSolved"),
+          targetAudience: stringFromForm(formData, "targetAudience"),
+        });
       const companyId = await saveVibeRaisingCompany(env, request, {
         companyId: activeCompany?.id ?? null,
         name: stringFromForm(formData, "companyName"),
@@ -211,12 +208,13 @@ export async function action({ request, context }: Route.ActionArgs) {
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
         location: stringFromForm(formData, "location"),
         abn: stringFromForm(formData, "abn"),
-        companyContext: stringFromForm(formData, "companyContext"),
+        companyContext,
         competitors: listFromForm(formData.get("competitors")),
         seedKeywords: listFromForm(formData.get("seedKeywords")),
         founderNames: listFromForm(formData.get("founderNames")),
         stage: stringFromForm(formData, "stage"),
         organizationKind: stringFromForm(formData, "organizationKind"),
+        notes: stringFromForm(formData, "targetAudience"),
         registered: true,
       });
       if (companyId) {
@@ -226,6 +224,13 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-autofill") {
+      const companyContext =
+        stringFromForm(formData, "companyContext") ||
+        combineStartupCompanyContext({
+          shortDescription: stringFromForm(formData, "shortDescription"),
+          problemSolved: stringFromForm(formData, "problemSolved"),
+          targetAudience: stringFromForm(formData, "targetAudience"),
+        });
       const result = await startVibeMarketingAutofill(env, request, {
         companyName: stringFromForm(formData, "companyName"),
         company_name: stringFromForm(formData, "companyName"),
@@ -237,21 +242,21 @@ export async function action({ request, context }: Route.ActionArgs) {
         organizationKind: stringFromForm(formData, "organizationKind"),
         organization_kind: stringFromForm(formData, "organizationKind"),
         existingFields: {
-          companyContext: stringFromForm(formData, "companyContext"),
+          companyContext,
           competitors: listFromForm(formData.get("competitors")),
           seedKeywords: listFromForm(formData.get("seedKeywords")),
           companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
         },
-        companyContext: stringFromForm(formData, "companyContext"),
+        companyContext,
         competitors: listFromForm(formData.get("competitors")),
         seedKeywords: listFromForm(formData.get("seedKeywords")),
       });
-      return { autofillRunId: result.runId, status: result.status };
+      return { intent, autofillRunId: result.runId, status: result.status, error: result.error, errors: result.errors };
     }
 
     if (intent === "start-baseline") {
       const result = await startVibeMarketingBaseline(env, request, {});
-      return { baselineRunId: result.runId, status: result.status };
+      return { intent, baselineRunId: result.runId, status: result.status, error: result.error };
     }
 
     if (intent === "refresh-baseline-google") {
@@ -449,882 +454,8 @@ function PanelHeader({
   );
 }
 
-function startupDefaultsFromBootstrap(bootstrap: VibeMarketingBootstrap): StartupDetailsFormValues {
-  return {
-    companyName: bootstrap.company.name ?? "",
-    domain: bootstrap.company.domain ?? bootstrap.organization.domain ?? "",
-    companyLinkedInUrl: bootstrap.organization.companyLinkedInUrl ?? bootstrap.company.companyLinkedInUrl ?? "",
-    location: bootstrap.company.location ?? "",
-    abn: bootstrap.company.abn ?? "",
-    brandName: bootstrap.settings.brandName ?? bootstrap.organization.name ?? bootstrap.company.name ?? "",
-    companyContext: bootstrap.settings.companyContext ?? "",
-    competitors: (bootstrap.organization.competitors ?? []).join("\n"),
-    seedKeywords: (bootstrap.organization.seedKeywords ?? []).join("\n"),
-    founderNames: (bootstrap.startupProfile.founderNames ?? []).join(", "),
-    stage: bootstrap.startupProfile.stage ?? "",
-    organizationKind: bootstrap.startupProfile.organizationKind ?? "",
-    notes: bootstrap.startupProfile.notes ?? "",
-  };
-}
-
-function isBlank(value: string | null | undefined) {
-  return !String(value ?? "").trim();
-}
-
-function startupValuesAreEqual(left: StartupDetailsFormValues | null | undefined, right: StartupDetailsFormValues | null | undefined) {
-  if (!left || !right) return false;
-  return (Object.keys(left) as StartupDetailsField[]).every((field) => String(left[field] ?? "") === String(right[field] ?? ""));
-}
-
-function listTextIsBlank(value: string | null | undefined) {
-  return listFromForm(String(value ?? "")).length === 0;
-}
-
-function stringList(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.map((item) => String(item ?? "").trim()).filter(Boolean);
-}
-
-function numericValue(value: unknown): number | undefined {
-  const numberValue = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(numberValue) ? numberValue : undefined;
-}
-
-function competitorSuggestion(value: unknown): VibeMarketingAutofillCompetitor | null {
-  if (!value || typeof value !== "object") return null;
-  const payload = value as Record<string, unknown>;
-  const name = String(payload.name ?? payload.company ?? payload.title ?? "").trim();
-  const domain = String(payload.domain ?? "").trim();
-  if (!name && !domain) return null;
-  const rawScore = typeof payload.score === "number" ? payload.score : Number(payload.score);
-  return {
-    name: name || domain,
-    domain,
-    linkedinUrl: payload.linkedinUrl ? String(payload.linkedinUrl) : payload.linkedin_url ? String(payload.linkedin_url) : undefined,
-    type: payload.type ? String(payload.type) : undefined,
-    score: Number.isFinite(rawScore) ? rawScore : undefined,
-    reason: payload.reason ? String(payload.reason) : undefined,
-    source: payload.source ? String(payload.source) : undefined,
-    evidence: Array.isArray(payload.evidence) ? payload.evidence.map(String).filter(Boolean) : undefined,
-    confidence: payload.confidence ? String(payload.confidence) : undefined,
-  };
-}
-
-function isCompetitorSuggestion(value: VibeMarketingAutofillCompetitor | null): value is VibeMarketingAutofillCompetitor {
-  return Boolean(value);
-}
-
-function competitorText(value: unknown): string {
-  if (typeof value === "string") return value.trim();
-  const suggestion = competitorSuggestion(value);
-  return suggestion?.domain || suggestion?.name || "";
-}
-
-function keywordGroups(value: unknown) {
-  if (!Array.isArray(value)) return [];
-  return value
-    .filter((group): group is Record<string, unknown> => Boolean(group && typeof group === "object"))
-    .map((group) => ({
-      group: group.group ? String(group.group) : group.name ? String(group.name) : undefined,
-      intent: group.intent ? String(group.intent) : undefined,
-      keywords: stringList(group.keywords),
-    }))
-    .filter((group) => group.keywords.length);
-}
-
-function competitorList(value: unknown): VibeMarketingAutofillCompetitor[] {
-  if (!Array.isArray(value)) return [];
-  return value.map(competitorSuggestion).filter(isCompetitorSuggestion);
-}
-
-function researchDepth(value: unknown): Record<string, number> | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const result: Record<string, number> = {};
-  for (const [key, rawValue] of Object.entries(value as Record<string, unknown>)) {
-    const numberValue = numericValue(rawValue);
-    if (typeof numberValue === "number") result[key] = numberValue;
-  }
-  return Object.keys(result).length ? result : undefined;
-}
-
-function autofillSources(value: unknown) {
-  if (!Array.isArray(value)) return [];
-  return value
-    .filter((source): source is Record<string, unknown> => Boolean(source && typeof source === "object"))
-    .map((source) => ({
-      url: String(source.url ?? ""),
-      title: source.title ? String(source.title) : undefined,
-      type: source.type ? String(source.type) : undefined,
-      query: source.query ? String(source.query) : undefined,
-      description: source.description ? String(source.description) : undefined,
-      source: source.source ? String(source.source) : undefined,
-    }))
-    .filter((source) => source.url);
-}
-
-function minimumsMet(value: unknown): Record<string, boolean> | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const result: Record<string, boolean> = {};
-  for (const [key, rawValue] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof rawValue === "boolean") result[key] = rawValue;
-  }
-  return Object.keys(result).length ? result : undefined;
-}
-
-function plainObject(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
-}
-
-function objectArray(value: unknown): Record<string, unknown>[] | undefined {
-  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === "object" && !Array.isArray(item))) : undefined;
-}
-
-function extractAutofill(run: VibeMarketingRunSummary | null | undefined): VibeMarketingAutofillResult | null {
-  const raw = run?.result?.autofill;
-  if (!raw || typeof raw !== "object") return null;
-  const payload = raw as Record<string, unknown>;
-  const competitorGroupsPayload = payload.competitorGroups && typeof payload.competitorGroups === "object" ? (payload.competitorGroups as Record<string, unknown>) : {};
-  const directCompetitors = competitorList(payload.directCompetitors ?? payload.direct_competitors ?? competitorGroupsPayload.directCompetitors);
-  const seoCompetitors = competitorList(payload.seoCompetitors ?? payload.seo_competitors ?? competitorGroupsPayload.seoCompetitors);
-  const adjacentOrganizations = competitorList(payload.adjacentOrganizations ?? payload.adjacent_organizations ?? competitorGroupsPayload.adjacentOrganizations);
-  const competitorCandidates = Array.isArray(payload.competitors)
-    ? payload.competitors
-    : Array.isArray(payload.competitorCandidates)
-      ? payload.competitorCandidates
-      : [];
-  const competitorSuggestions = [
-    ...directCompetitors,
-    ...seoCompetitors,
-    ...adjacentOrganizations,
-    ...competitorCandidates.map(competitorSuggestion).filter(isCompetitorSuggestion),
-  ];
-  const competitorStrings = [
-    ...directCompetitors.map((competitor) => competitor.domain || competitor.name),
-    ...competitorCandidates.map(competitorText),
-    ...stringList(payload.competitorDomains),
-    ...stringList(payload.competitorStrings),
-  ].filter(Boolean);
-  const seenCompetitors = new Set<string>();
-  const competitors = competitorStrings.filter((competitor) => {
-    const key = competitor.toLowerCase();
-    if (seenCompetitors.has(key)) return false;
-    seenCompetitors.add(key);
-    return true;
-  });
-  const groups = keywordGroups(payload.keywordGroups ?? payload.keyword_groups);
-  const seedKeywords = [
-    ...stringList(payload.seedKeywords),
-    ...stringList(payload.seed_keywords),
-    ...groups.flatMap((group) => group.keywords),
-  ];
-  const seenKeywords = new Set<string>();
-  return {
-    brandName: typeof payload.brandName === "string" ? payload.brandName : typeof payload.brand_name === "string" ? payload.brand_name : null,
-    companyLinkedInUrl:
-      typeof payload.companyLinkedInUrl === "string"
-        ? payload.companyLinkedInUrl
-        : typeof payload.company_linkedin_url === "string"
-          ? payload.company_linkedin_url
-          : null,
-    companyContext:
-      typeof payload.companyContext === "string"
-        ? payload.companyContext
-        : typeof payload.company_context === "string"
-          ? payload.company_context
-          : null,
-    competitors,
-    competitorSuggestions,
-    directCompetitors,
-    seoCompetitors,
-    adjacentOrganizations,
-    competitorGroups: {
-      directCompetitors,
-      seoCompetitors,
-      adjacentOrganizations,
-    },
-    seedKeywords: seedKeywords.filter((keyword) => {
-      const key = keyword.toLowerCase();
-      if (seenKeywords.has(key)) return false;
-      seenKeywords.add(key);
-      return true;
-    }),
-    keywordGroups: groups,
-    sources: autofillSources(payload.sources),
-    linkedinProfile:
-      payload.linkedinProfile && typeof payload.linkedinProfile === "object"
-        ? {
-            url: String((payload.linkedinProfile as Record<string, unknown>).url ?? ""),
-            title: (payload.linkedinProfile as Record<string, unknown>).title
-              ? String((payload.linkedinProfile as Record<string, unknown>).title)
-              : undefined,
-            description: (payload.linkedinProfile as Record<string, unknown>).description
-              ? String((payload.linkedinProfile as Record<string, unknown>).description)
-              : undefined,
-            vanityName: (payload.linkedinProfile as Record<string, unknown>).vanityName
-              ? String((payload.linkedinProfile as Record<string, unknown>).vanityName)
-              : undefined,
-            blocked: Boolean((payload.linkedinProfile as Record<string, unknown>).blocked),
-          }
-        : undefined,
-    linkedinSimilarSignals: autofillSources(payload.linkedinSimilarSignals ?? payload.linkedin_similar_signals),
-    sourceCount: numericValue(payload.sourceCount ?? payload.source_count),
-    competitorCount: numericValue(payload.competitorCount ?? payload.competitor_count),
-    seedKeywordCount: numericValue(payload.seedKeywordCount ?? payload.seed_keyword_count),
-    researchSummary: typeof payload.researchSummary === "string" ? payload.researchSummary : typeof payload.research_summary === "string" ? payload.research_summary : null,
-    researchDepth: researchDepth(payload.researchDepth ?? payload.research_depth),
-    researchQuality: plainObject(payload.researchQuality ?? payload.research_quality),
-    modelTrace: objectArray(payload.modelTrace ?? payload.model_trace),
-    queryLog: objectArray(payload.queryLog ?? payload.query_log),
-    evidenceMap: plainObject(payload.evidenceMap ?? payload.evidence_map),
-    stepDurations: researchDepth(payload.stepDurations ?? payload.step_durations),
-    minimumsMet: minimumsMet(payload.minimumsMet ?? payload.minimums_met),
-    warnings: Array.isArray(payload.warnings) ? payload.warnings.map(String).filter(Boolean) : [],
-  };
-}
-
-function autofillStepLabel(step?: string | null) {
-  const labels: Record<string, string> = {
-    resolve_company_identity: "Resolving company identity",
-    crawl_owned_web: "Crawling owned website",
-    crawl_website: "Crawling website",
-    scrape_website: "Crawling website",
-    research_public_web: "Researching public web",
-    research_linkedin_public: "Checking public LinkedIn signals",
-    discover_competitor_candidates: "Finding competitor candidates",
-    rank_competitors: "Ranking competitors",
-    generate_keyword_landscape: "Generating keywords",
-    synthesize_company_profile: "Writing company profile",
-    synthesize_company_context: "Writing company context",
-    generate_company_context: "Writing company context",
-    identify_competitors: "Finding competitors",
-    generate_seed_keywords: "Generating keywords",
-    generate_marketing_seeds: "Generating keywords",
-    finalize: "Ready to review",
-  };
-  return step ? labels[step] ?? step.replace(/_/g, " ") : "Researching company profile";
-}
-
-function AutofillStatusCard({
-  run,
-  runId,
-  pending,
-}: {
-  run?: VibeMarketingRunSummary | null;
-  runId?: string | null;
-  pending: boolean;
-}) {
-  if (!runId && !pending) return null;
-  const autofill = extractAutofill(run);
-  const isFailed = run?.status === "failed" || run?.status === "blocked";
-  const label = pending
-    ? "Starting profile research"
-    : run?.status === "completed"
-      ? "Ready to review"
-      : isFailed
-        ? "Research needs attention"
-        : autofillStepLabel(run?.currentStep);
-  const sourceCount = autofill?.sourceCount ?? autofill?.sources?.length ?? 0;
-  const competitorCount = autofill?.competitorCount ?? autofill?.competitorSuggestions?.length ?? autofill?.competitors?.length ?? 0;
-  const seedKeywordCount = autofill?.seedKeywordCount ?? autofill?.seedKeywords?.length ?? 0;
-  const linkedinSimilarCount = autofill?.researchDepth?.linkedinSimilarSignals ?? autofill?.linkedinSimilarSignals?.length ?? 0;
-  const modelTrace = autofill?.modelTrace ?? [];
-  const completedModelTrace = modelTrace.filter((entry) => entry.status === "completed");
-  const lastModel = [...modelTrace].reverse().find((entry) => typeof entry.model === "string")?.model;
-  const quality = autofill?.researchQuality ?? {};
-  const liveResearchAttempted = Boolean(quality.liveResearchAttempted || completedModelTrace.length);
-  const localStub = Boolean(quality.status === "local_stub" || autofill?.warnings?.some((warning) => warning.toLowerCase().includes("local stub")));
-  const completedWithoutTrace = run?.status === "completed" && !localStub && !liveResearchAttempted && sourceCount === 0;
-  return (
-    <div
-      className={clsx(
-        "rounded-xl border px-4 py-3 text-sm",
-        isFailed ? "border-red-200 bg-red-50 text-red-800" : "border-violet-100 bg-violet-50 text-violet-900",
-      )}
-    >
-      <div className="flex items-center gap-2 font-bold">
-        {pending || (!run || ["queued", "running"].includes(run.status)) ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-        <span>{label}</span>
-      </div>
-      {run?.errors?.length ? <p className="mt-2 font-semibold text-red-700">{run.errors[0]}</p> : null}
-      {autofill ? (
-        <div className="mt-2 flex flex-wrap gap-2 text-xs font-bold text-violet-800">
-          <span>{localStub ? "Local stub preview" : liveResearchAttempted ? "Live deep research" : "Research evidence pending"}</span>
-          <span>{sourceCount} sources reviewed</span>
-          <span>{competitorCount} competitors found</span>
-          <span>{seedKeywordCount} seed keywords generated</span>
-          {lastModel ? <span>Model: {String(lastModel)}</span> : null}
-          {linkedinSimilarCount ? <span>{linkedinSimilarCount} LinkedIn similar signals</span> : null}
-        </div>
-      ) : null}
-      {completedWithoutTrace ? (
-        <p className="mt-2 text-xs font-semibold text-amber-700">
-          This run completed without model or source evidence. Check that live content-factory research is connected instead of a fallback path.
-        </p>
-      ) : null}
-      {autofill?.sources?.length ? (
-        <p className="mt-2 text-xs font-semibold text-violet-700">
-          Sources: {autofill.sources.slice(0, 3).map((source) => source.title || source.url).join(", ")}
-        </p>
-      ) : null}
-      {autofill?.warnings?.length ? (
-        <p className="mt-2 text-xs font-semibold text-amber-700">{autofill.warnings[0]}</p>
-      ) : null}
-    </div>
-  );
-}
-
-type AutofillApplyField = "companyContext" | "competitors" | "seedKeywords";
-type AutofillApplyMode = "replace" | "append" | "keep";
-
-function ReviewActionButtons({
-  field,
-  replaceLabel,
-  onApplyField,
-}: {
-  field: AutofillApplyField;
-  replaceLabel: string;
-  onApplyField?: (field: AutofillApplyField, mode: AutofillApplyMode) => void;
-}) {
-  if (!onApplyField) return null;
-  return (
-    <div className="mt-2 flex flex-wrap gap-2">
-      <button type="button" onClick={() => onApplyField(field, "replace")} className="rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-black text-white shadow-sm transition hover:bg-violet-700">
-        {replaceLabel}
-      </button>
-      <button type="button" onClick={() => onApplyField(field, "append")} className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-black text-gray-700 transition hover:bg-gray-50">
-        Append
-      </button>
-      <button type="button" onClick={() => onApplyField(field, "keep")} className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-black text-gray-500 transition hover:bg-gray-50">
-        Keep current
-      </button>
-    </div>
-  );
-}
-
-function AutofillReviewPanel({
-  run,
-  values,
-  autofilledFields,
-  onApplyField,
-}: {
-  run?: VibeMarketingRunSummary | null;
-  values: StartupDetailsFormValues;
-  autofilledFields: StartupDetailsField[];
-  onApplyField?: (field: AutofillApplyField, mode: AutofillApplyMode) => void;
-}) {
-  if (run?.status !== "completed") return null;
-  const autofill = extractAutofill(run);
-  if (!autofill) return null;
-  const preservedFields = [
-    !autofilledFields.includes("companyContext") && !isBlank(values.companyContext) && autofill.companyContext ? "company context" : null,
-    !autofilledFields.includes("competitors") && !listTextIsBlank(values.competitors) && autofill.competitors?.length ? "competitors" : null,
-    !autofilledFields.includes("seedKeywords") && !listTextIsBlank(values.seedKeywords) && autofill.seedKeywords?.length ? "seed keywords" : null,
-  ].filter(Boolean);
-  const competitorSuggestions: VibeMarketingAutofillCompetitor[] = autofill.competitorSuggestions?.length
-    ? autofill.competitorSuggestions
-    : (autofill.competitors ?? []).map((competitor) => ({ name: competitor, domain: competitor }));
-  const directCompetitors = autofill.directCompetitors?.length ? autofill.directCompetitors : competitorSuggestions.filter((competitor) => competitor.type === "direct").slice(0, 8);
-  const seoCompetitors = autofill.seoCompetitors ?? [];
-  const adjacentOrganizations = autofill.adjacentOrganizations ?? [];
-  const sourceCount = autofill.sourceCount ?? autofill.sources?.length ?? 0;
-  const competitorCount = autofill.competitorCount ?? competitorSuggestions.length;
-  const seedKeywordCount = autofill.seedKeywordCount ?? autofill.seedKeywords?.length ?? 0;
-  const depth = autofill.researchDepth ?? {};
-  const modelTrace = autofill.modelTrace ?? [];
-  const lastModel = [...modelTrace].reverse().find((entry) => typeof entry.model === "string")?.model;
-  const completedModelCalls = modelTrace.filter((entry) => entry.status === "completed").length;
-  const quality = autofill.researchQuality ?? {};
-
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4 text-sm">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <p className="font-black text-gray-950">Research suggestions</p>
-          <p className="mt-1 text-gray-600">
-            {sourceCount} sources reviewed, {competitorCount} competitors found, {seedKeywordCount} seed keywords generated.
-          </p>
-          {lastModel ? (
-            <p className="mt-1 text-xs font-bold text-violet-700">
-              {completedModelCalls} GPT research pass{completedModelCalls === 1 ? "" : "es"} completed with {String(lastModel)}.
-            </p>
-          ) : quality.status === "local_stub" ? (
-            <p className="mt-1 text-xs font-bold text-amber-700">Local stub preview: no live crawl, search, or GPT synthesis ran.</p>
-          ) : null}
-        </div>
-      </div>
-      {Object.keys(depth).length ? (
-        <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {[
-            ["Owned pages", depth.ownedPagesCrawled],
-            ["Public sources", depth.publicSourcesReviewed],
-            ["LinkedIn signals", depth.linkedinPublicSignals],
-            ["LinkedIn similar", depth.linkedinSimilarSignals],
-            ["Candidates evaluated", depth.competitorCandidatesEvaluated],
-            ["Keywords", depth.seedKeywordsGenerated],
-          ]
-            .filter(([, value]) => typeof value === "number")
-            .map(([label, value]) => (
-              <div key={String(label)} className="rounded-lg bg-gray-50 px-3 py-2">
-                <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">{label}</p>
-                <p className="mt-1 text-base font-black text-gray-950">{value}</p>
-              </div>
-            ))}
-        </div>
-      ) : null}
-      {autofill.researchSummary ? (
-        <p className="mt-3 rounded-lg bg-violet-50 px-3 py-2 text-xs font-semibold text-violet-800">{autofill.researchSummary}</p>
-      ) : null}
-      {autofill.linkedinProfile?.url || autofill.linkedinSimilarSignals?.length ? (
-        <div className="mt-4 rounded-lg border border-violet-100 bg-violet-50 px-3 py-2">
-          <p className="text-xs font-black uppercase tracking-wide text-violet-500">LinkedIn public signals</p>
-          {autofill.linkedinProfile?.url ? (
-            <p className="mt-1 truncate text-xs font-bold text-violet-900">
-              Profile: {autofill.linkedinProfile.title || autofill.linkedinProfile.url}
-            </p>
-          ) : null}
-          {autofill.linkedinProfile?.description ? (
-            <p className="mt-1 line-clamp-2 text-xs font-semibold text-violet-800">{autofill.linkedinProfile.description}</p>
-          ) : null}
-          {autofill.linkedinSimilarSignals?.length ? (
-            <p className="mt-2 text-xs font-semibold text-violet-800">
-              Similar/co-mention signals: {autofill.linkedinSimilarSignals.slice(0, 4).map((signal) => signal.title || signal.url).join(", ")}
-            </p>
-          ) : null}
-        </div>
-      ) : null}
-      {preservedFields.length ? (
-        <div className="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-xs font-bold text-amber-800">
-          Existing {preservedFields.join(", ")} were kept. Use the actions below to replace, append, or keep each field before saving.
-        </div>
-      ) : null}
-      {!autofilledFields.includes("companyContext") && !isBlank(values.companyContext) && autofill.companyContext ? (
-        <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
-          <p className="text-xs font-black uppercase tracking-wide text-gray-500">Researched company context</p>
-          <p className="mt-1 line-clamp-5 whitespace-pre-line text-sm text-gray-700">{autofill.companyContext}</p>
-          <ReviewActionButtons field="companyContext" replaceLabel="Use researched context" onApplyField={onApplyField} />
-        </div>
-      ) : null}
-      {directCompetitors.length ? (
-        <div className="mt-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs font-black uppercase tracking-wide text-gray-500">Direct competitors</p>
-            {!autofilledFields.includes("competitors") && !listTextIsBlank(values.competitors) ? (
-              <ReviewActionButtons field="competitors" replaceLabel="Use researched list" onApplyField={onApplyField} />
-            ) : null}
-          </div>
-          <div className="mt-2 grid gap-2 sm:grid-cols-2">
-            {directCompetitors.slice(0, 6).map((competitor) => (
-              <div key={`${competitor.domain || competitor.name}`} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
-                <div className="flex items-start justify-between gap-2">
-                  <p className="font-bold text-gray-950">{competitor.name}</p>
-                  {typeof competitor.score === "number" ? <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-black text-emerald-700">{Math.round(competitor.score * 100)}</span> : null}
-                </div>
-                {competitor.domain ? <p className="text-xs font-semibold text-gray-600">{competitor.domain}</p> : null}
-                {competitor.reason ? <p className="mt-1 line-clamp-2 text-xs text-gray-600">{competitor.reason}</p> : null}
-                {competitor.linkedinUrl ? <p className="mt-1 truncate text-[11px] font-semibold text-violet-700">LinkedIn: {competitor.linkedinUrl}</p> : null}
-                {competitor.evidence?.length ? <p className="mt-1 line-clamp-2 text-[11px] font-semibold text-gray-500">Evidence: {competitor.evidence.slice(0, 2).join(" | ")}</p> : null}
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-      {seoCompetitors.length || adjacentOrganizations.length ? (
-        <div className="mt-4 grid gap-3 md:grid-cols-2">
-          {seoCompetitors.length ? (
-            <div>
-              <p className="text-xs font-black uppercase tracking-wide text-gray-500">SEO competitors</p>
-              <div className="mt-2 space-y-2">
-                {seoCompetitors.slice(0, 4).map((competitor) => (
-                  <div key={`${competitor.domain || competitor.name}`} className="rounded-lg bg-gray-50 px-3 py-2">
-                    <p className="text-sm font-bold text-gray-950">{competitor.name}</p>
-                    {competitor.reason ? <p className="mt-1 line-clamp-2 text-xs text-gray-600">{competitor.reason}</p> : null}
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : null}
-          {adjacentOrganizations.length ? (
-            <div>
-              <p className="text-xs font-black uppercase tracking-wide text-gray-500">Adjacent organizations</p>
-              <div className="mt-2 space-y-2">
-                {adjacentOrganizations.slice(0, 4).map((competitor) => (
-                  <div key={`${competitor.domain || competitor.name}`} className="rounded-lg bg-gray-50 px-3 py-2">
-                    <p className="text-sm font-bold text-gray-950">{competitor.name}</p>
-                    {competitor.reason ? <p className="mt-1 line-clamp-2 text-xs text-gray-600">{competitor.reason}</p> : null}
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-      {autofill.seedKeywords?.length ? (
-        <div className="mt-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs font-black uppercase tracking-wide text-gray-500">Seed keywords</p>
-            {!autofilledFields.includes("seedKeywords") && !listTextIsBlank(values.seedKeywords) ? (
-              <ReviewActionButtons field="seedKeywords" replaceLabel="Use researched keywords" onApplyField={onApplyField} />
-            ) : null}
-          </div>
-          {autofill.keywordGroups?.length ? (
-            <div className="mt-2 grid gap-2 md:grid-cols-2">
-              {autofill.keywordGroups.slice(0, 4).map((group) => (
-                <div key={`${group.group ?? "group"}-${group.keywords[0]}`} className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2">
-                  <p className="text-xs font-black text-gray-700">{group.group ?? "Keyword group"}</p>
-                  <p className="mt-1 text-xs font-semibold text-gray-500">{group.keywords.slice(0, 5).join(", ")}</p>
-                </div>
-              ))}
-            </div>
-          ) : null}
-          <div className="mt-2 flex flex-wrap gap-2">
-            {autofill.seedKeywords.slice(0, 20).map((keyword) => (
-              <span key={keyword} className="rounded-full bg-violet-50 px-3 py-1 text-xs font-bold text-violet-800">
-                {keyword}
-              </span>
-            ))}
-          </div>
-        </div>
-      ) : null}
-      {autofill.sources?.length ? (
-        <div className="mt-4">
-          <p className="text-xs font-black uppercase tracking-wide text-gray-500">Evidence</p>
-          <div className="mt-2 space-y-1">
-            {autofill.sources.slice(0, 4).map((source) => (
-              <p key={source.url} className="truncate text-xs font-semibold text-gray-600">
-                {source.type ? `${source.type}: ` : ""}
-                {source.title || source.url}
-              </p>
-            ))}
-          </div>
-        </div>
-      ) : null}
-      {autofill.warnings?.length ? (
-        <div className="mt-4 rounded-lg bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-          {autofill.warnings.slice(0, 2).join(" ")}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function baselineFromRun(run: VibeMarketingRunSummary | null | undefined): VibeMarketingWebsiteBaseline | null {
-  const raw = run?.result?.baseline;
-  if (!raw || typeof raw !== "object") return null;
-  const payload = raw as Record<string, unknown>;
-  return {
-    runId: run?.runId,
-    domain: typeof payload.domain === "string" ? payload.domain : run?.domain,
-    status: typeof payload.status === "string" ? payload.status : run?.status,
-    passed: run?.status === "completed",
-    collectedAt: typeof payload.collectedAt === "string" ? payload.collectedAt : typeof payload.collected_at === "string" ? payload.collected_at : run?.updatedAt,
-    overallScore: typeof payload.overallScore === "number" ? payload.overallScore : typeof payload.overall_score === "number" ? payload.overall_score : null,
-    summary: typeof payload.summary === "string" || (payload.summary && typeof payload.summary === "object") ? (payload.summary as VibeMarketingWebsiteBaseline["summary"]) : null,
-    metrics: payload.metrics && typeof payload.metrics === "object" ? (payload.metrics as VibeMarketingWebsiteBaseline["metrics"]) : {},
-    sourceStatus: payload.sourceStatus && typeof payload.sourceStatus === "object" ? (payload.sourceStatus as Record<string, string>) : {},
-    recommendations: Array.isArray(payload.recommendations) ? (payload.recommendations as Array<Record<string, unknown>>) : [],
-  };
-}
-
-function baselineSummaryText(summary: VibeMarketingWebsiteBaseline["summary"]) {
-  if (typeof summary === "string") return summary;
-  if (summary && typeof summary === "object" && typeof summary.text === "string") return summary.text;
-  return "Run a baseline to capture website performance before generating articles.";
-}
-
-function hasLegacyPageSpeedRateLimitMessage(metric?: VibeMarketingWebsiteBaselineMetric) {
-  const message = typeof metric?.message === "string" ? metric.message : "";
-  return /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message);
-}
-
-function metricStatus(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
-  if (label === "Lighthouse" && (metric?.reasonCode === "rate_limited" || hasLegacyPageSpeedRateLimitMessage(metric))) {
-    return "unavailable";
-  }
-  return metric?.status;
-}
-
-function metricScore(metric: VibeMarketingWebsiteBaselineMetric | undefined, status?: string | null) {
-  return status === "measured" && typeof metric?.score === "number" ? Math.round(metric.score) : null;
-}
-
-function metricMessage(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
-  if (label === "Lighthouse" && (metric?.reasonCode === "rate_limited" || hasLegacyPageSpeedRateLimitMessage(metric))) {
-    return "PageSpeed Insights is temporarily rate limited. Try again later.";
-  }
-  return typeof metric?.message === "string" ? metric.message : null;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
-}
-
-function recordsFrom(value: unknown): Record<string, unknown>[] {
-  return Array.isArray(value)
-    ? value.map(asRecord).filter((item): item is Record<string, unknown> => item !== null)
-    : [];
-}
-
-function recordNumber(record: Record<string, unknown> | null | undefined, key: string) {
-  return numericValue(record?.[key]) ?? 0;
-}
-
-function rowLabel(row: Record<string, unknown>) {
-  const keys = Array.isArray(row.keys) ? row.keys : [];
-  return String(keys[0] ?? row.page ?? row.query ?? row.date ?? "");
-}
-
-function formatInteger(value: unknown) {
-  return new Intl.NumberFormat("en-AU").format(Math.round(numericValue(value) ?? 0));
-}
-
-function formatPercent(value: unknown) {
-  const numberValue = numericValue(value) ?? 0;
-  const percent = Math.abs(numberValue) > 1 ? numberValue : numberValue * 100;
-  return `${percent.toFixed(1)}%`;
-}
-
-function formatPosition(value: unknown) {
-  const numberValue = numericValue(value);
-  return numberValue === undefined ? "—" : numberValue.toFixed(1);
-}
-
-function formatDateLabel(value: string) {
-  if (!value) return "";
-  const parsed = new Date(`${value}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
-function GoogleIcon({ className = "h-4 w-4" }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
-      <path
-        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"
-        fill="#4285F4"
-      />
-      <path
-        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-        fill="#34A853"
-      />
-      <path
-        d="M5.84 14.09A6.6 6.6 0 0 1 5.49 12c0-.73.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.78.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-        fill="#EA4335"
-      />
-    </svg>
-  );
-}
-
-function sourceStatusLabel(status?: string | null) {
-  if (status === "measured") return "Verified";
-  if (status === "needs_connection") return "Needs connection";
-  if (status === "error") return "Error";
-  return "Unavailable";
-}
-
-function SourceStatusBadge({ status }: { status?: string | null }) {
-  return (
-    <span
-      className={clsx(
-        "inline-flex rounded-full px-2 py-0.5 text-[11px] font-black",
-        status === "measured" && "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100",
-        status === "needs_connection" && "bg-amber-50 text-amber-700 ring-1 ring-amber-100",
-        status === "error" && "bg-red-50 text-red-700 ring-1 ring-red-100",
-        !["measured", "needs_connection", "error"].includes(String(status)) && "bg-gray-50 text-gray-600 ring-1 ring-gray-100",
-      )}
-    >
-      {sourceStatusLabel(status)}
-    </span>
-  );
-}
-
-function BaselineMetricCard({
-  label,
-  metric,
-}: {
-  label: string;
-  metric?: VibeMarketingWebsiteBaselineMetric;
-}) {
-  const status = metricStatus(label, metric);
-  const score = metricScore(metric, status);
-  const message = metricMessage(label, metric);
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4">
-      <div className="flex items-start justify-between gap-3">
-        <p className="text-sm font-black text-gray-950">{label}</p>
-        <SourceStatusBadge status={status} />
-      </div>
-      <p className="mt-3 text-2xl font-black text-gray-950">{score === null ? "—" : score}</p>
-      {message ? <p className="mt-2 line-clamp-4 break-words text-xs font-semibold text-gray-500">{message}</p> : null}
-    </div>
-  );
-}
-
-function SearchConsoleTrendChart({ rows }: { rows: Record<string, unknown>[] }) {
-  if (!rows.length) return null;
-  const width = 640;
-  const height = 180;
-  const padding = 18;
-  const clicks = rows.map((row) => recordNumber(row, "clicks"));
-  const impressions = rows.map((row) => recordNumber(row, "impressions"));
-  const clickMax = Math.max(1, ...clicks);
-  const impressionMax = Math.max(1, ...impressions);
-  const points = (values: number[], max: number) =>
-    values
-      .map((value, index) => {
-        const x = padding + (index * (width - padding * 2)) / Math.max(1, values.length - 1);
-        const y = height - padding - (value / max) * (height - padding * 2);
-        return `${x.toFixed(1)},${y.toFixed(1)}`;
-      })
-      .join(" ");
-  const firstLabel = formatDateLabel(rowLabel(rows[0]));
-  const lastLabel = formatDateLabel(rowLabel(rows[rows.length - 1]));
-
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm font-black text-gray-950">Search performance trend</p>
-        <div className="flex flex-wrap items-center gap-3 text-xs font-bold text-gray-500">
-          <span className="inline-flex items-center gap-1.5"><span className="h-2.5 w-2.5 rounded-full bg-[#34A853]" />Clicks</span>
-          <span className="inline-flex items-center gap-1.5"><span className="h-2.5 w-2.5 rounded-full bg-[#4285F4]" />Impressions</span>
-        </div>
-      </div>
-      <div className="mt-3 aspect-[16/5] w-full">
-        <svg viewBox={`0 0 ${width} ${height}`} className="h-full w-full" role="img" aria-label="Search Console clicks and impressions trend">
-          {[0, 1, 2, 3].map((line) => {
-            const y = padding + (line * (height - padding * 2)) / 3;
-            return <line key={line} x1={padding} x2={width - padding} y1={y} y2={y} stroke="#E5E7EB" strokeWidth="1" />;
-          })}
-          <polyline points={points(impressions, impressionMax)} fill="none" stroke="#4285F4" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" />
-          <polyline points={points(clicks, clickMax)} fill="none" stroke="#34A853" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </div>
-      {firstLabel || lastLabel ? (
-        <div className="mt-2 flex justify-between text-xs font-bold text-gray-400">
-          <span>{firstLabel}</span>
-          <span>{lastLabel}</span>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function SearchConsoleRowsTable({
-  title,
-  rows,
-  emptyLabel,
-}: {
-  title: string;
-  rows: Record<string, unknown>[];
-  emptyLabel: string;
-}) {
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4">
-      <p className="text-sm font-black text-gray-950">{title}</p>
-      {rows.length ? (
-        <div className="mt-3 overflow-hidden rounded-lg border border-gray-100">
-          <table className="min-w-full divide-y divide-gray-100 text-left text-xs">
-            <thead className="bg-gray-50 text-[11px] font-black uppercase text-gray-400">
-              <tr>
-                <th className="px-3 py-2">Item</th>
-                <th className="px-3 py-2 text-right">Clicks</th>
-                <th className="px-3 py-2 text-right">Impressions</th>
-                <th className="px-3 py-2 text-right">CTR</th>
-                <th className="px-3 py-2 text-right">Position</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100 bg-white">
-              {rows.slice(0, 6).map((row, index) => (
-                <tr key={`${rowLabel(row)}-${index}`}>
-                  <td className="max-w-[260px] truncate px-3 py-2 font-bold text-gray-700">{rowLabel(row) || "—"}</td>
-                  <td className="px-3 py-2 text-right font-semibold text-gray-600">{formatInteger(row.clicks)}</td>
-                  <td className="px-3 py-2 text-right font-semibold text-gray-600">{formatInteger(row.impressions)}</td>
-                  <td className="px-3 py-2 text-right font-semibold text-gray-600">{formatPercent(row.ctr)}</td>
-                  <td className="px-3 py-2 text-right font-semibold text-gray-600">{formatPosition(row.position)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-500">{emptyLabel}</p>
-      )}
-    </div>
-  );
-}
-
-function SearchConsolePanel({ traffic }: { traffic?: VibeMarketingWebsiteBaselineMetric }) {
-  const searchConsole = asRecord(traffic?.googleSearchConsole);
-  if (!searchConsole || searchConsole.status !== "measured") return null;
-  const summary = asRecord(searchConsole.last28Days) ?? {};
-  const dailyRows = recordsFrom(searchConsole.daily);
-  const topQueries = recordsFrom(searchConsole.topQueries);
-  const topPages = recordsFrom(searchConsole.topPages);
-  const analytics = asRecord(traffic?.googleAnalytics);
-  const analyticsSummary = asRecord(analytics?.last28Days);
-  const hasAnalytics = analytics?.status === "measured" && analyticsSummary;
-
-  return (
-    <div className="space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-base font-black text-gray-950">Google Search Console</p>
-          <p className="text-xs font-semibold text-gray-500">{String(searchConsole.siteUrl ?? "Verified property")}</p>
-        </div>
-        <SourceStatusBadge status="measured" />
-      </div>
-
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <div className="rounded-xl border border-gray-200 bg-white p-4">
-          <p className="text-xs font-black uppercase text-gray-400">Clicks</p>
-          <p className="mt-2 text-2xl font-black text-gray-950">{formatInteger(summary.clicks)}</p>
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-4">
-          <p className="text-xs font-black uppercase text-gray-400">Impressions</p>
-          <p className="mt-2 text-2xl font-black text-gray-950">{formatInteger(summary.impressions)}</p>
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-4">
-          <p className="text-xs font-black uppercase text-gray-400">CTR</p>
-          <p className="mt-2 text-2xl font-black text-gray-950">{formatPercent(summary.ctr)}</p>
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-4">
-          <p className="text-xs font-black uppercase text-gray-400">Avg position</p>
-          <p className="mt-2 text-2xl font-black text-gray-950">{formatPosition(summary.position)}</p>
-        </div>
-      </div>
-
-      <SearchConsoleTrendChart rows={dailyRows} />
-
-      <div className="grid gap-3 xl:grid-cols-2">
-        <SearchConsoleRowsTable title="Top queries" rows={topQueries} emptyLabel="No query rows returned." />
-        <SearchConsoleRowsTable title="Top pages" rows={topPages} emptyLabel="No page rows returned." />
-      </div>
-
-      {hasAnalytics ? (
-        <div className="grid gap-3 sm:grid-cols-3">
-          <div className="rounded-xl border border-gray-200 bg-white p-4">
-            <p className="text-xs font-black uppercase text-gray-400">Active users</p>
-            <p className="mt-2 text-2xl font-black text-gray-950">{formatInteger(analyticsSummary.activeUsers)}</p>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4">
-            <p className="text-xs font-black uppercase text-gray-400">Sessions</p>
-            <p className="mt-2 text-2xl font-black text-gray-950">{formatInteger(analyticsSummary.sessions)}</p>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4">
-            <p className="text-xs font-black uppercase text-gray-400">Engagement</p>
-            <p className="mt-2 text-2xl font-black text-gray-950">{formatPercent(analyticsSummary.engagementRate)}</p>
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 export default function FounderToolsMarketingCreate() {
-  const { bootstrap, activeStep, shouldRefreshGoogleBaseline } = useLoaderData<typeof loader>();
+  const { bootstrap, activeStep, requestedStep, shouldRefreshGoogleBaseline } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const latestActionIntent = actionDataIntent(actionData);
   const latestActionError = actionDataError(actionData);
@@ -1334,32 +465,8 @@ export default function FounderToolsMarketingCreate() {
     latestActionError && latestActionIntent !== "connect-github" && (!actionErrorStep || actionErrorStep === activeStep)
       ? latestActionError
       : null;
-  const autofillStartFetcher = useFetcher<{ autofillRunId?: string | null; status?: string; error?: string }>();
-  const autofillRunFetcher = useFetcher<VibeMarketingRunSummary>();
-  const baselineStartFetcher = useFetcher<{ baselineRunId?: string | null; status?: string; error?: string }>();
-  const baselineRunFetcher = useFetcher<VibeMarketingRunSummary>();
-  const googleBaselineFetcher = useFetcher<{ intent?: string; websiteBaseline?: VibeMarketingWebsiteBaseline; error?: string }>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
-  const startupDefaults = useMemo(() => startupDefaultsFromBootstrap(bootstrap), [bootstrap]);
-  const startupDefaultsSignature = useMemo(() => JSON.stringify(startupDefaults), [startupDefaults]);
-  const activeCompanyKey = String(
-    bootstrap.company.id ||
-      bootstrap.company.organizationId ||
-      bootstrap.organization.id ||
-      bootstrap.organization.domain ||
-      bootstrap.company.domain ||
-      "no-company",
-  );
-  const activeCompanyKeyRef = useRef(activeCompanyKey);
-  const [startupValues, setStartupValues] = useState<StartupDetailsFormValues>(startupDefaults);
-  const [autofillRunId, setAutofillRunId] = useState<string | null>(null);
-  const [autofillRequestSnapshot, setAutofillRequestSnapshot] = useState<StartupDetailsFormValues | null>(null);
-  const [baselineRunId, setBaselineRunId] = useState<string | null>(null);
-  const [googleBaseline, setGoogleBaseline] = useState<VibeMarketingWebsiteBaseline | null>(null);
-  const [appliedAutofillRunId, setAppliedAutofillRunId] = useState<string | null>(null);
-  const [autofilledFields, setAutofilledFields] = useState<StartupDetailsField[]>([]);
-  const googleAutoRefreshSubmittedRef = useRef(false);
   const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
   const latestDiscovery = bootstrap.latestRuns.find((run) => ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(run.workflow));
   const latestArticle = bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article"].includes(run.workflow));
@@ -1395,86 +502,6 @@ export default function FounderToolsMarketingCreate() {
     [selectableTopicCandidates, selectedTopicCandidateId],
   );
   const selectedTopicLabel = selectedTopicCandidate?.title ?? "Custom article";
-  const latestBaselineRun = bootstrap.latestRuns.find((run) => run.workflow === "website_baseline");
-  const autofillStartData = autofillStartFetcher.data;
-  const autofillRun = autofillRunFetcher.data as VibeMarketingRunSummary | undefined;
-  const baselineStartData = baselineStartFetcher.data;
-  const baselineRun = baselineRunFetcher.data as VibeMarketingRunSummary | undefined;
-  const autofillPending = autofillStartFetcher.state !== "idle";
-  const baselinePending = baselineStartFetcher.state !== "idle";
-  const googleBaselinePending = googleBaselineFetcher.state !== "idle";
-  const autofillPolling = Boolean(autofillRunId && (!autofillRun || ["queued", "running"].includes(autofillRun.status)));
-  const baselinePolling = Boolean(baselineRunId && (!baselineRun || ["queued", "running"].includes(baselineRun.status)));
-  const canStartAutofill = Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) && !autofillPending && !autofillPolling;
-  const effectiveBaseline = googleBaseline ?? baselineFromRun(baselineRun) ?? bootstrap.websiteBaseline;
-  const baselineMetrics = effectiveBaseline.metrics ?? {};
-  const canStartBaseline = Boolean(bootstrap.organization.domain || startupValues.domain.trim()) && !baselinePending && !baselinePolling;
-  const trafficMetric = baselineMetrics.traffic;
-  const trafficStatus = metricStatus("Traffic/users", trafficMetric);
-  const hasGoogleBaselineScopes = Boolean(bootstrap.googleBaselineConnection?.hasBaselineScopes);
-  const canRefreshGoogleBaseline = hasGoogleBaselineScopes && effectiveBaseline.status !== "missing" && !googleBaselinePending;
-  const googleBaselineButtonLabel =
-    trafficStatus === "measured" ? "Refresh Search Console data" : "Load Search Console data";
-  const startAutofill = () => {
-    const snapshot = { ...startupValues };
-    setAutofillRequestSnapshot(snapshot);
-    const formData = new FormData();
-    formData.set("intent", "start-autofill");
-    for (const [field, value] of Object.entries(snapshot)) {
-      formData.set(field, value);
-    }
-    autofillStartFetcher.submit(formData, { method: "POST" });
-  };
-  const startBaseline = () => {
-    setGoogleBaseline(null);
-    const formData = new FormData();
-    formData.set("intent", "start-baseline");
-    baselineStartFetcher.submit(formData, { method: "POST" });
-  };
-  const refreshGoogleBaseline = () => {
-    const formData = new FormData();
-    formData.set("intent", "refresh-baseline-google");
-    googleBaselineFetcher.submit(formData, { method: "POST" });
-  };
-  const applyAutofillField = (field: AutofillApplyField, mode: AutofillApplyMode) => {
-    if (mode === "keep") return;
-    const autofill = extractAutofill(autofillRun);
-    if (!autofill) return;
-    const researchedValues: Record<AutofillApplyField, string> = {
-      companyContext: autofill.companyContext ?? "",
-      competitors: (autofill.directCompetitors?.length ? autofill.directCompetitors : autofill.competitorSuggestions ?? [])
-        .map((competitor) => competitor.domain || competitor.name)
-        .filter(Boolean)
-        .join("\n"),
-      seedKeywords: (autofill.seedKeywords ?? []).join("\n"),
-    };
-    const suggestion = researchedValues[field]?.trim();
-    if (!suggestion) return;
-    setStartupValues((current) => {
-      if (mode === "replace") {
-        return { ...current, [field]: suggestion };
-      }
-      const existing = String(current[field] ?? "").trim();
-      if (!existing) return { ...current, [field]: suggestion };
-      if (existing.toLowerCase().includes(suggestion.toLowerCase())) return current;
-      const separator = field === "companyContext" ? "\n\n" : "\n";
-      return { ...current, [field]: `${existing}${separator}${suggestion}` };
-    });
-    setAutofilledFields((current) => (current.includes(field) ? current : [...current, field]));
-  };
-
-  useEffect(() => {
-    if (activeCompanyKeyRef.current === activeCompanyKey) return;
-    activeCompanyKeyRef.current = activeCompanyKey;
-    setStartupValues(startupDefaults);
-    setAutofillRequestSnapshot(null);
-    setAutofilledFields([]);
-    setAutofillRunId(null);
-    setBaselineRunId(null);
-    setGoogleBaseline(null);
-    setAppliedAutofillRunId(null);
-    googleAutoRefreshSubmittedRef.current = false;
-  }, [activeCompanyKey, startupDefaults, startupDefaultsSignature]);
 
   useEffect(() => {
     const selectionStillValid =
@@ -1485,94 +512,21 @@ export default function FounderToolsMarketingCreate() {
     }
   }, [defaultTopicCandidateId, selectableTopicCandidates, selectedTopicCandidateId]);
 
-  useEffect(() => {
-    if (autofillStartData?.autofillRunId) {
-      setAutofillRunId(autofillStartData.autofillRunId);
-      setAppliedAutofillRunId(null);
-      setAutofilledFields([]);
-    }
-  }, [autofillStartData?.autofillRunId]);
-
-  useEffect(() => {
-    if (baselineStartData?.baselineRunId) {
-      setBaselineRunId(baselineStartData.baselineRunId);
-      setGoogleBaseline(null);
-    }
-  }, [baselineStartData?.baselineRunId]);
-
-  useEffect(() => {
-    if (googleBaselineFetcher.data?.websiteBaseline) {
-      setGoogleBaseline(googleBaselineFetcher.data.websiteBaseline);
-    }
-  }, [googleBaselineFetcher.data?.websiteBaseline]);
-
-  useEffect(() => {
-    if (!shouldRefreshGoogleBaseline || googleAutoRefreshSubmittedRef.current) return;
-    if (activeStep !== "baseline" || !hasGoogleBaselineScopes || googleBaselinePending) return;
-    googleAutoRefreshSubmittedRef.current = true;
-    refreshGoogleBaseline();
-  }, [activeStep, googleBaselinePending, hasGoogleBaselineScopes, shouldRefreshGoogleBaseline]);
-
-  useEffect(() => {
-    if (!autofillRunId) return;
-    if (autofillRun && !["queued", "running"].includes(autofillRun.status)) return;
-    const href = `/founder-tools/marketing/autofill-runs/${encodeURIComponent(autofillRunId)}`;
-    autofillRunFetcher.load(href);
-    const timer = window.setInterval(() => {
-      autofillRunFetcher.load(href);
-    }, 2500);
-    return () => window.clearInterval(timer);
-  }, [autofillRunId, autofillRun?.status]);
-
-  useEffect(() => {
-    if (!baselineRunId) return;
-    if (baselineRun && !["queued", "running"].includes(baselineRun.status)) return;
-    const href = `/founder-tools/marketing/autofill-runs/${encodeURIComponent(baselineRunId)}`;
-    baselineRunFetcher.load(href);
-    const timer = window.setInterval(() => {
-      baselineRunFetcher.load(href);
-    }, 2500);
-    return () => window.clearInterval(timer);
-  }, [baselineRunId, baselineRun?.status]);
-
-  useEffect(() => {
-    if (!autofillRunId || appliedAutofillRunId === autofillRunId || autofillRun?.status !== "completed") return;
-    const autofill = extractAutofill(autofillRun);
-    if (!autofill) return;
-    if (autofillRequestSnapshot && !startupValuesAreEqual(startupValues, autofillRequestSnapshot)) {
-      setAutofilledFields([]);
-      setAppliedAutofillRunId(autofillRunId);
-      return;
-    }
-
-    setStartupValues((current) => {
-      const updates: Partial<StartupDetailsFormValues> = {};
-      const applied: StartupDetailsField[] = [];
-      if (isBlank(current.companyContext) && autofill.companyContext) {
-        updates.companyContext = autofill.companyContext;
-        applied.push("companyContext");
-      }
-      if (listTextIsBlank(current.competitors) && autofill.competitors?.length) {
-        updates.competitors = autofill.competitors.join("\n");
-        applied.push("competitors");
-      }
-      if (listTextIsBlank(current.seedKeywords) && autofill.seedKeywords?.length) {
-        updates.seedKeywords = autofill.seedKeywords.join("\n");
-        applied.push("seedKeywords");
-      }
-      setAutofilledFields(applied);
-      return Object.keys(updates).length ? { ...current, ...updates } : current;
-    });
-    setAppliedAutofillRunId(autofillRunId);
-  }, [appliedAutofillRunId, autofillRequestSnapshot, autofillRun, autofillRunId, startupValues]);
-
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+      <nav className="border-b border-gray-200 pb-4" aria-label="Breadcrumb">
+        <Link to="/founder-tools/marketing" className="inline-flex items-center gap-2 text-sm font-bold text-gray-500 hover:text-gray-800">
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to marketing
+        </Link>
+      </nav>
+
       <MarketingWorkflowShell
         progress={bootstrap.workflowProgress}
         viewedStepId={WORKFLOW_STEP_ID_BY_CREATE_STEP[activeStep]}
         title="Create and publish article"
         isSubmitting={isSubmitting}
+        showPrimaryAction={false}
       />
 
       {topActionError ? (
@@ -1582,209 +536,15 @@ export default function FounderToolsMarketingCreate() {
       ) : null}
 
       <main className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
-        {activeStep === "startupDetails" ? (
-          <>
-              <PanelHeader
-                title="Startup details"
-                description="This is the shared company profile used by Vibe Raising monthly updates and Vibe Marketing article generation."
-                passed={Boolean(bootstrap.checks.websiteProfile?.passed)}
-                explainer={STEP_EXPLAINERS.startupDetails}
-              />
-              <Form method="POST" className="space-y-6">
-                <FounderStartupDetailsStep
-                  defaults={{
-                    companyName: bootstrap.company.name,
-                    domain: bootstrap.company.domain ?? bootstrap.organization.domain,
-                    companyLinkedInUrl: bootstrap.organization.companyLinkedInUrl ?? bootstrap.company.companyLinkedInUrl,
-                    location: bootstrap.company.location,
-                    abn: bootstrap.company.abn,
-                    brandName: bootstrap.settings.brandName ?? bootstrap.organization.name,
-                    companyContext: bootstrap.settings.companyContext,
-                    competitors: bootstrap.organization.competitors,
-                    seedKeywords: bootstrap.organization.seedKeywords,
-                    founderNames: bootstrap.startupProfile.founderNames,
-                    stage: bootstrap.startupProfile.stage,
-                    organizationKind: bootstrap.startupProfile.organizationKind,
-                    notes: bootstrap.startupProfile.notes,
-                  }}
-                  values={startupValues}
-                  onValueChange={(field, value) => setStartupValues((current) => ({ ...current, [field]: value }))}
-                  autofilledFields={autofilledFields}
-                  afterBrandName={
-                    <div className="space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4">
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                          <p className="text-sm font-black text-gray-950">Company profile research</p>
-                          <p className="mt-1 text-sm text-gray-600">Crawl the public website and search results to fill blank marketing fields.</p>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={startAutofill}
-                          disabled={!canStartAutofill}
-                          className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-bold text-violet-700 shadow-sm transition hover:bg-violet-50 disabled:opacity-50"
-                        >
-                          {autofillPending || autofillPolling ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <SparklesIcon className="h-4 w-4" />}
-                          Research company profile
-                        </button>
-                      </div>
-                      {autofillStartData?.error ? (
-                        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
-                          {autofillStartData.error}
-                        </div>
-                      ) : null}
-                      <AutofillStatusCard run={autofillRun} runId={autofillRunId} pending={autofillPending} />
-                      <AutofillReviewPanel run={autofillRun} values={startupValues} autofilledFields={autofilledFields} onApplyField={applyAutofillField} />
-                    </div>
-                  }
-                />
-                <button type="submit" name="intent" value="save-startup-details" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                  Save and continue
-                </button>
-              </Form>
-            </>
-          ) : null}
-
-          {activeStep === "baseline" ? (
-            <>
-              <PanelHeader
-                title="Website baseline"
-                description="Capture the current website health, performance, search visibility, authority, AI visibility, and traffic data before article generation starts."
-                passed={Boolean(bootstrap.checks.baseline?.passed || effectiveBaseline.passed)}
-                explainer={STEP_EXPLAINERS.baseline}
-              />
-
-              <div className="space-y-5">
-                <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="flex items-start gap-3">
-                      <div className="rounded-lg bg-white p-2 text-violet-700 ring-1 ring-gray-200">
-                        <GlobeAltIcon className="h-5 w-5" />
-                      </div>
-                      <div>
-                        <p className="text-sm font-black text-gray-950">{bootstrap.organization.domain || startupValues.domain || "No domain saved"}</p>
-                        <p className="mt-1 text-sm text-gray-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
-                        {effectiveBaseline.collectedAt ? (
-                          <p className="mt-1 text-xs font-semibold text-gray-500">
-                            Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
-                            {effectiveBaseline.stale ? " · stale" : ""}
-                          </p>
-                        ) : null}
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={startBaseline}
-                        disabled={!canStartBaseline}
-                        className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
-                      >
-                        {baselinePending || baselinePolling ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <ChartBarIcon className="h-4 w-4" />}
-                        {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Run baseline" : "Rerun baseline"}
-                      </button>
-                      {hasGoogleBaselineScopes ? (
-                        <button
-                          type="button"
-                          onClick={refreshGoogleBaseline}
-                          disabled={!canRefreshGoogleBaseline}
-                          className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-800 shadow-sm transition hover:bg-gray-50 disabled:opacity-50"
-                        >
-                          {googleBaselinePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <GoogleIcon />}
-                          {googleBaselinePending ? "Loading Search Console..." : googleBaselineButtonLabel}
-                        </button>
-                      ) : bootstrap.googleBaselineConnection?.connectUrl ? (
-                        <a
-                          href={bootstrap.googleBaselineConnection.connectUrl}
-                          className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-800 shadow-sm transition hover:bg-gray-50"
-                        >
-                          <GoogleIcon />
-                          Connect Google Search Console
-                        </a>
-                      ) : (
-                        <button
-                          type="button"
-                          disabled
-                          className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-500 shadow-sm opacity-50"
-                        >
-                          <GoogleIcon />
-                          Connect Google Search Console
-                        </button>
-                      )}
-                      <Form method="POST">
-                        <input type="hidden" name="intent" value="skip-baseline" />
-                        <input type="hidden" name="reason" value="Skipped during onboarding" />
-                        <button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-50">
-                          Skip for now
-                        </button>
-                      </Form>
-                    </div>
-                  </div>
-                  {baselineStartData?.error ? (
-                    <div className="mt-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
-                      {baselineStartData.error}
-                    </div>
-                  ) : null}
-                  {googleBaselineFetcher.data?.error ? (
-                    <div className="mt-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
-                      {googleBaselineFetcher.data.error}
-                    </div>
-                  ) : null}
-                  {baselineRunId ? (
-                    <div className="mt-3 rounded-xl border border-violet-100 bg-white px-4 py-3 text-sm text-violet-900">
-                      <div className="flex items-center gap-2 font-bold">
-                        {baselinePending || baselinePolling ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                        <span>
-                          {baselineRun?.status === "completed"
-                            ? "Baseline ready"
-                            : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
-                              ? "Baseline needs attention"
-                              : "Collecting baseline"}
-                        </span>
-                      </div>
-                      {baselineRun?.errors?.length ? <p className="mt-2 font-semibold text-red-700">{baselineRun.errors[0]}</p> : null}
-                    </div>
-                  ) : null}
-                </div>
-
-                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                  <div className="rounded-xl border border-gray-200 bg-white p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <p className="text-sm font-black text-gray-950">Overall</p>
-                      <SourceStatusBadge status={effectiveBaseline.status === "completed" ? "measured" : effectiveBaseline.status} />
-                    </div>
-                    <p className="mt-3 text-3xl font-black text-gray-950">{typeof effectiveBaseline.overallScore === "number" ? effectiveBaseline.overallScore : "—"}</p>
-                  </div>
-                  <BaselineMetricCard label="Technical health" metric={baselineMetrics.technicalHealth} />
-                  <BaselineMetricCard label="Lighthouse" metric={baselineMetrics.lighthouse} />
-                  <BaselineMetricCard label="Organic search" metric={baselineMetrics.organicSearch} />
-                  <BaselineMetricCard label="AI visibility" metric={baselineMetrics.aiVisibility} />
-                  <BaselineMetricCard label="Authority" metric={baselineMetrics.authority} />
-                  <BaselineMetricCard label="Traffic/users" metric={trafficMetric} />
-                </div>
-
-                <SearchConsolePanel traffic={trafficMetric} />
-
-                {effectiveBaseline.recommendations?.length ? (
-                  <div className="rounded-xl border border-gray-200 bg-white p-4">
-                    <p className="text-sm font-black text-gray-950">Recommended fixes</p>
-                    <div className="mt-3 space-y-2">
-                      {effectiveBaseline.recommendations.slice(0, 4).map((recommendation, index) => (
-                        <div key={`${recommendation.title ?? recommendation.source ?? index}`} className="rounded-lg bg-gray-50 px-3 py-2">
-                          <p className="text-sm font-bold text-gray-950">{String(recommendation.title ?? "Review baseline recommendation")}</p>
-                          {recommendation.detail ? <p className="mt-1 text-xs font-semibold text-gray-600">{String(recommendation.detail)}</p> : null}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                <Link to="/founder-tools/marketing/create?step=github" className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black">
-                  Continue to GitHub
-                  <ArrowRightIcon className="h-4 w-4" />
-                </Link>
-              </div>
-            </>
-          ) : null}
+        {activeStep === "startupDetails" || activeStep === "baseline" ? (
+          <VibeMarketingStartupBaselineSetup
+            bootstrap={bootstrap}
+            error={topActionError}
+            variant="workflow"
+            focusSection={requestedStep === "baseline" ? "baseline" : "profile"}
+            autoRefreshGoogleBaseline={shouldRefreshGoogleBaseline}
+          />
+        ) : null}
 
           {activeStep === "github" ? (
             <>

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { clsx } from "clsx";
 
+import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { getEnv } from "~/lib/env.server";
 import {
   getVibeMarketingBootstrap,
@@ -2240,7 +2241,7 @@ export default function FounderToolsMarketing() {
       {shouldShowTopicPicker ? (
         <ReturningTopicPickerPage bootstrap={bootstrap} error={error} />
       ) : (
-        <FirstArticleSetupPage bootstrap={bootstrap} error={error} />
+        <VibeMarketingStartupBaselineSetup bootstrap={bootstrap} error={error} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Consolidates the Vibe Marketing startup details, AI fill, and baseline setup into one shared component.
- Reuses the shared setup on `/founder-tools/marketing`, `/founder-tools/marketing/create?step=startupDetails`, and `/founder-tools/marketing/create?step=baseline`.
- Keeps the 5-step workflow shell around create pages while removing duplicate startup/baseline UI and state from the create route.

## Validation
- `bun run typecheck`
- Browser checked `/founder-tools/marketing`, `/founder-tools/marketing/create?step=startupDetails`, and `/founder-tools/marketing/create?step=baseline` locally before creating this PR.
