### PR TITLE
[codex] Speed up Vibe Marketing step navigation

### DIFF
--- a/app/lib/vibe-marketing-step-revalidation.ts
+++ b/app/lib/vibe-marketing-step-revalidation.ts
@@ -1,0 +1,51 @@
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+
+const CREATE_FLOW_PATH = "/founder-tools/marketing/create";
+const VIEW_ONLY_SEARCH_PARAMS = new Set(["step", "googleBaseline"]);
+
+function normalizePathname(pathname: string) {
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+function searchParamsWithoutViewState(url: URL) {
+  const params = new URLSearchParams(url.search);
+  for (const key of VIEW_ONLY_SEARCH_PARAMS) {
+    params.delete(key);
+  }
+  params.sort();
+  return params.toString();
+}
+
+function viewStateChanged(currentUrl: URL, nextUrl: URL) {
+  for (const key of VIEW_ONLY_SEARCH_PARAMS) {
+    if (currentUrl.searchParams.get(key) !== nextUrl.searchParams.get(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isVibeMarketingCreateViewNavigation(currentUrl: URL, nextUrl: URL) {
+  const currentPathname = normalizePathname(currentUrl.pathname);
+  const nextPathname = normalizePathname(nextUrl.pathname);
+  if (currentPathname !== CREATE_FLOW_PATH || nextPathname !== CREATE_FLOW_PATH) {
+    return false;
+  }
+  if (!viewStateChanged(currentUrl, nextUrl)) {
+    return false;
+  }
+  return searchParamsWithoutViewState(currentUrl) === searchParamsWithoutViewState(nextUrl);
+}
+
+export function shouldSkipVibeMarketingCreateRevalidation({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  actionResult,
+  actionStatus,
+}: ShouldRevalidateFunctionArgs) {
+  if (formMethod || actionResult !== undefined || actionStatus !== undefined) {
+    return false;
+  }
+  return isVibeMarketingCreateViewNavigation(currentUrl, nextUrl);
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
-import { Form, Link, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+import { Form, Link, redirect, useActionData, useLoaderData, useNavigation, useSearchParams } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 import {
   ArrowLeftIcon,
@@ -18,6 +19,7 @@ import { CustomTopicDecisionCard, TopicDecisionCard } from "~/components/TopicDe
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { type VibeMarketingStepKey } from "~/components/VibeMarketingStepper";
 import { getEnv } from "~/lib/env.server";
+import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import { combineCompanyContext as combineStartupCompanyContext } from "~/lib/vibe-marketing-startup-setup";
 import {
   connectVibeMarketingGithub,
@@ -177,12 +179,15 @@ function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMark
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
   const bootstrap = await getVibeMarketingBootstrap(env, request);
-  const url = new URL(request.url);
-  const activeStep = resolveActiveStep(url.searchParams.get("step"), bootstrap);
-  const requestedStep = normalizeStep(url.searchParams.get("step"), activeStep);
-  return { bootstrap, activeStep, requestedStep, shouldRefreshGoogleBaseline: url.searchParams.get("googleBaseline") === "refresh" };
+  return { bootstrap };
+}
+
+export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
+  if (shouldSkipVibeMarketingCreateRevalidation(args)) {
+    return false;
+  }
+  return args.defaultShouldRevalidate;
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -455,7 +460,11 @@ function PanelHeader({
 }
 
 export default function FounderToolsMarketingCreate() {
-  const { bootstrap, activeStep, requestedStep, shouldRefreshGoogleBaseline } = useLoaderData<typeof loader>();
+  const { bootstrap } = useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
+  const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap);
+  const requestedStep = normalizeStep(searchParams.get("step"), activeStep);
+  const shouldRefreshGoogleBaseline = searchParams.get("googleBaseline") === "refresh";
   const actionData = useActionData<typeof action>();
   const latestActionIntent = actionDataIntent(actionData);
   const latestActionError = actionDataError(actionData);

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -1,4 +1,5 @@
 import type { Route } from "./+types/vibe-raising-app";
+import type { ShouldRevalidateFunctionArgs } from "react-router";
 import { useState } from "react";
 import {
   Outlet,
@@ -12,6 +13,7 @@ import {
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
 } from "~/lib/vibe-raising";
+import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import {
   BuildingOffice2Icon,
   CircleStackIcon,
@@ -39,6 +41,13 @@ function canAccessDuringCompanySetup(pathname: string) {
 export const meta: Route.MetaFunction = () => [
   { name: "robots", content: "noindex, nofollow" },
 ];
+
+export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
+  if (shouldSkipVibeMarketingCreateRevalidation(args)) {
+    return false;
+  }
+  return args.defaultShouldRevalidate;
+}
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);


### PR DESCRIPTION
## Summary
- Treat Vibe Marketing create-flow `step` and `googleBaseline` search params as client-side view state.
- Skip parent and child loader revalidation for same-path step-only navigation.
- Remove the duplicate founder auth/profile load from the create loader while keeping action auth intact.

## Why
Step-card clicks were rerunning the full React Router loader stack, which refetched auth/profile and Vibe Marketing bootstrap data even when only the visible step changed. That made simple screen changes feel like full page loads.

## Validation
- `bun run typecheck`
- `bun run build`
- Local Browser pass on patched frontend: direct create-flow load worked, step URL/back/forward worked, and step-only clicks produced no new `/founder-tools/profile/` or `/vibe-marketing/bootstrap/` API logs.

## Backend Pair
Companion backend PR removes read-time bootstrap writes and reuses topic candidate memory: MLAI-AUS-Inc/mlai-backend `codex/fast-step-navigation`.