### PR TITLE
[codex] Show hosted preview status

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -496,6 +496,16 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     fallbackReason: asNullableString(payload.fallbackReason) ?? asNullableString(payload.fallback_reason),
     nativePreviewFailure: asObjectRecord(payload.nativePreviewFailure ?? payload.native_preview_failure),
     visualFallback: asObjectRecord(payload.visualFallback ?? payload.visual_fallback),
+    platformProvider: asNullableString(payload.platformProvider) ?? asNullableString(payload.platform_provider),
+    platformStatus: asNullableString(payload.platformStatus) ?? asNullableString(payload.platform_status),
+    deploymentId: asNullableString(payload.deploymentId) ?? asNullableString(payload.deployment_id),
+    deploymentUrl: asNullableString(payload.deploymentUrl) ?? asNullableString(payload.deployment_url),
+    routeUrl: asNullableString(payload.routeUrl) ?? asNullableString(payload.route_url),
+    logsUrl: asNullableString(payload.logsUrl) ?? asNullableString(payload.logs_url),
+    commitSha: asNullableString(payload.commitSha) ?? asNullableString(payload.commit_sha),
+    branchName: asNullableString(payload.branchName) ?? asNullableString(payload.branch_name),
+    builderWorkflow: asNullableString(payload.builderWorkflow) ?? asNullableString(payload.builder_workflow),
+    builderRunUrl: asNullableString(payload.builderRunUrl) ?? asNullableString(payload.builder_run_url),
   };
 }
 

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1056,14 +1056,18 @@ function ArticlePreviewEmptyState({
   const previewStatus = String(preview?.status ?? "").trim().toLowerCase();
   const previewErrorCode = String(preview?.errorCode ?? "").trim().toLowerCase();
   const hasManifest = Boolean(run.componentManifest);
+  const hostedPreview = preview?.previewMode === "platform_deployment";
   const failed = Boolean(preview?.error || previewStatus === "failed" || previewStatus === "blocked");
   const retryablePreviewCodes = new Set([
     "clone_auth_failed",
     "dev_server_startup_failed",
+    "platform_preview_dispatch_failed",
+    "platform_preview_failed",
     "preview_proof_failed",
     "preview_runtime_failed",
     "preview_start_timeout",
     "preview_verification_failed",
+    "unsupported_runtime_for_v1",
   ]);
   const retryable = preview?.retryable !== false || retryablePreviewCodes.has(previewErrorCode);
   const statusLabel = previewStatus ? previewStatus.replace(/_/g, " ") : "not started";
@@ -1137,12 +1141,14 @@ function ArticlePreviewEmptyState({
             <ArrowPathIcon className="h-5 w-5 animate-spin" />
           </span>
           <div>
-            <h2 className="text-base font-black text-gray-950">Preparing article preview</h2>
+            <h2 className="text-base font-black text-gray-950">{hostedPreview ? "Building hosted preview" : "Preparing article preview"}</h2>
             <p className="mt-1 max-w-2xl text-sm font-semibold leading-6 text-gray-600">
-              The article is ready for review. We are preparing the exact website preview and comment layer.
+              {hostedPreview
+                ? "The article is ready for review. We are building and deploying an isolated preview URL for the exact website route."
+                : "The article is ready for review. We are preparing the exact website preview and comment layer."}
             </p>
             <p className="mt-2 text-xs font-black uppercase tracking-wide text-violet-700">
-              Preview status: {statusLabel}
+              Preview status: {preview?.platformStatus || statusLabel}
             </p>
           </div>
         </div>

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -322,6 +322,16 @@ export interface VibeMarketingLivePreview {
     assetProxyEnabled?: boolean;
     mockedRoutes?: string[];
   } | Record<string, unknown> | null;
+  platformProvider?: string | null;
+  platformStatus?: string | null;
+  deploymentId?: string | null;
+  deploymentUrl?: string | null;
+  routeUrl?: string | null;
+  logsUrl?: string | null;
+  commitSha?: string | null;
+  branchName?: string | null;
+  builderWorkflow?: string | null;
+  builderRunUrl?: string | null;
 }
 
 export type VibeMarketingComponentCommentStatus = "draft" | "submitted" | "applied" | "superseded" | string;


### PR DESCRIPTION
## Summary
- add hosted preview metadata to the frontend run model
- show a building-hosted-preview state for platform deployment previews
- keep hosted preview URLs rendered directly when available

## Checks
- bun run typecheck
- git diff --check