### PR TITLE
[codex] Simplify article system setup flow

### DIFF
--- a/app/components/ArticleSystemSurfaceSummary.tsx
+++ b/app/components/ArticleSystemSurfaceSummary.tsx
@@ -1,0 +1,243 @@
+import { CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { clsx } from "clsx";
+
+import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
+
+type SurfaceCandidate = {
+  key: string;
+  group: string;
+  kind: string;
+  path: string;
+  route: string;
+  systemType: string;
+  confidence: number | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+}
+
+function resultValue(run: VibeMarketingRunSummary, key: string): unknown {
+  if (run.result?.[key] !== undefined) return run.result[key];
+  const nested = asRecord(run.result?.result);
+  return nested[key];
+}
+
+function resultRecord(run: VibeMarketingRunSummary, key: string): Record<string, unknown> {
+  return asRecord(resultValue(run, key));
+}
+
+function routeFromPath(path: string) {
+  if (!path) return "";
+  if (path.startsWith("/")) return path;
+  if (/^https?:\/\//i.test(path)) {
+    try {
+      const url = new URL(path);
+      return url.pathname || "/";
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function candidateFromRaw(raw: unknown, index: number): SurfaceCandidate | null {
+  const payload = asRecord(raw);
+  const metadata = asRecord(payload.metadata);
+  const path = asString(payload.path_or_locator) || asString(payload.path) || asString(payload.file);
+  const route =
+    asString(metadata.route_path) ||
+    asString(metadata.listing_route) ||
+    asString(metadata.route_template) ||
+    asString(payload.route_template) ||
+    routeFromPath(path);
+  if (!path && !route) return null;
+  const confidenceValue = payload.confidence;
+  const confidence = typeof confidenceValue === "number" && Number.isFinite(confidenceValue) ? confidenceValue : null;
+  return {
+    key: `${path || route}-${index}`,
+    group: asString(payload.candidate_group) || asString(payload.kind) || "candidate",
+    kind: asString(payload.kind),
+    path,
+    route,
+    systemType: asString(payload.system_type),
+    confidence,
+  };
+}
+
+function articleSurfaceCandidates(run: VibeMarketingRunSummary): SurfaceCandidate[] {
+  const rawCandidates =
+    resultValue(run, "detected_candidates") ||
+    resultRecord(run, "article_system_readiness").detected_candidates ||
+    resultRecord(run, "scaffold_plan").detected_candidates;
+  const candidates = Array.isArray(rawCandidates) ? rawCandidates.map(candidateFromRaw).filter((item): item is SurfaceCandidate => Boolean(item)) : [];
+  const matched = candidateFromRaw(resultValue(run, "matched_article_surface"), -1);
+  const merged = matched ? [matched, ...candidates] : candidates;
+  const seen = new Set<string>();
+  return merged.filter((candidate) => {
+    const key = `${candidate.path}::${candidate.route}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function supportFiles(run: VibeMarketingRunSummary) {
+  const readiness = resultRecord(run, "article_system_readiness");
+  const setup = resultRecord(run, "article_system_setup");
+  const scaffoldPlan = resultRecord(run, "scaffold_plan");
+  const readinessRequired = asStringList(readiness.required_support_files);
+  const scaffoldRequired = asStringList(scaffoldPlan.required_support_files);
+  const required = readinessRequired.length ? readinessRequired : scaffoldRequired;
+  const missing =
+    asStringList(readiness.missing_support_files).length
+      ? asStringList(readiness.missing_support_files)
+      : asStringList(setup.missing_support_files).length
+        ? asStringList(setup.missing_support_files)
+        : asStringList(scaffoldPlan.missing_support_files);
+  const requiredSet = required.length ? required : missing;
+  const missingSet = new Set(missing);
+  return {
+    required: requiredSet,
+    missing,
+    found: requiredSet.filter((path) => !missingSet.has(path)),
+  };
+}
+
+function hintStatusTone(status: string) {
+  if (status === "matched") return "border-emerald-200 bg-emerald-50 text-emerald-800";
+  if (status === "unmatched" || status === "invalid") return "border-red-200 bg-red-50 text-red-800";
+  return "border-gray-200 bg-gray-50 text-gray-700";
+}
+
+export default function ArticleSystemSurfaceSummary({
+  run,
+  selectable = false,
+  fieldName = "articleSurfaceUrl",
+}: {
+  run: VibeMarketingRunSummary;
+  selectable?: boolean;
+  fieldName?: string;
+}) {
+  const candidates = articleSurfaceCandidates(run);
+  const files = supportFiles(run);
+  const hintStatus = asString(resultValue(run, "article_surface_hint_status")) || "ignored";
+  const hint = resultRecord(run, "article_surface_hint");
+  const readiness = resultRecord(run, "article_system_readiness");
+  const setup = resultRecord(run, "article_system_setup");
+  const readinessStatus = asString(readiness.status) || asString(setup.status);
+  const reason = asString(readiness.reason) || asString(resultValue(run, "scaffold_reason"));
+
+  if (!candidates.length && !files.required.length && hintStatus === "ignored" && !readinessStatus) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-base font-black text-gray-950">Article surface scan</h2>
+          <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+            Confirm the public route and repo files Content Factory will use before setup patches are approved.
+          </p>
+        </div>
+        <span className={clsx("inline-flex rounded-full border px-3 py-1 text-xs font-black uppercase", hintStatusTone(hintStatus))}>
+          Hint {hintStatus.replace(/_/g, " ")}
+        </span>
+      </div>
+
+      {asString(hint.route_path) ? (
+        <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs font-bold text-gray-600">
+          User hint: <span className="text-gray-950">{asString(hint.route_path)}</span>
+        </p>
+      ) : null}
+
+      {reason ? (
+        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-900">
+          {reason}
+        </div>
+      ) : null}
+
+      {candidates.length ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          {candidates.map((candidate, index) => {
+            const selectableValue = candidate.route || candidate.path;
+            const content = (
+              <>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-black text-gray-950">{candidate.route || candidate.path}</p>
+                    <p className="mt-1 text-xs font-bold uppercase tracking-wide text-gray-400">{candidate.group.replace(/_/g, " ")}</p>
+                  </div>
+                  {candidate.confidence !== null ? (
+                    <span className="rounded-full bg-violet-50 px-2 py-1 text-[11px] font-black text-violet-700">
+                      {Math.round(candidate.confidence * 100)}%
+                    </span>
+                  ) : null}
+                </div>
+                {candidate.path && candidate.path !== candidate.route ? (
+                  <p className="mt-3 break-all rounded-lg bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">{candidate.path}</p>
+                ) : null}
+                <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-wide text-gray-500">
+                  {candidate.kind ? <span className="rounded-full bg-gray-100 px-2 py-1">{candidate.kind}</span> : null}
+                  {candidate.systemType ? <span className="rounded-full bg-gray-100 px-2 py-1">{candidate.systemType}</span> : null}
+                  <span className="rounded-full bg-emerald-50 px-2 py-1 text-emerald-700">Patch only if confirmed safe</span>
+                </div>
+              </>
+            );
+            return selectable && selectableValue ? (
+              <label key={candidate.key} className="block cursor-pointer rounded-xl border border-gray-200 bg-white p-4 transition hover:border-violet-200 hover:bg-violet-50/40">
+                <div className="flex gap-3">
+                  <input
+                    type="radio"
+                    name={fieldName}
+                    value={selectableValue}
+                    defaultChecked={index === 0}
+                    className="mt-1 h-4 w-4 border-gray-300 text-violet-600 focus:ring-violet-500"
+                  />
+                  <div className="min-w-0 flex-1">{content}</div>
+                </div>
+              </label>
+            ) : (
+              <div key={candidate.key} className="rounded-xl border border-gray-200 bg-white p-4">
+                {content}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {files.required.length ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-4">
+            <div className="flex items-center gap-2 text-sm font-black text-emerald-900">
+              <CheckCircleIcon className="h-4 w-4" />
+              Support files found
+            </div>
+            <p className="mt-2 text-xs font-semibold leading-5 text-emerald-800">
+              {files.found.length ? files.found.join(", ") : "None confirmed yet"}
+            </p>
+          </div>
+          <div className="rounded-xl border border-amber-100 bg-amber-50 p-4">
+            <div className="flex items-center gap-2 text-sm font-black text-amber-900">
+              <ExclamationTriangleIcon className="h-4 w-4" />
+              Missing or planned files
+            </div>
+            <p className="mt-2 text-xs font-semibold leading-5 text-amber-800">
+              {files.missing.length ? files.missing.join(", ") : "No missing support files detected"}
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -317,7 +317,7 @@ export default function MarketingWorkflowShell({
         {displayGroups.map((group, index) => {
           const active = group.id === viewedGroup.id;
           const nextRequired = group.id === requiredGroup.id;
-          const locked = group.status === "locked";
+          const locked = group.status === "locked" && group.id !== "repo_article_system";
           const Icon = group.icon;
           const nextGroup = displayGroups[index + 1];
           const connectorNodeClass = connectorNodeTone(group, nextGroup, active, nextRequired);

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -11,6 +11,8 @@ import type {
   VibeMarketingContentPackage,
   VibeMarketingDraftArticle,
   VibeMarketingGuidedStep,
+  VibeMarketingGithubRepo,
+  VibeMarketingGithubReposResponse,
   VibeMarketingLivePreview,
   VibeMarketingPublishEvidence,
   VibeMarketingRunSummary,
@@ -70,6 +72,49 @@ function asStringRecord(value: unknown): Record<string, string> {
 
 function asObjectRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function normalizeGithubRepo(value: unknown): VibeMarketingGithubRepo | null {
+  const payload = asObjectRecord(value);
+  const fullName = asNullableString(payload.fullName) ?? asNullableString(payload.full_name);
+  if (!fullName) return null;
+  const defaultBranch = asNullableString(payload.defaultBranch) ?? asNullableString(payload.default_branch);
+  const installationId = asNullableString(payload.installationId) ?? asNullableString(payload.installation_id);
+  return {
+    fullName,
+    full_name: fullName,
+    owner: asNullableString(payload.owner) ?? undefined,
+    name: asNullableString(payload.name) ?? undefined,
+    private: Boolean(payload.private),
+    defaultBranch,
+    default_branch: defaultBranch,
+    installationId,
+    installation_id: installationId,
+  };
+}
+
+function normalizeGithubReposResponse(value: unknown): VibeMarketingGithubReposResponse {
+  const payload = asObjectRecord(value);
+  const rawRepos = Array.isArray(payload.repos) ? payload.repos : Array.isArray(payload.repositories) ? payload.repositories : [];
+  const repos = rawRepos.map(normalizeGithubRepo).filter((repo): repo is VibeMarketingGithubRepo => Boolean(repo));
+  const connectionState = asNullableString(payload.connectionState) ?? asNullableString(payload.connection_state);
+  const credentialSource = asNullableString(payload.credentialSource) ?? asNullableString(payload.credential_source);
+  const githubRepo = asNullableString(payload.githubRepo) ?? asNullableString(payload.github_repo);
+  const selectedRepo = asNullableString(payload.selectedRepo) ?? asNullableString(payload.selected_repo);
+  return {
+    status: asNullableString(payload.status) ?? "unavailable",
+    connectionState,
+    connection_state: connectionState,
+    credentialSource,
+    credential_source: credentialSource,
+    githubRepo,
+    github_repo: githubRepo,
+    selectedRepo,
+    selected_repo: selectedRepo,
+    repos,
+    repositories: repos,
+    error: asNullableString(payload.error),
+  };
 }
 
 function normalizeComponentCommentAnchor(raw: unknown): VibeMarketingComponentCommentAnchor | null {
@@ -1219,6 +1264,29 @@ export async function connectVibeMarketingGithub(env: Env, request: Request, bod
   };
 }
 
+export async function getVibeMarketingGithubRepos(env: Env, request: Request): Promise<VibeMarketingGithubReposResponse> {
+  if (shouldUseDevBackendStub()) {
+    return normalizeGithubReposResponse({
+      status: "connected",
+      connectionState: "connected",
+      githubRepo: "MLAI-AUS-Inc/mlai-au",
+      selectedRepo: "MLAI-AUS-Inc/mlai-au",
+      repos: [
+        {
+          fullName: "MLAI-AUS-Inc/mlai-au",
+          owner: "MLAI-AUS-Inc",
+          name: "mlai-au",
+          private: true,
+          defaultBranch: "main",
+        },
+      ],
+    });
+  }
+  const client = createApiClient(env, request);
+  const response = await client.get(`${BASE_PATH}/github/repos`);
+  return normalizeGithubReposResponse(response.data);
+}
+
 async function startMarketingRun(env: Env, request: Request, path: string, body: Record<string, unknown>) {
   if (shouldUseDevBackendStub()) {
     const runId = `dev-${path.replace(/[^a-z0-9]+/gi, "-")}-${Date.now().toString(36)}`;
@@ -1471,6 +1539,17 @@ export async function deleteVibeMarketingComponentComment(
 export async function submitVibeMarketingComponentComments(env: Env, request: Request, runId: string) {
   const client = createApiClient(env, request);
   const response = await client.post(`${BASE_PATH}/runs/${encodeURIComponent(runId)}/comments/submit`, {});
+  return normalizeMarketingRun(response.data);
+}
+
+export async function submitVibeMarketingArticleSystemComments(
+  env: Env,
+  request: Request,
+  runId: string,
+  body: Record<string, unknown>,
+) {
+  const client = createApiClient(env, request);
+  const response = await client.post(`${BASE_PATH}/runs/${encodeURIComponent(runId)}/article-system-revisions`, body);
   return normalizeMarketingRun(response.data);
 }
 

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -30,6 +30,7 @@ import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-
 import { combineCompanyContext as combineStartupCompanyContext } from "~/lib/vibe-marketing-startup-setup";
 import {
   connectVibeMarketingGithub,
+  getVibeMarketingGithubRepos,
   getVibeMarketingBootstrap,
   replayVibeMarketingDaily,
   refreshVibeMarketingBaselineGoogle,
@@ -41,7 +42,7 @@ import {
   startVibeMarketingDiscovery,
   startVibeMarketingScan,
 } from "~/lib/vibe-marketing";
-import type { VibeMarketingBootstrap } from "~/types/vibe-marketing";
+import type { VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
@@ -198,8 +199,13 @@ function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMark
   const requestedWorkflowStepId = WORKFLOW_STEP_ID_BY_CREATE_STEP[requested];
   const requestedWorkflowStep = bootstrap.workflowProgress?.steps?.find((step) => step.id === requestedWorkflowStepId);
   const contentOnlyAllowedStep = ["research", "chooseArticle"].includes(requested);
+  const repoArticleAllowedStep = ["github", "scan", "articleSystem"].includes(requested);
 
-  if (requestedWorkflowStep?.status === "locked" && !(contentOnlyAllowedStep && bootstrap.checks.baseline?.passed && !isGithubPublishingReady(bootstrap))) {
+  if (
+    requestedWorkflowStep?.status === "locked" &&
+    !repoArticleAllowedStep &&
+    !(contentOnlyAllowedStep && bootstrap.checks.baseline?.passed && !isGithubPublishingReady(bootstrap))
+  ) {
     return requiredStep;
   }
 
@@ -209,7 +215,22 @@ function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMark
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   const bootstrap = await getVibeMarketingBootstrap(env, request);
-  return { bootstrap };
+  let githubRepos: VibeMarketingGithubReposResponse = {
+    status: "unavailable",
+    repos: [],
+    repositories: [],
+  };
+  try {
+    githubRepos = await getVibeMarketingGithubRepos(env, request);
+  } catch (error) {
+    githubRepos = {
+      status: "unavailable",
+      repos: [],
+      repositories: [],
+      error: error instanceof Error ? error.message : "Unable to load repositories.",
+    };
+  }
+  return { bootstrap, githubRepos };
 }
 
 export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
@@ -323,6 +344,13 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (intent === "start-scan") {
       const result = await startVibeMarketingScan(env, request, {
         githubRepo: stringFromForm(formData, "githubRepo"),
+        github_repo: stringFromForm(formData, "githubRepo"),
+        articleSurfaceMode: "existing",
+        article_surface_mode: "existing",
+        articleSurfaceUrl: stringFromForm(formData, "articleSurfaceUrl"),
+        article_surface_url: stringFromForm(formData, "articleSurfaceUrl"),
+        autoSetupPreview: true,
+        auto_setup_preview: true,
       });
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       return redirect("/founder-tools/marketing/create?step=scan");
@@ -490,7 +518,7 @@ function PanelHeader({
 }
 
 export default function FounderToolsMarketingCreate() {
-  const { bootstrap } = useLoaderData<typeof loader>();
+  const { bootstrap, githubRepos } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
   const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap);
   const requestedStep = normalizeStep(searchParams.get("step"), activeStep);
@@ -499,7 +527,8 @@ export default function FounderToolsMarketingCreate() {
   const latestActionIntent = actionDataIntent(actionData);
   const latestActionError = actionDataError(actionData);
   const actionErrorStep = actionIntentStep(latestActionIntent);
-  const githubConnectError = activeStep === "github" && latestActionIntent === "connect-github" ? latestActionError : null;
+  const isRepoArticleStep = activeStep === "github" || activeStep === "scan" || activeStep === "articleSystem";
+  const githubConnectError = isRepoArticleStep && latestActionIntent === "connect-github" ? latestActionError : null;
   const topActionError =
     latestActionError && latestActionIntent !== "connect-github" && (!actionErrorStep || actionErrorStep === activeStep)
       ? latestActionError
@@ -540,6 +569,14 @@ export default function FounderToolsMarketingCreate() {
   const effectiveDeliveryMode = effectiveArticleDeliveryMode(bootstrap);
   const directPublishMode = effectiveDeliveryMode === "publish_code";
   const reviewDraftMode = effectiveDeliveryMode === "review_draft";
+  const githubRepoOptions = githubRepos.repos ?? githubRepos.repositories ?? [];
+  const selectedGithubRepo =
+    githubRepos.selectedRepo ??
+    githubRepos.selected_repo ??
+    bootstrap.settings.githubRepo ??
+    githubRepoOptions[0]?.fullName ??
+    "";
+  const [repoSelection, setRepoSelection] = useState(selectedGithubRepo);
   const deliveryModeNote = directPublishMode
     ? `This will generate a draft and prepare it for publishing through ${bootstrap.settings.githubRepo}.`
     : reviewDraftMode
@@ -560,6 +597,10 @@ export default function FounderToolsMarketingCreate() {
       setSelectedTopicCandidateId(defaultTopicCandidateId);
     }
   }, [defaultTopicCandidateId, selectableTopicCandidates, selectedTopicCandidateId]);
+
+  useEffect(() => {
+    setRepoSelection((current) => current || selectedGithubRepo);
+  }, [selectedGithubRepo]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
@@ -595,76 +636,98 @@ export default function FounderToolsMarketingCreate() {
           />
         ) : null}
 
-          {activeStep === "github" ? (
+          {activeStep === "github" || activeStep === "scan" || activeStep === "articleSystem" ? (
             <>
               <PanelHeader
-                title="Connect GitHub"
-                description="Optional: connect GitHub to publish generated articles directly through your website repository. Without it, we will create article copy and assets for manual publishing."
-                passed={githubReadyForPublishing}
-                explainer={STEP_EXPLAINERS.github}
+                title="Connect repo & article system"
+                description="Choose the GitHub repository, tell us where articles live, then scan before any setup or upgrade patch is approved."
+                passed={Boolean(bootstrap.checks.scaffold?.passed)}
+                explainer={STEP_EXPLAINERS.articleSystem}
               />
-              <Form method="POST" className="space-y-5">
-                <input type="hidden" name="intent" value="connect-github" />
-                <label className="block">
-                  <span className="mb-2 block text-sm font-bold text-gray-700">Repository</span>
-                  <input
-                    name="githubRepo"
-                    defaultValue={bootstrap.settings.githubRepo ?? ""}
-                    placeholder="owner/repo"
-                    className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
-                  />
-                </label>
-                <button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-60">
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CodeBracketIcon className="h-4 w-4" />}
-                  Connect GitHub
-                </button>
-                {githubConnectError ? (
-                  <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
-                    {githubConnectError}
-                  </div>
-                ) : null}
-              </Form>
-              {!githubReadyForPublishing ? (
-                <div className="mt-5 rounded-xl border border-violet-100 bg-violet-50/60 p-4">
-                  <p className="text-sm font-semibold leading-6 text-gray-700">
-                    You can skip GitHub and generate a content-only article package now. GitHub is only needed when you want us to publish through your site repository.
-                  </p>
-                  <Link to="/founder-tools/marketing/create?step=chooseArticle" className="mt-3 inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 text-sm font-black text-violet-700 shadow-sm ring-1 ring-violet-100 transition hover:bg-violet-50">
-                    Continue with content-only article
-                    <ArrowRightIcon className="h-4 w-4" />
-                  </Link>
-                </div>
-              ) : null}
-            </>
-          ) : null}
 
-          {activeStep === "scan" || activeStep === "articleSystem" ? (
-            <>
-              <PanelHeader
-                title={activeStep === "scan" ? "Scan repository" : "Prepare article system"}
-                description={
-                  githubReadyForPublishing
-                    ? "The scan detects your framework, build commands, article directories, registries, components, and safe publish targets."
-                    : "This setup is only needed for direct GitHub publishing. Content-only article generation can continue without it."
-                }
-                passed={activeStep === "scan" ? Boolean(bootstrap.checks.scan?.passed) : Boolean(bootstrap.checks.scaffold?.passed)}
-                explainer={STEP_EXPLAINERS[activeStep]}
-              />
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+                <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+                  <p className="text-sm font-black text-gray-950">GitHub connection</p>
+                  <p className="mt-1 text-sm font-semibold text-gray-600">
+                    {githubReadyForPublishing ? `Connected to ${bootstrap.settings.githubRepo}.` : "Connect GitHub so Content Factory can scan and publish through the website repo."}
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <span className={clsx("rounded-full px-3 py-1 text-xs font-black uppercase", githubReadyForPublishing ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700")}>
+                      {githubReadyForPublishing ? "Connected" : "Connection needed"}
+                    </span>
+                    {githubRepos.error ? <span className="rounded-full bg-red-50 px-3 py-1 text-xs font-black text-red-700">Repo list unavailable</span> : null}
+                  </div>
+                </div>
+
+                <Form method="POST" className="rounded-xl border border-gray-200 bg-white p-4">
+                  <input type="hidden" name="intent" value="connect-github" />
+                  <label className="block">
+                    <span className="mb-2 block text-sm font-bold text-gray-700">Repository</span>
+                    {githubRepoOptions.length ? (
+                      <select
+                        name="githubRepo"
+                        value={repoSelection}
+                        onChange={(event) => setRepoSelection(event.target.value)}
+                        className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                      >
+                        {githubRepoOptions.map((repo) => (
+                          <option key={repo.fullName} value={repo.fullName}>
+                            {repo.fullName}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        name="githubRepo"
+                        value={repoSelection}
+                        onChange={(event) => setRepoSelection(event.target.value)}
+                        placeholder="owner/repo"
+                        className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                      />
+                    )}
+                  </label>
+                  <button type="submit" disabled={isSubmitting || !repoSelection} className="mt-3 inline-flex items-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-60">
+                    {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CodeBracketIcon className="h-4 w-4" />}
+                    {githubReadyForPublishing ? "Reconnect GitHub" : "Connect GitHub"}
+                  </button>
+                  {githubConnectError ? (
+                    <div className="mt-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
+                      {githubConnectError}
+                    </div>
+                  ) : null}
+                </Form>
+              </div>
+
               {latestScan ? (
-                <div className="mb-5 rounded-xl border border-gray-100 bg-gray-50 p-4">
-                  <p className="text-sm font-black text-gray-950">Latest scan: {latestScan.status.replace(/_/g, " ")}</p>
-                  <p className="mt-1 text-xs font-semibold text-gray-500">{latestScan.currentStep ?? latestScan.runId}</p>
-                  <Link to={`/founder-tools/marketing/runs/${latestScan.runId}`} className="mt-3 inline-flex text-sm font-bold text-violet-700 hover:text-violet-900">
-                    View scan run
-                  </Link>
+                <div className="mt-5">
+                  <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+                    <p className="text-sm font-black text-gray-950">Latest scan: {latestScan.status.replace(/_/g, " ")}</p>
+                    <p className="mt-1 text-xs font-semibold text-gray-500">{latestScan.currentStep ?? latestScan.runId}</p>
+                    <Link to={`/founder-tools/marketing/runs/${latestScan.runId}`} className="mt-3 inline-flex text-sm font-bold text-violet-700 hover:text-violet-900">
+                      View scan run
+                    </Link>
+                  </div>
                 </div>
               ) : null}
-              <Form method="POST">
+
+              <Form method="POST" className="mt-5 space-y-5 rounded-xl border border-violet-100 bg-violet-50/30 p-4">
                 <input type="hidden" name="intent" value="start-scan" />
-                <input type="hidden" name="githubRepo" value={bootstrap.settings.githubRepo ?? ""} />
-                <button type="submit" disabled={isSubmitting || !bootstrap.settings.githubRepo} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
+                <input type="hidden" name="githubRepo" value={repoSelection} />
+                <label className="block">
+                  <span className="mb-2 block text-sm font-bold text-gray-700">Where should articles or blog posts live on this website?</span>
+                  <input
+                    name="articleSurfaceUrl"
+                    required
+                    placeholder="https://www.mlai.au/articles or /articles"
+                    className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                  />
+                  <span className="mt-2 block text-xs font-semibold text-gray-500">
+                    We verify this route against the repo before drafting the setup preview.
+                  </span>
+                </label>
+                <button type="submit" disabled={isSubmitting || !repoSelection} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
                   {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
-                  Run repository scan
+                  Scan and draft preview
                 </button>
               </Form>
               {!githubReadyForPublishing ? (

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -16,6 +16,7 @@ import {
 import { clsx } from "clsx";
 
 import ArticleRunStageProgress from "~/components/ArticleRunStageProgress";
+import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
@@ -28,6 +29,7 @@ import {
   getVibeMarketingBootstrap,
   getVibeMarketingRun,
   replayVibeMarketingDaily,
+  submitVibeMarketingArticleSystemComments,
   submitVibeMarketingComponentComments,
   startVibeMarketingLivePreview,
   startVibeMarketingArticle,
@@ -149,7 +151,16 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const runId = params.runId ?? "";
   const bootstrap = await getVibeMarketingBootstrap(env, request);
   const run = await getVibeMarketingRun(env, request, runId);
-  return { run, bootstrap };
+  const setupRunId = setupRunIdForRun(run);
+  let setupRun: VibeMarketingRunSummary | null = null;
+  if (setupRunId && setupRunId !== run.runId) {
+    try {
+      setupRun = await getVibeMarketingRun(env, request, setupRunId);
+    } catch {
+      setupRun = null;
+    }
+  }
+  return { run, bootstrap, setupRun };
 }
 
 export async function action({ request, params, context }: Route.ActionArgs) {
@@ -176,6 +187,15 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } else if (intent === "submit-component-comments") {
       const result = await submitVibeMarketingComponentComments(env, request, runId);
       if (result.runId && result.runId !== runId) {
+        throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      }
+    } else if (intent === "submit-article-system-comments") {
+      const setupRunId = stringFromForm(formData, "setupRunId") || runId;
+      const result = await submitVibeMarketingArticleSystemComments(env, request, setupRunId, {
+        body: stringFromForm(formData, "reviewComment"),
+        feedbackBatchId: stringFromForm(formData, "feedbackBatchId"),
+      });
+      if (result.runId) {
         throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       }
     } else if (intent === "accept-component-revision") {
@@ -517,6 +537,139 @@ function PublishApprovalPanel({
         </div>
         <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve publish" denyLabel="Deny publish" />
       </div>
+    </section>
+  );
+}
+
+function arrayResultValue(run: VibeMarketingRunSummary, key: string) {
+  const value = run.result?.[key];
+  if (Array.isArray(value)) return value;
+  const nestedResult = run.result?.["result"];
+  if (nestedResult && typeof nestedResult === "object") {
+    const nestedValue = (nestedResult as Record<string, unknown>)[key];
+    if (Array.isArray(nestedValue)) return nestedValue;
+  }
+  return [];
+}
+
+function articleSystemSetupPayload(run: VibeMarketingRunSummary) {
+  const direct = run.result?.["article_system_setup"];
+  if (direct && typeof direct === "object" && !Array.isArray(direct)) return direct as Record<string, unknown>;
+  const nestedResult = run.result?.["result"];
+  if (nestedResult && typeof nestedResult === "object") {
+    const nested = (nestedResult as Record<string, unknown>)["article_system_setup"];
+    if (nested && typeof nested === "object" && !Array.isArray(nested)) return nested as Record<string, unknown>;
+  }
+  return {};
+}
+
+function ArticleSystemSetupPreviewPanel({
+  run,
+  sourceRun,
+  isSubmitting,
+}: {
+  run: VibeMarketingRunSummary;
+  sourceRun?: VibeMarketingRunSummary | null;
+  isSubmitting: boolean;
+}) {
+  const setup = articleSystemSetupPayload(run);
+  const source = sourceRun ?? run;
+  const repo = run.githubRepo || source.githubRepo || stringResultValue(run, "github_repo", "githubRepo") || stringResultValue(source, "github_repo", "githubRepo");
+  const route =
+    run.routePath ||
+    source.routePath ||
+    stringResultValue(run, "route_path", "routePath") ||
+    stringResultValue(source, "route_path", "routePath") ||
+    (() => {
+      const hint = source.result?.["article_surface_hint"];
+      return hint && typeof hint === "object" ? String((hint as Record<string, unknown>).route_path ?? "") : "";
+    })();
+  const prUrl = run.prUrl || stringResultValue(run, "pr_url", "prUrl") || stringResultValue(source, "pr_url", "prUrl");
+  const previewUrl =
+    run.livePreview?.previewUrl ||
+    run.previewUrl ||
+    stringResultValue(run, "preview_url", "previewUrl") ||
+    stringResultValue(source, "preview_url", "previewUrl");
+  const setupRunId = setupRunIdForRun(run) || setupRunIdForRun(source) || run.runId;
+  const changedFiles = [
+    ...arrayResultValue(run, "changed_files_preview"),
+    ...(Array.isArray(setup.changed_files_preview) ? setup.changed_files_preview : []),
+  ]
+    .map((item) => String(item ?? "").trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  const canApprove = run.status === "awaiting_approval" || run.status === "approval_required";
+  const feedbackBatchId = `article-system-${setupRunId}-${Date.now().toString(36)}`;
+
+  return (
+    <section className="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="text-lg font-black text-gray-950">Article system preview</h2>
+          <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
+            Review the drafted articles page setup before it is merged into the website repo.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs font-black">
+            {repo ? <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-700">{repo}</span> : null}
+            {route ? <span className="rounded-full bg-violet-50 px-3 py-1 text-violet-700">{route}</span> : null}
+            {prUrl ? (
+              <a href={prUrl} target="_blank" rel="noreferrer" className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-700 hover:text-emerald-900">
+                Open PR
+              </a>
+            ) : null}
+          </div>
+        </div>
+        {canApprove ? <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve article system" denyLabel="Deny setup" /> : null}
+      </div>
+
+      <ArticleSystemSurfaceSummary run={source} />
+
+      {changedFiles.length ? (
+        <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+          <p className="text-sm font-black text-gray-950">Planned setup files</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {changedFiles.map((file) => (
+              <span key={file} className="rounded-lg bg-white px-3 py-2 font-mono text-xs font-semibold text-gray-600 shadow-sm">
+                {file}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {previewUrl ? (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
+          <iframe
+            title="Article system setup preview"
+            src={previewUrl}
+            className="h-[760px] w-full bg-white"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          />
+        </div>
+      ) : (
+        <div className="rounded-xl border border-violet-100 bg-violet-50 px-4 py-5 text-sm font-semibold text-violet-800">
+          The hosted preview is being built. Refreshing this page is safe.
+        </div>
+      )}
+
+      <Form method="POST" className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+        <input type="hidden" name="intent" value="submit-article-system-comments" />
+        <input type="hidden" name="setupRunId" value={setupRunId} />
+        <input type="hidden" name="feedbackBatchId" value={feedbackBatchId} />
+        <label className="block">
+          <span className="mb-2 block text-sm font-black text-gray-950">Review comments</span>
+          <textarea
+            name="reviewComment"
+            rows={3}
+            placeholder="Describe what should change in the articles page setup."
+            className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+          />
+        </label>
+        <button type="submit" disabled={isSubmitting} className="mt-3 inline-flex items-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-50">
+          {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+          Send setup comments
+        </button>
+      </Form>
     </section>
   );
 }
@@ -2002,6 +2155,14 @@ function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
   return "";
 }
 
+function setupRunIdForRun(run: VibeMarketingRunSummary) {
+  const direct = stringResultValue(run, "setup_run_id", "setupRunId", "scaffold_job_id", "scaffoldJobId");
+  if (direct) return direct;
+  const setup = articleSystemSetupPayload(run);
+  const setupRunId = setup.setup_run_id ?? setup.setupRunId;
+  return typeof setupRunId === "string" && setupRunId.trim() ? setupRunId.trim() : "";
+}
+
 function publishPrUrlForRun(run: VibeMarketingRunSummary) {
   return run.prUrl?.trim() || stringResultValue(run, "pr_url", "prUrl", "pull_request_url", "pullRequestUrl", "draft_pr_url", "draftPrUrl");
 }
@@ -2040,18 +2201,6 @@ function hasReviewTarget(run: VibeMarketingRunSummary) {
 
 function isRunApprovalRequired(run: VibeMarketingRunSummary) {
   return run.approvalState === "approval_required" || APPROVAL_GATE_STATUSES.has(run.status);
-}
-
-function isScaffoldApprovalGate(run: VibeMarketingRunSummary) {
-  const workflow = String(run.workflow ?? "");
-  if (!SCAN_WORKFLOWS.has(workflow)) return false;
-  const requestedAction = stringResultValue(run, "requested_action");
-  const scaffoldStatus = stringResultValue(run, "scaffold_status");
-  return (
-    isRunApprovalRequired(run) ||
-    (run.status === "awaiting_confirmation" &&
-      (requestedAction === "scaffold_publish_route" || scaffoldStatus === "approval_required"))
-  );
 }
 
 function isPublishApprovalGate(run: VibeMarketingRunSummary) {
@@ -2105,7 +2254,7 @@ function workflowProgressForRunPage(
 }
 
 export default function FounderToolsMarketingRun() {
-  const { run: loaderRun, bootstrap } = useLoaderData<typeof loader>();
+  const { run: loaderRun, bootstrap, setupRun: loaderSetupRun } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const runStatusFetcher = useFetcher<VibeMarketingRunSummary>();
@@ -2118,14 +2267,17 @@ export default function FounderToolsMarketingRun() {
   const shouldPoll = POLLING_STATUSES.has(run.status) || hasPendingArticlePreview(run) || hasPublishHandoffEvidence(run);
   const statusUrl = `/founder-tools/marketing/runs/${encodeURIComponent(loaderRun.runId)}/status`;
   const workflow = String(run.workflow ?? "");
+  const isScanRun = SCAN_WORKFLOWS.has(workflow);
+  const isArticleSystemSetupRun = workflow === "article_system_setup";
+  const setupRun = isArticleSystemSetupRun ? run : loaderSetupRun;
   const isArticleWorkflowRun = isArticleWorkflow(workflow);
   const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
   const hasArticlePreview = hasReadyArticlePreview(run);
   const isDiscoveryConfirmation =
     ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(workflow) &&
     run.status === "awaiting_confirmation";
-  const isScaffoldApproval = isScaffoldApprovalGate(run);
   const isPublishApproval = isPublishApprovalGate(run);
+  const effectiveSetupPreviewRun = setupRun?.livePreview?.previewUrl || setupRun?.previewUrl ? setupRun : isScanRun && setupRunIdForRun(run) ? run : setupRun;
   const showRunAttentionBanner = RESUMABLE_ATTENTION_STATUSES.has(run.status);
   const canResume = Boolean(run.resumeAvailable && RESUMABLE_ATTENTION_STATUSES.has(run.status));
   const discoveryCandidates = useMemo(
@@ -2295,23 +2447,14 @@ export default function FounderToolsMarketingRun() {
             </section>
           ) : null}
 
-          {isScaffoldApproval ? (
-            <section className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-900">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <h2 className="text-lg font-black text-amber-950">Scaffold approval</h2>
-                  <p className="mt-2 font-semibold">
-                    Review the scan result, then approve setup or deny the scaffold request.
-                  </p>
-                </div>
-                <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve setup" denyLabel="Deny setup" />
-              </div>
-              {run.result?.["route_path"] || run.result?.["path"] ? (
-                <p className="mt-3 break-all rounded-lg bg-white px-3 py-2 font-mono text-xs text-amber-900">
-                  {String(run.result?.["route_path"] ?? run.result?.["path"])}
-                </p>
-              ) : null}
-            </section>
+          {effectiveSetupPreviewRun ? (
+            <ArticleSystemSetupPreviewPanel
+              run={effectiveSetupPreviewRun}
+              sourceRun={isScanRun ? run : null}
+              isSubmitting={isSubmitting}
+            />
+          ) : isScanRun ? (
+            <ArticleSystemSurfaceSummary run={run} />
           ) : null}
 
           {showRunAttentionBanner ? (
@@ -2342,7 +2485,7 @@ export default function FounderToolsMarketingRun() {
             </div>
           ) : null}
 
-          {!isArticleGenerationRun ? <RunStepTimeline run={run} /> : null}
+          {!isArticleGenerationRun && !isScanRun && !isArticleSystemSetupRun ? <RunStepTimeline run={run} /> : null}
 
         </main>
       ) : null}

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -515,6 +515,33 @@ export interface VibeMarketingGoogleBaselineConnection {
   connectUrl?: string | null;
 }
 
+export interface VibeMarketingGithubRepo {
+  fullName: string;
+  full_name?: string;
+  owner?: string;
+  name?: string;
+  private?: boolean;
+  defaultBranch?: string | null;
+  default_branch?: string | null;
+  installationId?: string | null;
+  installation_id?: string | null;
+}
+
+export interface VibeMarketingGithubReposResponse {
+  status: string;
+  connectionState?: string | null;
+  connection_state?: string | null;
+  credentialSource?: string | null;
+  credential_source?: string | null;
+  githubRepo?: string | null;
+  github_repo?: string | null;
+  selectedRepo?: string | null;
+  selected_repo?: string | null;
+  repos: VibeMarketingGithubRepo[];
+  repositories?: VibeMarketingGithubRepo[];
+  error?: string | null;
+}
+
 export interface VibeMarketingBootstrap {
   company: VibeMarketingCompany;
   organization: VibeMarketingOrganization;


### PR DESCRIPTION
## Summary
- make Connect repo & article system navigable even when locked
- replace the setup step with repo selection plus required article route input
- send autoSetupPreview scans and show setup preview/review UI instead of the scaffold approval banner
- hide technical step timelines for scan/setup runs

## Validation
- npm run typecheck -- --pretty false
- git diff --check