### PR TITLE
[codex] Add GitHub article setup facelift

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1,0 +1,477 @@
+import { Form } from "react-router";
+import { clsx } from "clsx";
+import type { ChangeEvent, ReactNode } from "react";
+import {
+  Check,
+  CheckCircle2,
+  Code2,
+  ExternalLink,
+  Eye,
+  FileText,
+  Info,
+  Loader2,
+  LockKeyhole,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+import type { VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
+
+type ArticleSystemConnectionPanelProps = {
+  bootstrap: VibeMarketingBootstrap;
+  githubRepos: VibeMarketingGithubReposResponse;
+  isSubmitting: boolean;
+  repoSelection?: string;
+  onRepoSelectionChange?: (value: string) => void;
+  articleSurfaceDefault?: string;
+  articleSurfacePlaceholder?: string;
+  connectionError?: string | null;
+  scanRun?: VibeMarketingRunSummary | null;
+  framed?: boolean;
+};
+
+function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
+  return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
+}
+
+function githubConnectionState(githubRepos: VibeMarketingGithubReposResponse, bootstrap: VibeMarketingBootstrap) {
+  return String(
+    githubRepos.connectionState ??
+      githubRepos.connection_state ??
+      bootstrap.settings.githubConnectionState ??
+      githubRepos.status ??
+      "",
+  ).trim();
+}
+
+function isGithubConnected(githubRepos: VibeMarketingGithubReposResponse, bootstrap: VibeMarketingBootstrap) {
+  const state = githubConnectionState(githubRepos, bootstrap).toLowerCase();
+  return (
+    isGithubPublishingReady(bootstrap) ||
+    state === "connected" ||
+    state === "already_connected" ||
+    Boolean(githubRepos.repos?.length || githubRepos.repositories?.length)
+  );
+}
+
+function repoNames(githubRepos: VibeMarketingGithubReposResponse) {
+  return (githubRepos.repos?.length ? githubRepos.repos : githubRepos.repositories ?? [])
+    .map((repo) => repo.fullName || repo.full_name || [repo.owner, repo.name].filter(Boolean).join("/"))
+    .filter(Boolean);
+}
+
+function selectedRepoName({
+  bootstrap,
+  githubRepos,
+  repos,
+  repoSelection,
+}: {
+  bootstrap: VibeMarketingBootstrap;
+  githubRepos: VibeMarketingGithubReposResponse;
+  repos: string[];
+  repoSelection?: string;
+}) {
+  return (
+    repoSelection ||
+    githubRepos.selectedRepo ||
+    githubRepos.selected_repo ||
+    githubRepos.githubRepo ||
+    githubRepos.github_repo ||
+    bootstrap.settings.githubRepo ||
+    repos.find((repo) => repo.toLowerCase() === "mlai-aus-inc/mlai-au") ||
+    repos[0] ||
+    ""
+  );
+}
+
+function GitHubMark({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+      <path d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.42-4.04-1.42-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.83 2.8 1.3 3.49.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.4 11.4 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.81 5.63-5.49 5.93.43.37.82 1.1.82 2.22v3.29c0 .32.22.69.83.57A12 12 0 0 0 12 .5Z" />
+    </svg>
+  );
+}
+
+function TrustBullet({ children, tone = "violet" }: { children: string; tone?: "violet" | "blue" | "emerald" }) {
+  const toneClass = {
+    violet: "bg-violet-600 text-white",
+    blue: "bg-blue-600 text-white",
+    emerald: "bg-emerald-600 text-white",
+  }[tone];
+  return (
+    <li className="flex gap-3 text-sm font-medium leading-6 text-slate-700">
+      <span className={clsx("mt-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full", toneClass)}>
+        <Check className="h-3 w-3" strokeWidth={3} />
+      </span>
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function TrustCard({
+  title,
+  icon,
+  tone,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  tone: "violet" | "blue" | "emerald";
+  children: ReactNode;
+}) {
+  const styles = {
+    violet: {
+      card: "border-violet-100 bg-violet-50/50",
+      title: "text-violet-700",
+      icon: "from-violet-700 to-violet-500 text-white",
+    },
+    blue: {
+      card: "border-blue-100 bg-blue-50/50",
+      title: "text-blue-700",
+      icon: "from-blue-700 to-blue-500 text-white",
+    },
+    emerald: {
+      card: "border-emerald-100 bg-emerald-50/60",
+      title: "text-emerald-700",
+      icon: "from-emerald-700 to-emerald-500 text-white",
+    },
+  }[tone];
+  return (
+    <section className={clsx("rounded-2xl border p-5 shadow-sm", styles.card)}>
+      <div className="flex gap-4">
+        <div className={clsx("flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br shadow-sm", styles.icon)}>
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <h3 className={clsx("text-base font-black", styles.title)}>{title}</h3>
+          <ul className="mt-3 space-y-2">{children}</ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SmallProof({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-slate-500">
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+function PermissionPill({
+  children,
+  tone = "emerald",
+  icon,
+}: {
+  children: ReactNode;
+  tone?: "emerald" | "violet" | "slate";
+  icon: ReactNode;
+}) {
+  const toneClass = {
+    emerald: "bg-emerald-50 text-emerald-700 ring-emerald-100",
+    violet: "bg-violet-50 text-violet-700 ring-violet-100",
+    slate: "bg-slate-50 text-slate-700 ring-slate-100",
+  }[tone];
+  return (
+    <span className={clsx("inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-black ring-1", toneClass)}>
+      {icon}
+      {children}
+    </span>
+  );
+}
+
+function SafetyFeature({ icon, title, body }: { icon: ReactNode; title: string; body: string }) {
+  return (
+    <div className="flex items-center gap-3 border-slate-100 py-3 sm:border-r sm:pr-5 last:border-r-0">
+      <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-slate-50 text-violet-700">
+        {icon}
+      </div>
+      <div>
+        <p className="text-sm font-black text-slate-900">{title}</p>
+        <p className="text-xs font-semibold text-slate-500">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+function DisabledArticleLocationCard({ placeholder }: { placeholder: string }) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white/70 p-4 opacity-80">
+      <h3 className="text-base font-black text-slate-900">Where are your articles or blog posts?</h3>
+      <p className="mt-1 text-sm font-medium text-slate-500">Tell us where your content lives in this repository.</p>
+      <input
+        disabled
+        placeholder={placeholder}
+        className="mt-4 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-500 outline-none"
+      />
+      <p className="mt-2 text-xs font-semibold text-slate-500">Connect GitHub first, then choose a repository and scan this location.</p>
+      <div className="mt-4 inline-flex max-w-xl items-start gap-3 rounded-xl bg-violet-50 px-4 py-3 text-sm font-semibold text-slate-700">
+        <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
+          <Sparkles className="h-4 w-4" />
+        </span>
+        <span>We only create and update content within the article location you approve.</span>
+      </div>
+    </section>
+  );
+}
+
+export default function ArticleSystemConnectionPanel({
+  bootstrap,
+  githubRepos,
+  isSubmitting,
+  repoSelection,
+  onRepoSelectionChange,
+  articleSurfaceDefault = "",
+  articleSurfacePlaceholder = "https://www.mlai.au/articles or /articles",
+  connectionError,
+  scanRun,
+  framed = true,
+}: ArticleSystemConnectionPanelProps) {
+  const connected = isGithubConnected(githubRepos, bootstrap);
+  const repos = repoNames(githubRepos);
+  const selectedRepo = selectedRepoName({ bootstrap, githubRepos, repos, repoSelection });
+  const repoUrl = selectedRepo.includes("/") ? `https://github.com/${selectedRepo}` : "";
+  const locationPlaceholder = connected ? articleSurfacePlaceholder : "e.g. /content/articles";
+  const statusLabel = bootstrap.checks.scaffold?.passed ? "Ready" : connected ? "Connected" : "Ready";
+  const connectionLabel = githubConnectionState(githubRepos, bootstrap).replace(/_/g, " ") || (connected ? "connected" : "not connected");
+
+  const repoControlProps = onRepoSelectionChange
+    ? {
+        value: selectedRepo,
+        onChange: (event: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => onRepoSelectionChange(event.target.value),
+      }
+    : {
+        defaultValue: selectedRepo,
+      };
+
+  return (
+    <section className={clsx(framed && "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6")}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-black tracking-tight text-slate-950 sm:text-3xl">
+            Connect GitHub & set your articles location
+          </h2>
+          <p className="mt-3 max-w-5xl text-base font-medium leading-7 text-slate-600">
+            We connect to your repository so our AI agent can help you create content.
+            <br className="hidden sm:block" />
+            <span className="font-black text-slate-800"> You&apos;re always in control.</span> The AI will never publish or make changes unless you{" "}
+            <span className="font-black text-violet-700">specifically</span> approve them.
+          </p>
+        </div>
+        <span className="inline-flex w-fit items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-black text-emerald-700 ring-1 ring-emerald-100">
+          {statusLabel}
+          <CheckCircle2 className="h-4 w-4" />
+        </span>
+      </div>
+
+      <div className="mt-7 grid gap-4 lg:grid-cols-3">
+        <TrustCard title="You're always in control" tone="violet" icon={<ShieldCheck className="h-8 w-8" />}>
+          <TrustBullet tone="violet">We will never publish or make any changes unless you specifically approve.</TrustBullet>
+          <TrustBullet tone="violet">Every change is shown to you first for review.</TrustBullet>
+          <TrustBullet tone="violet">You decide what goes live.</TrustBullet>
+        </TrustCard>
+        <TrustCard title="Only your articles, never your code" tone="blue" icon={<Code2 className="h-8 w-8" />}>
+          <TrustBullet tone="blue">We only write to your articles/blogs location.</TrustBullet>
+          <TrustBullet tone="blue">We will never delete or change code or files in any other part of your app or website.</TrustBullet>
+          <TrustBullet tone="blue">Your app, settings and configuration stay untouched.</TrustBullet>
+        </TrustCard>
+        <TrustCard title="Secure & transparent" tone="emerald" icon={<LockKeyhole className="h-8 w-8" />}>
+          <TrustBullet tone="emerald">Connected via GitHub with granular permissions.</TrustBullet>
+          <TrustBullet tone="emerald">Your code and content stays yours.</TrustBullet>
+          <TrustBullet tone="emerald">You can disconnect at any time.</TrustBullet>
+        </TrustCard>
+      </div>
+
+      {!connected ? (
+        <section className="mt-5 rounded-2xl border border-slate-200 bg-white px-5 py-8 text-center shadow-sm">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-50 text-slate-950">
+            <GitHubMark className="h-8 w-8" />
+          </div>
+          <h3 className="mt-4 text-lg font-black text-slate-950">Connect your GitHub repository</h3>
+          <p className="mx-auto mt-2 max-w-2xl text-sm font-medium leading-6 text-slate-500">
+            This gives the AI agent permission to create and update content in your articles location only.
+          </p>
+          <Form method="POST" className="mt-5">
+            <input type="hidden" name="intent" value="connect-github" />
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center justify-center gap-3 rounded-xl bg-slate-950 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:opacity-50"
+            >
+              {isSubmitting ? <Loader2 className="h-5 w-5 animate-spin" /> : <GitHubMark className="h-5 w-5" />}
+              Connect GitHub
+            </button>
+          </Form>
+          <div className="mt-5 flex flex-wrap justify-center gap-4">
+            <SmallProof icon={<LockKeyhole className="h-4 w-4" />} label="Secure OAuth" />
+            <SmallProof icon={<ShieldCheck className="h-4 w-4" />} label="Granular permissions" />
+            <SmallProof icon={<Eye className="h-4 w-4" />} label="You're in control" />
+          </div>
+          <div className="mx-auto mt-5 flex max-w-3xl items-start gap-3 rounded-xl bg-violet-50 px-4 py-3 text-left text-sm font-semibold leading-5 text-slate-700">
+            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
+              <Sparkles className="h-4 w-4" />
+            </span>
+            <span>
+              We only request access to what we need. You can review and revoke access at any time.
+              <span className="ml-1 inline-flex items-center gap-1 font-black text-violet-700">
+                Learn more about our permissions <ExternalLink className="h-3.5 w-3.5" />
+              </span>
+            </span>
+          </div>
+          {connectionError ? (
+            <div className="mx-auto mt-4 max-w-3xl rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-left text-sm font-semibold text-red-700">
+              {connectionError}
+            </div>
+          ) : null}
+        </section>
+      ) : (
+        <section className="mt-5 rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex flex-col gap-4 p-5 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex gap-4">
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-950">
+                <GitHubMark className="h-8 w-8" />
+              </div>
+              <div>
+                <h3 className="text-lg font-black text-slate-950">GitHub connection</h3>
+                <p className="mt-2 text-sm font-black text-slate-700">
+                  Connected to {selectedRepo || "your selected repository"}
+                  {repoUrl ? (
+                    <a href={repoUrl} target="_blank" rel="noreferrer" className="ml-2 inline-flex text-slate-500 transition hover:text-violet-700">
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  ) : null}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <PermissionPill icon={<CheckCircle2 className="h-3.5 w-3.5" />}>Connected</PermissionPill>
+                  <PermissionPill tone="emerald" icon={<ShieldCheck className="h-3.5 w-3.5" />}>Write access limited</PermissionPill>
+                  <PermissionPill tone="slate" icon={<Info className="h-3.5 w-3.5" />}>{connectionLabel}</PermissionPill>
+                </div>
+                <p className="mt-4 max-w-2xl text-sm font-medium leading-6 text-slate-500">
+                  We have write access to create and update content in your articles location only.
+                  <span className="block font-black text-slate-700">We will never delete or change any other files.</span>
+                </p>
+              </div>
+            </div>
+            <Form method="POST">
+              <input type="hidden" name="intent" value="connect-github" />
+              {selectedRepo ? <input type="hidden" name="githubRepo" value={selectedRepo} /> : null}
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-black text-slate-900 shadow-sm transition hover:border-violet-200 hover:bg-violet-50 disabled:opacity-50"
+              >
+                <GitHubMark className="h-5 w-5" />
+                Change repository
+              </button>
+            </Form>
+          </div>
+          <div className="grid border-t border-slate-100 px-5 sm:grid-cols-2 lg:grid-cols-4">
+            <SafetyFeature icon={<FileText className="h-5 w-5" />} title="Can write to" body="Articles/blogs location only" />
+            <SafetyFeature icon={<ShieldCheck className="h-5 w-5 text-emerald-700" />} title="Will never delete" body="No file deletions, ever" />
+            <SafetyFeature icon={<Code2 className="h-5 w-5 text-blue-700" />} title="Will never touch code" body="No changes outside articles" />
+            <SafetyFeature icon={<Eye className="h-5 w-5 text-amber-600" />} title="Requires approval" body="Nothing goes live without you" />
+          </div>
+        </section>
+      )}
+
+      {connected ? (
+        <Form method="POST" className="mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <input type="hidden" name="intent" value="start-scan" />
+          <div className="grid gap-4 lg:grid-cols-[minmax(220px,360px)_1fr]">
+            <label className="block">
+              <span className="mb-2 block text-sm font-black text-slate-800">Repository</span>
+              {repos.length ? (
+                <select
+                  name="githubRepo"
+                  {...repoControlProps}
+                  className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                >
+                  {repos.map((repo) => (
+                    <option key={repo} value={repo}>
+                      {repo}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  name="githubRepo"
+                  {...repoControlProps}
+                  placeholder="owner/repo"
+                  className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                />
+              )}
+            </label>
+            <label className="block">
+              <span className="mb-2 block text-sm font-black text-slate-800">Where are your articles or blog posts?</span>
+              <input
+                name="articleSurfaceUrl"
+                required
+                defaultValue={articleSurfaceDefault}
+                placeholder={locationPlaceholder}
+                className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+              />
+              <span className="mt-2 block text-xs font-semibold text-slate-500">
+                Examples: /content/articles, /src/content/blog, /website/posts
+              </span>
+            </label>
+          </div>
+          <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="inline-flex max-w-xl items-start gap-3 rounded-xl bg-violet-50 px-4 py-3 text-sm font-semibold text-slate-700">
+              <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
+                <Sparkles className="h-4 w-4" />
+              </span>
+              <span>We&apos;ll only create and update content within this path. No other files or folders will be touched.</span>
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting || (repos.length > 0 && !selectedRepo)}
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
+            >
+              {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+              Scan repository
+            </button>
+          </div>
+        </Form>
+      ) : (
+        <div className="mt-5">
+          <DisabledArticleLocationCard placeholder={locationPlaceholder} />
+        </div>
+      )}
+
+      {scanRun ? (
+        <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs font-semibold text-slate-500">
+            {scanRun.stale
+              ? "This scan did not start on the worker queue. Retry it, or cancel and start with new details."
+              : "Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later."}
+          </p>
+          <Form method="POST" className="flex flex-col gap-2 sm:flex-row">
+            {scanRun.retryAvailable || scanRun.stale ? (
+              <button
+                type="submit"
+                name="intent"
+                value="retry-scan"
+                disabled={isSubmitting}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50"
+              >
+                <Loader2 className="h-4 w-4" />
+                Retry scan
+              </button>
+            ) : null}
+            <button
+              type="submit"
+              name="intent"
+              value="cancel-scan"
+              disabled={isSubmitting}
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 transition hover:bg-red-50 disabled:opacity-50"
+            >
+              Cancel scan
+            </button>
+          </Form>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -7,16 +7,15 @@ import {
   ArrowPathIcon,
   ArrowRightIcon,
   CheckCircleIcon,
-  CodeBracketIcon,
   InformationCircleIcon,
   LightBulbIcon,
   MagnifyingGlassIcon,
-  PlayIcon,
   RocketLaunchIcon,
 } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
+import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
 import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
 import {
   CustomTopicDecisionCard,
@@ -174,21 +173,6 @@ function createStepForWorkflowStep(stepId: string | null | undefined): VibeMarke
 
 function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
-}
-
-function githubConnectionState(githubRepos: VibeMarketingGithubReposResponse, bootstrap: VibeMarketingBootstrap) {
-  return String(
-    githubRepos.connectionState ??
-      githubRepos.connection_state ??
-      bootstrap.settings.githubConnectionState ??
-      githubRepos.status ??
-      "",
-  ).trim();
-}
-
-function isGithubConnected(githubRepos: VibeMarketingGithubReposResponse, bootstrap: VibeMarketingBootstrap) {
-  const state = githubConnectionState(githubRepos, bootstrap).toLowerCase();
-  return isGithubPublishingReady(bootstrap) || state === "connected" || state === "already_connected" || Boolean(githubRepos.repos?.length || githubRepos.repositories?.length);
 }
 
 function resultObject(value: unknown): Record<string, unknown> {
@@ -652,8 +636,6 @@ export default function FounderToolsMarketingCreate() {
     githubRepoOptions[0]?.fullName ??
     "";
   const [repoSelection, setRepoSelection] = useState(selectedGithubRepo);
-  const githubConnected = isGithubConnected(githubRepos, bootstrap);
-  const githubStateLabel = githubConnectionState(githubRepos, bootstrap).replace(/_/g, " ") || (githubConnected ? "connected" : "not connected");
   const latestScanNeedsSetupApproval = isScanAwaitingSetupApproval(latestScan);
   const latestScanSetupRunId = latestScan ? setupRunIdForRun(latestScan) : "";
   const latestScanIsConfirmed = latestScan?.status === "completed" || Boolean(bootstrap.checks.scaffold?.passed);
@@ -718,126 +700,16 @@ export default function FounderToolsMarketingCreate() {
 
           {activeStep === "github" || activeStep === "scan" || activeStep === "articleSystem" ? (
             <>
-              <PanelHeader
-                title="Connect repo & article system"
-                description="Choose the GitHub repository, tell us where articles live, then scan before any setup or upgrade patch is approved."
-                passed={Boolean(bootstrap.checks.scaffold?.passed)}
-                explainer={STEP_EXPLAINERS.articleSystem}
+              <ArticleSystemConnectionPanel
+                bootstrap={bootstrap}
+                githubRepos={githubRepos}
+                isSubmitting={isSubmitting}
+                repoSelection={repoSelection}
+                onRepoSelectionChange={setRepoSelection}
+                articleSurfacePlaceholder="https://www.mlai.au/articles or /articles"
+                connectionError={githubConnectError}
+                framed={false}
               />
-
-              {!githubConnected ? (
-                <div className="rounded-xl border border-violet-100 bg-violet-50/40 p-5">
-                  <div className="grid gap-4 lg:grid-cols-3">
-                    <div>
-                      <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">Why connect GitHub</p>
-                      <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">
-                        Content Factory needs read access to understand how this website stores articles before it can publish safely.
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">What the agent will do</p>
-                      <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">
-                        It scans routes and support files, then drafts setup changes on a review branch only after you approve.
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">Your control</p>
-                      <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">
-                        Nothing is merged or published until you inspect the hosted preview and approve the final step.
-                      </p>
-                    </div>
-                  </div>
-                  <Form method="POST" className="mt-5">
-                    <input type="hidden" name="intent" value="connect-github" />
-                    <button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-60">
-                      {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CodeBracketIcon className="h-4 w-4" />}
-                      Connect GitHub
-                    </button>
-                  </Form>
-                  {githubConnectError ? (
-                    <div className="mt-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
-                      {githubConnectError}
-                    </div>
-                  ) : null}
-                </div>
-              ) : (
-                <>
-                  <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
-                    <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
-                      <p className="text-sm font-black text-gray-950">GitHub connection</p>
-                      <p className="mt-1 text-sm font-semibold text-gray-600">
-                        {bootstrap.settings.githubRepo ? `Connected to ${bootstrap.settings.githubRepo}.` : "GitHub is connected. Choose the website repository before scanning."}
-                      </p>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-black uppercase text-emerald-700">
-                          {githubStateLabel}
-                        </span>
-                        {githubRepos.error ? <span className="rounded-full bg-red-50 px-3 py-1 text-xs font-black text-red-700">Repo list unavailable</span> : null}
-                      </div>
-                    </div>
-
-                    <Form method="POST" className="rounded-xl border border-gray-200 bg-white p-4">
-                      <input type="hidden" name="intent" value="connect-github" />
-                      {repoSelection ? <input type="hidden" name="githubRepo" value={repoSelection} /> : null}
-                      <p className="text-sm font-black text-gray-950">GitHub access</p>
-                      <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-                        Reconnect if the repo list is missing, stale, or the GitHub App needs access to another repository.
-                      </p>
-                      <button type="submit" disabled={isSubmitting} className="mt-3 inline-flex items-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-60">
-                        {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CodeBracketIcon className="h-4 w-4" />}
-                        Reconnect GitHub
-                      </button>
-                    </Form>
-                  </div>
-
-                  <Form method="POST" className="mt-5 space-y-5 rounded-xl border border-violet-100 bg-violet-50/30 p-4">
-                    <input type="hidden" name="intent" value="start-scan" />
-                    <div className="grid gap-4 lg:grid-cols-2">
-                      <label className="block">
-                        <span className="mb-2 block text-sm font-bold text-gray-700">Repository</span>
-                        {githubRepoOptions.length ? (
-                          <select
-                            name="githubRepo"
-                            value={repoSelection}
-                            onChange={(event) => setRepoSelection(event.target.value)}
-                            className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
-                          >
-                            {githubRepoOptions.map((repo) => (
-                              <option key={repo.fullName} value={repo.fullName}>
-                                {repo.fullName}
-                              </option>
-                            ))}
-                          </select>
-                        ) : (
-                          <input
-                            name="githubRepo"
-                            value={repoSelection}
-                            onChange={(event) => setRepoSelection(event.target.value)}
-                            placeholder="owner/repo"
-                            className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
-                          />
-                        )}
-                      </label>
-                      <label className="block">
-                        <span className="mb-2 block text-sm font-bold text-gray-700">Where should articles or blog posts live on this website?</span>
-                        <input
-                          name="articleSurfaceUrl"
-                          required
-                          placeholder="https://www.mlai.au/articles or /articles"
-                          className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
-                        />
-                        <span className="mt-2 block text-xs font-semibold text-gray-500">
-                          We verify this route against the repo before drafting any setup preview.
-                        </span>
-                      </label>
-                    </div>
-                    <button type="submit" disabled={isSubmitting || !repoSelection} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
-                      {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
-                      Scan repository
-                    </button>
-                  </Form>
-                </>
-              )}
 
               {latestScan ? (
                 <div className="mt-5 space-y-4">

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -6,7 +6,6 @@ import {
   ArrowLeftIcon,
   ArrowPathIcon,
   CheckCircleIcon,
-  CodeBracketIcon,
   EllipsisHorizontalIcon,
   ExclamationTriangleIcon,
   PaperAirplaneIcon,
@@ -17,6 +16,7 @@ import {
 import { clsx } from "clsx";
 
 import ArticleRunStageProgress from "~/components/ArticleRunStageProgress";
+import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
 import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
@@ -90,21 +90,6 @@ function isArticleGenerationWorkflow(workflow: string | null | undefined) {
 
 function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
-}
-
-function githubConnectionState(githubRepos: VibeMarketingGithubReposResponse, bootstrap: VibeMarketingBootstrap) {
-  return String(
-    githubRepos.connectionState ??
-      githubRepos.connection_state ??
-      bootstrap.settings.githubConnectionState ??
-      githubRepos.status ??
-      "",
-  ).trim();
-}
-
-function isGithubConnected(githubRepos: VibeMarketingGithubReposResponse, bootstrap: VibeMarketingBootstrap) {
-  const state = githubConnectionState(githubRepos, bootstrap).toLowerCase();
-  return isGithubPublishingReady(bootstrap) || state === "connected" || state === "already_connected" || Boolean(githubRepos.repos?.length || githubRepos.repositories?.length);
 }
 
 type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
@@ -659,111 +644,21 @@ function ArticleSystemScanFormPanel({
   githubRepos: VibeMarketingGithubReposResponse;
   isSubmitting: boolean;
 }) {
-  const repos = (githubRepos.repos?.length ? githubRepos.repos : githubRepos.repositories ?? [])
-    .map((repo) => repo.fullName || repo.full_name || [repo.owner, repo.name].filter(Boolean).join("/"))
-    .filter(Boolean);
   const selectedRepo =
     run.githubRepo ||
     stringResultValue(run, "github_repo", "githubRepo") ||
-    githubRepos.selectedRepo ||
-    githubRepos.selected_repo ||
-    githubRepos.githubRepo ||
-    githubRepos.github_repo ||
-    bootstrap.settings.githubRepo ||
-    repos.find((repo) => repo.toLowerCase() === "mlai-aus-inc/mlai-au") ||
-    repos[0] ||
     "";
-  const githubConnected = isGithubConnected(githubRepos, bootstrap);
-  const githubStateLabel = githubConnectionState(githubRepos, bootstrap).replace(/_/g, " ") || (githubConnected ? "connected" : "not connected");
 
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-lg font-black text-gray-950">Connect repo & article system</h2>
-          <p className="mt-1 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
-            Connect GitHub, choose the repo and public articles/blog route, then scan before setup changes are drafted.
-          </p>
-        </div>
-        <span className={clsx("inline-flex w-fit rounded-full px-3 py-1 text-xs font-black uppercase", githubConnected ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700")}>
-          GitHub {githubStateLabel}
-        </span>
-      </div>
-
-      {!githubConnected ? (
-        <div className="mt-4 rounded-xl border border-violet-100 bg-violet-50/40 p-4">
-          <div className="grid gap-3 lg:grid-cols-3">
-            <div>
-              <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">Why we need this</p>
-              <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">We scan the website repo to find the exact article route and files.</p>
-            </div>
-            <div>
-              <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">What the agent will do</p>
-              <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">It proposes a setup branch only after the scan confirms what needs to change.</p>
-            </div>
-            <div>
-              <p className="text-[11px] font-black uppercase tracking-wide text-violet-700">Safety</p>
-              <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">Nothing is merged or published until you approve the preview.</p>
-            </div>
-          </div>
-          <Form method="POST" className="mt-4">
-            <input type="hidden" name="intent" value="connect-github" />
-            <button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:opacity-50">
-              {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CodeBracketIcon className="h-4 w-4" />}
-              Connect GitHub
-            </button>
-          </Form>
-        </div>
-      ) : (
-        <>
-          <Form method="POST" className="mt-4 grid gap-4 lg:grid-cols-[1fr_1fr_auto] lg:items-end">
-            <input type="hidden" name="intent" value="start-scan" />
-            <label className="block">
-              <span className="mb-2 block text-sm font-black text-gray-950">Repository</span>
-              {repos.length ? (
-                <select name="githubRepo" defaultValue={selectedRepo} className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-bold text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10">
-                  {repos.map((repo) => <option key={repo} value={repo}>{repo}</option>)}
-                </select>
-              ) : (
-                <input name="githubRepo" defaultValue={selectedRepo} placeholder="owner/repo" className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-bold text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10" />
-              )}
-            </label>
-            <label className="block">
-              <span className="mb-2 block text-sm font-black text-gray-950">Where should articles or blog posts live on this website?</span>
-              <input name="articleSurfaceUrl" defaultValue={articleSurfaceRouteFromRun(run) || "/articles"} placeholder="/articles" className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-bold text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10" />
-            </label>
-            <button type="submit" disabled={isSubmitting || (repos.length > 0 && !selectedRepo)} className="inline-flex justify-center rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50">
-              {isSubmitting ? <ArrowPathIcon className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Scan repository
-            </button>
-          </Form>
-          <Form method="POST" className="mt-3">
-            <input type="hidden" name="intent" value="connect-github" />
-            {selectedRepo ? <input type="hidden" name="githubRepo" value={selectedRepo} /> : null}
-            <button type="submit" disabled={isSubmitting} className="text-sm font-black text-violet-700 transition hover:text-violet-900 disabled:opacity-50">
-              Reconnect GitHub
-            </button>
-          </Form>
-        </>
-      )}
-      <div className="mt-4 flex flex-col gap-3 border-t border-gray-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-xs font-semibold text-gray-500">
-          {run.stale ? "This scan did not start on the worker queue. Retry it, or cancel and start with new details." : "Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later."}
-        </p>
-        <Form method="POST" className="flex flex-col gap-2 sm:flex-row">
-          {run.retryAvailable || run.stale ? (
-            <button type="submit" name="intent" value="retry-scan" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50">
-              <ArrowPathIcon className="h-4 w-4" />
-              Retry scan
-            </button>
-          ) : null}
-          <button type="submit" name="intent" value="cancel-scan" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 transition hover:bg-red-50 disabled:opacity-50">
-            <XCircleIcon className="h-4 w-4" />
-            Cancel scan
-          </button>
-        </Form>
-      </div>
-    </section>
+    <ArticleSystemConnectionPanel
+      bootstrap={bootstrap}
+      githubRepos={githubRepos}
+      isSubmitting={isSubmitting}
+      repoSelection={selectedRepo}
+      articleSurfaceDefault={articleSurfaceRouteFromRun(run) || "/articles"}
+      articleSurfacePlaceholder="/articles"
+      scanRun={run}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- Add a reusable GitHub article setup panel matching the new trust-first mockups.
- Use the shared panel on both the create step and repo scan run page.
- Preserve existing GitHub connect, repo selection, scan, retry/cancel, scan review, and setup preview form intents.

## Validation
- `bun run typecheck -- --pretty false`
- `git diff --check --cached`
