### PR TITLE
[codex] Wire article review drafts into marketing UI

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -185,7 +185,7 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
       articleDeliveryMode:
         asNullableString(settings.articleDeliveryMode) ??
         asNullableString(settings.article_delivery_mode) ??
-        "publish_code",
+        "review_draft",
       githubRepo: asNullableString(settings.githubRepo) ?? asNullableString(settings.github_repo),
       dailyDiscoveryEnabled: Boolean(settings.dailyDiscoveryEnabled ?? settings.daily_discovery_enabled),
       dailyDiscoveryPriority: Number(settings.dailyDiscoveryPriority ?? 0) || 0,
@@ -434,6 +434,8 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     inspectorProtocolVersion: asNumber(payload.inspectorProtocolVersion) ?? asNumber(payload.inspector_protocol_version),
     inspectorMode: asNullableString(payload.inspectorMode) ?? asNullableString(payload.inspector_mode),
     error: asNullableString(payload.error),
+    errorCode: asNullableString(payload.errorCode) ?? asNullableString(payload.error_code),
+    retryable: Boolean(payload.retryable ?? true),
     workspacePath: asNullableString(payload.workspacePath) ?? asNullableString(payload.workspace_path),
     logPath: asNullableString(payload.logPath) ?? asNullableString(payload.log_path),
   };
