### PR TITLE
[codex] Fix live preview proxy routing

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -433,6 +433,8 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     available: Boolean(payload.available),
     status,
     previewUrl: asNullableString(payload.previewUrl) ?? asNullableString(payload.preview_url),
+    internalPreviewUrl: asNullableString(payload.internalPreviewUrl) ?? asNullableString(payload.internal_preview_url),
+    proxyPath: asNullableString(payload.proxyPath) ?? asNullableString(payload.proxy_path),
     routePath: asNullableString(payload.routePath) ?? asNullableString(payload.route_path),
     exactRender: Boolean(payload.exactRender ?? payload.exact_render),
     inspectorProtocolVersion: asNumber(payload.inspectorProtocolVersion) ?? asNumber(payload.inspector_protocol_version),

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -291,6 +291,8 @@ export interface VibeMarketingLivePreview {
   available: boolean;
   status: string;
   previewUrl?: string | null;
+  internalPreviewUrl?: string | null;
+  proxyPath?: string | null;
   routePath?: string | null;
   exactRender?: boolean;
   inspectorProtocolVersion?: number | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,9 @@ for (const envFile of envFiles) {
 
 const inspectorPort =
   process.env.CLOUDFLARE_INSPECTOR_PORT === "false" ? false : undefined;
+const livePreviewDisableHmr = ["1", "true", "yes", "on"].includes(
+  String(process.env.CF_LIVE_PREVIEW_DISABLE_HMR || "").trim().toLowerCase(),
+);
 
 export default defineConfig({
   plugins: [
@@ -42,6 +45,7 @@ export default defineConfig({
     tsconfigPaths(),
   ],
   server: {
+    ...(livePreviewDisableHmr ? { hmr: false as const } : {}),
     proxy: {
       '/api': {
         target: 'http://localhost',


### PR DESCRIPTION
## Summary
- disable Vite HMR when Content Factory starts review previews
- preserve internal preview/proxy metadata in frontend types and normalization
- leave normal local development HMR unchanged

## Validation
- bun run typecheck