### PR TITLE
[codex] Improve repository scan step UX

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1,9 +1,11 @@
-import { Form } from "react-router";
+import { Form, Link } from "react-router";
 import { clsx } from "clsx";
-import type { ChangeEvent, ReactNode } from "react";
+import { useEffect, useState, type ChangeEvent, type ReactNode } from "react";
 import {
+  ArrowRight,
   Check,
   CheckCircle2,
+  ChevronDown,
   Code2,
   ExternalLink,
   Eye,
@@ -15,6 +17,8 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
+import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import type { VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
 type ArticleSystemConnectionPanelProps = {
@@ -28,7 +32,12 @@ type ArticleSystemConnectionPanelProps = {
   connectionError?: string | null;
   scanRun?: VibeMarketingRunSummary | null;
   framed?: boolean;
+  showDenySetupAction?: boolean;
 };
+
+const SCAN_RUNNING_STATUSES = new Set(["queued", "running"]);
+const SCAN_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "denied"]);
+const SCAN_ACTION_NEEDED_STATUSES = new Set(["awaiting_confirmation", "awaiting_approval", "approval_required"]);
 
 function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
@@ -81,6 +90,61 @@ function selectedRepoName({
     repos.find((repo) => repo.toLowerCase() === "mlai-aus-inc/mlai-au") ||
     repos[0] ||
     ""
+  );
+}
+
+function resultObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function resultValue(run: VibeMarketingRunSummary, key: string): unknown {
+  if (run.result?.[key] !== undefined) return run.result[key];
+  const nested = resultObject(run.result?.result);
+  if (nested[key] !== undefined) return nested[key];
+  const latestControl = resultObject(run.result?.latest_control_response);
+  return latestControl[key];
+}
+
+function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
+  for (const key of keys) {
+    const value = resultValue(run, key);
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function articleSystemSetupPayload(run: VibeMarketingRunSummary) {
+  const direct = resultObject(run.result?.article_system_setup);
+  if (Object.keys(direct).length) return direct;
+  const nested = resultObject(resultObject(run.result?.result).article_system_setup);
+  if (Object.keys(nested).length) return nested;
+  return resultObject(resultObject(run.result?.latest_control_response).article_system_setup);
+}
+
+function setupRunIdForRun(run: VibeMarketingRunSummary) {
+  const direct = stringResultValue(run, "setup_run_id", "setupRunId", "scaffold_job_id", "scaffoldJobId");
+  if (direct) return direct;
+  const setup = articleSystemSetupPayload(run);
+  const value = setup.setup_run_id ?? setup.setupRunId;
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function isScanAwaitingSetupApproval(run: VibeMarketingRunSummary | null | undefined) {
+  if (!run) return false;
+  if (SCAN_ACTION_NEEDED_STATUSES.has(run.status)) return true;
+  const requestedAction = stringResultValue(run, "requested_action", "setup_requested_action");
+  return requestedAction === "article_system_setup" || requestedAction === "scaffold_publish_route";
+}
+
+function hasScanMissingArticleParts(run: VibeMarketingRunSummary | null | undefined, scaffoldReady: boolean) {
+  if (!run || scaffoldReady || SCAN_RUNNING_STATUSES.has(run.status)) return false;
+  const readiness = resultObject(resultValue(run, "article_system_readiness"));
+  const readinessStatus = String(readiness.status ?? "").trim().toLowerCase();
+  const scaffoldRequired = Boolean(resultValue(run, "scaffold_required") ?? readiness.scaffold_required);
+  return (
+    scaffoldRequired ||
+    ["manual_blocked", "missing", "needs_setup", "approval_required", "blocked"].includes(readinessStatus) ||
+    run.status === "completed"
   );
 }
 
@@ -228,6 +292,7 @@ export default function ArticleSystemConnectionPanel({
   connectionError,
   scanRun,
   framed = true,
+  showDenySetupAction = false,
 }: ArticleSystemConnectionPanelProps) {
   const connected = isGithubConnected(githubRepos, bootstrap);
   const repos = repoNames(githubRepos);
@@ -236,6 +301,26 @@ export default function ArticleSystemConnectionPanel({
   const locationPlaceholder = connected ? articleSurfacePlaceholder : "e.g. /content/articles";
   const statusLabel = bootstrap.checks.scaffold?.passed ? "Ready" : connected ? "Connected" : "Ready";
   const connectionLabel = githubConnectionState(githubRepos, bootstrap).replace(/_/g, " ") || (connected ? "connected" : "not connected");
+  const scaffoldReady = Boolean(bootstrap.checks.scaffold?.passed);
+  const scanRunning = Boolean(scanRun && SCAN_RUNNING_STATUSES.has(scanRun.status));
+  const scanFailed = Boolean(scanRun && SCAN_FAILED_STATUSES.has(scanRun.status));
+  const scanStale = Boolean(scanRun?.stale || scanRun?.staleReason === "scan_queue_not_started");
+  const scanNeedsSetupApproval = isScanAwaitingSetupApproval(scanRun);
+  const scanMissingArticleParts = hasScanMissingArticleParts(scanRun, scaffoldReady);
+  const setupRunId = scanRun ? setupRunIdForRun(scanRun) : "";
+  const previewShouldStartOpen = Boolean(scanNeedsSetupApproval || scanFailed || scanStale || scanMissingArticleParts);
+  const [articlePreviewOpen, setArticlePreviewOpen] = useState(previewShouldStartOpen);
+  const continueBlocked = Boolean(scanRun && (scanRunning || scanFailed || scanStale || scanNeedsSetupApproval));
+  const canContinue = connected && scaffoldReady && !continueBlocked;
+  const continueHelp = !scaffoldReady
+    ? "Scan the repository and complete any article-system setup before continuing."
+    : continueBlocked
+      ? "Resolve the current scan state before continuing."
+      : "Article system confirmed. You can continue to topic research.";
+
+  useEffect(() => {
+    setArticlePreviewOpen(previewShouldStartOpen);
+  }, [previewShouldStartOpen, scanRun?.runId, scanRun?.status]);
 
   const repoControlProps = onRepoSelectionChange
     ? {
@@ -430,7 +515,7 @@ export default function ArticleSystemConnectionPanel({
             <button
               type="submit"
               disabled={isSubmitting || (repos.length > 0 && !selectedRepo)}
-              className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 shadow-sm transition hover:bg-violet-50 disabled:opacity-50"
             >
               {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
               Scan repository
@@ -444,35 +529,135 @@ export default function ArticleSystemConnectionPanel({
       )}
 
       {scanRun ? (
-        <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-xs font-semibold text-slate-500">
-            {scanRun.stale
-              ? "This scan did not start on the worker queue. Retry it, or cancel and start with new details."
-              : "Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later."}
-          </p>
-          <Form method="POST" className="flex flex-col gap-2 sm:flex-row">
-            {scanRun.retryAvailable || scanRun.stale ? (
+        <div className="mt-5 space-y-4">
+          <MarketingRunProgressCard run={scanRun} />
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold text-slate-500">
+                {scanRun.stale
+                  ? "This scan did not start on the worker queue. Retry it, or cancel and start with new details."
+                  : "Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later."}
+              </p>
+              <Link
+                to={`/founder-tools/marketing/runs/${encodeURIComponent(scanRun.runId)}`}
+                className="mt-2 inline-flex text-xs font-black text-violet-700 transition hover:text-violet-900"
+              >
+                View scan run
+              </Link>
+            </div>
+            <Form method="POST" className="flex flex-col gap-2 sm:flex-row">
+              <input type="hidden" name="scanRunId" value={scanRun.runId} />
+              {scanRun.retryAvailable || scanRun.stale ? (
+                <button
+                  type="submit"
+                  name="intent"
+                  value="retry-scan"
+                  disabled={isSubmitting}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50"
+                >
+                  <Loader2 className="h-4 w-4" />
+                  Retry scan
+                </button>
+              ) : null}
               <button
                 type="submit"
                 name="intent"
-                value="retry-scan"
+                value="cancel-scan"
                 disabled={isSubmitting}
-                className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50"
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 transition hover:bg-red-50 disabled:opacity-50"
               >
-                <Loader2 className="h-4 w-4" />
-                Retry scan
+                Cancel scan
               </button>
-            ) : null}
-            <button
-              type="submit"
-              name="intent"
-              value="cancel-scan"
-              disabled={isSubmitting}
-              className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 transition hover:bg-red-50 disabled:opacity-50"
+            </Form>
+          </div>
+        </div>
+      ) : null}
+
+      {scanRun ? (
+        <section className="mt-5 rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <button
+            type="button"
+            onClick={() => setArticlePreviewOpen((open) => !open)}
+            className="flex w-full flex-col gap-3 p-4 text-left sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <p className="text-sm font-black text-slate-950">Article directory preview</p>
+              <p className="mt-1 text-xs font-semibold text-slate-500">
+                Review the route, files, and setup requirements Content Factory found for this repository.
+              </p>
+            </div>
+            <span className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-wide text-violet-700">
+              {articlePreviewOpen ? "Hide preview" : "Show preview"}
+              <ChevronDown className={clsx("h-4 w-4 transition", articlePreviewOpen && "rotate-180")} />
+            </span>
+          </button>
+          {articlePreviewOpen ? (
+            <div className="space-y-4 border-t border-slate-100 p-4">
+              <ArticleSystemSurfaceSummary run={scanRun} />
+              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                {scanNeedsSetupApproval ? (
+                  <Form method="POST">
+                    <input type="hidden" name="scanRunId" value={scanRun.runId} />
+                    <button
+                      type="submit"
+                      name="intent"
+                      value="build-article-system-preview"
+                      disabled={isSubmitting}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
+                    >
+                      {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                      Build article system preview
+                    </button>
+                  </Form>
+                ) : setupRunId ? (
+                  <Link
+                    to={`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 shadow-sm transition hover:bg-violet-50"
+                  >
+                    Open setup preview
+                    <ExternalLink className="h-4 w-4" />
+                  </Link>
+                ) : null}
+                {showDenySetupAction && scanNeedsSetupApproval ? (
+                  <Form method="POST">
+                    <button
+                      type="submit"
+                      name="intent"
+                      value="deny"
+                      disabled={isSubmitting}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50"
+                    >
+                      Deny setup
+                    </button>
+                  </Form>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {connected ? (
+        <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-5 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm font-semibold text-slate-500">{continueHelp}</p>
+          {canContinue ? (
+            <Link
+              to="/founder-tools/marketing/create?step=research"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700"
             >
-              Cancel scan
+              Continue
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          ) : (
+            <button
+              type="button"
+              disabled
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-6 py-3 text-sm font-black text-white opacity-45 shadow-sm"
+            >
+              Continue
+              <ArrowRight className="h-4 w-4" />
             </button>
-          </Form>
+          )}
         </div>
       ) : null}
     </section>

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -6,7 +6,6 @@ import {
   ArrowLeftIcon,
   ArrowPathIcon,
   ArrowRightIcon,
-  CheckCircleIcon,
   InformationCircleIcon,
   LightBulbIcon,
   MagnifyingGlassIcon,
@@ -16,7 +15,6 @@ import { clsx } from "clsx";
 
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
-import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
 import {
   CustomTopicDecisionCard,
   TopicDecisionCard,
@@ -223,13 +221,6 @@ function setupRunIdForRun(run: VibeMarketingRunSummary) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
 }
 
-function isScanAwaitingSetupApproval(run: VibeMarketingRunSummary | undefined) {
-  if (!run || !["repo_scan", "content_factory_scan"].includes(run.workflow)) return false;
-  if (["awaiting_confirmation", "awaiting_approval", "approval_required"].includes(run.status)) return true;
-  const requestedAction = stringResultValue(run, "requested_action", "setup_requested_action");
-  return requestedAction === "article_system_setup" || requestedAction === "scaffold_publish_route";
-}
-
 type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
 
 function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap): ArticleDeliveryMode {
@@ -420,7 +411,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-scan") {
-      const result = await startVibeMarketingScan(env, request, {
+      await startVibeMarketingScan(env, request, {
         githubRepo: stringFromForm(formData, "githubRepo"),
         github_repo: stringFromForm(formData, "githubRepo"),
         articleSurfaceMode: "existing",
@@ -430,7 +421,18 @@ export async function action({ request, context }: Route.ActionArgs) {
         autoSetupPreview: false,
         auto_setup_preview: false,
       });
-      if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      return redirect("/founder-tools/marketing/create?step=scan");
+    }
+
+    if (intent === "retry-scan" || intent === "cancel-scan") {
+      const scanRunId = stringFromForm(formData, "scanRunId");
+      if (!scanRunId) {
+        return { intent, error: "No repository scan was available to update." };
+      }
+      await controlVibeMarketingRun(env, request, scanRunId, intent === "retry-scan" ? "resume" : "cancel", {
+        ...(intent === "cancel-scan" ? { cleanup: true } : {}),
+        workflow: "repo_scan",
+      });
       return redirect("/founder-tools/marketing/create?step=scan");
     }
 
@@ -667,9 +669,6 @@ export default function FounderToolsMarketingCreate() {
     githubRepoOptions[0]?.fullName ??
     "";
   const [repoSelection, setRepoSelection] = useState(selectedGithubRepo);
-  const latestScanNeedsSetupApproval = isScanAwaitingSetupApproval(latestScan);
-  const latestScanSetupRunId = latestScan ? setupRunIdForRun(latestScan) : "";
-  const latestScanIsConfirmed = latestScan?.status === "completed" || Boolean(bootstrap.checks.scaffold?.passed);
   const deliveryModeNote = directPublishMode
     ? `This will generate a draft and prepare it for publishing through ${bootstrap.settings.githubRepo}.`
     : reviewDraftMode
@@ -743,48 +742,10 @@ export default function FounderToolsMarketingCreate() {
                 onRepoSelectionChange={setRepoSelection}
                 articleSurfacePlaceholder="https://www.mlai.au/articles or /articles"
                 connectionError={githubConnectError}
+                scanRun={latestScan}
                 framed={false}
               />
 
-              {latestScan ? (
-                <div className="mt-5 space-y-4">
-                  <div className={clsx("rounded-xl border p-4", latestScanNeedsSetupApproval ? "border-amber-200 bg-amber-50" : latestScanIsConfirmed ? "border-emerald-200 bg-emerald-50" : "border-gray-100 bg-gray-50")}>
-                    <p className="text-sm font-black text-gray-950">Latest scan: {latestScan.status.replace(/_/g, " ")}</p>
-                    <p className="mt-1 text-xs font-semibold text-gray-600">
-                      {latestScanNeedsSetupApproval
-                        ? "Scan complete. Review the detected article route and approve the setup preview build."
-                        : latestScanIsConfirmed
-                          ? "Article system confirmed. You can continue to article generation."
-                          : (latestScan.currentStep ?? latestScan.runId)}
-                    </p>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <Link to={`/founder-tools/marketing/runs/${latestScan.runId}`} className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-violet-700 hover:text-violet-900">
-                        View scan run
-                      </Link>
-                      {latestScanNeedsSetupApproval ? (
-                        <Form method="POST">
-                          <input type="hidden" name="scanRunId" value={latestScan.runId} />
-                          <button type="submit" name="intent" value="build-article-system-preview" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-3 py-2 text-sm font-bold text-white transition hover:bg-emerald-700 disabled:opacity-50">
-                            {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                            Build article system preview
-                          </button>
-                        </Form>
-                      ) : latestScanSetupRunId ? (
-                        <Link to={`/founder-tools/marketing/runs/${latestScanSetupRunId}`} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-3 py-2 text-sm font-bold text-white hover:bg-violet-700">
-                          Open setup preview
-                        </Link>
-                      ) : null}
-                      {latestScanIsConfirmed && !latestScanNeedsSetupApproval ? (
-                        <Link to="/founder-tools/marketing/create?step=research" className="inline-flex items-center gap-2 rounded-xl bg-emerald-700 px-3 py-2 text-sm font-bold text-white hover:bg-emerald-800">
-                          Continue
-                          <ArrowRightIcon className="h-4 w-4" />
-                        </Link>
-                      ) : null}
-                    </div>
-                  </div>
-                  {latestScanNeedsSetupApproval ? <ArticleSystemSurfaceSummary run={latestScan} /> : null}
-                </div>
-              ) : null}
               {!githubReadyForPublishing ? (
                 <div className="mt-5 rounded-xl border border-gray-200 bg-gray-50 p-4">
                   <p className="text-sm font-semibold leading-6 text-gray-700">

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -674,79 +674,8 @@ function ArticleSystemScanFormPanel({
       articleSurfaceDefault={articleSurfaceRouteFromRun(run) || "/articles"}
       articleSurfacePlaceholder="/articles"
       scanRun={run}
+      showDenySetupAction
     />
-  );
-}
-
-function ScanCompletionPanel({ bootstrap }: { bootstrap: VibeMarketingBootstrap }) {
-  const nextLabel = bootstrap.recommendedNextAction?.label || "Continue";
-  const nextHref = bootstrap.workflowProgress?.currentStepId === "publish" || bootstrap.recommendedNextAction?.key === "publish"
-    ? "/founder-tools/marketing/create?step=publish"
-    : "/founder-tools/marketing/create?step=chooseArticle";
-  return (
-    <section className="rounded-xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-start gap-3">
-          <CheckCircleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-700" />
-          <div>
-            <h2 className="text-base font-black text-emerald-950">Repository scan complete</h2>
-            <p className="mt-1 text-sm font-semibold text-emerald-800">The article system is ready. Continue to the next article workflow step.</p>
-          </div>
-        </div>
-        <Link to={nextHref} className="inline-flex items-center justify-center rounded-xl bg-emerald-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-800">{nextLabel}</Link>
-      </div>
-    </section>
-  );
-}
-
-function ScanSetupApprovalPanel({ run, isSubmitting }: { run: VibeMarketingRunSummary; isSubmitting: boolean }) {
-  const setup = articleSystemSetupPayload(run);
-  const route = articleSurfaceRouteFromRun(run) || run.routePath || "/articles";
-  const setupStatus = String(setup.status ?? run.status ?? "").replace(/_/g, " ");
-  const changedFiles = [
-    ...arrayResultValue(run, "changed_files_preview"),
-    ...(Array.isArray(setup.changed_files_preview) ? setup.changed_files_preview : []),
-  ]
-    .map((item) => String(item ?? "").trim())
-    .filter(Boolean)
-    .slice(0, 8);
-
-  return (
-    <section className="rounded-xl border border-amber-200 bg-amber-50 p-5 shadow-sm">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-lg font-black text-amber-950">Article system changes needed</h2>
-            {setupStatus ? <span className="rounded-full bg-white px-3 py-1 text-xs font-black uppercase text-amber-800">{setupStatus}</span> : null}
-          </div>
-          <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-amber-900">
-            The scan reviewed <span className="font-black">{route}</span> and found the website needs a small setup branch before new articles can be added safely.
-          </p>
-          {changedFiles.length ? (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {changedFiles.map((file) => (
-                <span key={file} className="rounded-lg bg-white px-3 py-2 font-mono text-xs font-semibold text-amber-900 shadow-sm">
-                  {file}
-                </span>
-              ))}
-            </div>
-          ) : null}
-          <p className="mt-3 text-xs font-semibold text-amber-800">
-            Building the preview creates a review branch and hosted Cloudflare preview. It does not merge or publish.
-          </p>
-        </div>
-        <Form method="POST" className="flex flex-col gap-2 sm:flex-row lg:flex-col">
-          <button type="submit" name="intent" value="build-article-system-preview" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50">
-            {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-            Build article system preview
-          </button>
-          <button type="submit" name="intent" value="deny" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50">
-            <XCircleIcon className="h-4 w-4" />
-            Deny setup
-          </button>
-        </Form>
-      </div>
-    </section>
   );
 }
 
@@ -2863,8 +2792,7 @@ export default function FounderToolsMarketingRun() {
 
       {!isCompletedArticleReviewPage ? (
         <main className="space-y-6">
-          {!isArticleGenerationRun ? <MarketingRunProgressCard run={run} /> : null}
-          {isScanCompleted ? <ScanCompletionPanel bootstrap={bootstrap} /> : null}
+          {!isArticleGenerationRun && !isScanRun ? <MarketingRunProgressCard run={run} /> : null}
 
           {isDiscoveryConfirmation ? (
             <section className="rounded-xl border border-violet-100 bg-white p-5 shadow-sm">
@@ -2918,14 +2846,7 @@ export default function FounderToolsMarketingRun() {
               isSubmitting={isSubmitting}
             />
           ) : isScanRun ? (
-            <div className="space-y-4">
-              <ArticleSystemSurfaceSummary run={run} />
-              {isScanActionNeeded ? (
-                <ScanSetupApprovalPanel run={run} isSubmitting={isSubmitting} />
-              ) : !isScanCompleted ? (
-                <ArticleSystemScanFormPanel run={run} bootstrap={bootstrap} githubRepos={githubRepos} isSubmitting={isSubmitting} />
-              ) : null}
-            </div>
+            <ArticleSystemScanFormPanel run={run} bootstrap={bootstrap} githubRepos={githubRepos} isSubmitting={isSubmitting} />
           ) : null}
 
           {showRunAttentionBanner ? (


### PR DESCRIPTION
## Summary
- keep repository scans inline on the scan step instead of jumping to a run page
- show scan progress, retry/cancel controls, and article directory preview inside the repo setup panel
- gate the final Continue CTA until the scaffold readiness check has passed
- reuse the same inline panel on direct scan run URLs to avoid duplicated progress UI

## Validation
- `bun run typecheck`
- `git diff --check`