### PR TITLE
[codex] Fix article workflow run UI

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -55,6 +55,20 @@ const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running"]);
 const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "cancelled", "denied"]);
 const RESEARCH_DONE_STATUSES = new Set(["completed", ...RESEARCH_FAILED_STATUSES]);
 
+const stableDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+function formatStableDate(value: string | null | undefined, fallback = "recently") {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return stableDateFormatter.format(date);
+}
+
 const PROFILE_RESEARCH_STEPS = [
   { id: "identity", label: "Resolving company identity", keys: ["queued", "resolve_company_identity", "profile_resolution"] },
   { id: "website", label: "Crawling owned website", keys: ["crawl_owned_web", "crawl_website", "scrape_website"] },
@@ -1392,7 +1406,7 @@ export default function VibeMarketingStartupBaselineSetup({
                   <p className="mt-1 text-sm font-semibold text-gray-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
                   {effectiveBaseline.collectedAt ? (
                     <p className="mt-1 text-xs font-semibold text-gray-500">
-                      Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
+                      Collected {formatStableDate(effectiveBaseline.collectedAt)}
                       {effectiveBaseline.stale ? " · stale" : ""}
                     </p>
                   ) : null}

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -14,7 +14,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 
-import ArticleRunStageProgress, { articleRunTechnicalProgressLabel } from "~/components/ArticleRunStageProgress";
+import ArticleRunStageProgress from "~/components/ArticleRunStageProgress";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
@@ -81,8 +81,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
-  const run = await getVibeMarketingRun(env, request, runId);
-  const bootstrap = await getVibeMarketingBootstrap(env, request);
+  const [run, bootstrap] = await Promise.all([
+    getVibeMarketingRun(env, request, runId),
+    getVibeMarketingBootstrap(env, request),
+  ]);
   return { run, bootstrap };
 }
 
@@ -376,32 +378,6 @@ function RunApprovalActions({
   );
 }
 
-function RunDiagnosticsDetails({ run }: { run: VibeMarketingRunSummary }) {
-  return (
-    <details className="rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm shadow-sm">
-      <summary className="cursor-pointer text-sm font-black text-gray-700">Run diagnostics</summary>
-      <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
-        <div>
-          <dt className="font-black uppercase tracking-wide text-gray-400">Run ID</dt>
-          <dd className="mt-1 break-all font-mono text-gray-600">{run.runId}</dd>
-        </div>
-        <div>
-          <dt className="font-black uppercase tracking-wide text-gray-400">Workflow</dt>
-          <dd className="mt-1 font-semibold text-gray-700">{run.workflow || "Not reported"}</dd>
-        </div>
-        <div>
-          <dt className="font-black uppercase tracking-wide text-gray-400">Status</dt>
-          <dd className="mt-1 font-semibold text-gray-700">{run.status || "Not reported"}</dd>
-        </div>
-        <div>
-          <dt className="font-black uppercase tracking-wide text-gray-400">Current step</dt>
-          <dd className="mt-1 font-semibold text-gray-700">{run.currentStep || "Not reported"}</dd>
-        </div>
-      </dl>
-    </details>
-  );
-}
-
 function PublishApprovalPanel({
   run,
   isSubmitting,
@@ -446,27 +422,6 @@ function PublishApprovalPanel({
         <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve publish" denyLabel="Deny publish" />
       </div>
     </section>
-  );
-}
-
-function TechnicalRunDetails({ run, defaultOpen = false }: { run: VibeMarketingRunSummary; defaultOpen?: boolean }) {
-  return (
-    <details className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm" open={defaultOpen}>
-      <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 text-left">
-        <span>
-          <span className="block text-lg font-black text-gray-950">Technical details</span>
-          <span className="mt-1 block text-sm font-semibold text-gray-500">
-            Internal pipeline checks are available for debugging.
-          </span>
-        </span>
-        <span className="rounded-full bg-gray-50 px-3 py-1.5 text-xs font-black uppercase tracking-wide text-gray-500">
-          {articleRunTechnicalProgressLabel(run)}
-        </span>
-      </summary>
-      <div className="mt-5 border-t border-gray-100 pt-5">
-        <RunStepTimeline run={run} framed={false} />
-      </div>
-    </details>
   );
 }
 
@@ -1578,7 +1533,6 @@ export default function FounderToolsMarketingRun() {
   const isArticleWorkflowRun = isArticleWorkflow(workflow);
   const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
   const contentPackage = run.contentPackage;
-  const runNeedsAttention = ["blocked", "failed", "blocked_verification", "denied", "cancelled"].includes(run.status);
   const hasArticlePreview =
     isArticleWorkflowRun &&
     Boolean(contentPackage?.contentPackaged || run.componentManifest);
@@ -1743,32 +1697,6 @@ export default function FounderToolsMarketingRun() {
             </section>
           ) : null}
 
-          {contentPackage?.contentPackaged ? (
-            <section className="rounded-xl border border-emerald-100 bg-white p-5 shadow-sm">
-              <h2 className="text-lg font-black text-gray-950">Content package</h2>
-              <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                <div className="rounded-xl bg-emerald-50 p-4">
-                  <p className="text-xs font-bold uppercase tracking-wide text-emerald-700">Title</p>
-                  <p className="mt-2 text-sm font-black text-emerald-950">{contentPackage.title ?? contentPackage.slug ?? "Generated article"}</p>
-                </div>
-                <div className="rounded-xl bg-gray-50 p-4">
-                  <p className="text-xs font-bold uppercase tracking-wide text-gray-500">Target keyword</p>
-                  <p className="mt-2 text-sm font-black text-gray-900">{contentPackage.targetKeyword ?? "Not reported"}</p>
-                </div>
-              </div>
-              {contentPackage.artifactPaths && Object.keys(contentPackage.artifactPaths).length > 0 ? (
-                <div className="mt-4 grid gap-2">
-                  {Object.entries(contentPackage.artifactPaths).slice(0, 8).map(([name, path]) => (
-                    <div key={name} className="rounded-lg bg-gray-50 px-3 py-2">
-                      <p className="text-xs font-black text-gray-700">{name}</p>
-                      <p className="mt-1 break-all font-mono text-xs text-gray-500">{path}</p>
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-            </section>
-          ) : null}
-
           {showRunAttentionBanner ? (
             <div className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-800">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -1797,20 +1725,13 @@ export default function FounderToolsMarketingRun() {
             </div>
           ) : null}
 
-          {isArticleGenerationRun ? (
-            <TechnicalRunDetails run={run} defaultOpen={runNeedsAttention} />
-          ) : (
-            <RunStepTimeline run={run} />
-          )}
-
-          <RunDiagnosticsDetails run={run} />
+          {!isArticleGenerationRun ? <RunStepTimeline run={run} /> : null}
 
           {contentPackage?.contentPackaged || run.componentManifest ? (
             <ComponentCommentsPanel run={run} selectedComponent={selectedComponent} isSubmitting={isSubmitting} />
           ) : null}
         </main>
       ) : null}
-      {isCompletedArticleReviewPage ? <RunDiagnosticsDetails run={run} /> : null}
     </div>
   );
 }

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -371,8 +371,17 @@ export async function action({ request, context }: Route.ActionArgs) {
         sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
 
-      if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
-      return redirect("/founder-tools/marketing/create?step=writeCheck");
+      if (result.runId) {
+        return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      }
+
+      return {
+        intent,
+        error:
+          result.error ||
+          result.errors?.[0] ||
+          "Article generation was accepted, but the backend did not return a run id. Refresh and try again.",
+      };
     }
 
     if (intent === "decline-topic") {
@@ -486,11 +495,22 @@ function companyInitials(name: string) {
   return words.slice(0, 2).map((word) => word[0]?.toUpperCase()).join("");
 }
 
-function formatArticleDate(value: string | null | undefined) {
-  if (!value) return "Recently";
+const stableDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+function formatStableDate(value: string | null | undefined, fallback = "Recently") {
+  if (!value) return fallback;
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "Recently";
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  if (Number.isNaN(date.getTime())) return fallback;
+  return stableDateFormatter.format(date);
+}
+
+function formatArticleDate(value: string | null | undefined) {
+  return formatStableDate(value, "Recently");
 }
 
 function startupTags(bootstrap: VibeMarketingBootstrap) {
@@ -1841,7 +1861,7 @@ function FirstArticleSetupPage({
                   <p className="mt-1 text-sm font-semibold text-slate-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
                   {effectiveBaseline.collectedAt ? (
                     <p className="mt-1 text-xs font-semibold text-slate-500">
-                      Collected {new Date(effectiveBaseline.collectedAt).toLocaleDateString()}
+                      Collected {formatStableDate(effectiveBaseline.collectedAt, "recently")}
                       {effectiveBaseline.stale ? " · stale" : ""}
                     </p>
                   ) : null}
@@ -1978,7 +1998,6 @@ function TopicRow({
   onSelect,
   onContinue,
   onDecline,
-  declineDisabled,
 }: {
   topic: VibeMarketingTopicCandidate;
   selected: boolean;
@@ -1986,7 +2005,6 @@ function TopicRow({
   onSelect: () => void;
   onContinue: () => void;
   onDecline: () => void;
-  declineDisabled?: boolean;
 }) {
   const score = opportunityLabel(topic.opportunityScore);
   const title = topic.title || topic.keyword;
@@ -2033,10 +2051,9 @@ function TopicRow({
             event.stopPropagation();
             onDecline();
           }}
-          disabled={declineDisabled}
           title={`Ignore suggestion: ${topic.keyword}`}
           aria-label={`Ignore suggestion: ${topic.keyword}`}
-          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 focus:outline-none focus:ring-4 focus:ring-rose-100 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 focus:outline-none focus:ring-4 focus:ring-rose-100"
         >
           <ThumbsDown className="h-4 w-4" />
         </button>
@@ -2096,6 +2113,41 @@ type TopicToast =
       message: string;
     };
 
+function TopicDeclineRequest({
+  topic,
+  onResult,
+}: {
+  topic: VibeMarketingTopicCandidate;
+  onResult: (data: TopicFeedbackActionData) => void;
+}) {
+  const fetcher = useFetcher<TopicFeedbackActionData>({ key: `decline-topic-${topic.id}` });
+  const submittedRef = useRef(false);
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (submittedRef.current) return;
+    submittedRef.current = true;
+
+    const formData = new FormData();
+    formData.set("intent", "decline-topic");
+    formData.set("topicCandidateId", topic.id);
+    formData.set("keyword", topic.keyword);
+    formData.set("sourceDiscoveryRunId", topic.sourceRunId ?? "");
+    fetcher.submit(formData, { method: "POST" });
+  }, [fetcher, topic.id, topic.keyword, topic.sourceRunId]);
+
+  useEffect(() => {
+    if (handledRef.current || fetcher.state !== "idle" || !fetcher.data) return;
+    handledRef.current = true;
+    onResult({
+      ...fetcher.data,
+      topicCandidateId: fetcher.data.topicCandidateId ?? topic.id,
+    });
+  }, [fetcher.data, fetcher.state, onResult, topic.id]);
+
+  return null;
+}
+
 function ReturningTopicPickerPage({
   bootstrap,
   error,
@@ -2104,7 +2156,6 @@ function ReturningTopicPickerPage({
   error: string | null;
 }) {
   const navigation = useNavigation();
-  const declineFetcher = useFetcher<TopicFeedbackActionData>();
   const restoreFetcher = useFetcher<TopicFeedbackActionData>();
   const baseTopics = useMemo(
     () => bootstrap.topicCandidates.filter((topic) => !topic.alreadyWritten).slice(0, 8),
@@ -2135,37 +2186,38 @@ function ReturningTopicPickerPage({
   const companyName = bootstrap.settings.brandName || bootstrap.organization.name || bootstrap.company.name || "YourStartup";
   const domain = bootstrap.company.domain || bootstrap.organization.domain;
   const tags = startupTags(bootstrap);
+  const [articleStartPending, setArticleStartPending] = useState(false);
   const isSubmitting = navigation.state === "submitting";
-  const declineBusy = declineFetcher.state !== "idle";
+  const isArticleStartNavigation = navigation.formData?.get("intent") === "start-article";
+  const articleSubmitting = articleStartPending || (navigation.state !== "idle" && isArticleStartNavigation);
   const restoreBusy = restoreFetcher.state !== "idle";
   const visibleTopics = topics.slice(0, visibleCount);
+  const [declineRequests, setDeclineRequests] = useState<Record<string, VibeMarketingTopicCandidate>>({});
 
   const submitSelectedTopic = useCallback(() => {
-    if (isSubmitting || !selectedTopic) return;
+    if (articleSubmitting || !selectedTopic) return;
     articleFormRef.current?.requestSubmit();
-  }, [isSubmitting, selectedTopic]);
+  }, [articleSubmitting, selectedTopic]);
 
-  function submitRestoreFeedback(feedbackId: string) {
+  const handleArticleSubmit = useCallback(() => {
+    setArticleStartPending(true);
+  }, []);
+
+  const submitRestoreFeedback = useCallback((feedbackId: string) => {
     const formData = new FormData();
     formData.set("intent", "restore-topic-feedback");
     formData.set("feedbackId", feedbackId);
     restoreFetcher.submit(formData, { method: "POST" });
-  }
+  }, [restoreFetcher]);
 
   function handleDeclineTopic(topic: VibeMarketingTopicCandidate) {
     setPendingDeclines((current) => ({ ...current, [topic.id]: topic }));
+    setDeclineRequests((current) => ({ ...current, [topic.id]: topic }));
     setSelectedTopicId((current) => {
       if (current !== topic.id) return current;
       return topics.find((candidate) => candidate.id !== topic.id)?.id ?? "";
     });
     setToast({ kind: "declined", topicId: topic.id, keyword: topic.keyword, feedbackId: null });
-
-    const formData = new FormData();
-    formData.set("intent", "decline-topic");
-    formData.set("topicCandidateId", topic.id);
-    formData.set("keyword", topic.keyword);
-    formData.set("sourceDiscoveryRunId", topic.sourceRunId ?? "");
-    declineFetcher.submit(formData, { method: "POST" });
   }
 
   function handleUndoDecline() {
@@ -2198,10 +2250,28 @@ function ReturningTopicPickerPage({
   }, [selectedTopicId, topics]);
 
   useEffect(() => {
-    const data = declineFetcher.data;
+    if (navigation.state !== "idle" && isArticleStartNavigation) {
+      setArticleStartPending(true);
+    }
+  }, [isArticleStartNavigation, navigation.state]);
+
+  useEffect(() => {
+    if (navigation.state === "idle") {
+      setArticleStartPending(false);
+    }
+  }, [navigation.state]);
+
+  const handleDeclineResult = useCallback((data: TopicFeedbackActionData) => {
     if (!data || data.intent !== "decline-topic") return;
     const topicId = data.topicCandidateId ?? "";
     const feedback = data.topicFeedback ?? null;
+    if (topicId) {
+      setDeclineRequests((current) => {
+        const next = { ...current };
+        delete next[topicId];
+        return next;
+      });
+    }
 
     if (data.error || !feedback) {
       setPendingDeclines((current) => {
@@ -2212,6 +2282,14 @@ function ReturningTopicPickerPage({
       if (topicId) undoRequestedTopicIds.current.delete(topicId);
       setToast({ kind: "error", message: data.error ?? "Could not ignore that suggestion." });
       return;
+    }
+
+    if (topicId) {
+      setPendingDeclines((current) => {
+        const next = { ...current };
+        delete next[topicId];
+        return next;
+      });
     }
 
     if (topicId && undoRequestedTopicIds.current.has(topicId)) {
@@ -2229,7 +2307,7 @@ function ReturningTopicPickerPage({
         ? { ...current, feedbackId: feedback.id }
         : current,
     );
-  }, [declineFetcher.data]);
+  }, [submitRestoreFeedback]);
 
   useEffect(() => {
     const data = restoreFetcher.data;
@@ -2244,7 +2322,7 @@ function ReturningTopicPickerPage({
   return (
     <div className="mx-auto max-w-[1500px] px-4 py-9 sm:px-6 lg:px-10">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(440px,0.92fr)] xl:items-start">
-        <Form ref={articleFormRef} method="POST" className="space-y-5">
+        <Form ref={articleFormRef} method="POST" onSubmit={handleArticleSubmit} className="space-y-5">
           <input type="hidden" name="intent" value="start-article" />
           <input type="hidden" name="topicCandidateId" value={activeTab === "choose" ? selectedTopicId : "__custom__"} />
           <input type="hidden" name="deliveryMode" value={bootstrap.settings.articleDeliveryMode ?? "publish_code"} />
@@ -2313,11 +2391,10 @@ function ReturningTopicPickerPage({
                         key={topic.id}
                         topic={topic}
                         selected={topic.id === selectedTopicId}
-                        submitting={isSubmitting}
+                        submitting={articleSubmitting}
                         onSelect={() => setSelectedTopicId(topic.id)}
                         onContinue={submitSelectedTopic}
                         onDecline={() => handleDeclineTopic(topic)}
-                        declineDisabled={declineBusy}
                       />
                     ))
                   ) : (
@@ -2397,6 +2474,9 @@ function ReturningTopicPickerPage({
                     </div>
                   </details>
                 ) : null}
+                {Object.values(declineRequests).map((topic) => (
+                  <TopicDeclineRequest key={topic.id} topic={topic} onResult={handleDeclineResult} />
+                ))}
               </>
             ) : (
               <>
@@ -2444,11 +2524,20 @@ function ReturningTopicPickerPage({
             </div>
             <button
               type="submit"
-              disabled={isSubmitting || (activeTab === "choose" && !selectedTopic)}
+              disabled={articleSubmitting || (activeTab === "choose" && !selectedTopic)}
               className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Create article from topic
-              <ArrowRight className="h-4 w-4" />
+              {articleSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Creating article...
+                </>
+              ) : (
+                <>
+                  Create article from topic
+                  <ArrowRight className="h-4 w-4" />
+                </>
+              )}
             </button>
           </div>
         </Form>


### PR DESCRIPTION
## Summary
- keep the topic picker article CTA in a pending state through submit and redirect loading, with explicit `Creating article...` feedback
- return a visible action error if article generation is accepted without a run id instead of falling through silently
- replace locale-dependent date rendering with fixed UTC formatting to avoid hydration text mismatches
- load article run details and workflow bootstrap data in parallel on run pages
- remove duplicate article-generation debug sections from the run page now that the stage progress card covers that detail

## Validation
- `bun run typecheck`
- `NODE_OPTIONS='--max-old-space-size=8192' bunx --yes react-router build`
- browser smoke opened `http://localhost:5173/founder-tools/marketing` with no console errors; local backend was unavailable, so real article creation was not exercised
