### PR TITLE
[codex] Add rich topic selection UI

### DIFF
--- a/app/components/TopicDecisionCard.tsx
+++ b/app/components/TopicDecisionCard.tsx
@@ -37,13 +37,10 @@ function titleCase(value: string) {
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
-function competitionPhrase(candidate: VibeMarketingTopicCandidate) {
-  const explicit = stringValue(candidate.competition);
-  if (explicit) return explicit.toLowerCase().includes("competition") ? explicit : `${explicit} competition`;
-  const difficulty = numericValue(candidate.difficulty);
-  if (difficulty === undefined) return null;
-  const tier = difficulty <= 35 ? "low" : difficulty <= 65 ? "moderate" : "high";
-  return `${tier} competition at ${formatNumber(difficulty)}/100`;
+function intentLabel(candidate: VibeMarketingTopicCandidate) {
+  const explicit = stringValue(candidate.intent);
+  if (explicit) return titleCase(explicit);
+  return "Informational";
 }
 
 function audienceFromCandidate(candidate: VibeMarketingTopicCandidate) {
@@ -71,99 +68,304 @@ function audienceFromCandidate(candidate: VibeMarketingTopicCandidate) {
   return `Readers searching for practical guidance on ${candidate.keyword}.`;
 }
 
+function difficultyLabel(value: unknown) {
+  const difficulty = numericValue(value);
+  if (difficulty === undefined) return "Unavailable";
+  if (difficulty <= 35) return "Low";
+  if (difficulty <= 65) return "Moderate";
+  return "High";
+}
+
+function trendRecord(candidate: VibeMarketingTopicCandidate) {
+  return recordValue(candidate.velocity);
+}
+
+function dailyVolumes(candidate: VibeMarketingTopicCandidate) {
+  const record = trendRecord(candidate);
+  const raw = record?.dailyVolumes ?? record?.daily_volumes;
+  if (!Array.isArray(raw)) return [];
+  return raw.map(numericValue).filter((value): value is number => value !== undefined);
+}
+
+function trendStatus(candidate: VibeMarketingTopicCandidate) {
+  const record = trendRecord(candidate);
+  return (
+    stringValue(record?.trendStatus) ||
+    stringValue(record?.trend_status) ||
+    stringValue(candidate.trend) ||
+    stringValue(candidate.interest)
+  );
+}
+
+function normalizedTrendStatus(candidate: VibeMarketingTopicCandidate) {
+  const status = trendStatus(candidate)?.toLowerCase();
+  if (!status) return null;
+  if (status.includes("breakout")) return "breakout";
+  if (status.includes("rising") || status.includes("growing")) return "rising";
+  if (status.includes("declin")) return "declining";
+  if (status.includes("stable")) return "stable";
+  return status;
+}
+
+function trendLabel(candidate: VibeMarketingTopicCandidate) {
+  const explicit = stringValue(candidate.trendLabel);
+  if (explicit) return explicit;
+  const status = normalizedTrendStatus(candidate);
+  if (status === "breakout") return "Breakout";
+  if (status === "rising") return "Growing";
+  if (status === "declining") return "Declining";
+  if (status === "stable") return "Stable";
+  return "Unavailable";
+}
+
+function trendSummary(candidate: VibeMarketingTopicCandidate) {
+  const explicit = stringValue(candidate.statsMeaning);
+  if (explicit) return explicit;
+  const score = numericValue(recordValue(candidate.velocity)?.velocityScore ?? recordValue(candidate.velocity)?.velocity_score);
+  const percent = score !== undefined ? `${score > 0 ? "+" : ""}${Math.round(score * 100)}%` : null;
+  const status = normalizedTrendStatus(candidate);
+  if (status === "breakout") return `${percent ?? "Strong"} recent growth in search interest.`;
+  if (status === "rising") return `${percent ?? "Growing"} recent search interest.`;
+  if (status === "declining") return `${percent ?? "Lower"} recent search interest.`;
+  if (status === "stable") return "Search interest looks steady.";
+  return "Trend data is not available yet.";
+}
+
+function opportunityScore(candidate: VibeMarketingTopicCandidate) {
+  return numericValue(candidate.opportunityScore);
+}
+
+export function topicOpportunityBadge(candidate: VibeMarketingTopicCandidate | null | undefined) {
+  if (!candidate) return "Custom topic";
+  const score = opportunityScore(candidate);
+  if (score !== undefined) {
+    if (score > 100) {
+      if (score >= 900) return "High opportunity";
+      if (score >= 500) return "Good opportunity";
+      return "Exploratory";
+    }
+    if (score >= 80) return "High opportunity";
+    if (score >= 40) return "Good opportunity";
+    return "Exploratory";
+  }
+  if (trendStatus(candidate)) return trendLabel(candidate);
+  return "Trend unavailable";
+}
+
 function whyTopic(candidate: VibeMarketingTopicCandidate) {
-  const parts: string[] = [];
-  const volume = numericValue(candidate.volume);
-  if (volume !== undefined) parts.push(`${formatNumber(volume)} monthly searches`);
-  const competition = competitionPhrase(candidate);
-  if (competition) parts.push(competition);
-  const trend = stringValue(candidate.trend) || stringValue(candidate.interest);
-  if (trend) parts.push(`${trend.toLowerCase().includes("interest") ? trend : `${trend} interest`}`);
-  const aiSearches = numericValue(candidate.aiSearches);
-  if (aiSearches !== undefined) parts.push(`${formatNumber(aiSearches)} AI searches/mo`);
-
-  const metrics = parts.length ? parts.join(", ") : null;
-  const reason = stringValue(candidate.reason);
-  if (metrics && reason) return `${metrics}. ${reason}`;
-  return metrics || reason || "Recommended from the latest topic discovery.";
+  return (
+    stringValue(candidate.whyRecommended) ||
+    stringValue(candidate.recommendationReason) ||
+    stringValue(candidate.reason) ||
+    "Recommended from the latest topic research."
+  );
 }
 
-function confidenceForCandidate(candidate: VibeMarketingTopicCandidate) {
-  const explicit = stringValue(candidate.confidence);
-  if (explicit) return titleCase(explicit);
-  const score = numericValue(candidate.opportunityScore);
-  if (score === undefined) return "Exploratory";
-  if (score >= 150) return "High";
-  if (score >= 50) return "Medium";
-  return "Exploratory";
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) {
+    return (
+      <div className="flex h-28 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 text-xs font-bold text-gray-400">
+        Trend unavailable
+      </div>
+    );
+  }
+  const width = 320;
+  const height = 112;
+  const padding = 10;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const points = values.map((value, index) => {
+    const x = padding + (index / Math.max(values.length - 1, 1)) * (width - padding * 2);
+    const y = height - padding - ((value - min) / span) * (height - padding * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const areaPoints = `${padding},${height - padding} ${points.join(" ")} ${width - padding},${height - padding}`;
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Search trend chart" className="h-28 w-full overflow-visible">
+      <polygon points={areaPoints} className="fill-violet-100/70" />
+      <polyline points={points.join(" ")} fill="none" stroke="currentColor" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" className="text-violet-600" />
+      {points.map((point) => {
+        const [cx, cy] = point.split(",");
+        return <circle key={point} cx={cx} cy={cy} r="3.5" className="fill-violet-600" />;
+      })}
+    </svg>
+  );
 }
 
-function opportunityText(candidate: VibeMarketingTopicCandidate) {
-  const score = numericValue(candidate.opportunityScore);
-  return score === undefined ? null : `Opportunity score ${formatNumber(score)}`;
+function MetricCard({ label, value, helper }: { label: string; value: string; helper?: string | null }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white px-3 py-2">
+      <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">{label}</p>
+      <p className="mt-1 text-sm font-black text-gray-950">{value}</p>
+      {helper ? <p className="mt-0.5 text-xs font-semibold text-gray-500">{helper}</p> : null}
+    </div>
+  );
+}
+
+function TopicDetails({ candidate }: { candidate: VibeMarketingTopicCandidate }) {
+  const relatedKeywords = candidate.relatedKeywords ?? [];
+  const paaQuestions = candidate.paaQuestions ?? [];
+  const saturation = recordValue(candidate.aiSaturation);
+  const serpNotes = [
+    saturation?.aiOverviewPresent ? "AI overview present" : null,
+    saturation?.featuredSnippetPresent ? "Featured snippet present" : null,
+    saturation?.videoCarouselPresent ? "Video carousel present" : null,
+    saturation?.knowledgePanelPresent ? "Knowledge panel present" : null,
+    stringValue(saturation?.hostilityRecommendation)
+      ? `SERP priority: ${titleCase(String(saturation?.hostilityRecommendation))}`
+      : null,
+  ].filter(Boolean);
+
+  return (
+    <div className="mt-4 grid gap-3 border-t border-gray-100 pt-4 lg:grid-cols-3">
+      <div className="rounded-lg bg-gray-50 px-3 py-3">
+        <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Why this topic</p>
+        <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{whyTopic(candidate)}</p>
+      </div>
+      <div className="rounded-lg bg-gray-50 px-3 py-3">
+        <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Related keywords</p>
+        {relatedKeywords.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {relatedKeywords.slice(0, 6).map((keyword) => (
+              <span key={keyword} className="rounded-full bg-white px-2.5 py-1 text-xs font-bold text-gray-600 ring-1 ring-gray-200">
+                {keyword}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-1 text-sm font-semibold text-gray-500">No related keyword data yet.</p>
+        )}
+      </div>
+      <div className="rounded-lg bg-gray-50 px-3 py-3">
+        <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Search notes</p>
+        {paaQuestions.length > 0 || serpNotes.length > 0 ? (
+          <div className="mt-2 space-y-2 text-sm font-semibold leading-5 text-gray-700">
+            {paaQuestions.slice(0, 3).map((item) => (
+              <p key={item.question}>{item.question}</p>
+            ))}
+            {serpNotes.map((note) => (
+              <p key={String(note)}>{note}</p>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-1 text-sm font-semibold text-gray-500">No extra SERP detail yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TopicMetricExplainerStrip() {
+  const items = [
+    ["Search volume", "How many people search each month."],
+    ["Trend", "Whether interest is growing, stable, or declining."],
+    ["Keyword difficulty", "How hard it may be to rank on Google."],
+    ["Opportunity score", "Our overall score for this topic."],
+  ];
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {items.map(([title, body]) => (
+        <div key={title} className="rounded-xl border border-gray-200 bg-white px-4 py-3">
+          <p className="text-sm font-black text-gray-950">{title}</p>
+          <p className="mt-1 text-sm font-semibold leading-5 text-gray-600">{body}</p>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export function TopicDecisionCard({
   candidate,
   checked,
+  expanded = false,
+  rank = 1,
   onChange,
+  onToggleDetails,
   name = "topicCandidateId",
 }: {
   candidate: VibeMarketingTopicCandidate;
   checked: boolean;
+  expanded?: boolean;
+  rank?: number;
   onChange: () => void;
+  onToggleDetails?: () => void;
   name?: string;
 }) {
-  const opportunity = opportunityText(candidate);
+  const volume = numericValue(candidate.volume);
+  const score = opportunityScore(candidate);
+  const trendValues = dailyVolumes(candidate);
+  const hasTrend = trendValues.length >= 2 || Boolean(trendStatus(candidate));
+  const opportunity = score === undefined ? "Unavailable" : formatNumber(score);
   return (
-    <label
+    <div
       className={clsx(
-        "block cursor-pointer rounded-xl border p-4 transition",
-        checked
-          ? "border-violet-400 bg-violet-50/70 shadow-sm ring-2 ring-violet-100"
-          : "border-gray-200 bg-white hover:border-violet-200 hover:bg-violet-50/30",
+        "rounded-xl border bg-white p-4 transition",
+        checked ? "border-violet-400 shadow-sm ring-2 ring-violet-100" : "border-gray-200 hover:border-violet-200",
       )}
     >
-      <div className="flex gap-3">
-        <input
-          type="radio"
-          name={name}
-          value={candidate.id}
-          checked={checked}
-          onChange={onChange}
-          className="mt-1 h-4 w-4 flex-none text-violet-600"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-            <div>
-              <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">What will we write?</p>
-              <h3 className="mt-1 text-base font-black leading-6 text-gray-950">{candidate.title}</h3>
-              <p className="mt-1 text-xs font-bold text-gray-500">Keyword: {candidate.keyword}</p>
-            </div>
-            <div className="flex flex-none flex-wrap items-center gap-2">
-              <span className="rounded-full bg-white px-3 py-1 text-xs font-black text-violet-700 ring-1 ring-violet-100">
-                Confidence: {confidenceForCandidate(candidate)}
-              </span>
-              {opportunity ? (
-                <span className="rounded-full bg-gray-50 px-3 py-1 text-xs font-bold text-gray-600 ring-1 ring-gray-100">
-                  {opportunity}
-                </span>
-              ) : null}
-            </div>
-          </div>
-          <div className="mt-4 grid gap-3 md:grid-cols-2">
-            <div className="rounded-lg bg-gray-50 px-3 py-2">
-              <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Who is it for?</p>
-              <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{audienceFromCandidate(candidate)}</p>
-            </div>
-            <div className="rounded-lg bg-gray-50 px-3 py-2">
-              <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Why this topic?</p>
-              <p className="mt-1 text-sm font-semibold leading-5 text-gray-700">{whyTopic(candidate)}</p>
-            </div>
+      <input
+        type="radio"
+        name={name}
+        value={candidate.id}
+        checked={checked}
+        onChange={onChange}
+        className="sr-only"
+      />
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(260px,1fr)_minmax(220px,0.75fr)_160px] xl:items-center">
+        <div className="flex min-w-0 gap-3">
+          <span className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-violet-600 text-sm font-black text-white">
+            {rank}
+          </span>
+          <div className="min-w-0">
+            <h3 className="text-lg font-black leading-6 text-gray-950">{candidate.title}</h3>
+            <p className="mt-1 text-sm font-bold text-gray-500">Keyword: {candidate.keyword}</p>
+            <span className="mt-3 inline-flex rounded-full bg-violet-100 px-3 py-1 text-xs font-black text-violet-700">
+              {intentLabel(candidate)}
+            </span>
+            <p className="mt-3 text-sm font-semibold leading-5 text-gray-600">{audienceFromCandidate(candidate)}</p>
           </div>
         </div>
+
+        <div className="rounded-xl border border-gray-100 bg-white px-4 py-3">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-xs font-black text-gray-950">Search trend</p>
+            <p className="text-xs font-bold text-gray-500">
+              {volume !== undefined ? `${formatNumber(volume)} searches/mo` : candidate.volumeDisplay ?? "Volume unavailable"}
+            </p>
+          </div>
+          <Sparkline values={trendValues} />
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
+          <MetricCard label="Search volume" value={volume !== undefined ? formatNumber(volume) : "Unavailable"} helper="per month" />
+          <MetricCard label="Difficulty" value={difficultyLabel(candidate.difficulty)} helper={numericValue(candidate.difficulty) !== undefined ? `${formatNumber(numericValue(candidate.difficulty)!)} / 100` : null} />
+          <MetricCard label="Opportunity" value={opportunity} helper={topicOpportunityBadge(candidate)} />
+          <MetricCard label="Trend" value={trendLabel(candidate)} helper={hasTrend ? trendSummary(candidate) : "Trend unavailable"} />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onToggleDetails}
+            className="inline-flex h-10 items-center justify-center rounded-lg border border-violet-200 px-4 text-sm font-black text-violet-700 transition hover:bg-violet-50"
+          >
+            {expanded ? "Hide details" : "View details"}
+          </button>
+          <button
+            type="button"
+            onClick={onChange}
+            className={clsx(
+              "inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-black transition",
+              checked ? "bg-violet-600 text-white shadow-sm" : "bg-gray-950 text-white hover:bg-black",
+            )}
+          >
+            {checked ? "Selected" : "Select topic"}
+          </button>
+        </div>
       </div>
-    </label>
+      {expanded ? <TopicDetails candidate={candidate} /> : null}
+    </div>
   );
 }
 
@@ -193,9 +395,9 @@ export function CustomTopicDecisionCard({
           className="mt-1 h-4 w-4 flex-none text-violet-600"
         />
         <div>
-          <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">What will we write?</p>
-          <h3 className="mt-1 text-base font-black text-gray-950">Custom article</h3>
-          <p className="mt-1 text-sm font-semibold text-gray-600">Use the keyword, title, and context fields below to define the article brief.</p>
+          <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Custom article</p>
+          <h3 className="mt-1 text-base font-black text-gray-950">Enter my own topic</h3>
+          <p className="mt-1 text-sm font-semibold text-gray-600">Use your own keyword, title, and article context.</p>
         </div>
       </div>
     </label>

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -255,6 +255,19 @@ function normalizeStartupProfile(payload: Record<string, unknown>): VibeMarketin
 function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
   const payload = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
   const keyword = asNullableString(payload.keyword) ?? asNullableString(payload.target_keyword) ?? "Topic";
+  const normalizePaaQuestions = (value: unknown): VibeMarketingTopicCandidate["paaQuestions"] => {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map((item) => (item && typeof item === "object" ? (item as Record<string, unknown>) : null))
+      .filter((item): item is Record<string, unknown> => Boolean(item))
+      .map((item) => ({
+        question: asNullableString(item.question) ?? "",
+        answerSnippet: asNullableString(item.answerSnippet) ?? asNullableString(item.answer_snippet),
+        depth: item.depth,
+        hasAiOverview: Boolean(item.hasAiOverview ?? item.has_ai_overview),
+      }))
+      .filter((item) => item.question);
+  };
   return {
     id: String(payload.id ?? keyword),
     keyword,
@@ -273,8 +286,10 @@ function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
     writtenArticle: normalizeWrittenTopic(payload.writtenArticle ?? payload.written_article),
     intent: payload.intent,
     difficulty: payload.difficulty,
+    difficultySource: payload.difficultySource ?? payload.difficulty_source,
     opportunityScore: payload.opportunityScore ?? payload.opportunity_score,
     volume: payload.volume,
+    volumeDisplay: asNullableString(payload.volumeDisplay) ?? asNullableString(payload.volume_display),
     tier: payload.tier,
     velocity: payload.velocity ?? payload.latestVelocity ?? payload.latest_velocity,
     aiSaturation:
@@ -282,6 +297,13 @@ function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
       payload.ai_saturation ??
       payload.latestSaturation ??
       payload.latest_saturation,
+    trendLabel: asNullableString(payload.trendLabel) ?? asNullableString(payload.trending_label),
+    statsMeaning: asNullableString(payload.statsMeaning) ?? asNullableString(payload.stats_meaning),
+    whyRecommended: asNullableString(payload.whyRecommended) ?? asNullableString(payload.why_recommended),
+    recommendationReason: asNullableString(payload.recommendationReason) ?? asNullableString(payload.recommendation_reason),
+    aiVolumeDisplay: asNullableString(payload.aiVolumeDisplay) ?? asNullableString(payload.ai_volume_display),
+    relatedKeywords: asStringList(payload.relatedKeywords ?? payload.related_keywords),
+    paaQuestions: normalizePaaQuestions(payload.paaQuestions ?? payload.paa_questions),
   };
 }
 

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -15,7 +15,12 @@ import {
 import { clsx } from "clsx";
 
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
-import { CustomTopicDecisionCard, TopicDecisionCard } from "~/components/TopicDecisionCard";
+import {
+  CustomTopicDecisionCard,
+  TopicDecisionCard,
+  TopicMetricExplainerStrip,
+  topicOpportunityBadge,
+} from "~/components/TopicDecisionCard";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { type VibeMarketingStepKey } from "~/components/VibeMarketingStepper";
 import { getEnv } from "~/lib/env.server";
@@ -518,6 +523,7 @@ export default function FounderToolsMarketingCreate() {
         : "No pending topics";
   const defaultTopicCandidateId = selectableTopicCandidates[0]?.id ?? "__custom__";
   const [selectedTopicCandidateId, setSelectedTopicCandidateId] = useState(defaultTopicCandidateId);
+  const [expandedTopicCandidateId, setExpandedTopicCandidateId] = useState<string | null>(null);
   const selectedTopicCandidate = useMemo(
     () => selectableTopicCandidates.find((candidate) => candidate.id === selectedTopicCandidateId) ?? null,
     [selectableTopicCandidates, selectedTopicCandidateId],
@@ -696,15 +702,14 @@ export default function FounderToolsMarketingCreate() {
           {activeStep === "chooseArticle" ? (
             <>
               <PanelHeader
-                title="Choose article"
+                title="Discover SEO article opportunities"
                 description={
                   directPublishMode
-                    ? "Pick a discovered topic and we will prepare it for your website repository."
-                    : "Pick a discovered topic and we will generate article copy and images for manual publishing."
+                    ? "We found topics your audience is already searching for. Pick one and we will prepare it for your website repository."
+                    : "We found topics your audience is already searching for. Pick one and we will generate article copy and images for manual publishing."
                 }
                 passed={Boolean(latestArticle || selectableTopicCandidates.length > 0)}
                 statusLabel={chooseArticleStatusLabel}
-                explainer={STEP_EXPLAINERS.chooseArticle}
               />
               {!bootstrap.checks.baseline?.passed ? (
                 <div className="mb-5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-800">
@@ -718,6 +723,7 @@ export default function FounderToolsMarketingCreate() {
                 <input type="hidden" name="intent" value="start-article" />
                 <input type="hidden" name="sourceDiscoveryRunId" value={latestDiscovery?.runId ?? ""} />
                 {!isCustomArticleSelected ? <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} /> : null}
+                <TopicMetricExplainerStrip />
                 <div className="grid gap-3">
                   {selectableTopicCandidates.length === 0 ? (
                     <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900">
@@ -726,12 +732,17 @@ export default function FounderToolsMarketingCreate() {
                         : "No pending discovered topics are available yet. Run topic research or enter a custom article."}
                     </div>
                   ) : null}
-                  {selectableTopicCandidates.map((candidate) => (
+                  {selectableTopicCandidates.map((candidate, index) => (
                     <TopicDecisionCard
                       key={candidate.id}
                       candidate={candidate}
+                      rank={index + 1}
+                      expanded={expandedTopicCandidateId === candidate.id}
                       checked={selectedTopicCandidateId === candidate.id}
                       onChange={() => setSelectedTopicCandidateId(candidate.id)}
+                      onToggleDetails={() =>
+                        setExpandedTopicCandidateId((current) => (current === candidate.id ? null : candidate.id))
+                      }
                     />
                   ))}
                   <CustomTopicDecisionCard
@@ -783,7 +794,12 @@ export default function FounderToolsMarketingCreate() {
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                       <p className="text-[11px] font-black uppercase tracking-wide text-gray-400">Selected topic</p>
-                      <p className="mt-1 max-w-2xl text-sm font-black leading-5 text-gray-950">{selectedTopicLabel}</p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <p className="max-w-2xl text-sm font-black leading-5 text-gray-950">{selectedTopicLabel}</p>
+                        <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-black text-emerald-700 ring-1 ring-emerald-100">
+                          {isCustomArticleSelected ? "Custom topic" : topicOpportunityBadge(selectedTopicCandidate)}
+                        </span>
+                      </div>
                       <p className="mt-1 max-w-2xl text-xs font-semibold leading-5 text-gray-500">{deliveryModeNote}</p>
                     </div>
                     <button type="submit" disabled={isSubmitting || !bootstrap.checks.baseline?.passed} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -207,11 +207,25 @@ export interface VibeMarketingTopicCandidate {
   writtenArticle?: VibeMarketingWrittenTopic | null;
   intent?: unknown;
   difficulty?: unknown;
+  difficultySource?: unknown;
   opportunityScore?: unknown;
   volume?: unknown;
+  volumeDisplay?: string | null;
   tier?: unknown;
   velocity?: unknown;
   aiSaturation?: unknown;
+  trendLabel?: string | null;
+  statsMeaning?: string | null;
+  whyRecommended?: string | null;
+  recommendationReason?: string | null;
+  aiVolumeDisplay?: string | null;
+  relatedKeywords?: string[];
+  paaQuestions?: Array<{
+    question: string;
+    answerSnippet?: string | null;
+    depth?: unknown;
+    hasAiOverview?: boolean;
+  }>;
 }
 
 export interface VibeMarketingTopicFeedback {


### PR DESCRIPTION
## Summary
- Replaces the dense choose-topic cards with ranked SEO opportunity rows.
- Adds metric explainers, inline SVG trend sparklines, score/volume/difficulty/trend cards, detail expansion, and a smaller custom-topic flow.
- Normalizes optional rich topic fields from bootstrap while preserving existing article generation form behavior.

## Validation
- bun run typecheck
- bun run build
- Browser smoke check for /founder-tools/marketing/create?step=chooseArticle