### PR TITLE
[codex] Show live preview diagnostics

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -442,6 +442,12 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     retryable: Boolean(payload.retryable ?? true),
     workspacePath: asNullableString(payload.workspacePath) ?? asNullableString(payload.workspace_path),
     logPath: asNullableString(payload.logPath) ?? asNullableString(payload.log_path),
+    failedPhase: asNullableString(payload.failedPhase) ?? asNullableString(payload.failed_phase),
+    failedCommand: asNullableString(payload.failedCommand) ?? asNullableString(payload.failed_command),
+    logExcerpt: asNullableString(payload.logExcerpt) ?? asNullableString(payload.log_excerpt),
+    verificationSkippedForPreview: Boolean(payload.verificationSkippedForPreview ?? payload.verification_skipped_for_preview),
+    renderMode: asNullableString(payload.renderMode) ?? asNullableString(payload.render_mode),
+    renderConfidence: asNullableString(payload.renderConfidence) ?? asNullableString(payload.render_confidence),
   };
 }
 

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -835,9 +835,14 @@ function ArticlePreviewEmptyState({
   const previewErrorCode = String(preview?.errorCode ?? "").trim().toLowerCase();
   const hasManifest = Boolean(run.componentManifest);
   const failed = Boolean(preview?.error || previewStatus === "failed" || previewStatus === "blocked");
-  const retryablePreviewCodes = new Set(["clone_auth_failed", "preview_start_timeout"]);
+  const retryablePreviewCodes = new Set(["clone_auth_failed", "preview_start_timeout", "preview_verification_failed"]);
   const retryable = preview?.retryable !== false || retryablePreviewCodes.has(previewErrorCode);
   const statusLabel = previewStatus ? previewStatus.replace(/_/g, " ") : "not started";
+  const diagnosticRows = [
+    preview?.failedPhase ? ["Phase", preview.failedPhase] : null,
+    preview?.failedCommand ? ["Command", preview.failedCommand] : null,
+  ].filter((row): row is [string, string] => Boolean(row));
+  const logExcerpt = String(preview?.logExcerpt ?? "").trim();
 
   if (failed) {
     return (
@@ -851,6 +856,21 @@ function ArticlePreviewEmptyState({
                 {preview?.error || "The article preview could not be prepared. Retry the preview when the generator is available."}
               </p>
               {preview?.errorCode ? <p className="mt-2 text-xs font-black uppercase text-red-700">Preview status: {preview.errorCode}</p> : null}
+              {diagnosticRows.length ? (
+                <dl className="mt-3 grid gap-1 text-xs font-semibold text-red-900">
+                  {diagnosticRows.map(([label, value]) => (
+                    <div key={label} className="grid gap-1 sm:grid-cols-[5rem_1fr]">
+                      <dt className="font-black uppercase text-red-700">{label}</dt>
+                      <dd className="break-words font-mono">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
+              {logExcerpt ? (
+                <pre className="mt-3 max-h-44 overflow-auto whitespace-pre-wrap rounded-lg border border-red-200 bg-white/75 p-3 font-mono text-[11px] leading-relaxed text-red-950">
+                  {logExcerpt}
+                </pre>
+              ) : null}
             </div>
           </div>
           {retryable ? (

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -300,6 +300,12 @@ export interface VibeMarketingLivePreview {
   retryable?: boolean;
   workspacePath?: string | null;
   logPath?: string | null;
+  failedPhase?: string | null;
+  failedCommand?: string | null;
+  logExcerpt?: string | null;
+  verificationSkippedForPreview?: boolean;
+  renderMode?: string | null;
+  renderConfidence?: string | null;
 }
 
 export type VibeMarketingComponentCommentStatus = "draft" | "submitted" | "applied" | "superseded" | string;


### PR DESCRIPTION
## Summary
- Normalize live-preview diagnostic fields from the backend.
- Show failed phase, failed command, and log excerpts in the review preview error panel.
- Treat preview_verification_failed as retryable so users can retry preview startup without regenerating the article.

## Validation
- bun run typecheck