### PR TITLE
Fix magic-link redirects away from run status JSON

### DIFF
--- a/app/lib/auth-return.ts
+++ b/app/lib/auth-return.ts
@@ -1,0 +1,70 @@
+export type AuthReturnAppName =
+  | "esafety"
+  | "hospital"
+  | "innovate-connect-alliance"
+  | "founder-tools"
+  | "vibe-raising";
+
+const LEGACY_FOUNDER_NEXT_PATHS: Record<string, string> = {
+  "/vibe-raising": "/founder-tools",
+  "/vibe-raising/": "/founder-tools",
+  "/vibe-raising/create-update": "/founder-tools/updates/create",
+  "/vibe-raising/connect-data": "/founder-tools/data-sources",
+  "/vibe-raising/companies": "/founder-tools/companies",
+  "/vibe-raising/company-setup": "/founder-tools/company-setup",
+  "/vibe-raising/discover": "/founder-tools/updates",
+};
+
+function isFounderToolsApp(app: AuthReturnAppName | string | null | undefined) {
+  return app === "founder-tools" || app === "vibe-raising";
+}
+
+function pathWithSearchAndHash(url: URL) {
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function getDefaultAuthNext(app: AuthReturnAppName | string | null | undefined, fallback = "/hackathons"): string {
+  if (app === "hospital") return "/hospital/app";
+  if (app === "esafety") return "/esafety/dashboard";
+  if (app === "innovate-connect-alliance") return "/innovate-connect-alliance";
+  if (isFounderToolsApp(app)) return "/founder-tools";
+  return fallback;
+}
+
+export function normalizeAuthNextForApp(
+  app: AuthReturnAppName | string | null | undefined,
+  nextValue: string | null | undefined,
+  options: { fallback?: string } = {},
+): string {
+  const fallback = options.fallback ?? getDefaultAuthNext(app);
+  const next = nextValue?.trim() || fallback;
+
+  if (!next.startsWith("/") || next.startsWith("//")) return fallback;
+
+  if (!isFounderToolsApp(app)) return next;
+
+  let target: URL;
+  try {
+    target = new URL(next, "https://mlai.local");
+  } catch {
+    return fallback;
+  }
+  const articleRunStatusMatch = target.pathname.match(/^\/founder-tools\/marketing\/runs\/([^/]+)\/status\/?$/);
+  if (articleRunStatusMatch) {
+    target.pathname = `/founder-tools/marketing/runs/${articleRunStatusMatch[1]}`;
+    return pathWithSearchAndHash(target);
+  }
+
+  const mappedPath = LEGACY_FOUNDER_NEXT_PATHS[target.pathname];
+  if (mappedPath) {
+    target.pathname = mappedPath;
+    return pathWithSearchAndHash(target);
+  }
+
+  if (target.pathname.startsWith("/vibe-raising/")) {
+    target.pathname = "/founder-tools/updates";
+    return pathWithSearchAndHash(target);
+  }
+
+  return next;
+}

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1,4 +1,5 @@
 import { redirect } from "react-router";
+import { normalizeAuthNextForApp } from "~/lib/auth-return";
 import type { User } from "~/types/user";
 import { createApiClient, shouldUseDevAuthBypass, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
 import { getCurrentUser } from "~/lib/auth";
@@ -1402,7 +1403,7 @@ export function getVibeRaisingLoginHref(
   nextOverride?: string,
 ): string {
   const url = new URL(request.url);
-  const next = nextOverride ?? `${url.pathname}${url.search}`;
+  const next = normalizeAuthNextForApp("founder-tools", nextOverride ?? `${url.pathname}${url.search}`);
   const params = new URLSearchParams({
     app: "founder-tools",
     next,

--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -1,12 +1,26 @@
 import type { Route } from "./+types/founder-tools.marketing.run-status";
+import { redirect } from "react-router";
 
 import { getEnv } from "~/lib/env.server";
 import { getVibeMarketingRun } from "~/lib/vibe-marketing";
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
 
+function isDocumentNavigation(request: Request) {
+  const fetchDest = request.headers.get("Sec-Fetch-Dest")?.toLowerCase();
+  const fetchMode = request.headers.get("Sec-Fetch-Mode")?.toLowerCase();
+  const accept = request.headers.get("Accept")?.toLowerCase() ?? "";
+
+  return fetchDest === "document" || fetchMode === "navigate" || accept.includes("text/html");
+}
+
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
+
+  if (isDocumentNavigation(request)) {
+    throw redirect(runId ? `/founder-tools/marketing/runs/${encodeURIComponent(runId)}` : "/founder-tools/marketing");
+  }
+
+  await requireVibeRaisingFounder(env, request);
   return Response.json(await getVibeMarketingRun(env, request, runId));
 }

--- a/app/routes/platform.login.tsx
+++ b/app/routes/platform.login.tsx
@@ -6,44 +6,13 @@ import { GradientBackground } from "~/components/GradientBackground";
 import { Field, Input, Label } from "@headlessui/react";
 import { clsx } from "clsx";
 import { getEnv } from "~/lib/env.server";
+import { normalizeAuthNextForApp } from "~/lib/auth-return";
 
 export const meta: Route.MetaFunction = () => [
     { title: "Sign In to the MLAI Platform | MLAI" },
     { name: "description", content: "Sign in to your MLAI account to access the community platform, event dashboards, and tools for Australia's AI and Machine Learning community." },
     { name: "robots", content: "noindex, nofollow" },
 ];
-
-function getDefaultNext(app: AuthAppName | null | undefined): string {
-    if (app === "hospital") return "/hospital/app";
-    if (app === "esafety") return "/esafety/dashboard";
-    if (app === "innovate-connect-alliance") return "/innovate-connect-alliance";
-    if (app === "founder-tools" || app === "vibe-raising") return "/founder-tools";
-    return "/hackathons";
-}
-
-const LEGACY_FOUNDER_NEXT_PATHS: Record<string, string> = {
-    "/vibe-raising": "/founder-tools",
-    "/vibe-raising/": "/founder-tools",
-    "/vibe-raising/create-update": "/founder-tools/updates/create",
-    "/vibe-raising/connect-data": "/founder-tools/data-sources",
-    "/vibe-raising/companies": "/founder-tools/companies",
-    "/vibe-raising/company-setup": "/founder-tools/company-setup",
-    "/vibe-raising/discover": "/founder-tools/updates",
-};
-
-function normalizeNextForApp(app: AuthAppName | null | undefined, nextValue: string | null | undefined): string {
-    const fallback = getDefaultNext(app);
-    const next = nextValue?.trim() || fallback;
-
-    if (!next.startsWith("/") || next.startsWith("//")) return fallback;
-    if (app !== "founder-tools" && app !== "vibe-raising") return next;
-
-    const target = new URL(next, "https://mlai.local");
-    const mappedPath = LEGACY_FOUNDER_NEXT_PATHS[target.pathname];
-    if (mappedPath) return `${mappedPath}${target.search}${target.hash}`;
-    if (target.pathname.startsWith("/vibe-raising/")) return `/founder-tools/updates${target.search}${target.hash}`;
-    return next;
-}
 
 function parseAuthApp(value: string | null): AuthAppName | null {
     if (value === "vibe-raising") return "founder-tools";
@@ -84,7 +53,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
     const url = new URL(request.url);
     const app = parseAuthApp(url.searchParams.get("app"));
-    const next = normalizeNextForApp(app, url.searchParams.get("next"));
+    const next = normalizeAuthNextForApp(app, url.searchParams.get("next"), { fallback: "/hackathons" });
     let user = null;
 
     try {
@@ -105,7 +74,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     const formData = await request.formData();
     const intent = formData.get("intent")?.toString() ?? "check";
     const app = parseAuthApp(formData.get("app")?.toString() ?? null) ?? undefined;
-    const next = normalizeNextForApp(app ?? null, formData.get("next")?.toString());
+    const next = normalizeAuthNextForApp(app ?? null, formData.get("next")?.toString(), { fallback: "/hackathons" });
     const email = String(formData.get("email") || "").trim();
     const role = formData.get("role")?.toString() as "participant" | "mentor" | "judge" | "organizer" ?? "participant";
 
@@ -163,7 +132,7 @@ export default function PlatformLogin() {
     const [searchParams] = useSearchParams();
     const app = parseAuthApp(searchParams.get("app"));
     const isFounderTools = app === "founder-tools";
-    const next = normalizeNextForApp(app, searchParams.get("next"));
+    const next = normalizeAuthNextForApp(app, searchParams.get("next"), { fallback: "/hackathons" });
     const error = searchParams.get("error");
     const submit = useSubmit();
 

--- a/app/routes/verify-email.tsx
+++ b/app/routes/verify-email.tsx
@@ -1,38 +1,8 @@
 import type { Route } from "./+types/verify-email";
 import { useLoaderData } from "react-router";
+import { normalizeAuthNextForApp } from "~/lib/auth-return";
 import { getEnv } from "~/lib/env.server";
 import { verifyMagicLinkWithCookies } from "~/lib/auth";
-
-function getDefaultNext(app: string | null): string {
-    if (app === "hospital") return "/hospital/app";
-    if (app === "innovate-connect-alliance") return "/innovate-connect-alliance";
-    if (app === "founder-tools" || app === "vibe-raising") return "/founder-tools";
-    return "/esafety/dashboard";
-}
-
-const LEGACY_FOUNDER_NEXT_PATHS: Record<string, string> = {
-    "/vibe-raising": "/founder-tools",
-    "/vibe-raising/": "/founder-tools",
-    "/vibe-raising/create-update": "/founder-tools/updates/create",
-    "/vibe-raising/connect-data": "/founder-tools/data-sources",
-    "/vibe-raising/companies": "/founder-tools/companies",
-    "/vibe-raising/company-setup": "/founder-tools/company-setup",
-    "/vibe-raising/discover": "/founder-tools/updates",
-};
-
-function normalizeNextForApp(app: string | null, nextValue: string | null): string {
-    const fallback = getDefaultNext(app);
-    const next = nextValue?.trim() || fallback;
-
-    if (!next.startsWith("/") || next.startsWith("//")) return fallback;
-    if (app !== "founder-tools" && app !== "vibe-raising") return next;
-
-    const target = new URL(next, "https://mlai.local");
-    const mappedPath = LEGACY_FOUNDER_NEXT_PATHS[target.pathname];
-    if (mappedPath) return `${mappedPath}${target.search}${target.hash}`;
-    if (target.pathname.startsWith("/vibe-raising/")) return `/founder-tools/updates${target.search}${target.hash}`;
-    return next;
-}
 
 function getLoginHref(app: string | null, next: string): string {
     const params = new URLSearchParams();
@@ -50,7 +20,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const url = new URL(request.url);
     const token = url.searchParams.get("token");
     const app = url.searchParams.get("app");
-    const next = normalizeNextForApp(app, url.searchParams.get("next"));
+    const next = normalizeAuthNextForApp(app, url.searchParams.get("next"), { fallback: "/esafety/dashboard" });
     const loginHref = getLoginHref(app, next);
 
     if (!token) {


### PR DESCRIPTION
## Summary
- centralize Founder Tools auth return URL normalization
- canonicalize `/founder-tools/marketing/runs/:runId/status` to the human run page
- redirect direct document navigations to the status resource before auth handling so magic-link `next` never points at raw JSON

## Root cause
Unauthenticated document requests to the polling status route could preserve `/status` as the login `next` URL, so the browser rendered the JSON resource after magic-link verification.

## Checks
- `bun run typecheck`
- `bun run build`
- local curl redirect check for `/founder-tools/marketing/runs/test-run/status`