### PR TITLE
[codex] Restyle marketing workflow stepper

### DIFF
--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -130,6 +130,38 @@ function statusTone(status: string) {
   return "border-gray-200 bg-gray-50 text-gray-500";
 }
 
+function statusTextTone(status: string, active: boolean) {
+  if (active) return "text-violet-700";
+  if (status === "complete") return "text-emerald-700";
+  if (status === "running") return "text-violet-700";
+  if (status === "needs_action" || status === "ready") return "text-amber-700";
+  if (status === "blocked") return "text-red-700";
+  return "text-gray-400";
+}
+
+function numberBadgeTone(status: string, active: boolean) {
+  if (active || status === "running") return "bg-violet-600 text-white shadow-lg shadow-violet-200";
+  if (status === "complete") return "bg-emerald-500 text-white shadow-lg shadow-emerald-100";
+  if (status === "needs_action" || status === "ready") return "bg-orange-500 text-white shadow-lg shadow-orange-100";
+  if (status === "blocked") return "bg-red-500 text-white shadow-lg shadow-red-100";
+  return "bg-gray-200 text-gray-500";
+}
+
+function iconCircleTone(status: string, active: boolean) {
+  if (active || status === "running") return "border-violet-200 bg-violet-100 text-violet-700 shadow-inner";
+  if (status === "complete") return "border-emerald-200 bg-emerald-50 text-emerald-700 shadow-inner";
+  if (status === "needs_action" || status === "ready") return "border-orange-200 bg-orange-50 text-orange-600 shadow-inner";
+  if (status === "blocked") return "border-red-200 bg-red-50 text-red-600 shadow-inner";
+  return "border-gray-100 bg-gray-50 text-gray-400";
+}
+
+function connectorTone(group: WorkflowDisplayGroup, nextGroup: WorkflowDisplayGroup | undefined, active: boolean, nextRequired: boolean) {
+  if (group.status === "complete" && nextGroup?.status === "complete") return "border-emerald-300 text-emerald-500";
+  if (active || nextRequired || nextGroup?.status === "running") return "border-violet-300 text-violet-500";
+  if (group.status === "complete") return "border-emerald-300 text-emerald-500";
+  return "border-gray-300 text-gray-300";
+}
+
 function StepStatusIcon({ status }: { status: string }) {
   if (status === "complete") return <CheckCircleIcon className="h-4 w-4" />;
   if (status === "running") return <ArrowPathIcon className="h-4 w-4 animate-spin" />;
@@ -253,28 +285,28 @@ export default function MarketingWorkflowShell({
   const activeDetailAnchorPercent = ((viewedIndex + 0.5) / Math.max(displayGroups.length, 1)) * 100;
 
   return (
-    <section className={clsx("rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5", className)}>
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+    <section className={clsx("rounded-2xl border border-gray-200 bg-white px-5 py-7 shadow-md shadow-gray-200/60 sm:px-8 sm:py-9", className)}>
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
-          <p className="text-xs font-extrabold uppercase tracking-wide text-violet-600">
-            Step {viewedIndex + 1} of {displayGroups.length}
+          <p className="text-sm font-black uppercase tracking-wide text-violet-600">
+            STEP {viewedIndex + 1} OF {displayGroups.length}
           </p>
-          <HeadingTag className={clsx("mt-1 font-black text-gray-950", titleAs === "h1" ? "text-2xl" : "text-xl")}>
+          <HeadingTag className={clsx("mt-3 font-black tracking-tight text-gray-950", titleAs === "h1" ? "text-4xl" : "text-3xl")}>
             {title}
           </HeadingTag>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className={clsx("inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-black", statusTone(viewedGroup.status))}>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <span className={clsx("inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-black", statusTone(viewedGroup.status))}>
               <StepStatusIcon status={viewedGroup.status} />
               {statusLabel(viewedGroup.status)}
             </span>
-            <span className="text-sm font-bold text-gray-700">{headerLabel}</span>
+            <span className="text-base font-black text-gray-700">{headerLabel}</span>
             {!viewingRequiredGroup ? (
-              <span className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-2.5 py-1 text-xs font-black text-violet-700">
+              <span className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-3 py-1.5 text-sm font-black text-violet-700">
                 Next required step: {requiredGroup.label}
               </span>
             ) : null}
           </div>
-          <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-500">
+          <p className="mt-4 max-w-3xl text-lg font-bold leading-7 text-gray-500">
             {subtitle ?? viewedGroup.summary}
           </p>
         </div>
@@ -293,67 +325,75 @@ export default function MarketingWorkflowShell({
         ) : null}
       </div>
 
-      <div className="mt-5 h-1.5 overflow-hidden rounded-full bg-gray-100" aria-hidden>
+      <div className="mt-9 h-2 overflow-hidden rounded-full bg-gray-100" aria-hidden>
         <div className="h-full rounded-full bg-violet-600 transition-all" style={{ width: `${percent}%` }} />
       </div>
 
-      <ol className="mt-5 grid gap-4 rounded-2xl border border-violet-100 bg-violet-50/60 p-4 shadow-sm shadow-violet-100/60 sm:grid-cols-2 lg:grid-cols-5 lg:p-5">
+      <ol className="mt-8 grid gap-5 rounded-2xl border border-violet-100 bg-violet-50/40 p-5 shadow-sm shadow-violet-100/60 sm:grid-cols-2 xl:grid-cols-5 xl:gap-8 xl:p-8">
         {displayGroups.map((group, index) => {
           const active = group.id === viewedGroup.id;
           const nextRequired = group.id === requiredGroup.id;
           const locked = group.status === "locked";
           const Icon = group.icon;
+          const nextGroup = displayGroups[index + 1];
+          const connectorClass = connectorTone(group, nextGroup, active, nextRequired);
           const content = (
-            <div className="relative flex h-full flex-col items-center gap-3 text-center">
+            <div className="relative flex h-full flex-col items-center text-center">
+              <span className={clsx("flex h-8 w-8 items-center justify-center rounded-full text-sm font-black", numberBadgeTone(group.status, active))}>
+                {index + 1}
+              </span>
               <span
                 className={clsx(
-                  "flex h-14 w-14 items-center justify-center rounded-full border transition",
-                  active && "border-violet-200 bg-violet-200 text-violet-700 shadow-sm",
-                  !active && group.status === "complete" && "border-emerald-200 bg-white text-emerald-600",
-                  !active && group.status === "running" && "border-violet-100 bg-white text-violet-600",
-                  !active && (group.status === "needs_action" || group.status === "ready") && "border-amber-200 bg-white text-amber-600",
-                  !active && group.status === "blocked" && "border-red-200 bg-white text-red-600",
-                  !active && locked && "border-gray-100 bg-white/70 text-gray-400",
+                  "mt-7 flex h-20 w-20 items-center justify-center rounded-full border transition",
+                  iconCircleTone(group.status, active),
                 )}
               >
                 {group.status === "complete" ? (
-                  <CheckCircleIcon className="h-6 w-6" />
+                  <CheckCircleIcon className="h-9 w-9" />
                 ) : group.status === "running" ? (
-                  <ArrowPathIcon className="h-6 w-6 animate-spin" />
+                  <ArrowPathIcon className="h-9 w-9 animate-spin" />
                 ) : (
-                  <Icon className="h-6 w-6" />
+                  <Icon className="h-9 w-9" />
                 )}
               </span>
-              <span className="max-w-[180px] text-sm font-black leading-5 text-gray-950">{group.label}</span>
-              <span className={clsx("text-xs font-bold", active ? "text-violet-700" : locked ? "text-gray-400" : "text-gray-500")}>
+              <span className="mt-7 max-w-[190px] text-lg font-black leading-6 text-gray-950">{group.label}</span>
+              <span className={clsx("mt-4 text-sm font-black", statusTextTone(group.status, active))}>
                 {statusLabel(group.status)}
               </span>
-              {nextRequired && !active ? (
-                <span className="rounded-full bg-violet-100 px-2 py-1 text-[10px] font-black uppercase text-violet-700">
+              {nextRequired ? (
+                <span className="mt-2 rounded-full bg-violet-100 px-3 py-1 text-[10px] font-black uppercase tracking-wide text-violet-700">
                   Next required
                 </span>
-              ) : null}
-              {index < displayGroups.length - 1 ? (
-                <ArrowRightIcon className="absolute -right-5 top-5 hidden h-5 w-5 text-gray-400 lg:block" />
               ) : null}
             </div>
           );
           return (
-            <li key={group.id} className="min-h-[156px]">
+            <li key={group.id} className="relative min-h-[268px]">
               {locked ? (
-                <div className="h-full rounded-xl px-3 py-4 opacity-70">{content}</div>
+                <div className="h-full rounded-2xl border border-gray-100 bg-white/65 px-4 py-6 opacity-80 shadow-sm">{content}</div>
               ) : (
                 <Link
                   to={group.href}
                   aria-current={active ? "step" : undefined}
                   className={clsx(
-                    "block h-full rounded-xl px-3 py-4 transition",
-                    active ? "bg-white shadow-sm ring-1 ring-violet-200" : "hover:bg-white/80",
+                    "block h-full rounded-2xl border bg-white px-4 py-6 transition",
+                    active
+                      ? "border-violet-200 shadow-lg shadow-violet-100/70 ring-1 ring-violet-100"
+                      : "border-gray-100 shadow-sm hover:border-violet-100 hover:shadow-md",
                   )}
                 >
                   {content}
                 </Link>
               )}
+              {index < displayGroups.length - 1 ? (
+                <div className={clsx("pointer-events-none absolute left-[calc(100%+0.25rem)] top-[43%] hidden w-7 items-center xl:flex", connectorClass)}>
+                  <span className="h-0 flex-1 border-t-2 border-dotted" />
+                  <span className="mx-1 flex h-6 w-6 items-center justify-center rounded-full border bg-white">
+                    <span className="h-3 w-3 rounded-full bg-current" />
+                  </span>
+                  <span className="h-0 flex-1 border-t-2 border-dotted" />
+                </div>
+              ) : null}
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
- Restyles the main marketing workflow stepper to match the provided reference image.
- Adds larger milestone cards, numbered badges, dotted desktop connectors, and stronger header/progress styling.
- Preserves existing workflow status logic, links, and route behavior.

## Validation
- bun run typecheck
- Local dev server started successfully; authenticated marketing route redirects to login when unauthenticated.
