### PR TITLE
[codex] Handle retryable review preview failures

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -453,7 +453,9 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     proofAttempts: Array.isArray(payload.proofAttempts ?? payload.proof_attempts)
       ? ((payload.proofAttempts ?? payload.proof_attempts) as Record<string, unknown>[])
       : [],
+    proofAcceptedWithWarnings: Boolean(payload.proofAcceptedWithWarnings ?? payload.proof_accepted_with_warnings),
     verificationSkippedForPreview: Boolean(payload.verificationSkippedForPreview ?? payload.verification_skipped_for_preview),
+    previewMode: asNullableString(payload.previewMode) ?? asNullableString(payload.preview_mode),
     renderMode: asNullableString(payload.renderMode) ?? asNullableString(payload.render_mode),
     renderConfidence: asNullableString(payload.renderConfidence) ?? asNullableString(payload.render_confidence),
   };

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -861,6 +861,8 @@ function ArticlePreviewEmptyState({
   const retryablePreviewCodes = new Set([
     "clone_auth_failed",
     "dev_server_startup_failed",
+    "preview_proof_failed",
+    "preview_runtime_failed",
     "preview_start_timeout",
     "preview_verification_failed",
   ]);

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -309,7 +309,9 @@ export interface VibeMarketingLivePreview {
   browserWarnings?: string[];
   assetWarnings?: string[];
   proofAttempts?: Record<string, unknown>[];
+  proofAcceptedWithWarnings?: boolean;
   verificationSkippedForPreview?: boolean;
+  previewMode?: string | null;
   renderMode?: string | null;
   renderConfidence?: string | null;
 }


### PR DESCRIPTION
## Summary
- Normalize new live preview metadata in the frontend API client.
- Treat preview_proof_failed and preview_runtime_failed as retryable preview failures.

## Validation
- bun run typecheck
- git diff --check