### PR TITLE
[codex] Improve Vibe Marketing local load performance

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -53,6 +53,7 @@ export const links: Route.LinksFunction = () => [
 
 export default function Layout() {
   const location = useLocation();
+  const shouldLoadThirdPartyAnalytics = import.meta.env.PROD;
 
   // Hide the global chrome inside authenticated app surfaces.
   const isEsafetyApp = location.pathname.startsWith("/esafety");
@@ -107,22 +108,26 @@ export default function Layout() {
         <Meta />
         <Links />
 
-        <script
-          src="https://analytics.ahrefs.com/analytics.js"
-          data-key="R27fA2BeFrzb0BXu5adbpQ"
-          async
-        ></script>
+        {shouldLoadThirdPartyAnalytics ? (
+          <script
+            src="https://analytics.ahrefs.com/analytics.js"
+            data-key="R27fA2BeFrzb0BXu5adbpQ"
+            async
+          ></script>
+        ) : null}
       </head>
       <body>
-        <noscript>
-          <img
-            alt=""
-            height="1"
-            width="1"
-            style={{ display: "none" }}
-            src="https://www.facebook.com/tr?id=925764322445149&ev=PageView&noscript=1"
-          />
-        </noscript>
+        {shouldLoadThirdPartyAnalytics ? (
+          <noscript>
+            <img
+              alt=""
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              src="https://www.facebook.com/tr?id=925764322445149&ev=PageView&noscript=1"
+            />
+          </noscript>
+        ) : null}
         {/* Only show platform-wide components if NOT in specific apps */}
         {!isAppRoute && <Sidebar />}
         {!isAppRoute && <SectionMarkers />}
@@ -132,46 +137,50 @@ export default function Layout() {
         {!isAppRoute && <Footer />}
         <ScrollRestoration />
 
-        {/* Google Analytics */}
-        <script
-          async
-          defer
-          src={`https://www.googletagmanager.com/gtag/js?id=G-JB8E813T8W}`}
-        />
-        <script
-          id="google-analytics"
-          async
-          suppressHydrationWarning={true}
-          dangerouslySetInnerHTML={{
-            __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-JB8E813T8W');
-          `,
-          }}
-        />
+        {shouldLoadThirdPartyAnalytics ? (
+          <>
+            {/* Google Analytics */}
+            <script
+              async
+              defer
+              src={`https://www.googletagmanager.com/gtag/js?id=G-JB8E813T8W}`}
+            />
+            <script
+              id="google-analytics"
+              async
+              suppressHydrationWarning={true}
+              dangerouslySetInnerHTML={{
+                __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-JB8E813T8W');
+            `,
+              }}
+            />
 
-        {/* Meta Pixel Code */}
-        <script
-          id="meta-pixel"
-          async
-          defer
-          dangerouslySetInnerHTML={{
-            __html: `
-          !function(f,b,e,v,n,t,s)
-          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-          n.queue=[];t=b.createElement(e);t.async=!0;
-          t.src=v;s=b.getElementsByTagName(e)[0];
-          s.parentNode.insertBefore(t,s)}(window, document,'script',
-          'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', '925764322445149');
-          fbq('track', 'PageView');
-          `,
-          }}
-        />
+            {/* Meta Pixel Code */}
+            <script
+              id="meta-pixel"
+              async
+              defer
+              dangerouslySetInnerHTML={{
+                __html: `
+            !function(f,b,e,v,n,t,s)
+            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('init', '925764322445149');
+            fbq('track', 'PageView');
+            `,
+              }}
+            />
+          </>
+        ) : null}
         <Scripts />
       </body>
     </html>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -84,7 +84,7 @@ export default [
   route("/vibe-raising-landing", "routes/vibe-raising-landing.tsx", { id: "legacy-vibe-raising-landing" }),
 
   // Founder Tools App routes
-  route("/founder-tools", "routes/vibe-raising-app.tsx", [
+  route("/founder-tools", "routes/vibe-raising-app.tsx", { id: "founder-tools-root" }, [
     index("routes/founder-tools.index.tsx"),
     route("updates", "routes/vibe-raising-app._index.tsx"),
     route("company-setup", "routes/vibe-raising-app.company-setup.tsx"),

--- a/app/routes/founder-tools.index.tsx
+++ b/app/routes/founder-tools.index.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/founder-tools.index";
-import { Link, redirect, useLoaderData, useNavigate, useOutletContext } from "react-router";
+import { Link, useLoaderData, useNavigate, useOutletContext, useRouteLoaderData } from "react-router";
 import {
   ArrowRightIcon,
   BuildingOffice2Icon,
@@ -18,10 +18,9 @@ import { getEnv } from "~/lib/env.server";
 import {
   getActiveVibeRaisingCompany,
   getVibeRaisingMonthlyUpdates,
-  getOptionalVibeRaisingContext,
-  getVibeRaisingLoginHref,
 } from "~/lib/vibe-raising";
 import type { VibeRaisingCompany } from "~/types/vibe-raising";
+import type { loader as founderToolsRootLoader } from "./vibe-raising-app";
 
 function detailValue(value: string | null | undefined) {
   return String(value ?? "").trim() || "-";
@@ -35,29 +34,27 @@ function companyInitials(company: VibeRaisingCompany | null) {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  const vibeContext = await getOptionalVibeRaisingContext(env, request);
-
-  if (!vibeContext.authUser) {
-    throw redirect(getVibeRaisingLoginHref(request));
+  let hasMonthlyUpdates = false;
+  try {
+    const monthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request);
+    hasMonthlyUpdates = monthlyUpdates.length > 0;
+  } catch (error: any) {
+    if (error?.response?.status !== 401) throw error;
   }
-
-  if (!vibeContext.appUser || !vibeContext.appUser.companyRegistered) {
-    throw redirect("/founder-tools/company-setup");
-  }
-
-  const monthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request);
 
   return {
-    user: vibeContext.appUser,
-    activeCompany: getActiveVibeRaisingCompany(vibeContext.appUser),
-    hasMonthlyUpdates: monthlyUpdates.length > 0,
+    hasMonthlyUpdates,
   };
 }
 
 export default function FounderToolsIndex() {
-  const { user, activeCompany, hasMonthlyUpdates } = useLoaderData<typeof loader>();
+  const { hasMonthlyUpdates } = useLoaderData<typeof loader>();
+  const rootData = useRouteLoaderData<typeof founderToolsRootLoader>("founder-tools-root");
+  const user = rootData?.appUser;
   const navigate = useNavigate();
   const { triggerAnnouncement } = useOutletContext<{ triggerAnnouncement: (cb?: () => void) => void }>();
+  if (!user) return null;
+  const activeCompany = getActiveVibeRaisingCompany(user);
   const details = [
     { label: "Website", value: detailValue(activeCompany?.domain), icon: GlobeAltIcon },
     { label: "Location", value: detailValue(activeCompany?.location), icon: MapPinIcon },

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -81,10 +81,8 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
-  const [run, bootstrap] = await Promise.all([
-    getVibeMarketingRun(env, request, runId),
-    getVibeMarketingBootstrap(env, request),
-  ]);
+  const bootstrap = await getVibeMarketingBootstrap(env, request);
+  const run = await getVibeMarketingRun(env, request, runId);
   return { run, bootstrap };
 }
 


### PR DESCRIPTION
## Summary
- Reuse the `/founder-tools` parent loader data on the dashboard route instead of repeating auth/profile loading.
- Load run-page bootstrap and run details sequentially to reduce SQLite contention in local dev.
- Gate Ahrefs, Google Analytics, and Meta Pixel to production builds only.

## Validation
- `bun run typecheck`
- `bun run build` (completed; IndexNow returned a non-blocking 403)