### PR TITLE
[codex] Fix marketing setup progression

### DIFF
--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -80,20 +80,20 @@ const WORKFLOW_DISPLAY_GROUPS: WorkflowDisplayGroupDefinition[] = [
     icon: UserCircleIcon,
   },
   {
-    id: "research_topic",
-    label: "Research & choose topic",
-    summary: "Find topic opportunities and choose the article brief.",
-    stepIds: ["research", "choose_topic"],
-    completionStepId: "choose_topic",
-    icon: MagnifyingGlassIcon,
-  },
-  {
     id: "repo_article_system",
     label: "Connect repo & article system",
     summary: "Connect GitHub, scan the repository, and prepare the article system.",
     stepIds: ["repo", "article_system"],
     completionStepId: "article_system",
     icon: CodeBracketIcon,
+  },
+  {
+    id: "research_topic",
+    label: "Research & choose topic",
+    summary: "Find topic opportunities and choose the article brief.",
+    stepIds: ["research", "choose_topic"],
+    completionStepId: "choose_topic",
+    icon: MagnifyingGlassIcon,
   },
   {
     id: "article_creation",

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -1510,7 +1510,8 @@ export default function VibeMarketingStartupBaselineSetup({
     message: googleTrafficMessage,
   };
   const embedded = variant === "workflow";
-  const shouldShowSecondaryAction = showSecondaryAction ?? !embedded;
+  const shouldShowSecondaryAction = showSecondaryAction ?? true;
+  const defaultPrimaryActionLabel = includeBaseline ? "Continue to GitHub setup" : embedded ? "Save and continue" : "Continue";
   const baselineActive = baselinePending || baselinePolling;
   const baselineDomain = effectiveBaseline.domain || startupValues.domain || bootstrap.organization.domain || bootstrap.company.domain || "No domain saved yet";
   const baselineScore = clampScore(effectiveBaseline.overallScore);
@@ -2402,15 +2403,6 @@ export default function VibeMarketingStartupBaselineSetup({
           Your data is secure and never shared.
         </p>
         <div className="flex flex-col gap-3 sm:flex-row">
-          {includeBaseline && embedded && focusSection === "baseline" ? (
-            <Link
-              to="/founder-tools/marketing/create?step=github"
-              className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
-            >
-              Continue to GitHub
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          ) : null}
           {shouldShowSecondaryAction ? (
             <button
               type="submit"
@@ -2431,7 +2423,7 @@ export default function VibeMarketingStartupBaselineSetup({
             className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
-            {primaryActionLabel ?? (embedded ? (focusSection === "baseline" ? "Save startup profile" : "Save and continue") : "Continue to website")}
+            {primaryActionLabel ?? defaultPrimaryActionLabel}
           </button>
         </div>
       </div>

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -333,7 +333,10 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (companyId) {
         await setVibeRaisingActiveCompany(env, request, companyId);
       }
-      return redirect("/founder-tools/marketing/create?step=baseline");
+      if (stringFromForm(formData, "nextAction") === "save-exit") {
+        return redirect("/founder-tools/marketing");
+      }
+      return redirect("/founder-tools/marketing/create?step=github");
     }
 
     if (intent === "start-autofill") {
@@ -759,7 +762,7 @@ export default function FounderToolsMarketingCreate() {
                         </Link>
                       ) : null}
                       {latestScanIsConfirmed && !latestScanNeedsSetupApproval ? (
-                        <Link to="/founder-tools/marketing/create?step=chooseArticle" className="inline-flex items-center gap-2 rounded-xl bg-emerald-700 px-3 py-2 text-sm font-bold text-white hover:bg-emerald-800">
+                        <Link to="/founder-tools/marketing/create?step=research" className="inline-flex items-center gap-2 rounded-xl bg-emerald-700 px-3 py-2 text-sm font-bold text-white hover:bg-emerald-800">
                           Continue
                           <ArrowRightIcon className="h-4 w-4" />
                         </Link>
@@ -774,8 +777,8 @@ export default function FounderToolsMarketingCreate() {
                   <p className="text-sm font-semibold leading-6 text-gray-700">
                     Skip repository setup for now and generate article copy and images for manual publishing.
                   </p>
-                  <Link to="/founder-tools/marketing/create?step=chooseArticle" className="mt-3 inline-flex items-center gap-2 rounded-xl bg-gray-950 px-4 py-2 text-sm font-black text-white transition hover:bg-black">
-                    Continue content-only
+                  <Link to="/founder-tools/marketing/create?step=research" className="mt-3 inline-flex items-center gap-2 rounded-xl bg-gray-950 px-4 py-2 text-sm font-black text-white transition hover:bg-black">
+                    Continue to topic research
                     <ArrowRightIcon className="h-4 w-4" />
                   </Link>
                 </div>

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -295,7 +295,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         return redirect("/founder-tools/marketing");
       }
 
-      return redirect("/founder-tools/marketing/create?step=baseline");
+      return redirect("/founder-tools/marketing/create?step=github");
     }
 
     if (intent === "start-autofill") {


### PR DESCRIPTION
## Summary
- route startup/profile continue actions directly to GitHub setup instead of the duplicate baseline stop
- make the primary setup CTA advance to GitHub setup and keep Save and exit as the secondary action
- show repo/article system as Step 2 and topic research as Step 3
- send repo setup continuation and content-only skip to topic research

## Validation
- bun run typecheck
- git diff --check

Note: existing unstaged local edits in VibeMarketingStartupBaselineSetup.tsx were intentionally left out of this PR.