### PR TITLE
[codex] Fix GA4 tracking

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
+- [x] Fix GA4 Measurement ID and SPA page-view tracking
 - [x] Update the main-page Slack invite link
 - [x] Update the Vibe Raising relationship callout heading to mention building investor relationships 6 months in advance
 - [x] Restore the Vibe Raising bottom cue text to "Don't Wait Until You Need Money"

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,12 +7,15 @@ import {
   ScrollRestoration,
   useLocation,
 } from "react-router";
+import { useEffect } from "react";
 import Footer from "~/components/footer";
 
 import type { Route } from "./+types/root";
 import "./app.css";
 import SectionMarkers from "./components/SectionMarkers";
 import Sidebar from "./components/sidebar";
+
+const GA_MEASUREMENT_ID = "G-1645KKLT8B";
 
 export const meta: Route.MetaFunction = () => [
   { title: "MLAI" },
@@ -54,6 +57,20 @@ export const links: Route.LinksFunction = () => [
 export default function Layout() {
   const location = useLocation();
   const shouldLoadThirdPartyAnalytics = import.meta.env.PROD;
+  const pagePath = `${location.pathname}${location.search}`;
+
+  useEffect(() => {
+    if (!shouldLoadThirdPartyAnalytics) return;
+
+    const gtag = (window as typeof window & { gtag?: (...args: unknown[]) => void }).gtag;
+    if (!gtag) return;
+
+    gtag("event", "page_view", {
+      page_path: pagePath,
+      page_location: `${window.location.origin}${pagePath}`,
+      page_title: document.title,
+    });
+  }, [pagePath, shouldLoadThirdPartyAnalytics]);
 
   // Hide the global chrome inside authenticated app surfaces.
   const isEsafetyApp = location.pathname.startsWith("/esafety");
@@ -143,7 +160,7 @@ export default function Layout() {
             <script
               async
               defer
-              src={`https://www.googletagmanager.com/gtag/js?id=G-JB8E813T8W}`}
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
             />
             <script
               id="google-analytics"
@@ -154,7 +171,7 @@ export default function Layout() {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', 'G-JB8E813T8W');
+              gtag('config', '${GA_MEASUREMENT_ID}', { send_page_view: false });
             `,
               }}
             />


### PR DESCRIPTION
## Summary

Fixes MLAI website GA4 tracking by pointing the global tag to the active Measurement ID and adding React Router page-view tracking for client-side navigation.

## Impact

GA4 should start receiving data for property `G-1645KKLT8B` after deploy. The malformed `gtag/js` URL and old `G-JB8E813T8W` ID are removed from the app.

## Validation

- `bun run typecheck`
- `bun run build`
- Inspected built assets and local production preview for `G-1645KKLT8B`, absence of `G-JB8E813T8W`, and no trailing-brace `gtag/js` URL
- Verified local SPA navigation queues a second `page_view` for `/sponsors` after navigating from `/`

Note: `bun run build` exits successfully, while the existing IndexNow postbuild submission still reports `403 — Forbidden`.
