### PR TITLE
[codex] Simplify article route picker

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -9,7 +9,6 @@ import {
   Code2,
   ExternalLink,
   Eye,
-  FileText,
   Info,
   Loader2,
   LockKeyhole,
@@ -25,6 +24,7 @@ type ArticleSystemConnectionPanelProps = {
   bootstrap: VibeMarketingBootstrap;
   githubRepos: VibeMarketingGithubReposResponse;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
   repoSelection?: string;
   onRepoSelectionChange?: (value: string) => void;
   articleSurfaceDefault?: string;
@@ -283,45 +283,11 @@ function PermissionPill({
   );
 }
 
-function SafetyFeature({ icon, title, body }: { icon: ReactNode; title: string; body: string }) {
-  return (
-    <div className="flex items-center gap-3 border-slate-100 py-3 sm:border-r sm:pr-5 last:border-r-0">
-      <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-slate-50 text-violet-700">
-        {icon}
-      </div>
-      <div>
-        <p className="text-sm font-black text-slate-900">{title}</p>
-        <p className="text-xs font-semibold text-slate-500">{body}</p>
-      </div>
-    </div>
-  );
-}
-
-function DisabledArticleLocationCard({ placeholder }: { placeholder: string }) {
-  return (
-    <section className="rounded-2xl border border-slate-200 bg-white/70 p-4 opacity-80">
-      <h3 className="text-base font-black text-slate-900">Where are your articles or blog posts?</h3>
-      <p className="mt-1 text-sm font-medium text-slate-500">Tell us where your content lives in this repository.</p>
-      <input
-        disabled
-        placeholder={placeholder}
-        className="mt-4 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-500 outline-none"
-      />
-      <p className="mt-2 text-xs font-semibold text-slate-500">Connect GitHub first, then choose a repository and scan this location.</p>
-      <div className="mt-4 inline-flex max-w-xl items-start gap-3 rounded-xl bg-violet-50 px-4 py-3 text-sm font-semibold text-slate-700">
-        <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
-          <Sparkles className="h-4 w-4" />
-        </span>
-        <span>We only create and update content within the article location you approve.</span>
-      </div>
-    </section>
-  );
-}
-
 export default function ArticleSystemConnectionPanel({
   bootstrap,
   githubRepos,
   isSubmitting,
+  isActionPending,
   repoSelection,
   onRepoSelectionChange,
   articleSurfaceDefault = "",
@@ -334,6 +300,7 @@ export default function ArticleSystemConnectionPanel({
 }: ArticleSystemConnectionPanelProps) {
   const inventoryFetcher = useFetcher();
   const revalidator = useRevalidator();
+  const actionPending = isActionPending ?? (() => isSubmitting);
   const connected = isGithubConnected(githubRepos, bootstrap);
   void showDenySetupAction;
   const repos = repoNames(githubRepos);
@@ -349,12 +316,24 @@ export default function ArticleSystemConnectionPanel({
   const scanNeedsSetupApproval = isScanAwaitingSetupApproval(scanRun);
   const scanMissingArticleParts = hasScanMissingArticleParts(scanRun, scaffoldReady);
   const setupRunId = scanRun ? setupRunIdForRun(scanRun) : "";
-  const previewShouldStartOpen = Boolean(scanNeedsSetupApproval || scanFailed || scanStale || scanMissingArticleParts);
-  const [articlePreviewOpen, setArticlePreviewOpen] = useState(previewShouldStartOpen);
   const inventoryScan = isInventoryScan(scanRun);
   const setupTargetScan = isSetupTargetScan(scanRun);
   const inventoryReady = Boolean(scanRun && inventoryScan && scanRun.status === "completed");
   const setupTargetReady = Boolean(scanRun && setupTargetScan && (scanNeedsSetupApproval || setupRunId));
+  const previewShouldStartOpen = Boolean(inventoryReady || setupTargetReady || scanFailed || scanStale || scanMissingArticleParts);
+  const [articlePreviewOpen, setArticlePreviewOpen] = useState(previewShouldStartOpen);
+  const [selectedArticleRoute, setSelectedArticleRoute] = useState("");
+  const [manualArticleRoute, setManualArticleRoute] = useState("");
+  const [githubAuthWaiting, setGithubAuthWaiting] = useState(() =>
+    typeof window !== "undefined" && window.sessionStorage.getItem("vibe-marketing:github-auth-open") === "true",
+  );
+  const hasExistingSurfaceChoice = Boolean(selectedArticleRoute || manualArticleRoute.trim());
+  const showScanProgress = Boolean(scanRun && (scanRunning || scanFailed || scanStale));
+  const scanStartPending = actionPending("start-scan") || inventoryFetcher.state !== "idle";
+  const retryScanPending = actionPending("retry-scan");
+  const cancelScanPending = actionPending("cancel-scan");
+  const confirmSurfacePending = actionPending("confirm-article-surface");
+  const createSurfacePending = actionPending("create-article-surface");
   const continueBlocked = Boolean(scanRun && (scanRunning || scanFailed || scanStale) && !setupTargetReady);
   const canContinue = connected && (scaffoldReady || setupTargetReady) && !continueBlocked;
   const continueHelp = setupTargetReady
@@ -368,6 +347,11 @@ export default function ArticleSystemConnectionPanel({
   useEffect(() => {
     setArticlePreviewOpen(previewShouldStartOpen);
   }, [previewShouldStartOpen, scanRun?.runId, scanRun?.status]);
+
+  useEffect(() => {
+    setSelectedArticleRoute("");
+    setManualArticleRoute("");
+  }, [scanRun?.runId]);
 
   useEffect(() => {
     if (!autoStartInventoryScan || !connected || !selectedRepo || scanRun || inventoryFetcher.state !== "idle") return;
@@ -402,8 +386,15 @@ export default function ArticleSystemConnectionPanel({
   useEffect(() => {
     if (connected && typeof window !== "undefined") {
       window.sessionStorage.removeItem("vibe-marketing:github-auth-open");
+      setGithubAuthWaiting(false);
     }
   }, [connected]);
+
+  const markGithubAuthOpen = () => {
+    if (typeof window === "undefined") return;
+    window.sessionStorage.setItem("vibe-marketing:github-auth-open", "true");
+    setGithubAuthWaiting(true);
+  };
 
   const repoControlProps = onRepoSelectionChange
     ? {
@@ -434,23 +425,25 @@ export default function ArticleSystemConnectionPanel({
         </span>
       </div>
 
-      <div className="mt-7 grid gap-4 lg:grid-cols-3">
-        <TrustCard title="You're always in control" tone="violet" icon={<ShieldCheck className="h-8 w-8" />}>
-          <TrustBullet tone="violet">We will never publish or make any changes unless you specifically approve.</TrustBullet>
-          <TrustBullet tone="violet">Every change is shown to you first for review.</TrustBullet>
-          <TrustBullet tone="violet">You decide what goes live.</TrustBullet>
-        </TrustCard>
-        <TrustCard title="Only your articles, never your code" tone="blue" icon={<Code2 className="h-8 w-8" />}>
-          <TrustBullet tone="blue">We only write to your articles/blogs location.</TrustBullet>
-          <TrustBullet tone="blue">We will never delete or change code or files in any other part of your app or website.</TrustBullet>
-          <TrustBullet tone="blue">Your app, settings and configuration stay untouched.</TrustBullet>
-        </TrustCard>
-        <TrustCard title="Secure & transparent" tone="emerald" icon={<LockKeyhole className="h-8 w-8" />}>
-          <TrustBullet tone="emerald">Connected via GitHub with granular permissions.</TrustBullet>
-          <TrustBullet tone="emerald">Your code and content stays yours.</TrustBullet>
-          <TrustBullet tone="emerald">You can disconnect at any time.</TrustBullet>
-        </TrustCard>
-      </div>
+      {!connected ? (
+        <div className="mt-7 grid gap-4 lg:grid-cols-3">
+          <TrustCard title="You're always in control" tone="violet" icon={<ShieldCheck className="h-8 w-8" />}>
+            <TrustBullet tone="violet">We will never publish or make any changes unless you specifically approve.</TrustBullet>
+            <TrustBullet tone="violet">Every change is shown to you first for review.</TrustBullet>
+            <TrustBullet tone="violet">You decide what goes live.</TrustBullet>
+          </TrustCard>
+          <TrustCard title="Only your articles, never your code" tone="blue" icon={<Code2 className="h-8 w-8" />}>
+            <TrustBullet tone="blue">We only write to your articles/blogs location.</TrustBullet>
+            <TrustBullet tone="blue">We will never delete or change code or files in any other part of your app or website.</TrustBullet>
+            <TrustBullet tone="blue">Your app, settings and configuration stay untouched.</TrustBullet>
+          </TrustCard>
+          <TrustCard title="Secure & transparent" tone="emerald" icon={<LockKeyhole className="h-8 w-8" />}>
+            <TrustBullet tone="emerald">Connected via GitHub with granular permissions.</TrustBullet>
+            <TrustBullet tone="emerald">Your code and content stays yours.</TrustBullet>
+            <TrustBullet tone="emerald">You can disconnect at any time.</TrustBullet>
+          </TrustCard>
+        </div>
+      ) : null}
 
       {!connected ? (
         <section className="mt-5 rounded-2xl border border-slate-200 bg-white px-5 py-8 text-center shadow-sm">
@@ -465,16 +458,18 @@ export default function ArticleSystemConnectionPanel({
             <input type="hidden" name="intent" value="connect-github" />
             <button
               type="submit"
-              onClick={() => {
-                if (typeof window !== "undefined") window.sessionStorage.setItem("vibe-marketing:github-auth-open", "true");
-              }}
-              disabled={isSubmitting}
+              onClick={markGithubAuthOpen}
               className="inline-flex items-center justify-center gap-3 rounded-xl bg-slate-950 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:opacity-50"
             >
-              {isSubmitting ? <Loader2 className="h-5 w-5 animate-spin" /> : <GitHubMark className="h-5 w-5" />}
-              Connect GitHub
+              <GitHubMark className="h-5 w-5" />
+              {githubAuthWaiting ? "Open GitHub again" : "Connect GitHub"}
             </button>
           </Form>
+          {githubAuthWaiting ? (
+            <div className="mx-auto mt-4 max-w-3xl rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-left text-sm font-semibold text-violet-800">
+              GitHub opened in a new tab. Finish authorising there, then return here; this page will refresh when the connection is ready.
+            </div>
+          ) : null}
           <div className="mt-5 flex flex-wrap justify-center gap-4">
             <SmallProof icon={<LockKeyhole className="h-4 w-4" />} label="Secure OAuth" />
             <SmallProof icon={<ShieldCheck className="h-4 w-4" />} label="Granular permissions" />
@@ -530,25 +525,16 @@ export default function ArticleSystemConnectionPanel({
               <input type="hidden" name="forceReconnect" value="true" />
               <button
                 type="submit"
-                onClick={() => {
-                  if (typeof window !== "undefined") window.sessionStorage.setItem("vibe-marketing:github-auth-open", "true");
-                }}
-                disabled={isSubmitting}
+                onClick={markGithubAuthOpen}
                 className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-black text-slate-900 shadow-sm transition hover:border-violet-200 hover:bg-violet-50 disabled:opacity-50"
               >
                 <GitHubMark className="h-5 w-5" />
-                Manage GitHub access
+                {githubAuthWaiting ? "Open GitHub again" : "Manage GitHub access"}
               </button>
               <p className="max-w-48 text-left text-xs font-semibold leading-5 text-slate-500 lg:text-right">
-                Use this if the repo you need is not listed.
+                {githubAuthWaiting ? "Waiting for the GitHub tab to finish authorising." : "Use this if the repo you need is not listed."}
               </p>
             </Form>
-          </div>
-          <div className="grid border-t border-slate-100 px-5 sm:grid-cols-2 lg:grid-cols-4">
-            <SafetyFeature icon={<FileText className="h-5 w-5" />} title="Can write to" body="Articles/blogs location only" />
-            <SafetyFeature icon={<ShieldCheck className="h-5 w-5 text-emerald-700" />} title="Will never delete" body="No file deletions, ever" />
-            <SafetyFeature icon={<Code2 className="h-5 w-5 text-blue-700" />} title="Will never touch code" body="No changes outside articles" />
-            <SafetyFeature icon={<Eye className="h-5 w-5 text-amber-600" />} title="Requires approval" body="Nothing goes live without you" />
           </div>
         </section>
       )}
@@ -582,37 +568,27 @@ export default function ArticleSystemConnectionPanel({
                 />
               )}
             </label>
-            <div className="rounded-xl bg-slate-50 px-4 py-3">
-              <p className="text-sm font-black text-slate-800">First we scan the repo.</p>
+            <div className="rounded-xl border border-slate-100 bg-slate-50 px-4 py-3">
+              <p className="text-sm font-black text-slate-800">Read-only inventory scan</p>
               <p className="mt-1 text-sm font-semibold leading-6 text-slate-500">
-                After the scan, choose from the routes we found or create a new articles directory. No setup changes are generated from this scan.
+                We will find likely article/blog pages and ask you to choose one. No setup files or pull requests are created from this scan.
               </p>
             </div>
           </div>
-          <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="inline-flex max-w-xl items-start gap-3 rounded-xl bg-violet-50 px-4 py-3 text-sm font-semibold text-slate-700">
-              <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
-                <Sparkles className="h-4 w-4" />
-              </span>
-              <span>We&apos;ll scan route and content structure first, then ask where article setup should happen.</span>
-            </div>
+          <div className="mt-4 flex justify-end">
             <button
               type="submit"
-              disabled={isSubmitting || inventoryFetcher.state !== "idle" || scanRunning || (repos.length > 0 && !selectedRepo)}
+              disabled={scanStartPending || scanRunning || (repos.length > 0 && !selectedRepo)}
               className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 shadow-sm transition hover:bg-violet-50 disabled:opacity-50"
             >
-              {isSubmitting || inventoryFetcher.state !== "idle" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-              Scan repository
+              {scanStartPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+              {scanStartPending ? "Starting scan..." : "Scan repository"}
             </button>
           </div>
         </Form>
-      ) : (
-        <div className="mt-5">
-          <DisabledArticleLocationCard placeholder={locationPlaceholder} />
-        </div>
-      )}
+      ) : null}
 
-      {scanRun ? (
+      {showScanProgress && scanRun ? (
         <div className="mt-5 space-y-4">
           <MarketingRunProgressCard run={scanRun} />
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -620,7 +596,9 @@ export default function ArticleSystemConnectionPanel({
               <p className="text-xs font-semibold text-slate-500">
                 {scanRun.stale
                   ? "This scan did not start on the worker queue. Retry it, or cancel and start with new details."
-                  : "Cancelling abandons this scan locally and ignores stale scan callbacks that arrive later."}
+                  : scanFailed
+                    ? "The scan needs attention. Retry it, or cancel and start again with a different repo."
+                    : "Scanning is read-only. No files are changed."}
               </p>
               <Link
                 to={`/founder-tools/marketing/runs/${encodeURIComponent(scanRun.runId)}`}
@@ -636,28 +614,29 @@ export default function ArticleSystemConnectionPanel({
                   type="submit"
                   name="intent"
                   value="retry-scan"
-                  disabled={isSubmitting}
+                  disabled={retryScanPending || cancelScanPending}
                   className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50"
                 >
-                  <Loader2 className="h-4 w-4" />
-                  Retry scan
+                  <Loader2 className={clsx("h-4 w-4", retryScanPending && "animate-spin")} />
+                  {retryScanPending ? "Retrying..." : "Retry scan"}
                 </button>
               ) : null}
               <button
                 type="submit"
                 name="intent"
                 value="cancel-scan"
-                disabled={isSubmitting}
+                disabled={retryScanPending || cancelScanPending}
                 className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-700 transition hover:bg-red-50 disabled:opacity-50"
               >
-                Cancel scan
+                {cancelScanPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                {cancelScanPending ? "Cancelling..." : "Cancel scan"}
               </button>
             </Form>
           </div>
         </div>
       ) : null}
 
-      {scanRun ? (
+      {scanRun && (inventoryReady || setupTargetReady || scanFailed || scanStale) ? (
         <section className="mt-5 rounded-2xl border border-slate-200 bg-white shadow-sm">
           <button
             type="button"
@@ -666,12 +645,14 @@ export default function ArticleSystemConnectionPanel({
           >
             <div>
               <p className="text-sm font-black text-slate-950">
-                {setupTargetScan ? "Article system target saved" : "Choose article location"}
+                {setupTargetReady ? "Article system target saved" : "Choose article location"}
               </p>
               <p className="mt-1 text-xs font-semibold text-slate-500">
-                {setupTargetScan
+                {setupTargetReady
                   ? "Continue to the generate step to build and review the article system preview."
-                  : "Pick a detected route from the scan, or create a new articles directory."}
+                  : scanFailed || scanStale
+                    ? "The scan could not confidently confirm a route. Try again, or paste a route after a successful scan."
+                    : "Pick a detected route from the scan, paste the correct URL, or create a new articles directory."}
               </p>
             </div>
             <span className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-wide text-violet-700">
@@ -681,7 +662,7 @@ export default function ArticleSystemConnectionPanel({
           </button>
           {articlePreviewOpen ? (
             <div className="space-y-4 border-t border-slate-100 p-4">
-              {setupTargetScan ? (
+              {setupTargetReady ? (
                 <>
                   <ArticleSystemSurfaceSummary run={scanRun} />
                   <div className="rounded-xl border border-violet-100 bg-violet-50 p-4">
@@ -697,14 +678,22 @@ export default function ArticleSystemConnectionPanel({
                     <input type="hidden" name="intent" value="confirm-article-surface" />
                     <input type="hidden" name="githubRepo" value={selectedRepo} />
                     <input type="hidden" name="sourceScanRunId" value={scanRun.runId} />
-                    <ArticleSystemSurfaceSummary run={scanRun} selectable fieldName="articleSurfaceUrl" />
+                    <ArticleSystemSurfaceSummary
+                      run={scanRun}
+                      selectable
+                      fieldName="articleSurfaceUrl"
+                      selectionValue={selectedArticleRoute}
+                      manualValue={manualArticleRoute}
+                      onSelectionValueChange={setSelectedArticleRoute}
+                      onManualValueChange={setManualArticleRoute}
+                    />
                     <button
                       type="submit"
-                      disabled={isSubmitting}
+                      disabled={confirmSurfacePending || createSurfacePending || !hasExistingSurfaceChoice}
                       className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
                     >
-                      {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-                      Continue to generate article system
+                      {confirmSurfacePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                      {confirmSurfacePending ? "Saving route..." : "Continue to generate article system"}
                     </button>
                   </Form>
                   <Form method="POST" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
@@ -722,15 +711,24 @@ export default function ArticleSystemConnectionPanel({
                     </label>
                     <button
                       type="submit"
-                      disabled={isSubmitting}
+                      disabled={confirmSurfacePending || createSurfacePending}
                       className="mt-3 inline-flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 shadow-sm transition hover:bg-violet-50 disabled:opacity-50"
                     >
-                      Create and continue
+                      {createSurfacePending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                      {createSurfacePending ? "Creating route..." : "Create and continue"}
                     </button>
                   </Form>
                 </>
               ) : (
-                <ArticleSystemSurfaceSummary run={scanRun} />
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+                  <p className="text-sm font-black text-amber-950">We could not confidently match an articles page.</p>
+                  <p className="mt-1 text-sm font-semibold leading-6 text-amber-800">
+                    Retry the scan, manage GitHub access if the repo is wrong, or start a new scan after choosing the correct repository.
+                  </p>
+                  <div className="mt-3">
+                    <ArticleSystemSurfaceSummary run={scanRun} />
+                  </div>
+                </div>
               )}
             </div>
           ) : null}

--- a/app/components/ArticleSystemSurfaceSummary.tsx
+++ b/app/components/ArticleSystemSurfaceSummary.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
+import { useState } from "react";
 
 import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
@@ -119,14 +120,31 @@ function hintStatusTone(status: string) {
   return "border-gray-200 bg-gray-50 text-gray-700";
 }
 
+function isSelectablePublicRoute(route: string) {
+  return Boolean(route && route.startsWith("/") && !/[{[]/.test(route));
+}
+
+function candidateLabel(candidate: SurfaceCandidate) {
+  if (candidate.route && candidate.path && candidate.path !== candidate.route) return `${candidate.route} - ${candidate.path}`;
+  return candidate.route || candidate.path;
+}
+
 export default function ArticleSystemSurfaceSummary({
   run,
   selectable = false,
   fieldName = "articleSurfaceUrl",
+  selectionValue,
+  manualValue,
+  onSelectionValueChange,
+  onManualValueChange,
 }: {
   run: VibeMarketingRunSummary;
   selectable?: boolean;
   fieldName?: string;
+  selectionValue?: string;
+  manualValue?: string;
+  onSelectionValueChange?: (value: string) => void;
+  onManualValueChange?: (value: string) => void;
 }) {
   const candidates = articleSurfaceCandidates(run);
   const files = supportFiles(run);
@@ -136,9 +154,109 @@ export default function ArticleSystemSurfaceSummary({
   const setup = resultRecord(run, "article_system_setup");
   const readinessStatus = asString(readiness.status) || asString(setup.status);
   const reason = asString(readiness.reason) || asString(resultValue(run, "scaffold_reason"));
+  const publicRouteCandidates = candidates.filter((candidate) => isSelectablePublicRoute(candidate.route));
+  const fileOnlyCandidates = candidates.filter((candidate) => !isSelectablePublicRoute(candidate.route));
+  const [internalSelection, setInternalSelection] = useState("");
+  const [internalManualValue, setInternalManualValue] = useState("");
+  const selectedRoute = selectionValue ?? internalSelection;
+  const pastedRoute = manualValue ?? internalManualValue;
+  const submittedRoute = pastedRoute.trim() || selectedRoute;
+  const selectedCandidate = publicRouteCandidates.find((candidate) => candidate.route === selectedRoute);
+  const updateSelection = (value: string) => {
+    onSelectionValueChange?.(value);
+    if (selectionValue === undefined) setInternalSelection(value);
+    onManualValueChange?.("");
+    if (manualValue === undefined) setInternalManualValue("");
+  };
+  const updateManualValue = (value: string) => {
+    onManualValueChange?.(value);
+    if (manualValue === undefined) setInternalManualValue(value);
+    if (value.trim()) {
+      onSelectionValueChange?.("");
+      if (selectionValue === undefined) setInternalSelection("");
+    }
+  };
 
   if (!candidates.length && !files.required.length && hintStatus === "ignored" && !readinessStatus) {
     return null;
+  }
+
+  if (selectable) {
+    return (
+      <section className="rounded-2xl border border-slate-200 bg-white p-4">
+        <input type="hidden" name={fieldName} value={submittedRoute} />
+        <div>
+          <h2 className="text-base font-black text-slate-950">Choose where articles live</h2>
+          <p className="mt-1 text-sm font-semibold leading-6 text-slate-500">
+            Select a public page found during the read-only scan, or paste the articles/blog URL yourself.
+          </p>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          <label className="block">
+            <span className="mb-2 block text-sm font-black text-slate-800">Choose the articles or blog page we found</span>
+            <select
+              value={selectedRoute}
+              onChange={(event) => updateSelection(event.target.value)}
+              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+            >
+              <option value="">Select a found route</option>
+              {publicRouteCandidates.map((candidate) => (
+                <option key={candidate.key} value={candidate.route}>
+                  {candidateLabel(candidate)}
+                </option>
+              ))}
+            </select>
+            {!publicRouteCandidates.length ? (
+              <span className="mt-2 block text-xs font-semibold text-slate-500">
+                We did not find a clean public articles route. Paste the URL/path, or create a new articles directory below.
+              </span>
+            ) : null}
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-black text-slate-800">Or paste the articles/blog URL or path</span>
+            <input
+              value={pastedRoute}
+              onChange={(event) => updateManualValue(event.target.value)}
+              placeholder="https://example.com/articles or /articles"
+              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+            />
+            <span className="mt-2 block text-xs font-semibold text-slate-500">Use this if the right route is not in the dropdown.</span>
+          </label>
+        </div>
+
+        {selectedCandidate?.path && selectedCandidate.path !== selectedCandidate.route ? (
+          <div className="mt-4 rounded-xl bg-slate-50 px-4 py-3">
+            <p className="text-xs font-black uppercase tracking-wide text-slate-400">Repo evidence</p>
+            <p className="mt-1 break-all text-sm font-semibold text-slate-700">{selectedCandidate.path}</p>
+          </div>
+        ) : null}
+
+        {fileOnlyCandidates.length ? (
+          <details className="mt-4 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+            <summary className="cursor-pointer text-sm font-black text-slate-800">Pages found without a public URL</summary>
+            <div className="mt-3 space-y-2">
+              {fileOnlyCandidates.map((candidate) => (
+                <div key={candidate.key} className="rounded-lg bg-white px-3 py-2 text-xs font-semibold text-slate-600">
+                  <p className="break-all font-black text-slate-800">{candidate.path || candidate.route}</p>
+                  {candidate.group ? <p className="mt-1 uppercase tracking-wide text-slate-400">{candidate.group.replace(/_/g, " ")}</p> : null}
+                </div>
+              ))}
+            </div>
+          </details>
+        ) : null}
+
+        <details className="mt-4 rounded-xl border border-slate-200 bg-white px-4 py-3">
+          <summary className="cursor-pointer text-sm font-black text-slate-800">Technical scan details</summary>
+          <div className="mt-3 space-y-3 text-sm font-semibold text-slate-600">
+            {asString(hint.route_path) ? <p>User hint: <span className="font-black text-slate-900">{asString(hint.route_path)}</span></p> : null}
+            <p>Hint status: <span className="font-black text-slate-900">{hintStatus.replace(/_/g, " ")}</span></p>
+            {reason ? <p className="rounded-lg bg-amber-50 px-3 py-2 text-amber-900">{reason}</p> : null}
+          </div>
+        </details>
+      </section>
+    );
   }
 
   return (
@@ -147,7 +265,7 @@ export default function ArticleSystemSurfaceSummary({
         <div>
           <h2 className="text-base font-black text-gray-950">Article surface scan</h2>
           <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-            Confirm the public route and repo files Content Factory will use before setup patches are approved.
+            Review the scanner findings if you need to audit the route or setup files.
           </p>
         </div>
         <span className={clsx("inline-flex rounded-full border px-3 py-1 text-xs font-black uppercase", hintStatusTone(hintStatus))}>
@@ -155,89 +273,79 @@ export default function ArticleSystemSurfaceSummary({
         </span>
       </div>
 
-      {asString(hint.route_path) ? (
-        <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs font-bold text-gray-600">
-          User hint: <span className="text-gray-950">{asString(hint.route_path)}</span>
-        </p>
-      ) : null}
+      <p className="mt-3 rounded-lg bg-slate-50 px-3 py-2 text-sm font-semibold text-slate-600">
+        {candidates.length
+          ? `${candidates.length} possible article surface${candidates.length === 1 ? "" : "s"} found.`
+          : "No public article surface candidates were confirmed."}
+      </p>
 
-      {reason ? (
-        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-900">
-          {reason}
-        </div>
-      ) : null}
+      <details className="mt-4 rounded-xl border border-slate-200 bg-white px-4 py-3">
+        <summary className="cursor-pointer text-sm font-black text-slate-800">Technical scan details</summary>
+        <div className="mt-4 space-y-4">
+          {asString(hint.route_path) ? (
+            <p className="rounded-lg bg-gray-50 px-3 py-2 text-xs font-bold text-gray-600">
+              User hint: <span className="text-gray-950">{asString(hint.route_path)}</span>
+            </p>
+          ) : null}
 
-      {candidates.length ? (
-        <div className="mt-4 grid gap-3 lg:grid-cols-2">
-          {candidates.map((candidate, index) => {
-            const selectableValue = candidate.route || candidate.path;
-            const content = (
-              <>
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-black text-gray-950">{candidate.route || candidate.path}</p>
-                    <p className="mt-1 text-xs font-bold uppercase tracking-wide text-gray-400">{candidate.group.replace(/_/g, " ")}</p>
+          {reason ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-900">
+              {reason}
+            </div>
+          ) : null}
+
+          {candidates.length ? (
+            <div className="grid gap-3 lg:grid-cols-2">
+              {candidates.map((candidate) => (
+                <div key={candidate.key} className="rounded-xl border border-gray-200 bg-white p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-black text-gray-950">{candidate.route || candidate.path}</p>
+                      <p className="mt-1 text-xs font-bold uppercase tracking-wide text-gray-400">{candidate.group.replace(/_/g, " ")}</p>
+                    </div>
+                    {candidate.confidence !== null ? (
+                      <span className="rounded-full bg-violet-50 px-2 py-1 text-[11px] font-black text-violet-700">
+                        {Math.round(candidate.confidence * 100)}%
+                      </span>
+                    ) : null}
                   </div>
-                  {candidate.confidence !== null ? (
-                    <span className="rounded-full bg-violet-50 px-2 py-1 text-[11px] font-black text-violet-700">
-                      {Math.round(candidate.confidence * 100)}%
-                    </span>
+                  {candidate.path && candidate.path !== candidate.route ? (
+                    <p className="mt-3 break-all rounded-lg bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">{candidate.path}</p>
                   ) : null}
+                  <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-wide text-gray-500">
+                    {candidate.kind ? <span className="rounded-full bg-gray-100 px-2 py-1">{candidate.kind}</span> : null}
+                    {candidate.systemType ? <span className="rounded-full bg-gray-100 px-2 py-1">{candidate.systemType}</span> : null}
+                    <span className="rounded-full bg-emerald-50 px-2 py-1 text-emerald-700">Patch only if confirmed safe</span>
+                  </div>
                 </div>
-                {candidate.path && candidate.path !== candidate.route ? (
-                  <p className="mt-3 break-all rounded-lg bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600">{candidate.path}</p>
-                ) : null}
-                <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-wide text-gray-500">
-                  {candidate.kind ? <span className="rounded-full bg-gray-100 px-2 py-1">{candidate.kind}</span> : null}
-                  {candidate.systemType ? <span className="rounded-full bg-gray-100 px-2 py-1">{candidate.systemType}</span> : null}
-                  <span className="rounded-full bg-emerald-50 px-2 py-1 text-emerald-700">Patch only if confirmed safe</span>
-                </div>
-              </>
-            );
-            return selectable && selectableValue ? (
-              <label key={candidate.key} className="block cursor-pointer rounded-xl border border-gray-200 bg-white p-4 transition hover:border-violet-200 hover:bg-violet-50/40">
-                <div className="flex gap-3">
-                  <input
-                    type="radio"
-                    name={fieldName}
-                    value={selectableValue}
-                    defaultChecked={index === 0}
-                    className="mt-1 h-4 w-4 border-gray-300 text-violet-600 focus:ring-violet-500"
-                  />
-                  <div className="min-w-0 flex-1">{content}</div>
-                </div>
-              </label>
-            ) : (
-              <div key={candidate.key} className="rounded-xl border border-gray-200 bg-white p-4">
-                {content}
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
+              ))}
+            </div>
+          ) : null}
 
-      {files.required.length ? (
-        <div className="mt-4 grid gap-3 lg:grid-cols-2">
-          <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-4">
-            <div className="flex items-center gap-2 text-sm font-black text-emerald-900">
-              <CheckCircleIcon className="h-4 w-4" />
-              Support files found
+          {files.required.length ? (
+            <div className="grid gap-3 lg:grid-cols-2">
+              <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-4">
+                <div className="flex items-center gap-2 text-sm font-black text-emerald-900">
+                  <CheckCircleIcon className="h-4 w-4" />
+                  Support files found
+                </div>
+                <p className="mt-2 text-xs font-semibold leading-5 text-emerald-800">
+                  {files.found.length ? files.found.join(", ") : "None confirmed yet"}
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-100 bg-amber-50 p-4">
+                <div className="flex items-center gap-2 text-sm font-black text-amber-900">
+                  <ExclamationTriangleIcon className="h-4 w-4" />
+                  Missing or planned files
+                </div>
+                <p className="mt-2 text-xs font-semibold leading-5 text-amber-800">
+                  {files.missing.length ? files.missing.join(", ") : "No missing support files detected"}
+                </p>
+              </div>
             </div>
-            <p className="mt-2 text-xs font-semibold leading-5 text-emerald-800">
-              {files.found.length ? files.found.join(", ") : "None confirmed yet"}
-            </p>
-          </div>
-          <div className="rounded-xl border border-amber-100 bg-amber-50 p-4">
-            <div className="flex items-center gap-2 text-sm font-black text-amber-900">
-              <ExclamationTriangleIcon className="h-4 w-4" />
-              Missing or planned files
-            </div>
-            <p className="mt-2 text-xs font-semibold leading-5 text-amber-800">
-              {files.missing.length ? files.missing.join(", ") : "No missing support files detected"}
-            </p>
-          </div>
+          ) : null}
         </div>
-      ) : null}
+      </details>
     </section>
   );
 }

--- a/app/components/MarketingRunProgressCard.tsx
+++ b/app/components/MarketingRunProgressCard.tsx
@@ -10,6 +10,16 @@ function labelForStatus(status: string) {
   return status.replace(/_/g, " ");
 }
 
+function shortErrorMessage(run: VibeMarketingRunSummary, error: string) {
+  if (["repo_scan", "content_factory_scan"].includes(run.workflow)) {
+    return "Repository scan failed. Retry the scan or choose a different repository.";
+  }
+  if (/Missing required .* components/i.test(error)) {
+    return "Article preview failed because required article components are missing.";
+  }
+  return "This run failed. Technical details are available if needed.";
+}
+
 export default function MarketingRunProgressCard({ run }: MarketingRunProgressCardProps) {
   const isFailed = ["failed", "blocked", "blocked_verification", "denied"].includes(run.status);
   const isScanRun = ["repo_scan", "content_factory_scan"].includes(run.workflow);
@@ -69,9 +79,10 @@ export default function MarketingRunProgressCard({ run }: MarketingRunProgressCa
             {completedSteps} of {totalSteps} run steps complete. Refreshing this page is safe.
           </p>
           {run.errors.length > 0 ? (
-            <div className="mt-3 rounded-xl border border-red-200 bg-white/80 px-4 py-3 text-sm text-red-700">
-              {run.errors[0]}
-            </div>
+            <details className="mt-3 rounded-xl border border-red-200 bg-white/80 px-4 py-3 text-sm text-red-700">
+              <summary className="cursor-pointer font-bold">{shortErrorMessage(run, run.errors[0])}</summary>
+              <p className="mt-2 break-words font-mono text-xs leading-5 text-red-600">{run.errors[0]}</p>
+            </details>
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Simplify the GitHub/article-system step into connect, repo scan, and explicit article-route choice states.
- Replace AI-selected article surface cards with a dropdown plus manual URL/path input after the read-only scan completes.
- Collapse technical scan details and raw run errors behind disclosures so users see shorter recovery messages first.

## Validation
- `bun run typecheck -- --pretty false`
