### PR TITLE
[codex] Fix GitHub access reconnect flow

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -354,17 +354,20 @@ export default function ArticleSystemConnectionPanel({
                 </p>
               </div>
             </div>
-            <Form method="POST">
+            <Form method="POST" className="flex flex-col items-start gap-2 lg:items-end">
               <input type="hidden" name="intent" value="connect-github" />
-              {selectedRepo ? <input type="hidden" name="githubRepo" value={selectedRepo} /> : null}
+              <input type="hidden" name="forceReconnect" value="true" />
               <button
                 type="submit"
                 disabled={isSubmitting}
                 className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-black text-slate-900 shadow-sm transition hover:border-violet-200 hover:bg-violet-50 disabled:opacity-50"
               >
                 <GitHubMark className="h-5 w-5" />
-                Change repository
+                Manage GitHub access
               </button>
+              <p className="max-w-48 text-left text-xs font-semibold leading-5 text-slate-500 lg:text-right">
+                Use this if the repo you need is not listed.
+              </p>
             </Form>
           </div>
           <div className="grid border-t border-slate-100 px-5 sm:grid-cols-2 lg:grid-cols-4">

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -389,13 +389,26 @@ export async function action({ request, context }: Route.ActionArgs) {
 
     if (intent === "connect-github") {
       const githubRepo = stringFromForm(formData, "githubRepo");
+      const forceReconnect = stringFromForm(formData, "forceReconnect") === "true";
       const response = await connectVibeMarketingGithub(
         env,
         request,
-        githubRepo ? { githubRepo, github_repo: githubRepo } : {},
+        {
+          ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),
+          ...(forceReconnect ? { forceReconnect: true, force_reconnect: true } : {}),
+        },
       );
       const authUrl = response.auth_url ?? response.authUrl;
       if (authUrl) throw redirect(authUrl);
+      if (forceReconnect) {
+        return {
+          intent,
+          error:
+            response.detail ??
+            response.error ??
+            "GitHub is connected, but we could not open the GitHub access settings. Use the repository dropdown if the repo is already listed.",
+        };
+      }
       const connectionState = response.connection_state ?? response.connectionState;
       if (response.status === "already_connected" || response.status === "connected" || connectionState === "connected") {
         return redirect("/founder-tools/marketing/create?step=scan");

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -184,13 +184,26 @@ export async function action({ request, params, context }: Route.ActionArgs) {
   try {
     if (intent === "connect-github") {
       const githubRepo = stringFromForm(formData, "githubRepo");
+      const forceReconnect = stringFromForm(formData, "forceReconnect") === "true";
       const response = await connectVibeMarketingGithub(
         env,
         request,
-        githubRepo ? { githubRepo, github_repo: githubRepo } : {},
+        {
+          ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),
+          ...(forceReconnect ? { forceReconnect: true, force_reconnect: true } : {}),
+        },
       );
       const authUrl = response.auth_url ?? response.authUrl;
       if (authUrl) throw redirect(authUrl);
+      if (forceReconnect) {
+        return {
+          intent,
+          error:
+            response.detail ??
+            response.error ??
+            "GitHub is connected, but we could not open the GitHub access settings. Use the repository dropdown if the repo is already listed.",
+        };
+      }
       throw redirect("/founder-tools/marketing/create?step=scan");
     } else if (intent === "add-component-comment") {
       const targetRunId = stringFromForm(formData, "targetRunId") || runId;


### PR DESCRIPTION
## Summary\n- Rename the connected GitHub action to manage access instead of changing the selected repo\n- Send a forced reconnect flag without the current repo so GitHub access settings open\n- Show an actionable error if forced reconnect returns no auth URL\n\n## Tests\n- bun run typecheck -- --pretty false