### PR TITLE
[codex] Add shared founder setup and manual document flow

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -74,6 +74,16 @@ type VibeMarketingStartupBaselineSetupProps = {
   variant?: SetupVariant;
   focusSection?: "profile" | "baseline";
   autoRefreshGoogleBaseline?: boolean;
+  includeBaseline?: boolean;
+  setupEyebrow?: string;
+  setupTitle?: string;
+  setupDescription?: string;
+  guidanceTitle?: string;
+  guidanceBody?: string;
+  guidanceTips?: string[];
+  primaryActionLabel?: string;
+  showSecondaryAction?: boolean;
+  advancedOpenByDefault?: boolean;
 };
 
 function listFromText(value: unknown): string[] {
@@ -739,6 +749,16 @@ export default function VibeMarketingStartupBaselineSetup({
   variant = "landing",
   focusSection = "profile",
   autoRefreshGoogleBaseline = false,
+  includeBaseline = true,
+  setupEyebrow = "Step 1 of 5",
+  setupTitle = "Tell us about your startup",
+  setupDescription = "This helps us understand your business, audience, and what makes you unique.",
+  guidanceTitle = "Why we ask this",
+  guidanceBody = "The more details you provide, the better we can research and write high-performing articles that rank and convert.",
+  guidanceTips = ["Be specific about what you do", "Focus on the value you deliver", "Think about your ideal customer", "You can always update this later"],
+  primaryActionLabel,
+  showSecondaryAction,
+  advancedOpenByDefault = false,
 }: VibeMarketingStartupBaselineSetupProps) {
   const navigation = useNavigation();
   const autofillStartFetcher = useFetcher<{
@@ -831,6 +851,7 @@ export default function VibeMarketingStartupBaselineSetup({
   const searchConsole = plainObject(trafficMetric?.googleSearchConsole);
   const searchConsoleSummary = plainObject(searchConsole?.last28Days);
   const embedded = variant === "workflow";
+  const shouldShowSecondaryAction = showSecondaryAction ?? !embedded;
 
   const inputClass =
     "w-full rounded-xl border border-gray-200 py-3 pr-4 text-sm font-medium text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500";
@@ -1032,10 +1053,10 @@ export default function VibeMarketingStartupBaselineSetup({
 
       <div className={clsx("grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px] xl:gap-12", embedded ? "" : "p-6 lg:p-8")}>
         <div>
-          <p className="text-sm font-black text-violet-700">Step 1 of 5</p>
-          <h2 className="mt-3 text-2xl font-black tracking-normal text-gray-950">Tell us about your startup</h2>
+          <p className="text-sm font-black text-violet-700">{setupEyebrow}</p>
+          <h2 className="mt-3 text-2xl font-black tracking-normal text-gray-950">{setupTitle}</h2>
           <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
-            This helps us understand your business, audience, and what makes you unique.
+            {setupDescription}
           </p>
 
           <div className="mt-8 grid gap-4 lg:grid-cols-2">
@@ -1173,7 +1194,7 @@ export default function VibeMarketingStartupBaselineSetup({
             </div>
           </div>
 
-          <details className="mt-8 rounded-2xl border border-gray-200 bg-gray-50/70 p-5" open={Boolean(startupValues.location || startupValues.abn || startupValues.founderNames || startupValues.stage || startupValues.organizationKind)}>
+          <details className="mt-8 rounded-2xl border border-gray-200 bg-gray-50/70 p-5" open={advancedOpenByDefault || Boolean(startupValues.location || startupValues.abn || startupValues.founderNames || startupValues.stage || startupValues.organizationKind)}>
             <summary className="cursor-pointer text-sm font-black text-gray-950">Advanced startup details</summary>
             <div className="mt-5 grid gap-5 lg:grid-cols-2">
               <FormField label="Startup location">
@@ -1248,14 +1269,14 @@ export default function VibeMarketingStartupBaselineSetup({
 
         <aside className="self-start rounded-2xl border border-gray-200 bg-white p-6">
           <h3 className="flex items-center gap-2 text-sm font-black text-gray-950">
-            Why we ask this <CheckCircle2 className="h-4 w-4 text-gray-400" />
+            {guidanceTitle} <CheckCircle2 className="h-4 w-4 text-gray-400" />
           </h3>
           <p className="mt-5 text-sm font-semibold leading-7 text-gray-600">
-            The more details you provide, the better we can research and write high-performing articles that rank and convert.
+            {guidanceBody}
           </p>
           <p className="mt-7 text-sm font-black text-gray-950">Tips</p>
           <ul className="mt-4 space-y-4 text-sm font-semibold text-gray-600">
-            {["Be specific about what you do", "Focus on the value you deliver", "Think about your ideal customer", "You can always update this later"].map((tip) => (
+            {guidanceTips.map((tip) => (
               <li key={tip} className="flex gap-3">
                 <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-violet-600" />
                 <span>{tip}</span>
@@ -1296,176 +1317,178 @@ export default function VibeMarketingStartupBaselineSetup({
         </aside>
       </div>
 
-      <section
-        ref={baselineRef}
-        className={clsx(
-          "border-t border-gray-100 bg-white py-8",
-          embedded ? "" : "px-6 lg:px-8",
-          focusSection === "baseline" && "scroll-mt-6",
-        )}
-      >
-        <div>
-          <p className="text-sm font-black text-violet-700">Optional baseline</p>
-          <h2 className="mt-3 text-2xl font-black tracking-normal text-gray-950">Measure where the website starts</h2>
-          <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
-            Connect Google Search Console first if you want search traffic included. Then generate a baseline snapshot for technical health, SEO,
-            authority, AI visibility, and traffic before the first article goes live.
-          </p>
-        </div>
-
-        <div className="mt-7 grid gap-4 lg:grid-cols-2">
-          <div className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
-            <div className="flex items-start gap-3">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">1</span>
-              <div className="min-w-0">
-                <p className="text-sm font-black text-gray-950">Connect Google Search Console</p>
-                <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-                  Optional. Connect it to include clicks, impressions, and search query data in the baseline.
-                </p>
-              </div>
-            </div>
-            <div className="mt-4 flex flex-wrap items-center gap-2">
-              {hasGoogleBaselineScopes ? (
-                <>
-                  <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-black text-emerald-700">
-                    <CheckCircle2 className="h-3.5 w-3.5" />
-                    Search Console connected
-                  </span>
-                  <button
-                    type="button"
-                    onClick={refreshGoogleBaseline}
-                    disabled={!canRefreshGoogleBaseline}
-                    className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {googleBaselinePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <GoogleIcon />}
-                    {trafficStatus === "measured" ? "Refresh Search Console" : "Load Search Console"}
-                  </button>
-                </>
-              ) : bootstrap.googleBaselineConnection?.connectUrl ? (
-                <a
-                  href={bootstrap.googleBaselineConnection.connectUrl}
-                  className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50"
-                >
-                  <GoogleIcon />
-                  Connect Google Search Console
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </a>
-              ) : (
-                <span className="rounded-full bg-white px-3 py-1.5 text-xs font-black text-gray-500 ring-1 ring-gray-200">
-                  Search Console can be skipped
-                </span>
-              )}
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
-            <div className="flex items-start gap-3">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">2</span>
-              <div className="min-w-0">
-                <p className="text-sm font-black text-gray-950">Generate baseline snapshot</p>
-                <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-                  This can run without Search Console. Use it to compare future article growth against today&apos;s website state.
-                </p>
-                <p className="mt-3 text-sm font-black text-gray-950">{effectiveBaseline.domain || startupValues.domain || "No domain saved yet"}</p>
-                <p className="mt-1 text-sm font-semibold text-gray-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
-                {effectiveBaseline.collectedAt ? (
-                  <p className="mt-1 text-xs font-semibold text-gray-500">
-                    Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
-                    {effectiveBaseline.stale ? " · stale" : ""}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={startBaseline}
-                disabled={!canStartBaseline}
-                className="inline-flex items-center gap-2 rounded-xl bg-violet-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <BarChart3 className="h-4 w-4" />}
-                {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Generate baseline" : "Rerun baseline"}
-              </button>
-              <button
-                type="button"
-                onClick={skipBaseline}
-                disabled={skipBaselinePending}
-                className="inline-flex items-center gap-2 rounded-xl border border-transparent bg-transparent px-4 py-2.5 text-sm font-black text-gray-600 transition hover:bg-white disabled:opacity-50"
-              >
-                Skip for now
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {baselineStartData?.error || googleBaselineFetcher.data?.error || skipBaselineFetcher.data?.error ? (
-          <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
-            {baselineStartData?.error ?? googleBaselineFetcher.data?.error ?? skipBaselineFetcher.data?.error}
-          </div>
-        ) : null}
-
-        {baselineRunId ? (
-          <div className="mt-4 rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-sm text-violet-900">
-            <div className="flex items-center gap-2 font-black">
-              {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-              <span>
-                {baselineRun?.status === "completed"
-                  ? "Baseline ready"
-                  : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
-                    ? "Baseline needs attention"
-                    : "Collecting baseline"}
-              </span>
-            </div>
-            {baselineRun?.errors?.length ? <p className="mt-2 font-semibold text-rose-700">{baselineRun.errors[0]}</p> : null}
-          </div>
-        ) : null}
-
-        <div className="mt-5 grid gap-3 rounded-2xl border border-gray-100 bg-gray-50/50 p-4 sm:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-xl border border-gray-200 bg-white p-4">
-            <div className="flex items-start justify-between gap-3">
-              <p className="text-sm font-black text-gray-950">Overall</p>
-              <SourceStatusBadge status={effectiveBaseline.status === "completed" ? "measured" : effectiveBaseline.status} />
-            </div>
-            <p className="mt-3 text-3xl font-black text-gray-950">
-              {typeof effectiveBaseline.overallScore === "number" ? effectiveBaseline.overallScore : "-"}
+      {includeBaseline ? (
+        <section
+          ref={baselineRef}
+          className={clsx(
+            "border-t border-gray-100 bg-white py-8",
+            embedded ? "" : "px-6 lg:px-8",
+            focusSection === "baseline" && "scroll-mt-6",
+          )}
+        >
+          <div>
+            <p className="text-sm font-black text-violet-700">Optional baseline</p>
+            <h2 className="mt-3 text-2xl font-black tracking-normal text-gray-950">Measure where the website starts</h2>
+            <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
+              Connect Google Search Console first if you want search traffic included. Then generate a baseline snapshot for technical health, SEO,
+              authority, AI visibility, and traffic before the first article goes live.
             </p>
           </div>
-          <BaselineMetricCard label="Technical health" metric={baselineMetrics.technicalHealth} />
-          <BaselineMetricCard label="Lighthouse" metric={baselineMetrics.lighthouse} />
-          <BaselineMetricCard label="Organic search" metric={baselineMetrics.organicSearch} />
-          <BaselineMetricCard label="AI visibility" metric={baselineMetrics.aiVisibility} />
-          <BaselineMetricCard label="Authority" metric={baselineMetrics.authority} />
-          <BaselineMetricCard label="Traffic/users" metric={trafficMetric} />
-          {searchConsole?.status === "measured" && searchConsoleSummary ? (
-            <div className="rounded-xl border border-gray-200 bg-white p-4">
-              <div className="flex items-start justify-between gap-3">
-                <p className="text-sm font-black text-gray-950">Search Console</p>
-                <GoogleIcon />
-              </div>
-              <p className="mt-3 text-2xl font-black text-gray-950">
-                {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.clicks) ?? 0))}
-              </p>
-              <p className="mt-1 text-xs font-semibold text-gray-500">
-                clicks from {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.impressions) ?? 0))} impressions
-              </p>
-            </div>
-          ) : null}
-        </div>
 
-        {effectiveBaseline.recommendations?.length ? (
-          <div className="mt-5 rounded-xl border border-gray-100 bg-white p-4">
-            <p className="text-sm font-black text-gray-950">Recommended fixes</p>
-            <div className="mt-3 grid gap-3 md:grid-cols-2">
-              {effectiveBaseline.recommendations.slice(0, 4).map((recommendation, index) => (
-                <div key={`${recommendation.title ?? recommendation.source ?? index}`} className="rounded-xl bg-gray-50 px-4 py-3">
-                  <p className="text-sm font-black text-gray-950">{String(recommendation.title ?? "Review baseline recommendation")}</p>
-                  {recommendation.detail ? <p className="mt-1 text-xs font-semibold text-gray-600">{String(recommendation.detail)}</p> : null}
+          <div className="mt-7 grid gap-4 lg:grid-cols-2">
+            <div className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
+              <div className="flex items-start gap-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">1</span>
+                <div className="min-w-0">
+                  <p className="text-sm font-black text-gray-950">Connect Google Search Console</p>
+                  <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+                    Optional. Connect it to include clicks, impressions, and search query data in the baseline.
+                  </p>
                 </div>
-              ))}
+              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                {hasGoogleBaselineScopes ? (
+                  <>
+                    <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-black text-emerald-700">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Search Console connected
+                    </span>
+                    <button
+                      type="button"
+                      onClick={refreshGoogleBaseline}
+                      disabled={!canRefreshGoogleBaseline}
+                      className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {googleBaselinePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <GoogleIcon />}
+                      {trafficStatus === "measured" ? "Refresh Search Console" : "Load Search Console"}
+                    </button>
+                  </>
+                ) : bootstrap.googleBaselineConnection?.connectUrl ? (
+                  <a
+                    href={bootstrap.googleBaselineConnection.connectUrl}
+                    className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50"
+                  >
+                    <GoogleIcon />
+                    Connect Google Search Console
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                ) : (
+                  <span className="rounded-full bg-white px-3 py-1.5 text-xs font-black text-gray-500 ring-1 ring-gray-200">
+                    Search Console can be skipped
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-gray-200 bg-gray-50/70 p-4">
+              <div className="flex items-start gap-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-xs font-black text-violet-700 shadow-sm ring-1 ring-violet-100">2</span>
+                <div className="min-w-0">
+                  <p className="text-sm font-black text-gray-950">Generate baseline snapshot</p>
+                  <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+                    This can run without Search Console. Use it to compare future article growth against today&apos;s website state.
+                  </p>
+                  <p className="mt-3 text-sm font-black text-gray-950">{effectiveBaseline.domain || startupValues.domain || "No domain saved yet"}</p>
+                  <p className="mt-1 text-sm font-semibold text-gray-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
+                  {effectiveBaseline.collectedAt ? (
+                    <p className="mt-1 text-xs font-semibold text-gray-500">
+                      Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
+                      {effectiveBaseline.stale ? " · stale" : ""}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={startBaseline}
+                  disabled={!canStartBaseline}
+                  className="inline-flex items-center gap-2 rounded-xl bg-violet-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <BarChart3 className="h-4 w-4" />}
+                  {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Generate baseline" : "Rerun baseline"}
+                </button>
+                <button
+                  type="button"
+                  onClick={skipBaseline}
+                  disabled={skipBaselinePending}
+                  className="inline-flex items-center gap-2 rounded-xl border border-transparent bg-transparent px-4 py-2.5 text-sm font-black text-gray-600 transition hover:bg-white disabled:opacity-50"
+                >
+                  Skip for now
+                </button>
+              </div>
             </div>
           </div>
-        ) : null}
-      </section>
+
+          {baselineStartData?.error || googleBaselineFetcher.data?.error || skipBaselineFetcher.data?.error ? (
+            <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+              {baselineStartData?.error ?? googleBaselineFetcher.data?.error ?? skipBaselineFetcher.data?.error}
+            </div>
+          ) : null}
+
+          {baselineRunId ? (
+            <div className="mt-4 rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-sm text-violet-900">
+              <div className="flex items-center gap-2 font-black">
+                {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                <span>
+                  {baselineRun?.status === "completed"
+                    ? "Baseline ready"
+                    : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
+                      ? "Baseline needs attention"
+                      : "Collecting baseline"}
+                </span>
+              </div>
+              {baselineRun?.errors?.length ? <p className="mt-2 font-semibold text-rose-700">{baselineRun.errors[0]}</p> : null}
+            </div>
+          ) : null}
+
+          <div className="mt-5 grid gap-3 rounded-2xl border border-gray-100 bg-gray-50/50 p-4 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-xl border border-gray-200 bg-white p-4">
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-sm font-black text-gray-950">Overall</p>
+                <SourceStatusBadge status={effectiveBaseline.status === "completed" ? "measured" : effectiveBaseline.status} />
+              </div>
+              <p className="mt-3 text-3xl font-black text-gray-950">
+                {typeof effectiveBaseline.overallScore === "number" ? effectiveBaseline.overallScore : "-"}
+              </p>
+            </div>
+            <BaselineMetricCard label="Technical health" metric={baselineMetrics.technicalHealth} />
+            <BaselineMetricCard label="Lighthouse" metric={baselineMetrics.lighthouse} />
+            <BaselineMetricCard label="Organic search" metric={baselineMetrics.organicSearch} />
+            <BaselineMetricCard label="AI visibility" metric={baselineMetrics.aiVisibility} />
+            <BaselineMetricCard label="Authority" metric={baselineMetrics.authority} />
+            <BaselineMetricCard label="Traffic/users" metric={trafficMetric} />
+            {searchConsole?.status === "measured" && searchConsoleSummary ? (
+              <div className="rounded-xl border border-gray-200 bg-white p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-sm font-black text-gray-950">Search Console</p>
+                  <GoogleIcon />
+                </div>
+                <p className="mt-3 text-2xl font-black text-gray-950">
+                  {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.clicks) ?? 0))}
+                </p>
+                <p className="mt-1 text-xs font-semibold text-gray-500">
+                  clicks from {new Intl.NumberFormat("en-AU").format(Math.round(numericValue(searchConsoleSummary.impressions) ?? 0))} impressions
+                </p>
+              </div>
+            ) : null}
+          </div>
+
+          {effectiveBaseline.recommendations?.length ? (
+            <div className="mt-5 rounded-xl border border-gray-100 bg-white p-4">
+              <p className="text-sm font-black text-gray-950">Recommended fixes</p>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                {effectiveBaseline.recommendations.slice(0, 4).map((recommendation, index) => (
+                  <div key={`${recommendation.title ?? recommendation.source ?? index}`} className="rounded-xl bg-gray-50 px-4 py-3">
+                    <p className="text-sm font-black text-gray-950">{String(recommendation.title ?? "Review baseline recommendation")}</p>
+                    {recommendation.detail ? <p className="mt-1 text-xs font-semibold text-gray-600">{String(recommendation.detail)}</p> : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
 
       <div className={clsx("flex flex-col gap-4 border-t border-gray-100 bg-gray-50/70 py-5 sm:flex-row sm:items-center sm:justify-between", embedded ? "" : "px-6 lg:px-8")}>
         <p className="flex items-center gap-3 text-sm font-bold text-gray-500">
@@ -1473,7 +1496,7 @@ export default function VibeMarketingStartupBaselineSetup({
           Your data is secure and never shared.
         </p>
         <div className="flex flex-col gap-3 sm:flex-row">
-          {embedded && focusSection === "baseline" ? (
+          {includeBaseline && embedded && focusSection === "baseline" ? (
             <Link
               to="/founder-tools/marketing/create?step=github"
               className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
@@ -1482,7 +1505,7 @@ export default function VibeMarketingStartupBaselineSetup({
               <ArrowRight className="h-4 w-4" />
             </Link>
           ) : null}
-          {!embedded ? (
+          {shouldShowSecondaryAction ? (
             <button
               type="submit"
               name="nextAction"
@@ -1502,7 +1525,7 @@ export default function VibeMarketingStartupBaselineSetup({
             className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
-            {embedded ? (focusSection === "baseline" ? "Save startup profile" : "Save and continue") : "Continue to website"}
+            {primaryActionLabel ?? (embedded ? (focusSection === "baseline" ? "Save startup profile" : "Save and continue") : "Continue to website")}
           </button>
         </div>
       </div>

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -26,6 +26,10 @@ import type {
   VibeRaisingLinearProjectPreview,
   VibeRaisingLinearProjectsResponse,
   VibeRaisingLinearProjectUpdatePreview,
+  VibeRaisingManualDocument,
+  VibeRaisingManualDocumentDownloadResponse,
+  VibeRaisingManualDocumentUploadResponse,
+  VibeRaisingManualDocumentUploadSessionResponse,
   VibeRaisingMetricSuggestion,
   VibeRaisingMonthlyUpdate,
   VibeRaisingProfile,
@@ -55,6 +59,9 @@ const ACTIVE_COMPANY_PATH = "/api/v1/founder-tools/active-company/";
 const UPDATES_PATH = "/api/v1/vibe-raising/updates/";
 const VIDEO_UPLOAD_SESSION_PATH = "/api/v1/vibe-raising/uploads/video/session/";
 const VIDEO_UPLOAD_COMPLETE_PATH = "/api/v1/vibe-raising/uploads/video/complete/";
+const MANUAL_DOCUMENTS_PATH = "/api/v1/vibe-raising/uploads/manual-documents/";
+const MANUAL_DOCUMENT_UPLOAD_SESSION_PATH = "/api/v1/vibe-raising/uploads/manual-documents/session/";
+const MANUAL_DOCUMENT_UPLOAD_COMPLETE_PATH = "/api/v1/vibe-raising/uploads/manual-documents/complete/";
 const STARTUP_UPDATE_BOOTSTRAP_PATH = "/api/v1/vibe-raising/startup-update/bootstrap/";
 const EMAIL_DRAFT_START_PATH = "/api/v1/vibe-raising/email-draft/start/";
 const EMAIL_DRAFT_STATUS_PATH = "/api/v1/vibe-raising/email-draft/status/";
@@ -117,6 +124,11 @@ const INPUT_SOURCE_DEFINITIONS: Record<VibeRaisingInputSourceKey, Omit<VibeRaisi
     key: "linear",
     label: "Linear",
     capabilities: ["context"],
+  },
+  manual_documents: {
+    key: "manual_documents",
+    label: "Manual documents",
+    capabilities: ["docs", "context"],
   },
 };
 
@@ -356,6 +368,49 @@ function asNullableNumber(value: unknown): number | null {
   return null;
 }
 
+function normalizeManualDocument(raw: unknown): VibeRaisingManualDocument | null {
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const id = asNullableString(payload.id);
+  const originalFilename =
+    asNullableString(payload.originalFilename) ??
+    asNullableString(payload.original_filename);
+  if (!id || !originalFilename) return null;
+  return {
+    id,
+    originalFilename,
+    contentType:
+      asNullableString(payload.contentType) ??
+      asNullableString(payload.content_type) ??
+      "",
+    fileSizeBytes:
+      asNullableNumber(payload.fileSizeBytes ?? payload.file_size_bytes) ?? 0,
+    extractionStatus:
+      asNullableString(payload.extractionStatus) ??
+      asNullableString(payload.extraction_status) ??
+      "pending",
+    textSizeChars:
+      asNullableNumber(payload.textSizeChars ?? payload.text_size_chars) ?? 0,
+    parseNotes:
+      asNullableString(payload.parseNotes) ??
+      asNullableString(payload.parse_notes),
+    lastError:
+      asNullableString(payload.lastError) ??
+      asNullableString(payload.last_error),
+    createdAt:
+      asNullableString(payload.createdAt) ??
+      asNullableString(payload.created_at),
+    updatedAt:
+      asNullableString(payload.updatedAt) ??
+      asNullableString(payload.updated_at),
+  };
+}
+
+function normalizeManualDocuments(raw: unknown): VibeRaisingManualDocument[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map(normalizeManualDocument).filter((item): item is VibeRaisingManualDocument => item !== null);
+}
+
 function normalizePastMonthSummary(raw: unknown) {
   const payload = unwrapPayload(raw) as Record<string, unknown>;
   return {
@@ -407,6 +462,7 @@ function normalizeDraftedContent(raw: unknown): VibeRaisingDraftedContent | null
       asNullableString(payload.sourceUrl) ??
       asNullableString(payload.source_url) ??
       undefined,
+    manualDocuments: normalizeManualDocuments(payload.manualDocuments ?? payload.manual_documents),
     videoUrl:
       asNullableString(payload.videoUrl) ??
       asNullableString(payload.video_url) ??
@@ -511,6 +567,7 @@ function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | nu
       asNullableString(payload.sourceUrl) ??
       asNullableString(payload.source_url) ??
       undefined,
+    manualDocuments: normalizeManualDocuments(payload.manualDocuments ?? payload.manual_documents),
     videoUrl:
       asNullableString(payload.videoUrl) ??
       asNullableString(payload.video_url) ??
@@ -590,6 +647,7 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
     sourceUrl:
       asNullableString(payload.sourceUrl) ??
       asNullableString(payload.source_url),
+    manualDocuments: normalizeManualDocuments(payload.manualDocuments ?? payload.manual_documents),
     videoUrl:
       asNullableString(payload.videoUrl) ??
       asNullableString(payload.video_url),
@@ -994,6 +1052,7 @@ function normalizeInputSourceProvider(value: unknown): VibeRaisingInputSourceKey
   if (normalized === "google_drive" || normalized === "drive") return "google_drive";
   if (normalized === "slack") return "slack";
   if (normalized === "linear") return "linear";
+  if (normalized === "manual_documents" || normalized === "manual") return "manual_documents";
   return null;
 }
 
@@ -1694,6 +1753,8 @@ export async function saveVibeRaisingMonthlyUpdate(
     videoContentType?: string | null;
     videoFileSizeBytes?: number | null;
     videoOriginalFilename?: string | null;
+    manualDocumentIds?: string[];
+    manualSummary?: string | null;
   },
 ): Promise<VibeRaisingMonthlyUpdate | null> {
   const buildDevSavedUpdate = () => {
@@ -1731,8 +1792,10 @@ export async function saveVibeRaisingMonthlyUpdate(
 
     const status = error.response?.status;
     const hasOptionalFields = Boolean(
-      body.summary ||
+        body.summary ||
         body.sourceUrl ||
+        (body.manualDocumentIds || []).length > 0 ||
+        body.manualSummary ||
         body.videoUrl ||
         body.learnings ||
         body.next30Days ||
@@ -1849,6 +1912,111 @@ export async function uploadVibeRaisingUpdateVideo(
   );
 }
 
+export async function listVibeRaisingManualDocuments(
+  backendBaseUrl: string,
+): Promise<VibeRaisingManualDocument[]> {
+  const response = await requestBrowserJson<Record<string, unknown>>(
+    backendBaseUrl,
+    MANUAL_DOCUMENTS_PATH,
+    { method: "GET" },
+  );
+  return normalizeManualDocuments(response.documents);
+}
+
+export async function uploadVibeRaisingManualDocument(
+  backendBaseUrl: string,
+  file: File,
+  signal?: AbortSignal,
+  onPhase?: (phase: "creating_session" | "uploading" | "finalizing") => void,
+): Promise<VibeRaisingManualDocument> {
+  onPhase?.("creating_session");
+  const session = await requestBrowserJson<VibeRaisingManualDocumentUploadSessionResponse>(
+    backendBaseUrl,
+    MANUAL_DOCUMENT_UPLOAD_SESSION_PATH,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        originalFilename: file.name,
+        contentType: file.type || "application/octet-stream",
+        fileSizeBytes: file.size,
+      }),
+      signal,
+    },
+  );
+
+  const uploadHeaders = new Headers(session.requiredHeaders || {});
+  if (!uploadHeaders.has("Content-Type")) {
+    uploadHeaders.set("Content-Type", session.contentType || file.type || "application/octet-stream");
+  }
+
+  onPhase?.("uploading");
+  let uploadResponse: Response;
+  try {
+    uploadResponse = await fetch(session.uploadUrl, {
+      method: "PUT",
+      headers: uploadHeaders,
+      body: file,
+      signal,
+    });
+  } catch (error: any) {
+    error.requestPath = "signed-storage-upload";
+    error.message = "Storage upload failed before the file reached Firebase. Check Firebase Storage CORS and try again.";
+    throw error;
+  }
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text().catch(() => "");
+    const error: any = new Error(
+      uploadResponse.status === 403
+        ? "The document upload session expired. Please select the document again."
+        : errorText || `Storage upload failed with status ${uploadResponse.status}`,
+    );
+    error.status = uploadResponse.status;
+    error.data = errorText;
+    error.requestPath = "signed-storage-upload";
+    throw error;
+  }
+
+  onPhase?.("finalizing");
+  const completed = await requestBrowserJson<VibeRaisingManualDocumentUploadResponse>(
+    backendBaseUrl,
+    MANUAL_DOCUMENT_UPLOAD_COMPLETE_PATH,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        storagePath: session.storagePath,
+        originalFilename: file.name,
+        contentType: session.contentType || file.type || "application/octet-stream",
+        fileSizeBytes: file.size,
+      }),
+      signal,
+    },
+  );
+  return completed.document;
+}
+
+export async function deleteVibeRaisingManualDocument(
+  backendBaseUrl: string,
+  documentId: string,
+): Promise<void> {
+  await requestBrowserJson<unknown>(
+    backendBaseUrl,
+    `${MANUAL_DOCUMENTS_PATH}${encodeURIComponent(documentId)}/`,
+    { method: "DELETE" },
+  );
+}
+
+export async function getVibeRaisingManualDocumentDownloadUrl(
+  backendBaseUrl: string,
+  documentId: string,
+): Promise<VibeRaisingManualDocumentDownloadResponse> {
+  return requestBrowserJson<VibeRaisingManualDocumentDownloadResponse>(
+    backendBaseUrl,
+    `${MANUAL_DOCUMENTS_PATH}${encodeURIComponent(documentId)}/download/`,
+    { method: "GET" },
+  );
+}
+
 export async function bootstrapVibeRaisingStartupUpdate(
   backendBaseUrl: string,
   options?: { next?: string },
@@ -1962,7 +2130,9 @@ export async function getVibeRaisingInputSourcesStatus(
   return { sources, financeUnavailable };
 }
 
-const CONNECTOR_PROVIDER_SLUGS: Record<Exclude<VibeRaisingInputSourceKey, "gmail">, string> = {
+type ConnectableVibeRaisingInputSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "manual_documents">;
+
+const CONNECTOR_PROVIDER_SLUGS: Record<ConnectableVibeRaisingInputSourceKey, string> = {
   stripe: "stripe",
   xero: "xero",
   bank_feed: "bank-feed",
@@ -1974,7 +2144,7 @@ const CONNECTOR_PROVIDER_SLUGS: Record<Exclude<VibeRaisingInputSourceKey, "gmail
 
 export function connectVibeRaisingInputSource(
   backendBaseUrl: string,
-  provider: Exclude<VibeRaisingInputSourceKey, "gmail">,
+  provider: ConnectableVibeRaisingInputSourceKey,
   nextUrl?: string,
 ): string {
   const normalizedBase = backendBaseUrl.endsWith("/") ? backendBaseUrl : `${backendBaseUrl}/`;
@@ -2821,6 +2991,8 @@ export async function runVibeRaisingStartupUpdate(
     forceRegenerate?: boolean;
     inputSources?: VibeRaisingInputSourceKey[];
     targetMonth?: string | null;
+    manualDocumentIds?: string[];
+    manualSummary?: string | null;
   },
 ): Promise<VibeRaisingStartupUpdateStatusResponse> {
   const body: Record<string, unknown> = {};
@@ -2836,6 +3008,16 @@ export async function runVibeRaisingStartupUpdate(
   if (inputSources.length > 0) {
     body.inputSources = inputSources;
     body.input_sources = inputSources;
+  }
+  const manualDocumentIds = Array.from(new Set((options?.manualDocumentIds ?? []).map((id) => id.trim()).filter(Boolean)));
+  if (manualDocumentIds.length > 0) {
+    body.manualDocumentIds = manualDocumentIds;
+    body.manual_document_ids = manualDocumentIds;
+  }
+  const manualSummary = String(options?.manualSummary || "").trim();
+  if (manualSummary) {
+    body.manualSummary = manualSummary;
+    body.manual_summary = manualSummary;
   }
 
   const response = await requestBrowserJson<Record<string, unknown>>(

--- a/app/routes/founder-tools.index.tsx
+++ b/app/routes/founder-tools.index.tsx
@@ -1,10 +1,215 @@
 import type { Route } from "./+types/founder-tools.index";
-import { redirect } from "react-router";
+import { Link, redirect, useLoaderData, useNavigate, useOutletContext } from "react-router";
+import {
+  ArrowRightIcon,
+  BuildingOffice2Icon,
+  ChartBarSquareIcon,
+  CheckBadgeIcon,
+  CircleStackIcon,
+  DocumentTextIcon,
+  GlobeAltIcon,
+  IdentificationIcon,
+  MapPinIcon,
+  MegaphoneIcon,
+  PencilSquareIcon,
+} from "@heroicons/react/24/outline";
 
-export const loader = async (_args: Route.LoaderArgs) => {
-  throw redirect("/founder-tools/updates");
-};
+import { getEnv } from "~/lib/env.server";
+import {
+  getActiveVibeRaisingCompany,
+  getVibeRaisingMonthlyUpdates,
+  getOptionalVibeRaisingContext,
+  getVibeRaisingLoginHref,
+} from "~/lib/vibe-raising";
+import type { VibeRaisingCompany } from "~/types/vibe-raising";
+
+function detailValue(value: string | null | undefined) {
+  return String(value ?? "").trim() || "-";
+}
+
+function companyInitials(company: VibeRaisingCompany | null) {
+  const name = company?.name ?? "Company";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  return parts.slice(0, 2).map((part) => part[0]?.toUpperCase()).join("") || "CO";
+}
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  const vibeContext = await getOptionalVibeRaisingContext(env, request);
+
+  if (!vibeContext.authUser) {
+    throw redirect(getVibeRaisingLoginHref(request));
+  }
+
+  if (!vibeContext.appUser || !vibeContext.appUser.companyRegistered) {
+    throw redirect("/founder-tools/company-setup");
+  }
+
+  const monthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request);
+
+  return {
+    user: vibeContext.appUser,
+    activeCompany: getActiveVibeRaisingCompany(vibeContext.appUser),
+    hasMonthlyUpdates: monthlyUpdates.length > 0,
+  };
+}
 
 export default function FounderToolsIndex() {
-  return null;
+  const { user, activeCompany, hasMonthlyUpdates } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const { triggerAnnouncement } = useOutletContext<{ triggerAnnouncement: (cb?: () => void) => void }>();
+  const details = [
+    { label: "Website", value: detailValue(activeCompany?.domain), icon: GlobeAltIcon },
+    { label: "Location", value: detailValue(activeCompany?.location), icon: MapPinIcon },
+    { label: "ABN", value: detailValue(activeCompany?.abn), icon: IdentificationIcon },
+    { label: "Status", value: activeCompany?.registered ? "Set up" : "Incomplete", icon: CheckBadgeIcon },
+  ];
+  const productLinks = [
+    {
+      label: "Vibe Raising",
+      href: "/founder-tools/updates",
+      icon: DocumentTextIcon,
+      accent: "bg-violet-50 text-violet-700 ring-violet-100",
+    },
+    {
+      label: "Vibe Marketing",
+      href: "/founder-tools/marketing",
+      icon: MegaphoneIcon,
+      accent: "bg-teal-50 text-teal-700 ring-teal-100",
+    },
+    {
+      label: "Data Sources",
+      href: "/founder-tools/data-sources",
+      icon: CircleStackIcon,
+      accent: "bg-sky-50 text-sky-700 ring-sky-100",
+    },
+    {
+      label: "Company Settings",
+      href: "/founder-tools/company-setup",
+      icon: PencilSquareIcon,
+      accent: "bg-slate-50 text-slate-700 ring-slate-100",
+    },
+  ];
+  const productCardClass =
+    "group rounded-2xl border border-gray-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-md";
+  const openFirstVibeRaisingUpdate = () => {
+    triggerAnnouncement(() => navigate("/founder-tools/updates/create"));
+  };
+
+  return (
+    <div className="min-h-screen bg-[#fbfaf8] px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+          <div className="h-24 bg-gradient-to-r from-violet-600 via-teal-500 to-cyan-400" />
+          <div className="p-6 sm:p-8">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div className="flex min-w-0 gap-4">
+                <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-gray-950 text-xl font-black text-white shadow-sm">
+                  {activeCompany?.domain ? (
+                    <img
+                      src={`https://www.google.com/s2/favicons?domain=${activeCompany.domain}&sz=128`}
+                      alt={activeCompany.name}
+                      className="h-10 w-10 rounded"
+                    />
+                  ) : (
+                    companyInitials(activeCompany)
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-black text-violet-700">Founder Tools</p>
+                  <h1 className="mt-1 truncate text-3xl font-black tracking-normal text-gray-950">
+                    {activeCompany?.name || user.companyName || "Your company"}
+                  </h1>
+                  <p className="mt-2 text-sm font-semibold text-gray-500">{user.email}</p>
+                </div>
+              </div>
+              <Link
+                to="/founder-tools/company-setup"
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+              >
+                <PencilSquareIcon className="h-4 w-4" />
+                Edit setup
+              </Link>
+            </div>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {details.map((detail) => {
+                const Icon = detail.icon;
+                return (
+                  <div key={detail.label} className="rounded-xl border border-gray-200 bg-gray-50/60 p-4">
+                    <div className="flex items-center gap-2 text-xs font-black uppercase text-gray-400">
+                      <Icon className="h-4 w-4" />
+                      {detail.label}
+                    </div>
+                    <p className="mt-3 truncate text-sm font-black text-gray-950">{detail.value}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-4">
+          {productLinks.map((item) => {
+            const Icon = item.icon;
+            const cardContent = (
+              <>
+                <div className="flex items-start justify-between gap-4">
+                  <span className={`flex h-11 w-11 items-center justify-center rounded-xl ring-1 ${item.accent}`}>
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <ArrowRightIcon className="h-5 w-5 text-gray-300 transition group-hover:translate-x-0.5 group-hover:text-gray-600" />
+                </div>
+                <p className="mt-5 text-base font-black text-gray-950">{item.label}</p>
+              </>
+            );
+
+            if (item.href === "/founder-tools/updates" && !hasMonthlyUpdates) {
+              return (
+                <button
+                  key={item.href}
+                  type="button"
+                  onClick={openFirstVibeRaisingUpdate}
+                  className={productCardClass}
+                >
+                  {cardContent}
+                </button>
+              );
+            }
+
+            return (
+              <Link
+                key={item.href}
+                to={item.href}
+                className={productCardClass}
+              >
+                {cardContent}
+              </Link>
+            );
+          })}
+        </section>
+
+        <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-50 text-gray-500 ring-1 ring-gray-100">
+                <ChartBarSquareIcon className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="text-sm font-black text-gray-950">Active company</p>
+                <p className="mt-1 text-sm font-semibold text-gray-500">{activeCompany?.name || user.companyName}</p>
+              </div>
+            </div>
+            <Link
+              to="/founder-tools/companies"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black"
+            >
+              <BuildingOffice2Icon className="h-4 w-4" />
+              Manage companies
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
 }

--- a/app/routes/platform.login.tsx
+++ b/app/routes/platform.login.tsx
@@ -21,6 +21,30 @@ function getDefaultNext(app: AuthAppName | null | undefined): string {
     return "/hackathons";
 }
 
+const LEGACY_FOUNDER_NEXT_PATHS: Record<string, string> = {
+    "/vibe-raising": "/founder-tools",
+    "/vibe-raising/": "/founder-tools",
+    "/vibe-raising/create-update": "/founder-tools/updates/create",
+    "/vibe-raising/connect-data": "/founder-tools/data-sources",
+    "/vibe-raising/companies": "/founder-tools/companies",
+    "/vibe-raising/company-setup": "/founder-tools/company-setup",
+    "/vibe-raising/discover": "/founder-tools/updates",
+};
+
+function normalizeNextForApp(app: AuthAppName | null | undefined, nextValue: string | null | undefined): string {
+    const fallback = getDefaultNext(app);
+    const next = nextValue?.trim() || fallback;
+
+    if (!next.startsWith("/") || next.startsWith("//")) return fallback;
+    if (app !== "founder-tools" && app !== "vibe-raising") return next;
+
+    const target = new URL(next, "https://mlai.local");
+    const mappedPath = LEGACY_FOUNDER_NEXT_PATHS[target.pathname];
+    if (mappedPath) return `${mappedPath}${target.search}${target.hash}`;
+    if (target.pathname.startsWith("/vibe-raising/")) return `/founder-tools/updates${target.search}${target.hash}`;
+    return next;
+}
+
 function parseAuthApp(value: string | null): AuthAppName | null {
     if (value === "vibe-raising") return "founder-tools";
     return value === "esafety" || value === "hospital" || value === "innovate-connect-alliance" || value === "founder-tools"
@@ -60,7 +84,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
     const url = new URL(request.url);
     const app = parseAuthApp(url.searchParams.get("app"));
-    const next = url.searchParams.get("next") || getDefaultNext(app);
+    const next = normalizeNextForApp(app, url.searchParams.get("next"));
     let user = null;
 
     try {
@@ -81,7 +105,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     const formData = await request.formData();
     const intent = formData.get("intent")?.toString() ?? "check";
     const app = parseAuthApp(formData.get("app")?.toString() ?? null) ?? undefined;
-    const next = formData.get("next")?.toString() ?? getDefaultNext(app ?? null);
+    const next = normalizeNextForApp(app ?? null, formData.get("next")?.toString());
     const email = String(formData.get("email") || "").trim();
     const role = formData.get("role")?.toString() as "participant" | "mentor" | "judge" | "organizer" ?? "participant";
 
@@ -139,7 +163,7 @@ export default function PlatformLogin() {
     const [searchParams] = useSearchParams();
     const app = parseAuthApp(searchParams.get("app"));
     const isFounderTools = app === "founder-tools";
-    const next = searchParams.get("next") || getDefaultNext(app);
+    const next = normalizeNextForApp(app, searchParams.get("next"));
     const error = searchParams.get("error");
     const submit = useSubmit();
 

--- a/app/routes/verify-email.tsx
+++ b/app/routes/verify-email.tsx
@@ -10,6 +10,30 @@ function getDefaultNext(app: string | null): string {
     return "/esafety/dashboard";
 }
 
+const LEGACY_FOUNDER_NEXT_PATHS: Record<string, string> = {
+    "/vibe-raising": "/founder-tools",
+    "/vibe-raising/": "/founder-tools",
+    "/vibe-raising/create-update": "/founder-tools/updates/create",
+    "/vibe-raising/connect-data": "/founder-tools/data-sources",
+    "/vibe-raising/companies": "/founder-tools/companies",
+    "/vibe-raising/company-setup": "/founder-tools/company-setup",
+    "/vibe-raising/discover": "/founder-tools/updates",
+};
+
+function normalizeNextForApp(app: string | null, nextValue: string | null): string {
+    const fallback = getDefaultNext(app);
+    const next = nextValue?.trim() || fallback;
+
+    if (!next.startsWith("/") || next.startsWith("//")) return fallback;
+    if (app !== "founder-tools" && app !== "vibe-raising") return next;
+
+    const target = new URL(next, "https://mlai.local");
+    const mappedPath = LEGACY_FOUNDER_NEXT_PATHS[target.pathname];
+    if (mappedPath) return `${mappedPath}${target.search}${target.hash}`;
+    if (target.pathname.startsWith("/vibe-raising/")) return `/founder-tools/updates${target.search}${target.hash}`;
+    return next;
+}
+
 function getLoginHref(app: string | null, next: string): string {
     const params = new URLSearchParams();
 
@@ -26,7 +50,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const url = new URL(request.url);
     const token = url.searchParams.get("token");
     const app = url.searchParams.get("app");
-    const next = url.searchParams.get("next") || getDefaultNext(app);
+    const next = normalizeNextForApp(app, url.searchParams.get("next"));
     const loginHref = getLoginHref(app, next);
 
     if (!token) {

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -881,7 +881,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                             consistent, transparent monthly updates.
                         </p>
                         <button
-                            onClick={() => triggerAnnouncement(() => navigate("/founder-tools/data-sources"))}
+                            onClick={() => triggerAnnouncement(() => navigate("/founder-tools/updates/create"))}
                             className="inline-flex items-center gap-3 px-8 py-4 bg-white text-gray-900 font-bold rounded-xl transition-all shadow-lg hover:shadow-xl hover:bg-gray-100 active:scale-[0.98]"
                         >
                             Create Your First Update

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -1,152 +1,346 @@
-import { Form, redirect, useLoaderData, useNavigation } from "react-router";
+import { redirect, useActionData, useLoaderData } from "react-router";
 import type { Route } from "./+types/vibe-raising-app.company-setup";
-import { ArrowPathIcon, BuildingOffice2Icon } from "@heroicons/react/24/outline";
-import FounderStartupDetailsStep from "~/components/FounderStartupDetailsStep";
+import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { getEnv } from "~/lib/env.server";
-import { getVibeMarketingBootstrap } from "~/lib/vibe-marketing";
 import {
-    getActiveVibeRaisingCompany,
-    requireVibeRaisingFounder,
-    saveVibeRaisingCompany,
-    setVibeRaisingActiveCompany,
+  getVibeMarketingBootstrap,
+  startVibeMarketingAutofill,
+} from "~/lib/vibe-marketing";
+import { combineCompanyContext } from "~/lib/vibe-marketing-startup-setup";
+import {
+  getActiveVibeRaisingCompany,
+  getOptionalVibeRaisingContext,
+  getVibeRaisingLoginHref,
+  saveVibeRaisingCompany,
+  saveVibeRaisingProfile,
+  setVibeRaisingActiveCompany,
 } from "~/lib/vibe-raising";
-
-function sanitizeNext(value: string | null) {
-    if (value?.startsWith("/founder-tools/marketing")) return value;
-    if (value?.startsWith("/founder-tools/companies")) return value;
-    if (value?.startsWith("/founder-tools/data-sources")) return value;
-    if (value?.startsWith("/founder-tools/updates")) return value;
-    return "/founder-tools/data-sources";
-}
+import type { VibeMarketingBootstrap } from "~/types/vibe-marketing";
+import type { VibeRaisingCompany, VibeRaisingProfile } from "~/types/vibe-raising";
 
 function listFromForm(value: FormDataEntryValue | null) {
-    return String(value ?? "")
-        .split(/[,\n]/)
-        .map((item) => item.trim())
-        .filter(Boolean);
+  return String(value ?? "")
+    .split(/[,\n]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function stringFromForm(formData: FormData, key: string) {
+  return String(formData.get(key) ?? "").trim();
+}
+
+function fieldLabel(field: string) {
+  const labels: Record<string, string> = {
+    companyLinkedInUrl: "Company LinkedIn URL",
+    company_linkedin_url: "Company LinkedIn URL",
+    organizationKind: "Organization type",
+    organization_kind: "Organization type",
+    companyId: "Company",
+    company_id: "Company",
+    name: "Company name",
+    domain: "Website domain",
+    abn: "ABN",
+    location: "Startup location",
+    non_field_errors: "Company details",
+  };
+  return labels[field] ?? field.replace(/_/g, " ");
+}
+
+function readableBackendError(error: any) {
+  const data = error?.data ?? error?.response?.data;
+
+  if (typeof data === "string" && data.trim()) {
+    return data.trim();
+  }
+
+  if (data && typeof data === "object") {
+    const payload = data as Record<string, unknown>;
+    for (const key of ["detail", "error", "message"]) {
+      const value = payload[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+
+    const fieldMessages = Object.entries(payload)
+      .flatMap(([field, value]) => {
+        const messages = Array.isArray(value) ? value : [value];
+        return messages
+          .map((item) => String(item ?? "").trim())
+          .filter(Boolean)
+          .map((message) => `${fieldLabel(field)}: ${message}`);
+      })
+      .filter(Boolean);
+
+    if (fieldMessages.length > 0) {
+      return fieldMessages.join(" ");
+    }
+  }
+
+  return error?.message ?? "Company details could not be saved.";
+}
+
+function emptyBootstrap(profile: VibeRaisingProfile | null, company: VibeRaisingCompany | null): VibeMarketingBootstrap {
+  const companyName = company?.name ?? profile?.organizationName ?? "";
+  const domain = company?.domain ?? "";
+
+  return {
+    company: {
+      id: company?.id ?? "",
+      name: companyName,
+      domain,
+      companyLinkedInUrl: company?.companyLinkedInUrl ?? null,
+      location: company?.location ?? null,
+      abn: company?.abn ?? null,
+      organizationId: null,
+    },
+    organization: {
+      id: null,
+      name: companyName,
+      domain,
+      companyLinkedInUrl: company?.companyLinkedInUrl ?? null,
+      competitors: [],
+      seedKeywords: [],
+    },
+    settings: {
+      brandName: companyName || null,
+      companyContext: null,
+      articleDeliveryMode: "publish_code",
+      githubRepo: null,
+      dailyDiscoveryEnabled: false,
+      dailyDiscoveryPriority: 0,
+      defaultTimezone: null,
+      githubConnectionState: null,
+    },
+    startupProfile: {
+      founderNames: [],
+      stage: null,
+      organizationKind: null,
+      notes: null,
+      companyAliases: companyName ? [companyName] : [],
+      domainAliases: domain ? [domain] : [],
+      competitorDomains: [],
+      positiveKeywords: [],
+    },
+    websiteBaseline: {
+      status: "missing",
+      passed: false,
+      skipped: false,
+      domain,
+      collectedAt: null,
+      overallScore: null,
+      summary: null,
+      sourceStatus: {},
+      metrics: {},
+      recommendations: [],
+    },
+    googleBaselineConnection: {
+      connected: false,
+      hasBaselineScopes: false,
+      status: "needs_connection",
+      connectUrl: null,
+    },
+    checks: {},
+    latestRuns: [],
+    latestRunsByWorkflow: {},
+    topicCandidates: [],
+    hiddenTopicCandidates: [],
+    writtenTopics: [],
+    publishEvidence: {},
+    guidedSteps: [],
+    currentGuidedStep: "startupDetails",
+    recommendedNextAction: { key: "startupDetails", label: "Add startup details" },
+    workflowProgress: null,
+    hasCompletedArticleFlow: false,
+    startPageMode: "first_article_setup",
+  };
+}
+
+function companyContextFromForm(formData: FormData) {
+  return (
+    stringFromForm(formData, "companyContext") ||
+    combineCompanyContext({
+      shortDescription: stringFromForm(formData, "shortDescription"),
+      problemSolved: stringFromForm(formData, "problemSolved"),
+      targetAudience: stringFromForm(formData, "targetAudience"),
+    })
+  );
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-    const env = getEnv(context);
-    const { appUser: user } = await requireVibeRaisingFounder(env, request);
-    const url = new URL(request.url);
-    const isAddingNew = url.searchParams.get("new") === "true";
-    const isEditing = url.searchParams.get("edit") === "true";
-    const next = sanitizeNext(url.searchParams.get("next"));
-    const activeCompany = getActiveVibeRaisingCompany(user);
+  const env = getEnv(context);
+  const vibeContext = await getOptionalVibeRaisingContext(env, request);
 
-    // If not adding or editing a company and already registered, skip setup
-    if (!isAddingNew && !isEditing && user.companyRegistered) {
-        throw redirect(next);
-    }
+  if (!vibeContext.authUser) {
+    throw redirect(getVibeRaisingLoginHref(request));
+  }
 
-    let marketingBootstrap = null;
+  const url = new URL(request.url);
+  const isAddingNew = url.searchParams.get("new") === "true";
+  const activeCompany = isAddingNew
+    ? null
+    : vibeContext.appUser
+      ? getActiveVibeRaisingCompany(vibeContext.appUser)
+      : vibeContext.profile
+        ? getActiveVibeRaisingCompany(vibeContext.profile)
+        : null;
+
+  let bootstrap = emptyBootstrap(vibeContext.profile, activeCompany);
+  if (activeCompany && !isAddingNew) {
     try {
-        marketingBootstrap = await getVibeMarketingBootstrap(env, request);
+      bootstrap = await getVibeMarketingBootstrap(env, request);
     } catch {
-        marketingBootstrap = null;
+      bootstrap = emptyBootstrap(vibeContext.profile, activeCompany);
     }
+  }
 
-    return { user, activeCompany, isAddingNew, isEditing, next, marketingBootstrap };
+  return {
+    bootstrap,
+    isAddingNew,
+    isEditingExisting: Boolean(activeCompany && !isAddingNew && activeCompany.registered),
+  };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
-    const env = getEnv(context);
-    const { appUser: user } = await requireVibeRaisingFounder(env, request);
-    const url = new URL(request.url);
-    const isAddingNew = url.searchParams.get("new") === "true";
-    const next = sanitizeNext(url.searchParams.get("next"));
-    const formData = await request.formData();
-    const activeCompany = getActiveVibeRaisingCompany(user);
+  const env = getEnv(context);
+  const vibeContext = await getOptionalVibeRaisingContext(env, request);
 
-    const companyName =
-        formData.get("companyName")?.toString() || activeCompany?.name || user.companyName;
-    const domain = formData.get("domain")?.toString() || "";
-    const abn = formData.get("abn")?.toString() || "";
-    const location = formData.get("location")?.toString().trim() || "";
-    const companyId = await saveVibeRaisingCompany(env, request, {
-        companyId: isAddingNew ? null : activeCompany?.id ?? null,
-        name: companyName,
-        domain,
-        companyLinkedInUrl: formData.get("companyLinkedInUrl")?.toString().trim() || "",
-        abn,
-        ...(location ? { location } : {}),
-        brandName: formData.get("brandName")?.toString().trim() || companyName,
-        companyContext: formData.get("companyContext")?.toString().trim() || "",
+  if (!vibeContext.authUser) {
+    throw redirect(getVibeRaisingLoginHref(request));
+  }
+
+  const url = new URL(request.url);
+  const isAddingNew = url.searchParams.get("new") === "true";
+  const formData = await request.formData();
+  const intent = stringFromForm(formData, "intent");
+  const companyContext = companyContextFromForm(formData);
+
+  try {
+    if (intent === "start-autofill") {
+      if (!vibeContext.profile) {
+        await saveVibeRaisingProfile(env, request, {
+          role: "founder",
+          organizationName: null,
+        });
+      }
+
+      const result = await startVibeMarketingAutofill(env, request, {
+        companyName: stringFromForm(formData, "companyName"),
+        company_name: stringFromForm(formData, "companyName"),
+        domain: stringFromForm(formData, "domain"),
+        companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
+        company_linkedin_url: stringFromForm(formData, "companyLinkedInUrl"),
+        location: stringFromForm(formData, "location"),
+        abn: stringFromForm(formData, "abn"),
+        organizationKind: stringFromForm(formData, "organizationKind"),
+        organization_kind: stringFromForm(formData, "organizationKind"),
+        existingFields: {
+          companyContext,
+          competitors: listFromForm(formData.get("competitors")),
+          seedKeywords: listFromForm(formData.get("seedKeywords")),
+          companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
+        },
+        companyContext,
         competitors: listFromForm(formData.get("competitors")),
         seedKeywords: listFromForm(formData.get("seedKeywords")),
-        founderNames: listFromForm(formData.get("founderNames")),
-        stage: formData.get("stage")?.toString().trim() || "",
-        notes: formData.get("notes")?.toString().trim() || "",
-        registered: true,
+      });
+      return { intent, autofillRunId: result.runId, status: result.status, error: result.error, errors: result.errors };
+    }
+
+    if (intent !== "save-startup-details") {
+      return null;
+    }
+
+    const companyName = stringFromForm(formData, "companyName");
+    const domain = stringFromForm(formData, "domain");
+    if (!companyName) {
+      return { intent, error: "Add your startup or company name before continuing." };
+    }
+    if (!domain) {
+      return { intent, error: "Add your website domain before continuing." };
+    }
+
+    if (!vibeContext.profile) {
+      await saveVibeRaisingProfile(env, request, {
+        role: "founder",
+        organizationName: null,
+      });
+    }
+
+    const activeCompany = vibeContext.appUser
+      ? getActiveVibeRaisingCompany(vibeContext.appUser)
+      : vibeContext.profile
+        ? getActiveVibeRaisingCompany(vibeContext.profile)
+        : null;
+    const companyId = await saveVibeRaisingCompany(env, request, {
+      companyId: isAddingNew ? null : activeCompany?.id ?? null,
+      name: companyName,
+      domain,
+      companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
+      location: stringFromForm(formData, "location"),
+      abn: stringFromForm(formData, "abn"),
+      brandName: companyName,
+      companyContext,
+      competitors: listFromForm(formData.get("competitors")),
+      seedKeywords: listFromForm(formData.get("seedKeywords")),
+      founderNames: listFromForm(formData.get("founderNames")),
+      stage: stringFromForm(formData, "stage"),
+      organizationKind: stringFromForm(formData, "organizationKind"),
+      notes: stringFromForm(formData, "targetAudience"),
+      registered: true,
     });
 
-    if (isAddingNew) {
-        if (companyId) {
-            await setVibeRaisingActiveCompany(env, request, companyId);
-        }
-        return redirect(next);
-    }
-
     if (companyId) {
-        await setVibeRaisingActiveCompany(env, request, companyId);
+      await setVibeRaisingActiveCompany(env, request, companyId);
     }
+  } catch (error: any) {
+    if (error instanceof Response) throw error;
+    return { intent, error: readableBackendError(error) };
+  }
 
-    return redirect(next);
+  throw redirect("/founder-tools");
 }
 
 export default function CompanySetup() {
-    const { user, activeCompany, isAddingNew, isEditing, next, marketingBootstrap } = useLoaderData<typeof loader>();
-    const navigation = useNavigation();
-    const isSubmitting = navigation.state === "submitting";
+  const { bootstrap, isAddingNew, isEditingExisting } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const error = actionData && typeof actionData === "object" && "error" in actionData ? String(actionData.error ?? "") : null;
+  const title = isAddingNew ? "Add a company" : isEditingExisting ? "Edit company setup" : "Set up your company";
 
-    return (
-        <div className="flex items-center justify-center p-4 min-h-[70vh]">
-            <div className="w-full max-w-3xl">
-                <div className="rounded-2xl border border-[var(--vr-color-border)] bg-[var(--vr-color-card)] p-8 shadow-lg sm:p-12">
-                    {/* Header */}
-                    <div className="text-center mb-8">
-                        <div className="mb-4 inline-flex h-14 w-14 items-center justify-center rounded-full bg-[rgba(0,255,215,0.14)]">
-                            <BuildingOffice2Icon className="h-7 w-7 text-[var(--vr-color-primary)]" />
-                        </div>
-                        <h1 className="mb-2 text-2xl font-bold text-[var(--vr-color-text)]">
-                            {isAddingNew ? "Add Another Company" : isEditing ? "Edit company details" : "Let's start with some basic details"}
-                        </h1>
-                    </div>
-
-                    <Form method="POST" className="space-y-6">
-                        <input type="hidden" name="next" value={next} />
-                        <FounderStartupDetailsStep
-                            defaults={{
-                                companyName: isAddingNew ? "" : activeCompany?.name || user.companyName,
-                                domain: isAddingNew ? "" : activeCompany?.domain || "",
-                                companyLinkedInUrl: isAddingNew ? "" : marketingBootstrap?.organization.companyLinkedInUrl ?? activeCompany?.companyLinkedInUrl ?? "",
-                                location: isAddingNew ? "" : activeCompany?.location || "",
-                                abn: isAddingNew ? "" : activeCompany?.abn || "",
-                                brandName: marketingBootstrap?.settings.brandName ?? activeCompany?.name ?? user.companyName,
-                                companyContext: marketingBootstrap?.settings.companyContext ?? "",
-                                competitors: marketingBootstrap?.organization.competitors ?? [],
-                                seedKeywords: marketingBootstrap?.organization.seedKeywords ?? [],
-                                founderNames: marketingBootstrap?.startupProfile.founderNames ?? [],
-                                stage: marketingBootstrap?.startupProfile.stage ?? "",
-                                notes: marketingBootstrap?.startupProfile.notes ?? "",
-                            }}
-                            compact
-                        />
-
-                        {/* Submit */}
-                        <button
-                            type="submit"
-                            disabled={isSubmitting}
-                            className={`mt-2 flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-6 py-4 font-bold text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition-all duration-200
-                                ${isSubmitting ? "opacity-70 cursor-not-allowed" : "hover:bg-[var(--vr-palette-black)] hover:shadow-xl active:scale-[0.98]"}`}
-                        >
-                            {isSubmitting && <ArrowPathIcon className="w-5 h-5 animate-spin" aria-hidden="true" />}
-                            {isSubmitting ? "Saving..." : isAddingNew ? "Add Company" : isEditing ? "Save Details" : "Continue"}
-                        </button>
-                    </Form>
-                </div>
-            </div>
+  return (
+    <div className="min-h-screen bg-[#fbfaf8] px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-6">
+          <p className="text-sm font-black text-violet-700">Founder Tools</p>
+          <h1 className="mt-2 text-3xl font-black tracking-normal text-gray-950">{title}</h1>
+          <p className="mt-2 max-w-2xl text-sm font-semibold leading-6 text-gray-600">
+            These details power Vibe Raising and Vibe Marketing, so you only need to set them up once.
+          </p>
         </div>
-    );
+
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
+          <VibeMarketingStartupBaselineSetup
+            bootstrap={bootstrap}
+            error={error}
+            variant="workflow"
+            includeBaseline={false}
+            setupEyebrow="Company setup"
+            setupTitle="Tell us about your startup"
+            setupDescription="This shared profile is used across Vibe Raising and Vibe Marketing."
+            guidanceTitle="Shared profile"
+            guidanceBody="The same company details will be reused for investor updates, marketing research, and article generation."
+            guidanceTips={[
+              "Use the public website domain",
+              "Add LinkedIn if the company name is ambiguous",
+              "Describe your customer and problem clearly",
+              "You can edit these details later",
+            ]}
+            primaryActionLabel={isAddingNew ? "Add company" : "Save and go to dashboard"}
+            showSecondaryAction={false}
+            advancedOpenByDefault
+          />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -10,6 +10,8 @@ import {
   CheckIcon,
   CheckCircleIcon,
   ChevronDownIcon,
+  CloudArrowUpIcon,
+  DocumentTextIcon,
   FolderIcon,
   LinkIcon,
   LockClosedIcon,
@@ -29,6 +31,10 @@ import {
   getVibeRaisingInputSourcesStatus,
   getVibeRaisingLinearPreview,
   getVibeRaisingLinearProjects,
+  listVibeRaisingManualDocuments,
+  uploadVibeRaisingManualDocument,
+  deleteVibeRaisingManualDocument,
+  getVibeRaisingManualDocumentDownloadUrl,
   getVibeRaisingSlackChannels,
   getVibeRaisingSlackPreview,
   getVibeRaisingXeroPreview,
@@ -47,6 +53,7 @@ import type {
   VibeRaisingLinearPreview,
   VibeRaisingLinearProject,
   VibeRaisingLinearProjectsResponse,
+  VibeRaisingManualDocument,
   VibeRaisingSlackChannel,
   VibeRaisingSlackChannelsResponse,
   VibeRaisingSlackPreview,
@@ -134,34 +141,55 @@ const EMPTY_SOURCES: VibeRaisingInputSourceSummary[] = [
 ];
 
 type ManualMaterialsState = {
-  sourceUrl: string;
   summary: string;
+  manualDocumentIds: string[];
+  documents: VibeRaisingManualDocument[];
 };
 
+type OAuthSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "manual_documents">;
+
+function isOAuthSourceKey(key: VibeRaisingInputSourceKey): key is OAuthSourceKey {
+  return key !== "gmail" && key !== "manual_documents";
+}
+
 function readStoredManualMaterials(): ManualMaterialsState {
-  if (typeof window === "undefined") return { sourceUrl: "", summary: "" };
+  if (typeof window === "undefined") return { summary: "", manualDocumentIds: [], documents: [] };
   try {
     const raw = window.localStorage.getItem(MANUAL_MATERIALS_STORAGE_KEY);
-    if (!raw) return { sourceUrl: "", summary: "" };
-    const parsed = JSON.parse(raw) as { sourceUrl?: unknown; summary?: unknown };
+    if (!raw) return { summary: "", manualDocumentIds: [], documents: [] };
+    const parsed = JSON.parse(raw) as {
+      sourceUrl?: unknown;
+      summary?: unknown;
+      manualDocumentIds?: unknown;
+      documents?: unknown;
+    };
+    const documents = Array.isArray(parsed.documents)
+      ? parsed.documents.filter((item): item is VibeRaisingManualDocument => Boolean(item && typeof item === "object" && "id" in item))
+      : [];
+    const manualDocumentIds = Array.isArray(parsed.manualDocumentIds)
+      ? parsed.manualDocumentIds.map((item) => String(item || "").trim()).filter(Boolean)
+      : documents.map((document) => document.id);
+
     return {
-      sourceUrl: typeof parsed.sourceUrl === "string" ? parsed.sourceUrl : "",
       summary: typeof parsed.summary === "string" ? parsed.summary : "",
+      manualDocumentIds,
+      documents: documents.filter((document) => manualDocumentIds.includes(document.id)),
     };
   } catch {
-    return { sourceUrl: "", summary: "" };
+    return { summary: "", manualDocumentIds: [], documents: [] };
   }
 }
 
 function writeStoredManualMaterials(materials: ManualMaterialsState) {
   if (typeof window === "undefined") return;
-  const sourceUrl = materials.sourceUrl.trim();
   const summary = materials.summary.trim();
-  if (!sourceUrl && !summary) {
+  const manualDocumentIds = Array.from(new Set(materials.manualDocumentIds.map((item) => item.trim()).filter(Boolean)));
+  const documents = materials.documents.filter((document) => manualDocumentIds.includes(document.id));
+  if (manualDocumentIds.length === 0 && !summary) {
     window.localStorage.removeItem(MANUAL_MATERIALS_STORAGE_KEY);
     return;
   }
-  window.localStorage.setItem(MANUAL_MATERIALS_STORAGE_KEY, JSON.stringify({ sourceUrl, summary }));
+  window.localStorage.setItem(MANUAL_MATERIALS_STORAGE_KEY, JSON.stringify({ summary, manualDocumentIds, documents }));
 }
 
 const SOURCE_COPY: Record<VibeRaisingInputSourceKey, { description: string; connectedUse: string }> = {
@@ -196,6 +224,10 @@ const SOURCE_COPY: Record<VibeRaisingInputSourceKey, { description: string; conn
   linear: {
     description: "Pull project updates, active workstreams, and key tasks from Linear.",
     connectedUse: "Projects, tasks, updates",
+  },
+  manual_documents: {
+    description: "Use uploaded founder documents as deterministic context.",
+    connectedUse: "Documents, summary",
   },
 };
 
@@ -1433,7 +1465,7 @@ function ManualMaterialsCard({
   summary: string;
   onToggle: () => void;
 }) {
-  const cardCaption = "Add a source link or a short written summary for context outside your connected tools.";
+  const cardCaption = "Upload private documents or add a short written summary for context outside your connected tools.";
 
   return (
     <button
@@ -1457,7 +1489,7 @@ function ManualMaterialsCard({
         )}
       >
         <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
-          <LinkIcon className="h-6 w-6 sm:h-8 sm:w-8" />
+          <DocumentTextIcon className="h-6 w-6 sm:h-8 sm:w-8" />
         </div>
         <h3
           className={clsx(
@@ -1496,7 +1528,7 @@ function ManualMaterialsCard({
         </p>
 
         <div className="mt-2 flex flex-wrap gap-1 sm:mt-3">
-          {["Link", "Summary"].map((item) => (
+          {["Documents", "Summary"].map((item) => (
             <span
               key={item}
               className="rounded-full bg-gray-50 px-1.5 py-0.5 text-[9px] font-bold text-slate-500 sm:text-[10px]"
@@ -1689,7 +1721,12 @@ export default function ConnectData() {
   const [savingLinearProjects, setSavingLinearProjects] = useState(false);
   const [selectedLinearProjectIds, setSelectedLinearProjectIds] = useState<Set<string>>(new Set());
   const [manualMaterials, setManualMaterials] = useState<ManualMaterialsState>(() => readStoredManualMaterials());
+  const [manualDocuments, setManualDocuments] = useState<VibeRaisingManualDocument[]>(() => readStoredManualMaterials().documents);
+  const [loadingManualDocuments, setLoadingManualDocuments] = useState(false);
+  const [manualDocumentUploadStatus, setManualDocumentUploadStatus] = useState<"idle" | "creating_session" | "uploading" | "finalizing">("idle");
+  const [manualDocumentError, setManualDocumentError] = useState<string | null>(null);
   const [manualMaterialsExpanded, setManualMaterialsExpanded] = useState(false);
+  const manualDocumentInputRef = useRef<HTMLInputElement | null>(null);
   const defaultSelectionAppliedRef = useRef(false);
   const slackSelectionTouchedRef = useRef(false);
   const linearSelectionTouchedRef = useRef(false);
@@ -1705,13 +1742,14 @@ export default function ConnectData() {
   );
   const slackChannels = useMemo(() => Object.values(slackChannelsById), [slackChannelsById]);
   const linearProjects = useMemo(() => Object.values(linearProjectsById), [linearProjectsById]);
-  const hasManualMaterials = Boolean(manualMaterials.sourceUrl.trim() || manualMaterials.summary.trim());
+  const selectedManualDocumentIds = useMemo(() => new Set(manualMaterials.manualDocumentIds), [manualMaterials.manualDocumentIds]);
+  const hasManualMaterials = Boolean(manualMaterials.manualDocumentIds.length > 0 || manualMaterials.summary.trim());
   const manualMaterialsSummary = hasManualMaterials
     ? [
-      manualMaterials.sourceUrl.trim() ? "URL added" : null,
+      manualMaterials.manualDocumentIds.length > 0 ? `${manualMaterials.manualDocumentIds.length} document${manualMaterials.manualDocumentIds.length === 1 ? "" : "s"} selected` : null,
       manualMaterials.summary.trim() ? "summary added" : null,
     ].filter((value): value is string => Boolean(value)).join(" and ")
-    : "Add a source link or a short written summary when you want extra context in the draft.";
+    : "Upload private documents or add a short written summary when you want extra context in the draft.";
   const gmailSource = sourceByKey.get("gmail");
   const shouldShowGmailPreview = gmailSource?.status === "connected" || gmailSource?.status === "syncing" || gmailSource?.status === "error";
   const bankFeedSource = sourceByKey.get("bank_feed");
@@ -1753,6 +1791,39 @@ export default function ConnectData() {
       setManualMaterialsExpanded(true);
     }
   }, [hasManualMaterials]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingManualDocuments(true);
+    setManualDocumentError(null);
+    listVibeRaisingManualDocuments(backendBaseUrl)
+      .then((documents) => {
+        if (cancelled) return;
+        setManualDocuments(documents);
+        setManualMaterials((previous) => {
+          const selectedIds = new Set(previous.manualDocumentIds);
+          const selectedDocuments = documents.filter((document) => selectedIds.has(document.id));
+          const nextMaterials = {
+            ...previous,
+            manualDocumentIds: selectedDocuments.map((document) => document.id),
+            documents: selectedDocuments,
+          };
+          writeStoredManualMaterials(nextMaterials);
+          return nextMaterials;
+        });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setManualDocumentError(error instanceof Error ? error.message : "We couldn't load uploaded documents.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingManualDocuments(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [backendBaseUrl]);
 
   useEffect(() => {
     if (!shouldShowGmailPreview) {
@@ -2046,6 +2117,7 @@ export default function ConnectData() {
         return;
       }
 
+      if (!isOAuthSourceKey(source.key)) return;
       window.location.assign(connectVibeRaisingInputSource(backendBaseUrl, source.key, currentReturnPath));
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : `We couldn't connect ${source.label}.`);
@@ -2340,8 +2412,12 @@ export default function ConnectData() {
     }
     writeStoredManualMaterials(manualMaterials);
     const target = new URL(next, "http://mlai.local");
-    if (includeInputs && selectedSources.size > 0) {
-      target.searchParams.set("inputs", Array.from(selectedSources).join(","));
+    const draftSources = new Set(selectedSources);
+    if (includeInputs && hasManualMaterials) {
+      draftSources.add("manual_documents");
+    }
+    if (includeInputs && draftSources.size > 0) {
+      target.searchParams.set("inputs", Array.from(draftSources).join(","));
     } else {
       target.searchParams.delete("inputs");
     }
@@ -2349,7 +2425,7 @@ export default function ConnectData() {
   };
 
   const handleManualMaterialsContinue = () => {
-    if (selectedSourceList.length === 0) {
+    if (selectedSourceList.length === 0 && !hasManualMaterials) {
       setShowNoSourcesModal(true);
       return;
     }
@@ -2369,8 +2445,72 @@ export default function ConnectData() {
     });
   };
 
+  const updateManualDocumentSelection = (document: VibeRaisingManualDocument, selected: boolean) => {
+    setManualMaterials((previous) => {
+      const idSet = new Set(previous.manualDocumentIds);
+      if (selected) {
+        idSet.add(document.id);
+      } else {
+        idSet.delete(document.id);
+      }
+      const documentsById = new Map([...manualDocuments, ...previous.documents, document].map((item) => [item.id, item]));
+      const nextMaterials = {
+        ...previous,
+        manualDocumentIds: Array.from(idSet),
+        documents: Array.from(idSet)
+          .map((documentId) => documentsById.get(documentId))
+          .filter((item): item is VibeRaisingManualDocument => Boolean(item)),
+      };
+      writeStoredManualMaterials(nextMaterials);
+      return nextMaterials;
+    });
+  };
+
   const clearManualMaterials = () => {
-    updateManualMaterials({ sourceUrl: "", summary: "" });
+    updateManualMaterials({ summary: "", manualDocumentIds: [], documents: [] });
+  };
+
+  const handleManualDocumentFile = async (file: File | null | undefined) => {
+    if (!file) return;
+    setManualDocumentError(null);
+    try {
+      const document = await uploadVibeRaisingManualDocument(
+        backendBaseUrl,
+        file,
+        undefined,
+        setManualDocumentUploadStatus,
+      );
+      setManualDocuments((previous) => [document, ...previous.filter((item) => item.id !== document.id)]);
+      updateManualDocumentSelection(document, true);
+    } catch (error) {
+      setManualDocumentError(error instanceof Error ? error.message : "We couldn't upload that document.");
+    } finally {
+      setManualDocumentUploadStatus("idle");
+      if (manualDocumentInputRef.current) {
+        manualDocumentInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleDeleteManualDocument = async (document: VibeRaisingManualDocument) => {
+    setManualDocumentError(null);
+    try {
+      await deleteVibeRaisingManualDocument(backendBaseUrl, document.id);
+      setManualDocuments((previous) => previous.filter((item) => item.id !== document.id));
+      updateManualDocumentSelection(document, false);
+    } catch (error) {
+      setManualDocumentError(error instanceof Error ? error.message : "We couldn't delete that document.");
+    }
+  };
+
+  const handleOpenManualDocument = async (document: VibeRaisingManualDocument) => {
+    setManualDocumentError(null);
+    try {
+      const response = await getVibeRaisingManualDocumentDownloadUrl(backendBaseUrl, document.id);
+      window.open(response.downloadUrl, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      setManualDocumentError(error instanceof Error ? error.message : "We couldn't open that document.");
+    }
   };
 
   const handleStepperClick = (step: MonthlyUpdateStepKey) => {
@@ -2392,7 +2532,7 @@ export default function ConnectData() {
   const stickyStatusDetail = selectedSourceList.length > 0
     ? selectedSourceList.map((source) => source.label).join(", ")
     : hasManualMaterials
-      ? "Your URL or summary will be included in the draft."
+      ? "Your uploaded documents or summary will be included in the draft."
       : "Continue with manual input only, or connect a source first.";
   const stickyStatusIcon = selectedSourceList.length > 0 ? (
     <div className="flex -space-x-2">
@@ -2496,7 +2636,7 @@ export default function ConnectData() {
             >
               <div className="flex items-center justify-between gap-4">
                 <p className="text-sm font-bold text-slate-500">
-                  Add a source URL or a short written summary for extra context.
+                  Upload documents or add a short written summary for extra context.
                 </p>
                 {hasManualMaterials ? (
                   <button
@@ -2509,30 +2649,104 @@ export default function ConnectData() {
                 ) : null}
               </div>
 
-              <label className="block">
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                <div>
                 <span className="mb-1.5 flex items-center gap-2 text-sm font-bold text-gray-700">
-                  <LinkIcon className="h-4 w-4 text-gray-400" />
-                  Source URL
+                    <DocumentTextIcon className="h-4 w-4 text-gray-400" />
+                    Documents
                 </span>
-                <input
-                  type="url"
-                  value={manualMaterials.sourceUrl}
-                  onChange={(event) => updateManualMaterials({ sourceUrl: event.target.value })}
-                  placeholder="https://docs.google.com/document/..."
-                  className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 outline-none transition-all placeholder:text-gray-400 focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
-                />
-              </label>
+                  <input
+                    ref={manualDocumentInputRef}
+                    type="file"
+                    className="sr-only"
+                    accept=".pdf,.docx,.pptx,.xlsx,.xlsm,.csv,.txt,.md,.html,.htm,.rtf,.odt"
+                    onChange={(event) => void handleManualDocumentFile(event.target.files?.[0])}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => manualDocumentInputRef.current?.click()}
+                    onDragOver={(event) => {
+                      event.preventDefault();
+                      event.dataTransfer.dropEffect = "copy";
+                    }}
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      void handleManualDocumentFile(event.dataTransfer.files?.[0]);
+                    }}
+                    disabled={manualDocumentUploadStatus !== "idle"}
+                    className="flex min-h-36 w-full flex-col items-center justify-center rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-5 text-center transition hover:border-[var(--vr-color-primary)] hover:bg-[rgba(0,255,215,0.08)] disabled:cursor-wait disabled:opacity-70"
+                  >
+                    <CloudArrowUpIcon className="h-8 w-8 text-[var(--vr-color-primary)]" />
+                    <span className="mt-3 text-sm font-extrabold text-gray-900">
+                      {manualDocumentUploadStatus === "idle" ? "Upload a document" : "Uploading document..."}
+                    </span>
+                    <span className="mt-1 text-xs font-medium text-slate-500">
+                      PDF, DOCX, PPTX, XLSX, CSV, TXT, MD, HTML, RTF, or ODT up to 25 MB.
+                    </span>
+                  </button>
+                  {manualDocumentError ? (
+                    <p className="mt-2 text-sm font-semibold text-red-600">{manualDocumentError}</p>
+                  ) : null}
+                  <div className="mt-3 space-y-2">
+                    {loadingManualDocuments ? (
+                      <p className="text-sm font-semibold text-slate-500">Loading uploaded documents...</p>
+                    ) : manualDocuments.length > 0 ? (
+                      manualDocuments.map((document) => {
+                        const selected = selectedManualDocumentIds.has(document.id);
+                        return (
+                          <div
+                            key={document.id}
+                            className={clsx(
+                              "flex items-center justify-between gap-3 rounded-xl border px-3 py-2",
+                              selected ? "border-[rgba(0,255,215,0.34)] bg-[rgba(0,255,215,0.08)]" : "border-gray-200 bg-white",
+                            )}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => updateManualDocumentSelection(document, !selected)}
+                              className="min-w-0 flex-1 text-left"
+                            >
+                              <p className="truncate text-sm font-extrabold text-gray-900">{document.originalFilename}</p>
+                              <p className="mt-0.5 text-xs font-medium text-slate-500">
+                                {document.extractionStatus === "processed" ? "Ready for AI context" : document.extractionStatus}
+                              </p>
+                            </button>
+                            <div className="flex shrink-0 items-center gap-1">
+                              <button
+                                type="button"
+                                onClick={() => void handleOpenManualDocument(document)}
+                                className="rounded-lg border border-gray-200 px-2 py-1 text-xs font-bold text-gray-600 transition hover:bg-gray-50"
+                              >
+                                Open
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => void handleDeleteManualDocument(document)}
+                                className="rounded-lg border border-red-100 px-2 py-1 text-xs font-bold text-red-600 transition hover:bg-red-50"
+                              >
+                                Delete
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <p className="text-sm font-semibold text-slate-500">No uploaded documents yet.</p>
+                    )}
+                  </div>
+                </div>
 
-              <label className="block">
-                <span className="mb-1.5 block text-sm font-bold text-gray-700">Short summary</span>
-                <textarea
-                  value={manualMaterials.summary}
-                  onChange={(event) => updateManualMaterials({ summary: event.target.value })}
-                  rows={4}
-                  placeholder="Topline context investors should read before the detailed sections..."
-                  className="w-full resize-none rounded-xl border border-gray-200 px-4 py-3 text-sm leading-relaxed text-gray-900 outline-none transition-all placeholder:text-gray-400 focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
-                />
-              </label>
+                <label className="block">
+                  <span className="mb-1.5 block text-sm font-bold text-gray-700">Short summary</span>
+                  <textarea
+                    value={manualMaterials.summary}
+                    onChange={(event) => updateManualMaterials({ summary: event.target.value })}
+                    rows={4}
+                    placeholder="Topline context investors should read before the detailed sections..."
+                    className="w-full resize-none rounded-xl border border-gray-200 px-4 py-3 text-sm leading-relaxed text-gray-900 outline-none transition-all placeholder:text-gray-400 focus:border-[var(--vr-color-primary)] focus:ring-4 focus:ring-[rgba(0,128,128,0.10)]"
+                  />
+                </label>
+              </div>
             </div>
           ) : null}
         </div>

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -1,5 +1,5 @@
 import { Form, Link, useActionData, useLocation, useNavigate, useNavigation, useLoaderData, redirect } from "react-router";
-import React, { startTransition, useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import React, { startTransition, useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import type { Route } from "./+types/vibe-raising-app.create-update";
 import { getEnv } from "~/lib/env.server";
 import {
@@ -45,6 +45,7 @@ import VibeRaisingStickyStepBar from "~/components/VibeRaisingStickyStepBar";
 import { getVibeRaisingMonthTheme, parseVibeRaisingMonthYear, VIBE_RAISING_MONTH_OPTIONS, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
 import type {
     VibeRaisingInputSourceKey,
+    VibeRaisingManualDocument,
     VibeRaisingMetricSuggestion,
     VibeRaisingMonthlyUpdate,
     VibeRaisingStartupUpdateStatusResponse,
@@ -60,6 +61,7 @@ const VALID_INPUT_SOURCE_KEYS = new Set<VibeRaisingInputSourceKey>([
     "google_drive",
     "slack",
     "linear",
+    "manual_documents",
 ]);
 
 const INPUT_SOURCE_LABELS: Record<VibeRaisingInputSourceKey, string> = {
@@ -71,6 +73,7 @@ const INPUT_SOURCE_LABELS: Record<VibeRaisingInputSourceKey, string> = {
     google_drive: "Google Drive",
     slack: "Slack",
     linear: "Linear",
+    manual_documents: "Manual documents",
 };
 
 const DEFAULT_BACKEND_BASE_URL = "https://api.mlai.au";
@@ -78,18 +81,33 @@ const MANUAL_MATERIALS_STORAGE_KEY = "vibe_raising_manual_materials";
 const SHOW_AI_REVIEW_FEEDBACK = false;
 const DRAFT_REVIEW_FORM_ID = "vibe-raising-draft-review-form";
 
-function readStoredManualMaterials(): { summary: string; sourceUrl: string } {
-    if (typeof window === "undefined") return { summary: "", sourceUrl: "" };
+function readStoredManualMaterials(): { summary: string; sourceUrl: string; manualDocumentIds: string[]; documents: VibeRaisingManualDocument[] } {
+    if (typeof window === "undefined") return { summary: "", sourceUrl: "", manualDocumentIds: [], documents: [] };
     try {
         const raw = window.localStorage.getItem(MANUAL_MATERIALS_STORAGE_KEY);
-        if (!raw) return { summary: "", sourceUrl: "" };
-        const parsed = JSON.parse(raw) as { summary?: unknown; sourceUrl?: unknown };
+        if (!raw) return { summary: "", sourceUrl: "", manualDocumentIds: [], documents: [] };
+        const parsed = JSON.parse(raw) as {
+            summary?: unknown;
+            sourceUrl?: unknown;
+            manualDocumentIds?: unknown;
+            documents?: unknown;
+        };
+        const documents = Array.isArray(parsed.documents)
+            ? parsed.documents.filter((item): item is VibeRaisingManualDocument =>
+                Boolean(item && typeof item === "object" && typeof (item as VibeRaisingManualDocument).id === "string"),
+            )
+            : [];
+        const manualDocumentIds = Array.isArray(parsed.manualDocumentIds)
+            ? parsed.manualDocumentIds.map((item) => String(item || "").trim()).filter(Boolean)
+            : documents.map((document) => document.id);
         return {
             summary: typeof parsed.summary === "string" ? parsed.summary : "",
             sourceUrl: typeof parsed.sourceUrl === "string" ? parsed.sourceUrl : "",
+            manualDocumentIds,
+            documents,
         };
     } catch {
-        return { summary: "", sourceUrl: "" };
+        return { summary: "", sourceUrl: "", manualDocumentIds: [], documents: [] };
     }
 }
 
@@ -230,12 +248,18 @@ export async function action({ request, context }: Route.ActionArgs) {
         const metricSuggestions = metricSuggestionsFromKeys(selectedMetricKeys, metrics);
         const rawVideoUrl = String(formData.get("videoUrl") || "").trim();
         const rawVideoFileSizeBytes = Number(formData.get("videoFileSizeBytes") || 0);
+        const manualDocumentIds = String(formData.get("manualDocumentIds") || "")
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean);
 
         await saveVibeRaisingMonthlyUpdate(env, request, {
             month: String(formData.get("month") || "").trim(),
             year: Number(formData.get("year") || 0),
             summary: String(formData.get("summary") || "").trim() || null,
             sourceUrl: String(formData.get("sourceUrl") || "").trim() || null,
+            manualDocumentIds,
+            manualSummary: String(formData.get("manualSummary") || "").trim() || null,
             videoUrl: rawVideoUrl && !rawVideoUrl.startsWith("blob:") ? rawVideoUrl : null,
             videoStoragePath: String(formData.get("videoStoragePath") || "").trim() || null,
             videoContentType: String(formData.get("videoContentType") || "").trim() || null,
@@ -1518,8 +1542,19 @@ export default function CreateUpdate() {
     // State declarations
     const [isClientMounted, setIsClientMounted] = useState(false);
     const [showEmailWizard, setShowEmailWizard] = useState(false);
-    const [summary, setSummary] = useState<string>(() => defaultData?.summary || readStoredManualMaterials().summary || "");
-    const [sourceUrl, setSourceUrl] = useState<string>(() => defaultData?.sourceUrl || readStoredManualMaterials().sourceUrl || "");
+    const storedManualMaterials = useMemo(() => readStoredManualMaterials(), []);
+    const [manualSummary, setManualSummary] = useState<string>(() => storedManualMaterials.summary || "");
+    const [manualDocumentIds, setManualDocumentIds] = useState<string[]>(() => {
+        const defaultDocuments = Array.isArray(defaultData?.manualDocuments) ? defaultData.manualDocuments : [];
+        if (defaultDocuments.length > 0) return defaultDocuments.map((document: VibeRaisingManualDocument) => document.id);
+        return storedManualMaterials.manualDocumentIds;
+    });
+    const [manualDocuments, setManualDocuments] = useState<VibeRaisingManualDocument[]>(() => {
+        const defaultDocuments = Array.isArray(defaultData?.manualDocuments) ? defaultData.manualDocuments : [];
+        return defaultDocuments.length > 0 ? defaultDocuments : storedManualMaterials.documents;
+    });
+    const [summary, setSummary] = useState<string>(() => defaultData?.summary || storedManualMaterials.summary || "");
+    const [sourceUrl, setSourceUrl] = useState<string>(() => defaultData?.sourceUrl || storedManualMaterials.sourceUrl || "");
     const [highlights, setHighlights] = useState<string>(defaultData?.highlights || "");
     const [challenges, setChallenges] = useState<string>(defaultData?.challenges || "");
     const [asks, setAsks] = useState<string>(defaultData?.asks || "");
@@ -1645,6 +1680,11 @@ export default function CreateUpdate() {
         setNext30Days(data.next30Days || "");
         setSummary(data.summary || "");
         setSourceUrl(data.sourceUrl || data.source_url || "");
+        if (Array.isArray(data.manualDocuments || data.manual_documents)) {
+            const documents = (data.manualDocuments || data.manual_documents) as VibeRaisingManualDocument[];
+            setManualDocuments(documents);
+            setManualDocumentIds(documents.map((document) => document.id));
+        }
         if (data.videoUrl || data.video_url) {
             const nextVideoUrl = data.videoUrl || data.video_url;
             setUploadedVideoUrl(nextVideoUrl);
@@ -1983,6 +2023,8 @@ export default function CreateUpdate() {
                     ...(shouldForceRegenerate ? { forceRegenerate: true } : {}),
                     inputSources: selectedInputSources,
                     targetMonth: targetMonthIso,
+                    manualDocumentIds,
+                    manualSummary,
                 },
             );
             emailDraftIgnoredRunIdRef.current = null;
@@ -2003,7 +2045,7 @@ export default function CreateUpdate() {
         } finally {
             setEmailDraftActionBusy(false);
         }
-    }, [backendBaseUrl, emailDraftForceRegenerateKey, selectedInputSources, targetMonthIso]);
+    }, [backendBaseUrl, emailDraftForceRegenerateKey, manualDocumentIds, manualSummary, selectedInputSources, targetMonthIso]);
 
     const startDraftFromSelectedInputs = useCallback(async (options?: { forceRegenerate?: boolean }) => {
         if (!canGenerateDraftFromEmail) {
@@ -2228,6 +2270,9 @@ export default function CreateUpdate() {
                 editorMonthKeyRef.current = selectedMonthUpdateKey;
                 setSummary("");
                 setSourceUrl("");
+                setManualDocumentIds([]);
+                setManualDocuments([]);
+                setManualSummary("");
                 resetVideoUpload();
                 setHighlights("");
                 setChallenges("");
@@ -2249,6 +2294,9 @@ export default function CreateUpdate() {
 
         setSummary(existingUpdateForSelectedMonth.summary || "");
         setSourceUrl(existingUpdateForSelectedMonth.sourceUrl || "");
+        setManualDocuments(existingUpdateForSelectedMonth.manualDocuments || []);
+        setManualDocumentIds((existingUpdateForSelectedMonth.manualDocuments || []).map((document) => document.id));
+        setManualSummary("");
         setUploadedVideoUrl(existingUpdateForSelectedMonth.videoUrl || "");
         setVideoPreviewUrl(existingUpdateForSelectedMonth.videoUrl || null);
         setVideoStoragePath(existingUpdateForSelectedMonth.videoStoragePath || "");
@@ -2475,7 +2523,7 @@ export default function CreateUpdate() {
             return;
         }
         if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
-            setRecordingError("Recording is not supported in this browser. Upload a file or add a source URL instead.");
+            setRecordingError("Recording is not supported in this browser. Upload a file or add manual materials instead.");
             return;
         }
 
@@ -2524,7 +2572,7 @@ export default function CreateUpdate() {
             recorder.start();
             setIsRecording(true);
         } catch {
-            setRecordingError("We couldn't access your camera or microphone. Upload a file or add a source URL instead.");
+            setRecordingError("We couldn't access your camera or microphone. Upload a file or add manual materials instead.");
             setIsRecording(false);
             setRecordingMode(null);
             stopMediaStream();
@@ -2564,6 +2612,14 @@ export default function CreateUpdate() {
             if (draft.year) setSelectedYear(Number(draft.year));
             setSummary(draft.summary || "");
             setSourceUrl(draft.sourceUrl || "");
+            if (Array.isArray(draft.manualDocuments || draft.manual_documents)) {
+                const documents = (draft.manualDocuments || draft.manual_documents) as VibeRaisingManualDocument[];
+                setManualDocuments(documents);
+                setManualDocumentIds(documents.map((document) => document.id));
+            }
+            if (draft.manualSummary || draft.manual_summary) {
+                setManualSummary(draft.manualSummary || draft.manual_summary);
+            }
             revokeVideoPreviewObjectUrl();
             setUploadedVideoUrl(draft.videoUrl || "");
             setVideoPreviewUrl(draft.videoUrl || null);
@@ -3000,6 +3056,11 @@ export default function CreateUpdate() {
         const reviewYear = Number(reviewData?.year || selectedYear);
         const reviewSummary = String(reviewData?.summary || "").trim();
         const reviewSourceUrl = String(reviewData?.sourceUrl || "").trim();
+        const reviewManualDocuments = Array.isArray(reviewData?.manualDocuments || reviewData?.manual_documents)
+            ? (reviewData.manualDocuments || reviewData.manual_documents) as VibeRaisingManualDocument[]
+            : manualDocuments;
+        const reviewManualDocumentIds = reviewManualDocuments.map((document) => document.id);
+        const reviewManualSummary = String(reviewData?.manualSummary || reviewData?.manual_summary || manualSummary || "").trim();
         const reviewVideoUrl = String(reviewData?.videoUrl || (previewMediaKind === "video" ? videoPreviewUrl : "") || "").trim();
         const reviewVideoStoragePath = String(reviewData?.videoStoragePath || videoStoragePath || "").trim();
         const reviewVideoContentType = String(reviewData?.videoContentType || videoContentType || "").trim();
@@ -3432,13 +3493,15 @@ export default function CreateUpdate() {
                                         <input type="hidden" name="intent" value="publish" />
                                         <input type="hidden" name="summary" value={reviewSummary} />
                                         <input type="hidden" name="sourceUrl" value={reviewSourceUrl} />
+                                        <input type="hidden" name="manualDocumentIds" value={reviewManualDocumentIds.join(",")} />
+                                        <input type="hidden" name="manualSummary" value={reviewManualSummary} />
                                         <input type="hidden" name="videoUrl" value={reviewVideoUrl} />
                                         <input type="hidden" name="videoStoragePath" value={reviewVideoStoragePath} />
                                         <input type="hidden" name="videoContentType" value={reviewVideoContentType} />
                                         <input type="hidden" name="videoFileSizeBytes" value={reviewVideoFileSizeBytes ?? ""} />
                                         <input type="hidden" name="videoOriginalFilename" value={reviewVideoOriginalFilename} />
                                         {Object.entries(data || {})
-                                            .filter(([key]) => !["summary", "sourceUrl", "videoUrl", "videoStoragePath", "videoContentType", "videoFileSizeBytes", "videoOriginalFilename"].includes(key))
+                                            .filter(([key]) => !["summary", "sourceUrl", "manualDocumentIds", "manualSummary", "manualDocuments", "videoUrl", "videoStoragePath", "videoContentType", "videoFileSizeBytes", "videoOriginalFilename"].includes(key))
                                             .map(([key, value]) => (
                                                 <input key={key} type="hidden" name={key} value={value as any} />
                                             ))}
@@ -3932,6 +3995,8 @@ export default function CreateUpdate() {
                 />
                 <input type="hidden" name="summary" value={summary} />
                 <input type="hidden" name="sourceUrl" value={sourceUrl} />
+                <input type="hidden" name="manualDocumentIds" value={manualDocumentIds.join(",")} />
+                <input type="hidden" name="manualSummary" value={manualSummary} />
                 <input type="hidden" name="videoUrl" value={uploadedVideoUrl} />
                 <input type="hidden" name="videoStoragePath" value={videoStoragePath} />
                 <input type="hidden" name="videoContentType" value={videoContentType} />
@@ -3966,6 +4031,17 @@ export default function CreateUpdate() {
                                     </span>
                                 )}
                             </div>
+                            {manualDocuments.length > 0 ? (
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                    {manualDocuments.map((document) => (
+                                        <span key={document.id} className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700 ring-1 ring-emerald-100">
+                                            {document.originalFilename}
+                                        </span>
+                                    ))}
+                                </div>
+                            ) : null}
+                        </div>
+                        <div className="flex shrink-0 justify-end">
                             {!isEdit && (
                                 <Link
                                     to="/founder-tools/data-sources"

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -3,35 +3,38 @@ import { useState } from "react";
 import {
   Outlet,
   redirect,
-  useActionData,
   useLoaderData,
-  useLocation,
-  useNavigation,
 } from "react-router";
 import AuthenticatedLayout from "~/components/AuthenticatedLayout";
-import VibeRaisingOnboardingCard from "~/components/VibeRaisingOnboardingCard";
 import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import { getEnv } from "~/lib/env.server";
 import {
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
-  saveVibeRaisingCompany,
-  saveVibeRaisingProfile,
-  setVibeRaisingActiveCompany,
 } from "~/lib/vibe-raising";
 import {
   BuildingOffice2Icon,
   CircleStackIcon,
   DocumentTextIcon,
+  HomeIcon,
   MegaphoneIcon,
 } from "@heroicons/react/24/outline";
 
 const FOUNDER_NAVIGATION = [
+  { name: "Dashboard", href: "/founder-tools", icon: HomeIcon, exact: true },
   { name: "Vibe Raising", href: "/founder-tools/updates", icon: DocumentTextIcon, exact: true },
   { name: "Vibe Marketing", href: "/founder-tools/marketing", icon: MegaphoneIcon },
   { name: "Data Sources", href: "/founder-tools/data-sources", icon: CircleStackIcon },
   { name: "Companies", href: "/founder-tools/companies", icon: BuildingOffice2Icon },
 ];
+
+function canAccessDuringCompanySetup(pathname: string) {
+  return (
+    pathname === "/founder-tools/company-setup" ||
+    pathname === "/founder-tools/company-setup/" ||
+    pathname.startsWith("/founder-tools/marketing/autofill-runs/")
+  );
+}
 
 export const meta: Route.MetaFunction = () => [
   { name: "robots", content: "noindex, nofollow" },
@@ -40,9 +43,22 @@ export const meta: Route.MetaFunction = () => [
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   const vibeContext = await getOptionalVibeRaisingContext(env, request);
+  const pathname = new URL(request.url).pathname;
 
   if (!vibeContext.authUser) {
     throw redirect(getVibeRaisingLoginHref(request));
+  }
+
+  if (!vibeContext.appUser && !canAccessDuringCompanySetup(pathname)) {
+    throw redirect("/founder-tools/company-setup");
+  }
+
+  if (
+    vibeContext.appUser &&
+    !vibeContext.appUser.companyRegistered &&
+    !canAccessDuringCompanySetup(pathname)
+  ) {
+    throw redirect("/founder-tools/company-setup");
   }
 
   return {
@@ -52,58 +68,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   };
 }
 
-export async function action({ request, context }: Route.ActionArgs) {
-  const env = getEnv(context);
-  const vibeContext = await getOptionalVibeRaisingContext(env, request);
-
-  if (!vibeContext.authUser) {
-    throw redirect(getVibeRaisingLoginHref(request));
-  }
-
-  const formData = await request.formData();
-  const intent = formData.get("intent")?.toString();
-
-  if (intent !== "complete-onboarding") {
-    return null;
-  }
-
-  const role = "founder";
-  const organizationName = formData.get("organizationName")?.toString().trim();
-
-  if (!organizationName) {
-    return { error: "Please provide your startup name." };
-  }
-
-  try {
-    await saveVibeRaisingProfile(env, request, {
-      role,
-      organizationName: null,
-    });
-
-    const companyId = await saveVibeRaisingCompany(env, request, {
-      name: organizationName,
-      registered: false,
-    });
-
-    if (companyId) {
-      await setVibeRaisingActiveCompany(env, request, companyId);
-    }
-
-    return redirect("/founder-tools/company-setup?next=/founder-tools/updates");
-  } catch (error) {
-    console.error("Failed to complete Vibe Raising onboarding:", error);
-    return {
-      error:
-        "We couldn't save your Vibe Raising profile right now. Please try again.",
-    };
-  }
-}
-
 export default function VibeRaisingApp() {
-  const { user, profile, appUser } = useLoaderData<typeof loader>();
-  const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const location = useLocation();
+  const { user } = useLoaderData<typeof loader>();
   const [showAnnouncement, setShowAnnouncement] = useState(false);
   const [onCompleteCallback, setOnCompleteCallback] =
     useState<(() => void) | undefined>();
@@ -112,37 +78,6 @@ export default function VibeRaisingApp() {
     setOnCompleteCallback(() => callback);
     setShowAnnouncement(true);
   };
-
-  if (!appUser && location.pathname.startsWith("/founder-tools/marketing")) {
-    return (
-      <AuthenticatedLayout
-        user={user}
-        navigation={FOUNDER_NAVIGATION}
-        userNavigation={[]}
-        logoutAction="/founder-tools/logout"
-      >
-        <Outlet context={{ triggerAnnouncement }} />
-      </AuthenticatedLayout>
-    );
-  }
-
-  if (!appUser) {
-    return (
-      <main className="min-h-screen bg-[var(--vr-color-app-bg)] px-4 py-12 sm:px-6 lg:px-8">
-        <div className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-6xl items-center justify-center">
-          <VibeRaisingOnboardingCard
-            email={user.email}
-            isSubmitting={navigation.state === "submitting"}
-            error={actionData?.error}
-            defaultRole={profile?.role ?? "founder"}
-            defaultOrganizationName={
-              profile?.organizationName ?? profile?.companies[0]?.name ?? ""
-            }
-          />
-        </div>
-      </main>
-    );
-  }
 
   return (
     <AuthenticatedLayout

--- a/app/routes/vibe-raising-landing.tsx
+++ b/app/routes/vibe-raising-landing.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useState } from "react";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 import {
   ArrowRightIcon,
   ChartBarIcon,
@@ -11,7 +10,6 @@ import {
   UserGroupIcon,
 } from "@heroicons/react/24/outline";
 import ResponsibleInvestorsSection from "~/components/ResponsibleInvestorsSection";
-import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import type { Route } from "./+types/vibe-raising-landing";
 
 const PAGE_TITLE = "MLAI Vibe Raising";
@@ -34,23 +32,8 @@ export async function loader({}: Route.LoaderArgs) {
 }
 
 export default function VibeRaisingPage({}: Route.ComponentProps) {
-  const navigate = useNavigate();
-  const [showIntro, setShowIntro] = useState(false);
-
-  const enterApp = useCallback(() => {
-    navigate("/founder-tools/updates");
-  }, [navigate]);
-
   return (
     <main className="bg-white text-gray-950">
-      {showIntro ? (
-        <VibeRaisingIntroPopup
-          onDismiss={() => setShowIntro(false)}
-          onComplete={enterApp}
-          onSkip={enterApp}
-        />
-      ) : null}
-
       <section className="relative min-h-[86vh] overflow-hidden">
         <img
           src="/hero-bg.jpg"
@@ -72,14 +55,13 @@ export default function VibeRaisingPage({}: Route.ComponentProps) {
               optional Gmail context so investors can scan your momentum and act on it.
             </p>
             <div className="mt-9 flex flex-col gap-3 sm:flex-row">
-              <button
-                type="button"
-                onClick={() => setShowIntro(true)}
+              <Link
+                to="/platform/login?app=founder-tools&next=/founder-tools"
                 className="inline-flex items-center justify-center gap-3 rounded-xl bg-white px-7 py-4 text-sm font-black text-gray-950 shadow-xl shadow-black/20 transition hover:bg-gray-100 active:scale-[0.98]"
               >
                 Start your update
                 <ArrowRightIcon className="h-5 w-5" />
-              </button>
+              </Link>
               <a
                 href="#google-data"
                 className="inline-flex items-center justify-center rounded-xl border border-white/25 bg-white/10 px-7 py-4 text-sm font-black text-white backdrop-blur-sm transition hover:bg-white/15"

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -57,6 +57,7 @@ export interface VibeRaisingDraftedContent {
   year?: number;
   summary?: string;
   sourceUrl?: string;
+  manualDocuments?: VibeRaisingManualDocument[];
   videoUrl?: string;
   videoStoragePath?: string;
   videoContentType?: string;
@@ -82,6 +83,7 @@ export interface VibeRaisingMonthlyUpdate {
   status?: string | null;
   summary?: string | null;
   sourceUrl?: string | null;
+  manualDocuments?: VibeRaisingManualDocument[];
   videoUrl?: string | null;
   videoStoragePath?: string | null;
   videoContentType?: string | null;
@@ -114,6 +116,39 @@ export interface VibeRaisingVideoUploadSessionResponse {
   requiredHeaders: Record<string, string>;
 }
 
+export interface VibeRaisingManualDocument {
+  id: string;
+  originalFilename: string;
+  contentType: string;
+  fileSizeBytes: number;
+  extractionStatus: "pending" | "hydrated" | "processed" | "unsupported" | "error" | string;
+  textSizeChars: number;
+  parseNotes?: string | null;
+  lastError?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface VibeRaisingManualDocumentUploadResponse {
+  document: VibeRaisingManualDocument;
+}
+
+export interface VibeRaisingManualDocumentUploadSessionResponse {
+  uploadUrl: string;
+  storagePath: string;
+  contentType: string;
+  fileSizeBytes?: number;
+  expiresAt: string;
+  maxUploadBytes: number;
+  requiredHeaders: Record<string, string>;
+}
+
+export interface VibeRaisingManualDocumentDownloadResponse {
+  downloadUrl: string;
+  expiresAt: string;
+  document: VibeRaisingManualDocument;
+}
+
 export interface VibeRaisingVideoCompressionMetadata {
   compressed?: boolean;
   originalFilename?: string;
@@ -131,7 +166,8 @@ export type VibeRaisingInputSourceKey =
   | "notion"
   | "google_drive"
   | "slack"
-  | "linear";
+  | "linear"
+  | "manual_documents";
 
 export type VibeRaisingInputSourceStatus =
   | "connected"
@@ -497,6 +533,7 @@ export interface VibeRaisingEmailDraftMonth {
   year?: number;
   summary?: string;
   sourceUrl?: string;
+  manualDocuments?: VibeRaisingManualDocument[];
   videoUrl?: string;
   videoStoragePath?: string;
   videoContentType?: string;


### PR DESCRIPTION
## Summary
- Route first-time founder users through the shared company setup flow and land completed setup on `/founder-tools`.
- Make the Vibe Raising public CTA go to login, and use the intro video modal from the dashboard when no monthly updates exist.
- Replace manual source URL collection with private document uploads and selected document context in the create-update flow.
- Add frontend client methods for manual document list/upload/delete/download URL access.

## Validation
- `bun run typecheck`
- `git diff --check`