### PR TITLE
[codex] Keep marketing actions loading until state updates

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -1,4 +1,4 @@
-import { Form, Link, useFetcher, useNavigation } from "react-router";
+import { Form, Link, useFetcher, useLocation, useNavigation } from "react-router";
 import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import {
   AlertTriangle,
@@ -6,6 +6,7 @@ import {
   BadgeInfo,
   BarChart3,
   Building2,
+  ChevronDown,
   CheckCircle2,
   ExternalLink,
   FileText,
@@ -35,6 +36,7 @@ import {
   type StartupSetupField,
   type StartupSetupValues,
 } from "~/lib/vibe-marketing-startup-setup";
+import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import type {
   VibeMarketingAutofillCompetitor,
   VibeMarketingAutofillResult,
@@ -102,6 +104,7 @@ type VibeMarketingStartupBaselineSetupProps = {
   setupProgressPercent?: number | null;
   setupProgressLabel?: string;
   showSetupProgress?: boolean;
+  collapseCompletedSectionsByDefault?: boolean;
 };
 
 function listFromText(value: unknown): string[] {
@@ -824,6 +827,15 @@ function RequiredPill() {
   return <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-[10px] font-black text-emerald-700">Required</span>;
 }
 
+function CompletePill() {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-black uppercase tracking-wide text-emerald-700 ring-1 ring-emerald-100">
+      <CheckCircle2 className="h-3.5 w-3.5" />
+      Complete
+    </span>
+  );
+}
+
 function StepNumberBadge({ children }: { children: ReactNode }) {
   return (
     <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-violet-700 text-xl font-black text-white shadow-sm shadow-violet-200">
@@ -839,6 +851,48 @@ function AiAssistPill() {
       Will be filled by AI
     </span>
   );
+}
+
+function hasSetupText(value: string | null | undefined) {
+  return Boolean(String(value ?? "").trim());
+}
+
+function isBasicsComplete(values: StartupSetupValues) {
+  return hasSetupText(values.companyName) && hasSetupText(values.domain);
+}
+
+function isCompanyDetailsComplete(values: StartupSetupValues) {
+  return hasSetupText(values.shortDescription) && (hasSetupText(values.targetAudience) || hasSetupText(values.problemSolved));
+}
+
+function defaultSectionExpanded(values: StartupSetupValues, complete: (values: StartupSetupValues) => boolean, collapseCompletedSectionsByDefault: boolean) {
+  return !collapseCompletedSectionsByDefault || !complete(values);
+}
+
+function basicsSummary(values: StartupSetupValues) {
+  return [values.companyName.trim(), values.domain.trim(), values.companyLinkedInUrl.trim() ? "LinkedIn added" : ""].filter(Boolean).join(" • ");
+}
+
+function savedCompanyDetailLabels(values: StartupSetupValues) {
+  return [
+    hasSetupText(values.shortDescription) ? "description" : "",
+    hasSetupText(values.problemSolved) ? "what you do" : "",
+    hasSetupText(values.targetAudience) ? "audience" : "",
+    hasSetupText(values.location) ? "location" : "",
+    hasSetupText(values.founderNames) ? "founders" : "",
+    hasSetupText(values.stage) ? "stage" : "",
+    hasSetupText(values.organizationKind) ? "organization type" : "",
+    hasSetupText(values.seedKeywords) ? "keywords" : "",
+    hasSetupText(values.competitors) ? "competitors" : "",
+  ].filter(Boolean);
+}
+
+function companyDetailsSummary(values: StartupSetupValues) {
+  const labels = savedCompanyDetailLabels(values);
+  if (!labels.length) return "No company details saved yet.";
+  if (labels.length === 1) return `${labels[0]} saved.`;
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]} saved.`;
+  return `${labels[0]}, ${labels[1]}, and ${labels.length - 2} more saved.`;
 }
 
 function CompanyDetailsPanel({
@@ -1331,6 +1385,7 @@ function ProfileResearchProgressCard({
   const effectiveStatus = run?.status ?? startStatus ?? (pending ? "queued" : null);
   const active = pending || (!isResearchTerminalStatus(effectiveStatus) && (!run || isResearchRunningStatus(run.status)));
   const failed = isResearchFailedStatus(effectiveStatus) || unavailable;
+  const completed = run?.status === "completed" && !failed;
   const completedSteps = completedResearchStepCount(run, pending);
   const totalSteps = PROFILE_RESEARCH_STEPS.length;
   const progressLabel = `${Math.min(completedSteps, totalSteps)} of ${totalSteps} steps`;
@@ -1366,20 +1421,27 @@ function ProfileResearchProgressCard({
           ? partial
             ? "border-amber-200 bg-amber-50 text-amber-950"
             : "border-rose-200 bg-rose-50 text-rose-900"
-          : "border-purple-100 bg-gradient-to-br from-purple-50 via-violet-50 to-indigo-50 text-violet-950",
+          : completed
+            ? "border-emerald-200 bg-emerald-50 text-emerald-950"
+            : "border-purple-100 bg-gradient-to-br from-purple-50 via-violet-50 to-indigo-50 text-violet-950",
       )}
     >
       <div
         className={clsx(
           "absolute right-0 top-0 -mr-10 -mt-10 h-36 w-36 rounded-full blur-3xl",
-          failed ? (partial ? "bg-amber-200/30" : "bg-rose-200/30") : "bg-purple-200/30",
+          failed ? (partial ? "bg-amber-200/30" : "bg-rose-200/30") : completed ? "bg-emerald-200/40" : "bg-purple-200/30",
         )}
       />
       <div className="relative z-10 flex gap-4">
-        <div className={clsx("flex h-12 w-12 shrink-0 items-center justify-center rounded-xl", failed ? (partial ? "bg-amber-100" : "bg-rose-100") : "bg-purple-100")}>
+        <div
+          className={clsx(
+            "flex h-12 w-12 shrink-0 items-center justify-center rounded-xl",
+            failed ? (partial ? "bg-amber-100" : "bg-rose-100") : completed ? "bg-emerald-100" : "bg-purple-100",
+          )}
+        >
           {failed ? (
             <AlertTriangle className={clsx("h-6 w-6", partial ? "text-amber-600" : "text-rose-600")} />
-          ) : run?.status === "completed" ? (
+          ) : completed ? (
             <CheckCircle2 className="h-6 w-6 text-emerald-600" />
           ) : (
             <Sparkles className="h-6 w-6 text-purple-600" />
@@ -1389,19 +1451,34 @@ function ProfileResearchProgressCard({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-3">
             <p className="text-base font-black text-gray-950">{label}</p>
-            <span className={clsx("rounded-full px-2.5 py-1 text-[11px] font-black uppercase tracking-wide", failed ? (partial ? "bg-white/80 text-amber-700" : "bg-white/80 text-rose-700") : "bg-white/80 text-purple-700")}>
-              {failed ? (partial ? "Review needed" : "Retry available") : progressLabel}
+            <span
+              className={clsx(
+                "rounded-full px-2.5 py-1 text-[11px] font-black uppercase tracking-wide",
+                failed
+                  ? partial
+                    ? "bg-white/80 text-amber-700"
+                    : "bg-white/80 text-rose-700"
+                  : completed
+                    ? "bg-white/80 text-emerald-700"
+                    : "bg-white/80 text-purple-700",
+              )}
+            >
+              {failed ? (partial ? "Review needed" : "Retry available") : completed ? "Complete" : progressLabel}
             </span>
           </div>
 
-          <p className="mt-1 text-sm font-semibold text-gray-700">
-            {pending ? "Contacting the AI fill service" : run?.status === "completed" || partial ? "AI suggestions have been applied to the form." : autofillStepLabel(run?.currentStep)}
-          </p>
-          <p className="mt-1 text-sm font-medium text-gray-500">
-            {active ? "Usually takes 1-3 minutes. Refreshing the page is safe." : failed ? (partial ? "The form is unlocked so you can review, edit, or retry." : "The form is unlocked so you can retry or fill the fields manually.") : "Review the populated fields before continuing."}
-          </p>
+          {!completed ? (
+            <>
+              <p className="mt-1 text-sm font-semibold text-gray-700">
+                {pending ? "Contacting the AI fill service" : partial ? "AI suggestions have been applied to the form." : autofillStepLabel(run?.currentStep)}
+              </p>
+              <p className="mt-1 text-sm font-medium text-gray-500">
+                {active ? "Usually takes 1-3 minutes. Refreshing the page is safe." : failed ? (partial ? "The form is unlocked so you can review, edit, or retry." : "The form is unlocked so you can retry or fill the fields manually.") : "Review the populated fields before continuing."}
+              </p>
+            </>
+          ) : null}
 
-          {!failed ? (
+          {!failed && !completed ? (
             <div className="mt-4 space-y-2">
               <ProfileResearchSegments completedSteps={completedSteps} totalSteps={totalSteps} failed={false} />
               <p className="text-xs font-semibold text-gray-500">We will keep checking until the fields below are ready to review.</p>
@@ -1430,13 +1507,13 @@ function ProfileResearchProgressCard({
           ) : null}
 
           {autofill ? (
-            <div className="mt-4 flex flex-wrap gap-2 text-xs font-black text-violet-800">
+            <div className={clsx("mt-4 flex flex-wrap gap-2 text-xs font-black", completed ? "text-emerald-800" : "text-violet-800")}>
               <span>{sourceCount} sources reviewed</span>
               <span>{competitorCount} competitors found</span>
               <span>{seedKeywordCount} high-fit keywords selected</span>
             </div>
           ) : null}
-          {autofill?.warnings?.length ? <p className="mt-2 text-xs font-semibold text-amber-700">{autofill.warnings[0]}</p> : null}
+          {autofill?.warnings?.length && !completed ? <p className="mt-2 text-xs font-semibold text-amber-700">{autofill.warnings[0]}</p> : null}
         </div>
       </div>
     </div>
@@ -1458,8 +1535,10 @@ export default function VibeMarketingStartupBaselineSetup({
   setupProgressPercent = 20,
   setupProgressLabel = "20% complete",
   showSetupProgress = true,
+  collapseCompletedSectionsByDefault = true,
 }: VibeMarketingStartupBaselineSetupProps) {
   const navigation = useNavigation();
+  const location = useLocation();
   const autofillStartFetcher = useFetcher<{
     intent?: string;
     autofillRunId?: string | null;
@@ -1488,6 +1567,8 @@ export default function VibeMarketingStartupBaselineSetup({
   const autofillPollStateRef = useRef(autofillRunFetcher.state);
   const baselinePollStateRef = useRef(baselineRunFetcher.state);
   const [startupValues, setStartupValues] = useState<StartupSetupValues>(startupDefaults);
+  const [basicsExpanded, setBasicsExpanded] = useState(() => defaultSectionExpanded(startupDefaults, isBasicsComplete, collapseCompletedSectionsByDefault));
+  const [companyDetailsExpanded, setCompanyDetailsExpanded] = useState(() => defaultSectionExpanded(startupDefaults, isCompanyDetailsComplete, collapseCompletedSectionsByDefault));
   const [autofillRunId, setAutofillRunId] = useState<string | null>(null);
   const [appliedAutofillRunId, setAppliedAutofillRunId] = useState<string | null>(null);
   const [baselineRunId, setBaselineRunId] = useState<string | null>(null);
@@ -1520,7 +1601,6 @@ export default function VibeMarketingStartupBaselineSetup({
     effectiveBaseline.status !== "missing" &&
       (effectiveBaseline.passed || effectiveBaseline.status === "completed" || typeof effectiveBaseline.overallScore === "number"),
   );
-  const isSubmitting = navigation.state === "submitting";
   const autofillPending = autofillStartFetcher.state !== "idle";
   const baselinePending = baselineStartFetcher.state !== "idle";
   const googleBaselinePending = googleBaselineFetcher.state !== "idle";
@@ -1551,6 +1631,15 @@ export default function VibeMarketingStartupBaselineSetup({
       compactCompanyName === compactCompanyName.toUpperCase() &&
       !startupValues.companyLinkedInUrl.trim(),
   );
+  const savePending = useMarketingActionPending({
+    navigationState: navigation.state,
+    navigationFormData: navigation.formData,
+    clearSignal: `${location.pathname}${location.search}:${activeCompanyKey}:${startupDefaultsSignature}`,
+    errorKey: error ? "save-startup-details" : null,
+  });
+  const saveExitPending = savePending.isPending("save-startup-details:save-exit");
+  const continuePending = savePending.isPending("save-startup-details:continue");
+  const saveActionPending = savePending.isAnyPending;
   const searchConsole = plainObject(trafficMetric?.googleSearchConsole);
   const searchConsoleSummary = plainObject(searchConsole?.last28Days);
   const trafficMetricMessage = metricMessage("Traffic/users", trafficMetric);
@@ -1583,6 +1672,17 @@ export default function VibeMarketingStartupBaselineSetup({
       ? "Baseline action failed. You can keep going, retry, or reconnect the data source later."
       : baselineActionError
     : null;
+  const autofillStartHasImmediateError = Boolean(autofillStartData?.error && !autofillStartData?.autofillRunId);
+  const autofillRunFailed = Boolean(autofillRun && isResearchFailedStatus(autofillRun.status));
+  const profileResearchRequiresExpandedSections = Boolean(
+    autofillPending || autofillPolling || autofillStalled || autofillUnavailable || autofillStartHasImmediateError || autofillStartError || autofillRunFailed,
+  );
+  const basicsComplete = isBasicsComplete(startupValues);
+  const companyDetailsComplete = isCompanyDetailsComplete(startupValues);
+  const basicsContentExpanded =
+    !collapseCompletedSectionsByDefault || !basicsComplete || basicsExpanded || profileResearchRequiresExpandedSections;
+  const companyDetailsContentExpanded =
+    !collapseCompletedSectionsByDefault || !companyDetailsComplete || companyDetailsExpanded || profileResearchRequiresExpandedSections;
   const normalizedSetupProgress =
     typeof setupProgressPercent === "number" && Number.isFinite(setupProgressPercent)
       ? Math.max(0, Math.min(100, setupProgressPercent))
@@ -1653,6 +1753,8 @@ export default function VibeMarketingStartupBaselineSetup({
     if (activeCompanyKeyRef.current === activeCompanyKey) return;
     activeCompanyKeyRef.current = activeCompanyKey;
     setStartupValues(startupDefaults);
+    setBasicsExpanded(defaultSectionExpanded(startupDefaults, isBasicsComplete, collapseCompletedSectionsByDefault));
+    setCompanyDetailsExpanded(defaultSectionExpanded(startupDefaults, isCompanyDetailsComplete, collapseCompletedSectionsByDefault));
     setAutofillRunId(null);
     setBaselineRunId(null);
     setGoogleBaseline(null);
@@ -1662,7 +1764,7 @@ export default function VibeMarketingStartupBaselineSetup({
     setAutofillLastPollAt(null);
     setAutofillProgressSignature("");
     googleAutoRefreshSubmittedRef.current = false;
-  }, [activeCompanyKey, startupDefaults, startupDefaultsSignature]);
+  }, [activeCompanyKey, collapseCompletedSectionsByDefault, startupDefaults, startupDefaultsSignature]);
 
   useEffect(() => {
     if (focusSection !== "baseline") return;
@@ -1838,16 +1940,35 @@ export default function VibeMarketingStartupBaselineSetup({
           </div>
         </section>
 
-        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_390px]">
+        <div className={clsx("grid gap-5", basicsContentExpanded && "xl:grid-cols-[minmax(0,1fr)_390px]")}>
           <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6">
-            <div className="flex items-start gap-4">
-              <StepNumberBadge>1</StepNumberBadge>
-              <div>
-                <h3 className="text-xl font-black tracking-normal text-gray-950">Add the basics</h3>
-                <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">These details help our AI find the right information about your company.</p>
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex items-start gap-4">
+                <StepNumberBadge>1</StepNumberBadge>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <h3 className="text-xl font-black tracking-normal text-gray-950">Add the basics</h3>
+                    {basicsComplete ? <CompletePill /> : null}
+                  </div>
+                  <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">These details help our AI find the right information about your company.</p>
+                </div>
               </div>
+              {basicsComplete ? (
+                <button
+                  type="button"
+                  onClick={() => setBasicsExpanded((current) => !current)}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                  aria-expanded={basicsContentExpanded}
+                >
+                  {basicsContentExpanded ? "Collapse" : "Edit"}
+                  <ChevronDown className={clsx("h-4 w-4 transition", basicsContentExpanded && "rotate-180")} />
+                </button>
+              ) : null}
             </div>
 
+            {!basicsContentExpanded ? <p className="mt-4 rounded-xl bg-slate-50 px-4 py-3 text-sm font-bold text-slate-600">{basicsSummary(startupValues)}</p> : null}
+
+            <div className={clsx(!basicsContentExpanded && "hidden")}>
             <div className="mt-6 grid gap-5 lg:grid-cols-2">
               <FormField label="Company name" badge={<RequiredPill />} className="lg:col-span-2">
                 <div className="relative">
@@ -1940,9 +2061,10 @@ export default function VibeMarketingStartupBaselineSetup({
                 retryDisabled={!canRetryAutofill}
               />
             </div>
+            </div>
           </section>
 
-          <aside className="self-start rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <aside className={clsx("self-start rounded-xl border border-gray-200 bg-white p-6 shadow-sm", !basicsContentExpanded && "hidden")}>
             <h3 className="text-base font-black text-gray-950">What happens next?</h3>
             <div className="mt-5 space-y-5">
               <NextStepItem icon={Search} title="We research your company" body="Our AI looks at your website, LinkedIn page, and other trusted sources." />
@@ -1962,20 +2084,36 @@ export default function VibeMarketingStartupBaselineSetup({
         </div>
 
         <section className={clsx("rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:p-7", researchLocked && "bg-gray-50/80")}>
-          <div className="flex items-start gap-5">
-            <StepNumberBadge>2</StepNumberBadge>
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-3">
-                <h3 className="text-2xl font-black tracking-normal text-gray-950">Company details</h3>
-                <AiAssistPill />
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-5">
+              <StepNumberBadge>2</StepNumberBadge>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h3 className="text-2xl font-black tracking-normal text-gray-950">Company details</h3>
+                  <AiAssistPill />
+                  {companyDetailsComplete ? <CompletePill /> : null}
+                </div>
+                <p className="mt-2 text-base font-semibold leading-7 text-gray-600">
+                  Sit back while we gather information about your business, then review and edit anything.
+                </p>
               </div>
-              <p className="mt-2 text-base font-semibold leading-7 text-gray-600">
-                Sit back while we gather information about your business, then review and edit anything.
-              </p>
             </div>
+            {companyDetailsComplete ? (
+              <button
+                type="button"
+                onClick={() => setCompanyDetailsExpanded((current) => !current)}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                aria-expanded={companyDetailsContentExpanded}
+              >
+                {companyDetailsContentExpanded ? "Collapse" : "Edit"}
+                <ChevronDown className={clsx("h-4 w-4 transition", companyDetailsContentExpanded && "rotate-180")} />
+              </button>
+            ) : null}
           </div>
 
-          <div className="mt-7 border-t border-gray-100 pt-7">
+          {!companyDetailsContentExpanded ? <p className="mt-4 rounded-xl bg-slate-50 px-4 py-3 text-sm font-bold text-slate-600">{companyDetailsSummary(startupValues)}</p> : null}
+
+          <div className={clsx("mt-7 border-t border-gray-100 pt-7", !companyDetailsContentExpanded && "hidden")}>
             <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
               <FormField label="Startup location">
                 <div className="relative">
@@ -2455,33 +2593,33 @@ export default function VibeMarketingStartupBaselineSetup({
         </section>
       ) : null}
 
-      <div className={clsx("flex flex-col gap-4 border-t border-gray-100 bg-gray-50/70 py-5 sm:flex-row sm:items-center sm:justify-between", embedded ? "" : "px-6 lg:px-8")}>
+      <div className="flex flex-col gap-4 border-t border-gray-100 bg-gray-50/70 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
         <p className="flex items-center gap-3 text-sm font-bold text-gray-500">
           <ShieldCheck className="h-5 w-5 text-gray-400" />
           Your data is secure and never shared.
         </p>
-        <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
           {shouldShowSecondaryAction ? (
             <button
               type="submit"
               name="nextAction"
               value="save-exit"
-              disabled={isSubmitting || researchLocked}
-              className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={saveActionPending || researchLocked}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 sm:px-6"
             >
-              <Save className="h-4 w-4" />
-              Save and exit
+              {saveExitPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              {saveExitPending ? "Saving..." : "Save and exit"}
             </button>
           ) : null}
           <button
             type="submit"
             name="nextAction"
             value="continue"
-            disabled={isSubmitting || researchLocked}
-            className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-700 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={saveActionPending || researchLocked}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-violet-700 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50 sm:px-7"
           >
-            {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
-            {primaryActionLabel ?? defaultPrimaryActionLabel}
+            {continuePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+            {continuePending ? "Continuing..." : primaryActionLabel ?? defaultPrimaryActionLabel}
           </button>
         </div>
       </div>

--- a/app/lib/vibe-marketing-pending-actions.ts
+++ b/app/lib/vibe-marketing-pending-actions.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type FormDataLike = {
+  get(name: string): FormDataEntryValue | null;
+} | null | undefined;
+
+type PendingAction = {
+  key: string;
+  clearSignal: string;
+  startedAt: number;
+};
+
+type UseMarketingActionPendingOptions = {
+  navigationState: string;
+  navigationFormData?: FormDataLike;
+  clearSignal: string;
+  errorKey?: string | null;
+};
+
+function formDataString(formData: FormDataLike, key: string) {
+  const value = formData?.get(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function baseActionKey(key: string) {
+  return key.split(":")[0] ?? key;
+}
+
+function actionKeysMatch(candidate: string | null | undefined, target: string) {
+  if (!candidate) return false;
+  if (candidate === target) return true;
+  return !target.includes(":") && baseActionKey(candidate) === target;
+}
+
+export function marketingActionKeyFromFormData(formData: FormDataLike) {
+  const intent = formDataString(formData, "intent");
+  const nextAction = formDataString(formData, "nextAction");
+  if (intent && nextAction) return `${intent}:${nextAction}`;
+  return intent || nextAction || null;
+}
+
+export function useMarketingActionPending({
+  navigationState,
+  navigationFormData,
+  clearSignal,
+  errorKey,
+}: UseMarketingActionPendingOptions) {
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const clearSignalRef = useRef(clearSignal);
+  const navigationKey = navigationState !== "idle" ? marketingActionKeyFromFormData(navigationFormData) : null;
+
+  useEffect(() => {
+    clearSignalRef.current = clearSignal;
+  }, [clearSignal]);
+
+  useEffect(() => {
+    if (!navigationKey) return;
+    setPending((current) =>
+      current?.key === navigationKey
+        ? current
+        : {
+            key: navigationKey,
+            clearSignal: clearSignalRef.current,
+            startedAt: Date.now(),
+          },
+    );
+  }, [navigationKey]);
+
+  useEffect(() => {
+    if (!pending || navigationState !== "idle") return;
+    if (errorKey && actionKeysMatch(pending.key, errorKey)) {
+      setPending(null);
+      return;
+    }
+    if (clearSignal !== pending.clearSignal) {
+      setPending(null);
+    }
+  }, [clearSignal, errorKey, navigationState, pending]);
+
+  const activeKey = navigationKey ?? pending?.key ?? null;
+  const isPending = useCallback(
+    (...keys: string[]) => keys.some((key) => actionKeysMatch(activeKey, key)),
+    [activeKey],
+  );
+
+  return useMemo(
+    () => ({
+      activeKey,
+      isAnyPending: Boolean(activeKey),
+      isPending,
+      clearPending: () => setPending(null),
+      pendingStartedAt: pending?.startedAt ?? null,
+    }),
+    [activeKey, isPending, pending?.startedAt],
+  );
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -872,8 +872,8 @@ const DEV_BOOTSTRAP: VibeMarketingBootstrap = {
   hasCompletedArticleFlow: false,
   startPageMode: "first_article_setup",
   workflowProgress: {
-    currentStepId: "choose_topic",
-    nextStepId: "generate",
+    currentStepId: "research",
+    nextStepId: "choose_topic",
     steps: [
       {
         id: "profile",
@@ -919,20 +919,20 @@ const DEV_BOOTSTRAP: VibeMarketingBootstrap = {
         id: "research",
         label: "Research topics",
         phase: "Plan",
-        status: "complete",
+        status: "ready",
         href: "/founder-tools/marketing/create?step=research",
         summary: "Find article candidates from the company context.",
-        primaryAction: null,
+        primaryAction: { label: "Start topic research", href: "/founder-tools/marketing/create?step=research" },
         order: 5,
       },
       {
         id: "choose_topic",
         label: "Choose topic",
         phase: "Plan",
-        status: "needs_action",
+        status: "locked",
         href: "/founder-tools/marketing/create?step=chooseArticle",
         summary: "Pick a discovered topic or enter a custom article brief.",
-        primaryAction: { label: "Choose article topic", href: "/founder-tools/marketing/create?step=chooseArticle" },
+        primaryAction: null,
         order: 6,
       },
       {

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
-import { Form, Link, redirect, useActionData, useLoaderData, useNavigation, useSearchParams } from "react-router";
+import { Form, Link, redirect, useActionData, useLoaderData, useLocation, useNavigation, useSearchParams } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 import {
   ArrowLeftIcon,
@@ -26,6 +26,7 @@ import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartup
 import { type VibeMarketingStepKey } from "~/components/VibeMarketingStepper";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
+import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import { combineCompanyContext as combineStartupCompanyContext } from "~/lib/vibe-marketing-startup-setup";
 import {
@@ -680,7 +681,7 @@ export default function FounderToolsMarketingCreate() {
       ? latestActionError
       : null;
   const navigation = useNavigation();
-  const isSubmitting = navigation.state === "submitting";
+  const location = useLocation();
   const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
   const pendingArticleSystemScan = scanRunHasPendingArticleSystemSetup(latestScan) ? latestScan : null;
   const pendingArticleSystemSetupRunId = pendingArticleSystemScan ? setupRunIdForRun(pendingArticleSystemScan) : "";
@@ -688,6 +689,35 @@ export default function FounderToolsMarketingCreate() {
   const latestArticle = bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article"].includes(run.workflow));
   const latestContentPackage = latestArticle?.contentPackage ?? bootstrap.publishEvidence?.contentPackage ?? null;
   const contentPackageReady = Boolean(latestContentPackage?.contentPackaged);
+  const pendingActions = useMarketingActionPending({
+    navigationState: navigation.state,
+    navigationFormData: navigation.formData,
+    clearSignal: [
+      location.pathname,
+      location.search,
+      activeStep,
+      latestScan?.runId,
+      latestScan?.status,
+      latestScan?.stale,
+      latestScan?.retryAvailable,
+      latestScan ? setupRunIdForRun(latestScan) : "",
+      latestDiscovery?.runId,
+      latestDiscovery?.status,
+      latestArticle?.runId,
+      latestArticle?.status,
+      bootstrap.checks.scaffold?.passed,
+      bootstrap.checks.dailyAutomation?.passed,
+      bootstrap.settings.dailyDiscoveryEnabled,
+      bootstrap.topicCandidates.length,
+    ].join("|"),
+    errorKey: latestActionError ? latestActionIntent : null,
+  });
+  const isSubmitting = pendingActions.isAnyPending;
+  const discoveryPending = pendingActions.isPending("start-discovery");
+  const articleStartPending = pendingActions.isPending("start-article");
+  const buildArticleSystemPreviewPending = pendingActions.isPending("build-article-system-preview");
+  const saveDailyPending = pendingActions.isPending("save-daily");
+  const dailyReplayPending = pendingActions.isPending("daily-replay");
   const selectableTopicCandidates = useMemo(
     () => bootstrap.topicCandidates.filter((candidate) => !candidate.alreadyWritten).slice(0, 5),
     [bootstrap.topicCandidates],
@@ -794,6 +824,7 @@ export default function FounderToolsMarketingCreate() {
                 bootstrap={bootstrap}
                 githubRepos={githubRepos}
                 isSubmitting={isSubmitting}
+                isActionPending={pendingActions.isPending}
                 repoSelection={repoSelection}
                 onRepoSelectionChange={setRepoSelection}
                 articleSurfacePlaceholder="https://www.mlai.au/articles or /articles"
@@ -838,8 +869,8 @@ export default function FounderToolsMarketingCreate() {
               <Form method="POST">
                 <input type="hidden" name="intent" value="start-discovery" />
                 <button type="submit" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <MagnifyingGlassIcon className="h-4 w-4" />}
-                  Start topic research
+                  {discoveryPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <MagnifyingGlassIcon className="h-4 w-4" />}
+                  {discoveryPending ? "Starting research..." : "Start topic research"}
                 </button>
               </Form>
               {latestDiscovery ? <Link to={`/founder-tools/marketing/runs/${latestDiscovery.runId}`} className="mt-4 inline-flex text-sm font-bold text-violet-700">View latest research run</Link> : null}
@@ -963,8 +994,8 @@ export default function FounderToolsMarketingCreate() {
                       <p className="mt-1 max-w-2xl text-xs font-semibold leading-5 text-gray-500">{deliveryModeNote}</p>
                     </div>
                     <button type="submit" disabled={isSubmitting || !bootstrap.checks.baseline?.passed} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
-                      {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                      Generate draft article
+                      {articleStartPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
+                      {articleStartPending ? "Starting article..." : "Generate draft article"}
                     </button>
                   </div>
                 </div>
@@ -1028,8 +1059,8 @@ export default function FounderToolsMarketingCreate() {
                         disabled={isSubmitting}
                         className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60"
                       >
-                        {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                        Generate article system preview
+                        {buildArticleSystemPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
+                        {buildArticleSystemPreviewPending ? "Generating preview..." : "Generate article system preview"}
                       </button>
                     </Form>
                   ) : (
@@ -1087,10 +1118,12 @@ export default function FounderToolsMarketingCreate() {
                 </label>
                 <div className="flex flex-wrap gap-3">
                   <button type="submit" name="intent" value="save-daily" disabled={isSubmitting} className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
-                    Save daily settings
+                    {saveDailyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : null}
+                    {saveDailyPending ? "Saving..." : "Save daily settings"}
                   </button>
                   <button type="submit" name="intent" value="daily-replay" disabled={isSubmitting || !bootstrap.checks.dailyAutomation?.passed} className="inline-flex items-center gap-2 rounded-xl border border-gray-200 px-5 py-3 text-sm font-bold text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-60">
-                    Run today now
+                    {dailyReplayPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : null}
+                    {dailyReplayPending ? "Starting..." : "Run today now"}
                   </button>
                 </div>
               </Form>

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/founder-tools.marketing.run";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useNavigation } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation } from "react-router";
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
@@ -22,6 +22,7 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
 import { getEnv } from "~/lib/env.server";
+import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   connectVibeMarketingGithub,
   controlVibeMarketingRun,
@@ -211,13 +212,13 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       return { ok: true, comment };
     } else if (intent === "update-component-comment") {
       const commentId = stringFromForm(formData, "commentId");
-      if (!commentId) return { error: "Comment id is required." };
+      if (!commentId) return { intent, error: "Comment id is required." };
       const targetRunId = stringFromForm(formData, "targetRunId") || runId;
       const comment = await updateVibeMarketingComponentComment(env, request, targetRunId, commentId, componentCommentPayloadFromForm(formData));
       return { ok: true, comment };
     } else if (intent === "delete-component-comment") {
       const commentId = stringFromForm(formData, "commentId");
-      if (!commentId) return { error: "Comment id is required." };
+      if (!commentId) return { intent, error: "Comment id is required." };
       const targetRunId = stringFromForm(formData, "targetRunId") || runId;
       const componentFeedback = await deleteVibeMarketingComponentComment(env, request, targetRunId, commentId);
       return { ok: true, componentFeedback };
@@ -263,13 +264,13 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } else if (intent === "retry-scan") {
       const result = await controlVibeMarketingRun(env, request, runId, "resume", { workflow: "repo_scan" });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
-      return { error: result.errors?.[0] || "Repository scan could not be retried." };
+      return { intent, error: result.errors?.[0] || "Repository scan could not be retried." };
     } else if (intent === "start-scan") {
       const githubRepo = stringFromForm(formData, "githubRepo") || stringFromForm(formData, "github_repo");
       const articleSurfaceUrl = stringFromForm(formData, "articleSurfaceUrl") || stringFromForm(formData, "article_surface_url");
       const scanPurpose = stringFromForm(formData, "scanPurpose") || "inventory";
-      if (!githubRepo) return { error: "Choose a GitHub repository before scanning." };
-      if (scanPurpose !== "inventory" && !articleSurfaceUrl) return { error: "Enter the articles or blog URL before scanning." };
+      if (!githubRepo) return { intent, error: "Choose a GitHub repository before scanning." };
+      if (scanPurpose !== "inventory" && !articleSurfaceUrl) return { intent, error: "Enter the articles or blog URL before scanning." };
       const result = await startVibeMarketingScan(env, request, {
         githubRepo,
         github_repo: githubRepo,
@@ -287,12 +288,12 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         auto_setup_preview: false,
       });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
-      return { error: result.error || result.errors?.[0] || "Repository scan could not be started." };
+      return { intent, error: result.error || result.errors?.[0] || "Repository scan could not be started." };
     } else if (intent === "confirm-article-surface" || intent === "create-article-surface") {
       const githubRepo = stringFromForm(formData, "githubRepo") || stringFromForm(formData, "github_repo");
       const articleSurfaceUrl = stringFromForm(formData, "articleSurfaceUrl") || stringFromForm(formData, "article_surface_url");
-      if (!githubRepo) return { error: "Choose a GitHub repository before continuing." };
-      if (!articleSurfaceUrl) return { error: "Choose or enter an article/blog route before continuing." };
+      if (!githubRepo) return { intent, error: "Choose a GitHub repository before continuing." };
+      if (!articleSurfaceUrl) return { intent, error: "Choose or enter an article/blog route before continuing." };
       const result = await startVibeMarketingScan(env, request, {
         githubRepo,
         github_repo: githubRepo,
@@ -308,7 +309,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         auto_setup_preview: false,
       });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
-      return { error: result.error || result.errors?.[0] || "Article system setup could not be started." };
+      return { intent, error: result.error || result.errors?.[0] || "Article system setup could not be started." };
     } else if (intent === "build-article-system-preview") {
       const result = await controlVibeMarketingRun(env, request, runId, "approve", { workflow: "repo_scan" });
       const setupRunId = setupRunIdForRun(result);
@@ -349,7 +350,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       const targetKeyword = stringFromForm(formData, "targetKeyword") || candidateKeyword || selectedCandidate?.keyword || customTitle;
       const topic = customTitle || targetKeyword;
       if (!topic && !targetKeyword) {
-        return { error: "Choose a discovered topic or enter a custom title or keyword before generating an article." };
+        return { intent, error: "Choose a discovered topic or enter a custom title or keyword before generating an article." };
       }
       const result = await startVibeMarketingArticle(env, request, {
         topic,
@@ -368,6 +369,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
   } catch (error: any) {
     if (error instanceof Response) throw error;
     return {
+      intent,
       error:
         error?.data?.detail ??
         error?.response?.data?.detail ??
@@ -555,13 +557,17 @@ function RunStepTimeline({ run, framed = true }: { run: VibeMarketingRunSummary;
 
 function RunApprovalActions({
   isSubmitting,
+  isActionPending,
   approveLabel = "Approve",
   denyLabel = "Deny",
 }: {
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
   approveLabel?: string;
   denyLabel?: string;
 }) {
+  const approvePending = isActionPending?.("approve") ?? isSubmitting;
+  const denyPending = isActionPending?.("deny") ?? isSubmitting;
   return (
     <div className="flex flex-wrap gap-2">
       <Form method="POST">
@@ -572,8 +578,8 @@ function RunApprovalActions({
           disabled={isSubmitting}
           className="inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50"
         >
-          <XCircleIcon className="h-4 w-4" />
-          {denyLabel}
+          {denyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <XCircleIcon className="h-4 w-4" />}
+          {denyPending ? "Denying..." : denyLabel}
         </button>
       </Form>
       <Form method="POST">
@@ -584,8 +590,8 @@ function RunApprovalActions({
           disabled={isSubmitting}
           className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
         >
-          <CheckCircleIcon className="h-4 w-4" />
-          {approveLabel}
+          {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+          {approvePending ? "Approving..." : approveLabel}
         </button>
       </Form>
     </div>
@@ -595,9 +601,11 @@ function RunApprovalActions({
 function PublishApprovalPanel({
   run,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const previewUrl = run.previewUrl || stringResultValue(run, "preview_url", "previewUrl", "article_url", "articleUrl");
   const prUrl = run.prUrl || stringResultValue(run, "pr_url", "prUrl", "pull_request_url", "pullRequestUrl");
@@ -633,7 +641,7 @@ function PublishApprovalPanel({
             ) : null}
           </div>
         </div>
-        <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve publish" denyLabel="Deny publish" />
+        <RunApprovalActions isSubmitting={isSubmitting} isActionPending={isActionPending} approveLabel="Approve publish" denyLabel="Deny publish" />
       </div>
     </section>
   );
@@ -682,11 +690,13 @@ function ArticleSystemScanFormPanel({
   bootstrap,
   githubRepos,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   bootstrap: VibeMarketingBootstrap;
   githubRepos: VibeMarketingGithubReposResponse;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const selectedRepo =
     run.githubRepo ||
@@ -698,6 +708,7 @@ function ArticleSystemScanFormPanel({
       bootstrap={bootstrap}
       githubRepos={githubRepos}
       isSubmitting={isSubmitting}
+      isActionPending={isActionPending}
       repoSelection={selectedRepo}
       articleSurfaceDefault={articleSurfaceRouteFromRun(run) || "/articles"}
       articleSurfacePlaceholder="/articles"
@@ -713,12 +724,14 @@ function ArticleSystemSetupPreviewPanel({
   selectedComponent,
   onSelectComponent,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   sourceRun?: VibeMarketingRunSummary | null;
   selectedComponent: VibeMarketingComponentManifestItem | null;
   onSelectComponent: (component: VibeMarketingComponentManifestItem | null) => void;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const setup = articleSystemSetupPayload(run);
   const source = sourceRun ?? run;
@@ -799,6 +812,9 @@ function ArticleSystemSetupPreviewPanel({
         actionSlot={(reviewState) => {
           const needsCommentSubmitFirst = reviewState.draftComments.length > 0 || reviewState.hasPendingRevisionBatch;
           const approveDisabled = isSubmitting || needsCommentSubmitFirst;
+          const submitCommentsPending = isActionPending?.("submit-article-system-comments") ?? isSubmitting;
+          const denyPending = isActionPending?.("deny") ?? isSubmitting;
+          const approvePending = isActionPending?.("approve") ?? isSubmitting;
           return (
             <div className="flex flex-col gap-2 sm:flex-row">
               <Form method="POST">
@@ -810,8 +826,8 @@ function ArticleSystemSetupPreviewPanel({
                   disabled={isSubmitting || !reviewState.canSendRevisionRequest}
                   className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-                  {reviewState.canRetrySubmittedBatch ? "Retry setup comments" : "Send setup comments"}
+                  {submitCommentsPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+                  {submitCommentsPending ? "Sending..." : reviewState.canRetrySubmittedBatch ? "Retry setup comments" : "Send setup comments"}
                 </button>
               </Form>
               {canApprove ? (
@@ -824,8 +840,8 @@ function ArticleSystemSetupPreviewPanel({
                       disabled={isSubmitting}
                       className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50 sm:w-auto"
                     >
-                      <XCircleIcon className="h-4 w-4" />
-                      Deny setup
+                      {denyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <XCircleIcon className="h-4 w-4" />}
+                      {denyPending ? "Denying..." : "Deny setup"}
                     </button>
                   </Form>
                   <Form method="POST">
@@ -837,8 +853,8 @@ function ArticleSystemSetupPreviewPanel({
                       title={needsCommentSubmitFirst ? "Send or clear draft setup comments before approving." : undefined}
                       className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
                     >
-                      <CheckCircleIcon className="h-4 w-4" />
-                      Approve article system
+                      {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                      {approvePending ? "Approving..." : "Approve article system"}
                     </button>
                   </Form>
                 </>
@@ -1492,11 +1508,13 @@ function LiveArticlePreviewPanel({
   selectedComponent,
   onSelectComponent,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   selectedComponent: VibeMarketingComponentManifestItem | null;
   onSelectComponent: (component: VibeMarketingComponentManifestItem | null) => void;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const publishStep = run.workflowProgress?.steps.find((step) => step.id === "publish");
   const acceptArticleIntent = publishStep?.primaryAction?.intent ?? "promote-bundle";
@@ -1533,6 +1551,9 @@ function LiveArticlePreviewPanel({
               publishStep?.status === "ready" &&
               acceptArticleIntent,
           );
+          const acceptArticlePending = isActionPending?.(acceptArticleIntent) ?? isSubmitting;
+          const acceptRevisionPending = isActionPending?.("accept-component-revision") ?? isSubmitting;
+          const submitCommentsPending = isActionPending?.("submit-component-comments") ?? isSubmitting;
           return (
             <div className="flex flex-col gap-2 sm:flex-row">
               {canAcceptArticleForPublish ? (
@@ -1544,8 +1565,8 @@ function LiveArticlePreviewPanel({
                     disabled={isSubmitting}
                     className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
                   >
-                    {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                    Accept article and continue
+                    {acceptArticlePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                    {acceptArticlePending ? "Continuing..." : "Accept article and continue"}
                   </button>
                 </Form>
               ) : null}
@@ -1559,8 +1580,8 @@ function LiveArticlePreviewPanel({
                     disabled={isSubmitting}
                     className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
                   >
-                    <CheckCircleIcon className="h-4 w-4" />
-                    Accept revised article
+                    {acceptRevisionPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                    {acceptRevisionPending ? "Accepting..." : "Accept revised article"}
                   </button>
                 </Form>
               ) : null}
@@ -1572,8 +1593,8 @@ function LiveArticlePreviewPanel({
                   disabled={isSubmitting || !reviewState.canSendRevisionRequest}
                   className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-                  {reviewState.canRetrySubmittedBatch ? "Retry AI revision request" : "Send comments for AI revision"}
+                  {submitCommentsPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+                  {submitCommentsPending ? "Sending..." : reviewState.canRetrySubmittedBatch ? "Retry AI revision request" : "Send comments for AI revision"}
                 </button>
               </Form>
             </div>
@@ -1587,9 +1608,11 @@ function LiveArticlePreviewPanel({
 function ArticlePreviewEmptyState({
   run,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const preview = run.livePreview;
   const previewStatus = String(preview?.status ?? "").trim().toLowerCase();
@@ -1631,6 +1654,7 @@ function ArticlePreviewEmptyState({
   ).trim();
   const displayError =
     String(preview?.error || nativeError || "The article preview could not be prepared. Retry the preview when the generator is available.").trim();
+  const retryPreviewPending = isActionPending?.("start-live-preview") ?? isSubmitting;
   const diagnosticRows = [
     failedPhase ? ["Phase", failedPhase] : null,
     failedCommand ? ["Command", failedCommand] : null,
@@ -1690,11 +1714,11 @@ function ArticlePreviewEmptyState({
                 type="submit"
                 name="intent"
                 value="start-live-preview"
-                disabled={isSubmitting}
+                disabled={retryPreviewPending}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-800 shadow-sm transition hover:bg-red-100 disabled:opacity-50 sm:w-auto"
               >
-                {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
-                Retry preview
+                {retryPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
+                {retryPreviewPending ? "Starting preview..." : "Retry preview"}
               </button>
             </Form>
           ) : (
@@ -1748,11 +1772,13 @@ function ArticleGenerationReviewDetail({
   selectedComponent,
   onSelectComponent,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   selectedComponent: VibeMarketingComponentManifestItem | null;
   onSelectComponent: (component: VibeMarketingComponentManifestItem | null) => void;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const hasArticlePreview = hasReadyArticlePreview(run);
   return (
@@ -1764,9 +1790,10 @@ function ArticleGenerationReviewDetail({
           selectedComponent={selectedComponent}
           onSelectComponent={onSelectComponent}
           isSubmitting={isSubmitting}
+          isActionPending={isActionPending}
         />
       ) : (
-        <ArticlePreviewEmptyState run={run} isSubmitting={isSubmitting} />
+        <ArticlePreviewEmptyState run={run} isSubmitting={isSubmitting} isActionPending={isActionPending} />
       )}
     </div>
   );
@@ -1776,10 +1803,12 @@ function PublishAndAutomateDetail({
   run,
   bootstrap,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   bootstrap: VibeMarketingBootstrap;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const publishStep = run.workflowProgress?.steps.find((step) => step.id === "publish");
   const automationStep = run.workflowProgress?.steps.find((step) => step.id === "automation");
@@ -1833,6 +1862,10 @@ function PublishAndAutomateDetail({
     stringResultValue(run, "pr_number", "pull_request_number", "draft_pr_number") ||
     prNumberFromPullUrl(prUrl);
   const checksStatus = stringResultValue(run, "checks_status", "checksStatus");
+  const promotePending = isActionPending?.("promote-bundle", "publish-pr") ?? isSubmitting;
+  const mergePending = isActionPending?.("merge-publish-pr") ?? isSubmitting;
+  const enableDailyPending = isActionPending?.("enable-daily-automation") ?? isSubmitting;
+  const runDailyPending = isActionPending?.("run-daily-discovery-now") ?? isSubmitting;
   const mergeStatus = stringResultValue(run, "merge_status", "mergeStatus");
   const isMerged = mergeStatus === "merged";
   const dailyCheck = bootstrap.checks.dailyAutomation as
@@ -1918,8 +1951,8 @@ function PublishAndAutomateDetail({
                   disabled={isSubmitting}
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <ArrowPathIcon className="h-4 w-4" />}
-                  {publishChildMissingRemote ? "Retry creating PR" : "Resume publish PR"}
+                  <ArrowPathIcon className={clsx("h-4 w-4", promotePending && "animate-spin")} />
+                  {promotePending ? "Preparing PR..." : publishChildMissingRemote ? "Retry creating PR" : "Resume publish PR"}
                 </button>
               </Form>
             ) : publishChildApprovalRequired ? (
@@ -1935,7 +1968,7 @@ function PublishAndAutomateDetail({
                     Open publish review
                   </a>
                 ) : (
-                  <RunApprovalActions isSubmitting={isSubmitting} approveLabel="Approve publish" denyLabel="Deny publish" />
+                  <RunApprovalActions isSubmitting={isSubmitting} isActionPending={isActionPending} approveLabel="Approve publish" denyLabel="Deny publish" />
                 )}
               </div>
             ) : publishHandoffStale ? (
@@ -1950,8 +1983,8 @@ function PublishAndAutomateDetail({
                   disabled={isSubmitting}
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <ArrowPathIcon className="h-4 w-4" />}
-                  Retry creating PR
+                  <ArrowPathIcon className={clsx("h-4 w-4", promotePending && "animate-spin")} />
+                  {promotePending ? "Preparing PR..." : "Retry creating PR"}
                 </button>
               </Form>
             ) : (
@@ -1966,8 +1999,8 @@ function PublishAndAutomateDetail({
                   disabled={isSubmitting}
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-                  Create publish PR
+                  {promotePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+                  {promotePending ? "Creating PR..." : "Create publish PR"}
                 </button>
               </Form>
             )}
@@ -1992,8 +2025,8 @@ function PublishAndAutomateDetail({
                   disabled={isSubmitting || !prUrl}
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:bg-gray-100 disabled:text-gray-500"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                  Check and merge
+                  {mergePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                  {mergePending ? "Checking..." : "Check and merge"}
                 </button>
               </Form>
             )}
@@ -2021,8 +2054,8 @@ function PublishAndAutomateDetail({
                   disabled={isSubmitting || dailyEnabled || !dailyReady}
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:bg-gray-100 disabled:text-gray-500"
                 >
-                  {dailyEnabled ? <CheckCircleIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
-                  {dailyEnabled ? "Enabled" : "Enable Slack reminder"}
+                  {enableDailyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : dailyEnabled ? <CheckCircleIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
+                  {enableDailyPending ? "Enabling..." : dailyEnabled ? "Enabled" : "Enable Slack reminder"}
                 </button>
               </Form>
               <Form method="POST">
@@ -2031,9 +2064,10 @@ function PublishAndAutomateDetail({
                   name="intent"
                   value="run-daily-discovery-now"
                   disabled={isSubmitting || !dailyEnabled}
-                  className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-50"
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:opacity-50"
                 >
-                  Run today now
+                  {runDailyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : null}
+                  {runDailyPending ? "Starting..." : "Run today now"}
                 </button>
               </Form>
             </div>
@@ -2435,13 +2469,16 @@ function hasExternalPublishEvidence(run: VibeMarketingRunSummary) {
 function ArticleRunActionsMenu({
   run,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const canCancel = canCancelArticleRun(run);
+  const cancelPending = isActionPending?.("cancel-article") ?? isSubmitting;
 
   return (
     <div className="relative">
@@ -2488,7 +2525,7 @@ function ArticleRunActionsMenu({
             <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                disabled={isSubmitting}
+                disabled={cancelPending}
                 onClick={() => setConfirmOpen(false)}
                 className="inline-flex justify-center rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-700 transition hover:bg-gray-50 disabled:opacity-50"
               >
@@ -2499,11 +2536,11 @@ function ArticleRunActionsMenu({
                   type="submit"
                   name="intent"
                   value="cancel-article"
-                  disabled={isSubmitting}
+                  disabled={cancelPending}
                   className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-red-700 disabled:opacity-50 sm:w-auto"
                 >
-                  {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <TrashIcon className="h-4 w-4" />}
-                  Cancel article
+                  {cancelPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <TrashIcon className="h-4 w-4" />}
+                  {cancelPending ? "Cancelling..." : "Cancel article"}
                 </button>
               </Form>
             </div>
@@ -2517,9 +2554,11 @@ function ArticleRunActionsMenu({
 function ArticleWorkflowPrimaryAction({
   run,
   isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const publishStep = run.workflowProgress?.steps.find((step) => step.id === "publish");
   const publishUrl = publishPreviewUrlForRun(run) || publishPrUrlForRun(run);
@@ -2528,11 +2567,12 @@ function ArticleWorkflowPrimaryAction({
   if (isPublishApprovalGate(run)) return null;
 
   if (publishStep?.status === "ready" && publishStep.primaryAction?.intent) {
+    const publishPending = isActionPending?.(publishStep.primaryAction.intent) ?? isSubmitting;
     return (
       <Form method="POST">
         <button type="submit" name="intent" value={publishStep.primaryAction.intent} disabled={isSubmitting} className={`${buttonClass} bg-gray-950 text-white hover:bg-black`}>
-          {isSubmitting ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-          {publishStep.primaryAction.label || "Publish to website"}
+          {publishPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+          {publishPending ? "Preparing publish..." : publishStep.primaryAction.label || "Publish to website"}
         </button>
       </Form>
     );
@@ -2669,13 +2709,13 @@ export default function FounderToolsMarketingRun() {
   const { run: loaderRun, bootstrap, setupRun: loaderSetupRun, githubRepos } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
+  const location = useLocation();
   const runStatusFetcher = useFetcher<VibeMarketingRunSummary>();
   const previewStartFetcher = useFetcher<typeof action>();
   const previewStartRunRef = useRef("");
   const [polledRun, setPolledRun] = useState<VibeMarketingRunSummary | null>(null);
   const run = polledRun ?? loaderRun;
   const [selectedComponent, setSelectedComponent] = useState<VibeMarketingComponentManifestItem | null>(null);
-  const isSubmitting = navigation.state === "submitting";
   const statusUrl = `/founder-tools/marketing/runs/${encodeURIComponent(loaderRun.runId)}/status`;
   const workflow = String(run.workflow ?? "");
   const isScanRun = SCAN_WORKFLOWS.has(workflow);
@@ -2725,6 +2765,34 @@ export default function FounderToolsMarketingRun() {
       previewStatus !== "starting" &&
       previewStartFetcher.state === "idle",
   );
+  const pendingActions = useMarketingActionPending({
+    navigationState: navigation.state,
+    navigationFormData: navigation.formData,
+    clearSignal: [
+      location.pathname,
+      location.search,
+      run.runId,
+      run.status,
+      run.currentStep,
+      run.updatedAt,
+      run.previewUrl,
+      run.prUrl,
+      run.publishChildStatus,
+      run.publishChildRecoverable,
+      run.publishChildWaitReason,
+      run.livePreview?.status,
+      run.livePreview?.previewUrl,
+      run.componentFeedback?.latestBatch?.id,
+      run.componentFeedback?.latestBatch?.status,
+      run.workflowProgress?.steps.map((step) => `${step.id}:${step.status}`).join(","),
+      setupRun?.runId,
+      setupRun?.status,
+      bootstrap.latestRuns.map((item) => `${item.runId}:${item.status}`).join(","),
+      bootstrap.settings.dailyDiscoveryEnabled,
+    ].join("|"),
+    errorKey: actionData?.error && typeof actionData.intent === "string" ? actionData.intent : null,
+  });
+  const isSubmitting = pendingActions.isAnyPending || previewStartFetcher.state !== "idle";
 
   useEffect(() => {
     setPolledRun(null);
@@ -2799,24 +2867,25 @@ export default function FounderToolsMarketingRun() {
         title={directPublishMode || isPublishAutomateView ? "Create and publish article" : "Create article"}
         titleAs="h1"
         isSubmitting={isSubmitting}
-        topRightActionSlot={isArticleWorkflowRun ? <ArticleRunActionsMenu run={run} isSubmitting={isSubmitting} /> : undefined}
-        primaryActionSlot={isArticleWorkflowRun && directPublishMode && !isPublishAutomateView ? <ArticleWorkflowPrimaryAction run={run} isSubmitting={isSubmitting} /> : undefined}
+        topRightActionSlot={isArticleWorkflowRun ? <ArticleRunActionsMenu run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : undefined}
+        primaryActionSlot={isArticleWorkflowRun && directPublishMode && !isPublishAutomateView ? <ArticleWorkflowPrimaryAction run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : undefined}
         activeDetailSlot={
           isArticleGenerationRun && isPublishAutomateView ? (
-            <PublishAndAutomateDetail run={run} bootstrap={bootstrap} isSubmitting={isSubmitting} />
+            <PublishAndAutomateDetail run={run} bootstrap={bootstrap} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
           ) : isArticleGenerationRun ? (
             <ArticleGenerationReviewDetail
               run={run}
               selectedComponent={selectedComponent}
               onSelectComponent={setSelectedComponent}
               isSubmitting={isSubmitting || previewStartFetcher.state !== "idle"}
+              isActionPending={pendingActions.isPending}
             />
           ) : undefined
         }
         activeDetailLabel={isPublishAutomateView ? "Publish & automate progress" : "Generating article progress"}
       />
 
-      {isPublishApproval && directPublishMode ? <PublishApprovalPanel run={run} isSubmitting={isSubmitting} /> : null}
+      {isPublishApproval && directPublishMode ? <PublishApprovalPanel run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : null}
 
       {!isCompletedArticleReviewPage ? (
         <main className="space-y-6">
@@ -2851,8 +2920,8 @@ export default function FounderToolsMarketingRun() {
                         <p className="mt-1 max-w-2xl text-sm font-black leading-5 text-gray-950">{selectedDiscoveryCandidate.title}</p>
                       </div>
                       <button type="submit" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50">
-                        <CheckCircleIcon className="h-4 w-4" />
-                        Generate draft article
+                        {pendingActions.isPending("start-article") ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                        {pendingActions.isPending("start-article") ? "Starting article..." : "Generate draft article"}
                       </button>
                     </div>
                   </div>
@@ -2872,9 +2941,10 @@ export default function FounderToolsMarketingRun() {
               selectedComponent={selectedComponent}
               onSelectComponent={setSelectedComponent}
               isSubmitting={isSubmitting}
+              isActionPending={pendingActions.isPending}
             />
           ) : isScanRun ? (
-            <ArticleSystemScanFormPanel run={run} bootstrap={bootstrap} githubRepos={githubRepos} isSubmitting={isSubmitting} />
+            <ArticleSystemScanFormPanel run={run} bootstrap={bootstrap} githubRepos={githubRepos} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
           ) : null}
 
           {showRunAttentionBanner ? (
@@ -2896,8 +2966,8 @@ export default function FounderToolsMarketingRun() {
                       disabled={isSubmitting}
                       className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm font-bold text-amber-900 shadow-sm transition hover:bg-amber-100 disabled:opacity-50 sm:w-auto"
                     >
-                      <PlayIcon className="h-4 w-4" />
-                      Resume run
+                      {pendingActions.isPending("resume") ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
+                      {pendingActions.isPending("resume") ? "Resuming..." : "Resume run"}
                     </button>
                   </Form>
                 ) : null}

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/founder-tools.marketing";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useNavigation } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation } from "react-router";
 import type { KeyboardEvent, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -28,6 +28,7 @@ import { clsx } from "clsx";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
+import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   controlVibeMarketingRun,
   getVibeMarketingBootstrap,
@@ -494,6 +495,12 @@ function actionError(data: unknown): string | null {
   if (!data || typeof data !== "object" || !("error" in data)) return null;
   const error = (data as { error?: unknown }).error;
   return typeof error === "string" ? error : null;
+}
+
+function actionIntent(data: unknown): string | null {
+  if (!data || typeof data !== "object" || !("intent" in data)) return null;
+  const intent = (data as { intent?: unknown }).intent;
+  return typeof intent === "string" ? intent : null;
 }
 
 function numericValue(value: unknown): number | null {
@@ -2323,11 +2330,14 @@ function TopicDeclineRequest({
 function ReturningTopicPickerPage({
   bootstrap,
   error,
+  errorIntent,
 }: {
   bootstrap: VibeMarketingBootstrap;
   error: string | null;
+  errorIntent?: string | null;
 }) {
   const navigation = useNavigation();
+  const location = useLocation();
   const restoreFetcher = useFetcher<TopicFeedbackActionData>();
   const baseTopics = useMemo(
     () => bootstrap.topicCandidates.filter((topic) => !topic.alreadyWritten).slice(0, 8),
@@ -2366,10 +2376,19 @@ function ReturningTopicPickerPage({
   const companyName = bootstrap.settings.brandName || bootstrap.organization.name || bootstrap.company.name || "YourStartup";
   const domain = bootstrap.company.domain || bootstrap.organization.domain;
   const tags = startupTags(bootstrap);
-  const [articleStartPending, setArticleStartPending] = useState(false);
-  const isSubmitting = navigation.state === "submitting";
-  const isArticleStartNavigation = navigation.formData?.get("intent") === "start-article";
-  const articleSubmitting = articleStartPending || (navigation.state !== "idle" && isArticleStartNavigation);
+  const latestArticleRunId =
+    bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article", "article_revision"].includes(run.workflow))?.runId ?? "";
+  const latestDiscoveryRunId =
+    bootstrap.latestRuns.find((run) => ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(run.workflow))?.runId ?? "";
+  const pendingActions = useMarketingActionPending({
+    navigationState: navigation.state,
+    navigationFormData: navigation.formData,
+    clearSignal: `${location.pathname}${location.search}:${latestArticleRunId}:${latestDiscoveryRunId}:${bootstrap.topicCandidates.length}`,
+    errorKey: error ? errorIntent : null,
+  });
+  const isSubmitting = pendingActions.isAnyPending;
+  const articleSubmitting = pendingActions.isPending("start-article");
+  const discoverySubmitting = pendingActions.isPending("start-discovery", "discovery");
   const restoreBusy = restoreFetcher.state !== "idle";
   const visibleTopics = topics.slice(0, visibleCount);
   const [declineRequests, setDeclineRequests] = useState<Record<string, VibeMarketingTopicCandidate>>({});
@@ -2378,10 +2397,6 @@ function ReturningTopicPickerPage({
     if (articleSubmitting || !selectedTopic) return;
     articleFormRef.current?.requestSubmit();
   }, [articleSubmitting, selectedTopic]);
-
-  const handleArticleSubmit = useCallback(() => {
-    setArticleStartPending(true);
-  }, []);
 
   const submitRestoreFeedback = useCallback((feedbackId: string) => {
     const formData = new FormData();
@@ -2428,18 +2443,6 @@ function ReturningTopicPickerPage({
       setSelectedTopicId(topics[0].id);
     }
   }, [selectedTopicId, topics]);
-
-  useEffect(() => {
-    if (navigation.state !== "idle" && isArticleStartNavigation) {
-      setArticleStartPending(true);
-    }
-  }, [isArticleStartNavigation, navigation.state]);
-
-  useEffect(() => {
-    if (navigation.state === "idle") {
-      setArticleStartPending(false);
-    }
-  }, [navigation.state]);
 
   const handleDeclineResult = useCallback((data: TopicFeedbackActionData) => {
     if (!data || data.intent !== "decline-topic") return;
@@ -2502,7 +2505,7 @@ function ReturningTopicPickerPage({
   return (
     <div className="mx-auto max-w-[1500px] px-4 py-9 sm:px-6 lg:px-10">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(440px,0.92fr)] xl:items-start">
-        <Form ref={articleFormRef} method="POST" onSubmit={handleArticleSubmit} className="space-y-5">
+        <Form ref={articleFormRef} method="POST" className="space-y-5">
           <input type="hidden" name="intent" value="start-article" />
           <input type="hidden" name="topicCandidateId" value={activeTab === "choose" ? selectedTopicId : "__custom__"} />
           <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} />
@@ -2774,8 +2777,8 @@ function ReturningTopicPickerPage({
                   disabled={isSubmitting}
                   className="inline-flex items-center justify-center gap-2 rounded-xl border border-violet-300 bg-white px-5 py-3 text-sm font-black text-violet-700 transition hover:bg-violet-50 disabled:opacity-50"
                 >
-                  <Sparkles className="h-4 w-4" />
-                  Generate ideas
+                  {discoverySubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                  {discoverySubmitting ? "Generating ideas..." : "Generate ideas"}
                 </button>
               </Form>
             </div>
@@ -2797,12 +2800,13 @@ export default function FounderToolsMarketing() {
   const { bootstrap } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const error = actionError(actionData);
+  const errorIntent = actionIntent(actionData);
   const shouldShowTopicPicker = bootstrap.startPageMode === "topic_picker" || Boolean(bootstrap.hasCompletedArticleFlow);
 
   return (
     <div className="min-h-screen bg-[#fbfaf8]">
       {shouldShowTopicPicker ? (
-        <ReturningTopicPickerPage bootstrap={bootstrap} error={error} />
+        <ReturningTopicPickerPage bootstrap={bootstrap} error={error} errorIntent={errorIntent} />
       ) : (
         <VibeMarketingStartupBaselineSetup bootstrap={bootstrap} error={error} />
       )}


### PR DESCRIPTION
## Summary
- add a reusable marketing pending-action hook that keeps clicked actions loading until route/data/run evidence changes or an action error returns
- apply durable loading to company setup, marketing dashboard CTAs, repo scan/setup actions, research/article starts, run controls, preview, publish, and daily automation buttons
- keep GitHub OAuth in a persistent waiting state while the original tab revalidates the connection

## Tests
- bun run typecheck