### PR TITLE
[codex] Fix stale repo scan recovery UI

### DIFF
--- a/app/components/MarketingRunProgressCard.tsx
+++ b/app/components/MarketingRunProgressCard.tsx
@@ -13,10 +13,13 @@ function labelForStatus(status: string) {
 export default function MarketingRunProgressCard({ run }: MarketingRunProgressCardProps) {
   const isFailed = ["failed", "blocked", "blocked_verification", "denied"].includes(run.status);
   const isScanRun = ["repo_scan", "content_factory_scan"].includes(run.workflow);
+  const isStaleQueuedScan = isScanRun && Boolean(run.stale || run.staleReason === "scan_queue_not_started");
   const isScanActionNeeded = isScanRun && ["awaiting_confirmation", "awaiting_approval", "approval_required"].includes(run.status);
-  const isRunning = ["queued", "running", "awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status) && !isScanActionNeeded;
-  const statusLabel = isScanActionNeeded ? "scan complete, action needed" : labelForStatus(run.status);
-  const currentStepLabel = isScanActionNeeded
+  const isRunning = ["queued", "running", "awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status) && !isScanActionNeeded && !isStaleQueuedScan;
+  const statusLabel = isStaleQueuedScan ? "scan did not start" : isScanActionNeeded ? "scan complete, action needed" : labelForStatus(run.status);
+  const currentStepLabel = isStaleQueuedScan
+    ? "The scan worker did not pick up this job. Retry the scan or cancel it and start again."
+    : isScanActionNeeded
     ? "The repository scan finished. Choose the article route, start a new setup preview, or cancel this scan."
     : run.currentStep
       ? run.currentStep.replace(/_/g, " ")
@@ -28,17 +31,17 @@ export default function MarketingRunProgressCard({ run }: MarketingRunProgressCa
     <div
       className={clsx(
         "relative overflow-hidden rounded-xl border p-5 shadow-sm",
-        isFailed ? "border-red-200 bg-red-50" : "border-violet-100 bg-violet-50/70",
+        isFailed || isStaleQueuedScan ? "border-red-200 bg-red-50" : "border-violet-100 bg-violet-50/70",
       )}
     >
       <div className="flex items-start gap-4">
-        <div className={clsx("flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl", isFailed ? "bg-red-100 text-red-600" : "bg-white text-violet-600")}>
-          {isFailed ? <ExclamationTriangleIcon className="h-6 w-6" /> : isRunning ? <ArrowPathIcon className="h-6 w-6 animate-spin" /> : <SparklesIcon className="h-6 w-6" />}
+        <div className={clsx("flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl", isFailed || isStaleQueuedScan ? "bg-red-100 text-red-600" : "bg-white text-violet-600")}>
+          {isFailed || isStaleQueuedScan ? <ExclamationTriangleIcon className="h-6 w-6" /> : isRunning ? <ArrowPathIcon className="h-6 w-6 animate-spin" /> : <SparklesIcon className="h-6 w-6" />}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <h2 className="text-base font-black text-gray-950">{run.workflow.replace(/_/g, " ")}</h2>
-            <span className={clsx("rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide", isFailed ? "bg-red-100 text-red-700" : "bg-white text-violet-700")}>
+            <span className={clsx("rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide", isFailed || isStaleQueuedScan ? "bg-red-100 text-red-700" : "bg-white text-violet-700")}>
               {statusLabel}
             </span>
           </div>

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -209,6 +209,11 @@ export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
     publishChildStatus: asNullableString(payload.publishChildStatus) ?? asNullableString(payload.publish_child_status),
     publishChildRecoverable: Boolean(payload.publishChildRecoverable ?? payload.publish_child_recoverable),
     publishChildWaitReason: asNullableString(payload.publishChildWaitReason) ?? asNullableString(payload.publish_child_wait_reason),
+    stale: Boolean(payload.stale),
+    staleReason: asNullableString(payload.staleReason) ?? asNullableString(payload.stale_reason),
+    retryAvailable: Boolean(payload.retryAvailable ?? payload.retry_available),
+    queueName: asNullableString(payload.queueName) ?? asNullableString(payload.queue_name),
+    queuedAt: asNullableString(payload.queuedAt) ?? asNullableString(payload.queued_at),
     result:
       payload.result && typeof payload.result === "object"
         ? (payload.result as Record<string, unknown>)

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -232,6 +232,10 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } else if (intent === "cancel-scan") {
       await controlVibeMarketingRun(env, request, runId, "cancel", { cleanup: true, workflow: "repo_scan" });
       throw redirect("/founder-tools/marketing/create?step=scan");
+    } else if (intent === "retry-scan") {
+      const result = await controlVibeMarketingRun(env, request, runId, "resume", { workflow: "repo_scan" });
+      if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      return { error: result.errors?.[0] || "Repository scan could not be retried." };
     } else if (intent === "start-scan") {
       const githubRepo = stringFromForm(formData, "githubRepo") || stringFromForm(formData, "github_repo");
       const articleSurfaceUrl = stringFromForm(formData, "articleSurfaceUrl") || stringFromForm(formData, "article_surface_url");
@@ -662,8 +666,16 @@ function ArticleSystemScanFormPanel({
         </button>
       </Form>
       <div className="mt-4 flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-xs font-semibold text-gray-500">Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later.</p>
-        <Form method="POST">
+        <p className="text-xs font-semibold text-gray-500">
+          {run.stale ? "This scan did not start on the worker queue. Retry it, or cancel and start with new details." : "Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later."}
+        </p>
+        <Form method="POST" className="flex flex-col gap-2 sm:flex-row">
+          {run.retryAvailable || run.stale ? (
+            <button type="submit" name="intent" value="retry-scan" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50">
+              <ArrowPathIcon className="h-4 w-4" />
+              Retry scan
+            </button>
+          ) : null}
           <button type="submit" name="intent" value="cancel-scan" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 transition hover:bg-red-50 disabled:opacity-50">
             <XCircleIcon className="h-4 w-4" />
             Cancel scan
@@ -2491,10 +2503,11 @@ export default function FounderToolsMarketingRun() {
   const statusUrl = `/founder-tools/marketing/runs/${encodeURIComponent(loaderRun.runId)}/status`;
   const workflow = String(run.workflow ?? "");
   const isScanRun = SCAN_WORKFLOWS.has(workflow);
+  const isStaleScan = isScanRun && Boolean(run.stale || run.staleReason === "scan_queue_not_started");
   const isScanActionNeeded = isScanRun && ["awaiting_confirmation", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const shouldPoll =
-    (POLLING_STATUSES.has(run.status) && !isScanActionNeeded && !isScanCompleted) ||
+    (POLLING_STATUSES.has(run.status) && !isScanActionNeeded && !isScanCompleted && !isStaleScan) ||
     hasPendingArticlePreview(run) ||
     hasPublishHandoffEvidence(run);
   const isArticleSystemSetupRun = workflow === "article_system_setup";

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -53,6 +53,11 @@ export interface VibeMarketingRunSummary {
   publishChildStatus?: string | null;
   publishChildRecoverable?: boolean;
   publishChildWaitReason?: string | null;
+  stale?: boolean;
+  staleReason?: string | null;
+  retryAvailable?: boolean;
+  queueName?: string | null;
+  queuedAt?: string | null;
   result?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary
- render stale queued repo scans as action-needed failures instead of active spinners
- add retry support for stale repo scans
- keep cancel recovery visible and stop polling once stale scan metadata is present

## Validation
- npm run typecheck -- --pretty false