### PR TITLE
Surface visual preview fallback diagnostics

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -62,6 +62,10 @@ function asStringRecord(value: unknown): Record<string, string> {
   return Object.fromEntries(entries);
 }
 
+function asObjectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
 function normalizeComponentCommentAnchor(raw: unknown): VibeMarketingComponentCommentAnchor | null {
   const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : null;
   if (!payload) return null;
@@ -458,6 +462,9 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     previewMode: asNullableString(payload.previewMode) ?? asNullableString(payload.preview_mode),
     renderMode: asNullableString(payload.renderMode) ?? asNullableString(payload.render_mode),
     renderConfidence: asNullableString(payload.renderConfidence) ?? asNullableString(payload.render_confidence),
+    fallbackReason: asNullableString(payload.fallbackReason) ?? asNullableString(payload.fallback_reason),
+    nativePreviewFailure: asObjectRecord(payload.nativePreviewFailure ?? payload.native_preview_failure),
+    visualFallback: asObjectRecord(payload.visualFallback ?? payload.visual_fallback),
   };
 }
 

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -635,15 +635,35 @@ function LiveArticlePreviewPanel({
   const canSendRevisionRequest = draftComments.length > 0 || canRetrySubmittedBatch;
   const commentModeActive = Boolean(inspectorProtocolVersion && inspectorProtocolVersion >= 2 && inspectorMode === "comment");
   const previewWarnings = useMemo(
-    () =>
-      Array.from(
+    () => {
+      const visualFallback =
+        preview?.visualFallback && typeof preview.visualFallback === "object"
+          ? (preview.visualFallback as Record<string, unknown>)
+          : {};
+      const nativePreviewFailure =
+        preview?.nativePreviewFailure && typeof preview.nativePreviewFailure === "object"
+          ? (preview.nativePreviewFailure as Record<string, unknown>)
+          : {};
+      const cssWarnings = Array.isArray(visualFallback.cssWarnings)
+        ? visualFallback.cssWarnings.map((warning) => String(warning ?? "").trim()).filter(Boolean)
+        : [];
+      const nativeFailure = typeof nativePreviewFailure.error === "string" ? nativePreviewFailure.error.trim() : "";
+      return Array.from(
         new Set([
+          ...(preview?.previewMode === "visual_static_fallback"
+            ? [
+                "Visual fallback preview: layout and content are reviewable, but production runtime behavior was not fully reproduced.",
+              ]
+            : []),
           ...(preview?.proofWarnings ?? []),
           ...(preview?.browserWarnings ?? []),
           ...(preview?.assetWarnings ?? []),
+          ...cssWarnings,
+          ...(nativeFailure ? [`Native preview failed: ${nativeFailure}`] : []),
         ]),
-      ).slice(0, 5),
-    [preview?.assetWarnings, preview?.browserWarnings, preview?.proofWarnings],
+      ).slice(0, 8);
+    },
+    [preview],
   );
   const sourceRunId =
     latestBatch?.sourceRunId ||

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -314,6 +314,14 @@ export interface VibeMarketingLivePreview {
   previewMode?: string | null;
   renderMode?: string | null;
   renderConfidence?: string | null;
+  fallbackReason?: string | null;
+  nativePreviewFailure?: Record<string, unknown>;
+  visualFallback?: {
+    cssSources?: string[];
+    cssWarnings?: string[];
+    assetProxyEnabled?: boolean;
+    mockedRoutes?: string[];
+  } | Record<string, unknown> | null;
 }
 
 export type VibeMarketingComponentCommentStatus = "draft" | "submitted" | "applied" | "superseded" | string;


### PR DESCRIPTION
Summary:
- Adds frontend types and normalization for visual fallback live-preview metadata.
- Shows a compact visual fallback warning while keeping comment pinning behavior unchanged.
- Surfaces CSS warnings and native preview failure diagnostics under existing preview warnings.

Tests:
- bun run typecheck
- git diff --check