@@ -637,7 +639,7 @@ const DEV_BOOTSTRAP: VibeMarketingBootstrap = {
   settings: {
     brandName: null,
     companyContext: null,
-    articleDeliveryMode: "publish_code",
+    articleDeliveryMode: "review_draft",
     githubRepo: null,
     dailyDiscoveryEnabled: false,
     githubConnectionState: null,

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -173,11 +173,14 @@ function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
 }
 
-function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap) {
-  if (bootstrap.settings.articleDeliveryMode === "content_only") {
-    return "content_only";
+type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
+
+function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap): ArticleDeliveryMode {
+  const configured = bootstrap.settings.articleDeliveryMode;
+  if (configured === "review_draft" || configured === "content_only") {
+    return configured;
   }
-  return isGithubPublishingReady(bootstrap) ? "publish_code" : "content_only";
+  return isGithubPublishingReady(bootstrap) ? "review_draft" : "content_only";
 }
 
 function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMarketingBootstrap): VibeMarketingStepKey {
@@ -528,13 +531,18 @@ export default function FounderToolsMarketingCreate() {
   const githubReadyForPublishing = isGithubPublishingReady(bootstrap);
   const effectiveDeliveryMode = effectiveArticleDeliveryMode(bootstrap);
   const directPublishMode = effectiveDeliveryMode === "publish_code";
+  const reviewDraftMode = effectiveDeliveryMode === "review_draft";
   const deliveryModeNote = directPublishMode
     ? `This will generate a draft and prepare it for publishing through ${bootstrap.settings.githubRepo}.`
-    : "This will generate article copy and images for manual publishing.";
+    : reviewDraftMode
+      ? "This will generate an article preview for comments before publishing."
+      : "This will generate article copy and images for manual publishing.";
   const reviewDescription =
     directPublishMode
       ? "The run workspace shows generation status, revision controls, preview links, PR links, and publish approval."
-      : "The run workspace shows generated article copy, image assets, and revision controls for manual publishing.";
+      : reviewDraftMode
+        ? "The run workspace shows the generated article preview, component comments, and AI revision controls before publishing."
+        : "The run workspace shows generated article copy, image assets, and revision controls for manual publishing.";
 
   useEffect(() => {
     const selectionStillValid =
@@ -784,6 +792,7 @@ export default function FounderToolsMarketingCreate() {
                       <label className="block">
                         <span className="mb-2 block text-sm font-bold text-gray-700">Delivery mode</span>
                         <select name="deliveryMode" defaultValue={effectiveDeliveryMode} className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-bold outline-none focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10">
+                          <option value="review_draft">Review draft first</option>
                           <option value="publish_code">Publish code</option>
                           <option value="content_only">Content only</option>
                         </select>
@@ -826,6 +835,8 @@ export default function FounderToolsMarketingCreate() {
                     : activeStep === "reviewPublish"
                       ? effectiveDeliveryMode === "publish_code"
                         ? "Review publish"
+                        : effectiveDeliveryMode === "review_draft"
+                          ? "Review draft"
                         : "Review content package"
                       : "Write and check"
                 }

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -82,11 +82,14 @@ function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
 }
 
-function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap) {
-  if (bootstrap.settings.articleDeliveryMode === "content_only") {
-    return "content_only";
+type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
+
+function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap): ArticleDeliveryMode {
+  const configured = bootstrap.settings.articleDeliveryMode;
+  if (configured === "review_draft" || configured === "content_only") {
+    return configured;
   }
-  return isGithubPublishingReady(bootstrap) ? "publish_code" : "content_only";
+  return isGithubPublishingReady(bootstrap) ? "review_draft" : "content_only";
 }
 
 function hasReadyArticlePreview(run: VibeMarketingRunSummary) {
@@ -151,10 +154,14 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         sourceRunId: stringFromForm(formData, "sourceRunId"),
       });
     } else if (intent === "start-live-preview") {
-      const result = await startVibeMarketingLivePreview(env, request, runId, { force: stringFromForm(formData, "force") === "true" });
-      if (result.runId && result.runId !== runId) {
-        throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      const run = await startVibeMarketingLivePreview(env, request, runId, {
+        force: stringFromForm(formData, "force") === "true",
+        localRepoPath: stringFromForm(formData, "localRepoPath"),
+      });
+      if (run.runId && run.runId !== runId) {
+        throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}`);
       }
+      return { ok: true, run };
     } else if (intent === "cancel-article") {
       await controlVibeMarketingRun(env, request, runId, "cancel", { cleanup: true });
       throw redirect("/founder-tools/marketing/create?step=chooseArticle");
@@ -832,6 +839,7 @@ function ArticlePreviewEmptyState({
               <p className="mt-1 font-semibold">
                 {preview?.error || "The article preview could not be prepared. Retry the preview when the generator is available."}
               </p>
+              {preview?.errorCode ? <p className="mt-2 text-xs font-black uppercase text-red-700">Preview status: {preview.errorCode}</p> : null}
             </div>
           </div>
           <Form method="POST">
@@ -1311,7 +1319,7 @@ function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
 
 function deliveryModeForRun(run: VibeMarketingRunSummary, bootstrap: VibeMarketingBootstrap) {
   const runMode = stringResultValue(run, "resolved_delivery_mode", "delivery_mode", "deliveryMode");
-  if (runMode === "publish_code" || runMode === "content_only") {
+  if (runMode === "review_draft" || runMode === "publish_code" || runMode === "content_only") {
     return runMode;
   }
   return effectiveArticleDeliveryMode(bootstrap);
@@ -1454,6 +1462,14 @@ export default function FounderToolsMarketingRun() {
   }, [loaderRun.runId, runStatusFetcher.data, runStatusFetcher.state]);
 
   useEffect(() => {
+    const data = previewStartFetcher.data;
+    const nextRun = data && typeof data === "object" && "run" in data ? (data.run as VibeMarketingRunSummary) : null;
+    if (nextRun?.runId === loaderRun.runId) {
+      setPolledRun(nextRun);
+    }
+  }, [loaderRun.runId, previewStartFetcher.data]);
+
+  useEffect(() => {
     if (!isDiscoveryConfirmation) return;
     const firstCandidateId = discoveryCandidates[0]?.id ?? "";
     const selectionStillValid = discoveryCandidates.some((candidate) => candidate.id === selectedDiscoveryCandidateId);
@@ -1511,7 +1527,7 @@ export default function FounderToolsMarketingRun() {
               run={run}
               selectedComponent={selectedComponent}
               onSelectComponent={setSelectedComponent}
-              isSubmitting={isSubmitting}
+              isSubmitting={isSubmitting || previewStartFetcher.state !== "idle"}
             />
           ) : undefined
         }

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -129,7 +129,8 @@ export default function FounderToolsMarketingSettings() {
           </label>
           <label className="block">
             <span className="mb-2 block text-sm font-bold text-gray-700">Delivery mode</span>
-            <select name="articleDeliveryMode" defaultValue={bootstrap.settings.articleDeliveryMode ?? "publish_code"} className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-bold outline-none focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10">
+            <select name="articleDeliveryMode" defaultValue={bootstrap.settings.articleDeliveryMode ?? "review_draft"} className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-bold outline-none focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10">
+              <option value="review_draft">Review draft first</option>
               <option value="publish_code">Publish code</option>
               <option value="content_only">Content only</option>
             </select>

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -84,11 +84,14 @@ function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
 }
 
-function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap) {
-  if (bootstrap.settings.articleDeliveryMode === "content_only") {
-    return "content_only";
+type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
+
+function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap): ArticleDeliveryMode {
+  const configured = bootstrap.settings.articleDeliveryMode;
+  if (configured === "review_draft" || configured === "content_only") {
+    return configured;
   }
-  return isGithubPublishingReady(bootstrap) ? "publish_code" : "content_only";
+  return isGithubPublishingReady(bootstrap) ? "review_draft" : "content_only";
 }
 
 function combineCompanyContext({
@@ -135,7 +138,7 @@ function emptyBootstrapFromProfile(profile: VibeRaisingProfile | null): VibeMark
     settings: {
       brandName: companyName || null,
       companyContext: null,
-      articleDeliveryMode: "publish_code",
+      articleDeliveryMode: "review_draft",
       githubRepo: null,
       dailyDiscoveryEnabled: false,
       githubConnectionState: null,
@@ -2200,7 +2203,9 @@ function ReturningTopicPickerPage({
   const directPublishMode = effectiveDeliveryMode === "publish_code";
   const deliveryModeNote = directPublishMode
     ? `This will generate a draft and prepare it for publishing through ${bootstrap.settings.githubRepo}.`
-    : "This will generate article copy and images for manual publishing.";
+    : effectiveDeliveryMode === "review_draft"
+      ? "This will generate an article preview for comments before publishing."
+      : "This will generate article copy and images for manual publishing.";
   const companyName = bootstrap.settings.brandName || bootstrap.organization.name || bootstrap.company.name || "YourStartup";
   const domain = bootstrap.company.domain || bootstrap.organization.domain;
   const tags = startupTags(bootstrap);

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -105,7 +105,7 @@ function emptyBootstrap(profile: VibeRaisingProfile | null, company: VibeRaising
     settings: {
       brandName: companyName || null,
       companyContext: null,
-      articleDeliveryMode: "publish_code",
+      articleDeliveryMode: "review_draft",
       githubRepo: null,
       dailyDiscoveryEnabled: false,
       dailyDiscoveryPriority: 0,

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -295,6 +295,8 @@ export interface VibeMarketingLivePreview {
   inspectorProtocolVersion?: number | null;
   inspectorMode?: string | null;
   error?: string | null;
+  errorCode?: string | null;
+  retryable?: boolean;
   workspacePath?: string | null;
   logPath?: string | null;
 }


### PR DESCRIPTION
## Summary
- default article creation/settings UI to review draft first
- auto-start live previews for review-ready article runs
- surface preview error codes and keep publish controls scoped to direct publish runs

## Validation
- bun run typecheck