### PR TITLE
[codex] Update main page Slack invite

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
+- [x] Update the main-page Slack invite link
 - [x] Update the Vibe Raising relationship callout heading to mention building investor relationships 6 months in advance
 - [x] Restore the Vibe Raising bottom cue text to "Don't Wait Until You Need Money"
 - [x] Update the Vibe Raising bottom cue text to the new 6-month investor relationship line

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -48,7 +48,7 @@ const footerNavigation = {
     },
     {
       name: "Slack",
-      href: "https://join.slack.com/t/mlai-aus/shared_invite/zt-36v55lk77-LbIvbAPH~9E83zEgXlXRSg",
+      href: "https://join.slack.com/t/mlai-aus/shared_invite/zt-3xsuoq3yb-_hah3nVNtga9pFQUvsxJeQ",
       icon: (props: any) => (
         <svg
           className="h-6 w-6"

--- a/app/components/hero.tsx
+++ b/app/components/hero.tsx
@@ -10,7 +10,7 @@ export default function Hero() {
         <div className="flex justify-between items-start gap-4">
           {/* Join Slack - Top Left */}
           <a
-            href="https://join.slack.com/t/mlai-aus/shared_invite/zt-36v55lk77-LbIvbAPH~9E83zEgXlXRSg"
+            href="https://join.slack.com/t/mlai-aus/shared_invite/zt-3xsuoq3yb-_hah3nVNtga9pFQUvsxJeQ"
             target="_blank"
             rel="noopener noreferrer nofollow"
             className="inline-flex items-center gap-2 sm:gap-3 px-4 sm:px-6 py-2 sm:py-3 bg-[#4A154B] text-white text-sm sm:text-base font-medium rounded-full hover:bg-[#611f69] transition-colors"


### PR DESCRIPTION
## Summary

Updates the MLAI homepage Slack invite URL in the hero CTA and shared footer social link.

## Impact

Visitors using the main page Slack entry points are sent to the current Slack shared invite.

## Validation

- Checked the staged diff for the three intended files only.
- Confirmed the new invite appears in the homepage hero and footer components.

Typecheck was not run because this is a URL-only content change.