### PR TITLE
[codex] Frame first-run article setup UX

### DIFF
--- a/app/components/ArticleRunStageProgress.tsx
+++ b/app/components/ArticleRunStageProgress.tsx
@@ -56,10 +56,10 @@ const ARTICLE_PROGRESS_STAGES: StageDefinition[] = [
   },
   {
     id: "article_system",
-    label: "Understanding article system",
-    activeText: "Finding the right article structure and publishing path.",
-    completeText: "The article system is understood.",
-    pendingText: "The article system is checked after repository access.",
+    label: "Understanding articles location",
+    activeText: "Finding the right articles/blogs structure and publishing path.",
+    completeText: "The articles location is understood.",
+    pendingText: "The articles location is checked after repository access.",
   },
   {
     id: "startup_context",

--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -533,7 +533,7 @@ export default function ArticleSystemConnectionPanel({
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 className="text-2xl font-black tracking-tight text-slate-950 sm:text-3xl">
-            Connect GitHub & set your articles location
+            Connect GitHub & set your articles/blogs location
           </h2>
           <p className="mt-3 max-w-4xl text-base font-medium leading-7 text-slate-600">
             Choose the repository that contains your website, run a read-only scan, then choose where articles should live.
@@ -719,7 +719,7 @@ export default function ArticleSystemConnectionPanel({
         {inventoryReady ? (
           <FlowStep
             number={3}
-            title="Choose your articles location"
+            title="Choose your articles/blogs location"
             description="Pick the right place from routes we found, paste a path manually, or create a new articles directory."
           >
             <div className="space-y-3">
@@ -807,7 +807,7 @@ export default function ArticleSystemConnectionPanel({
         ) : null}
 
         {selectedSurfaceUrl || setupTargetReady ? (
-          <FlowStep number={4} title="Article location selected">
+          <FlowStep number={4} title="Articles/blogs location selected">
             {setupTargetReady ? (
               <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
                 <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
@@ -816,9 +816,9 @@ export default function ArticleSystemConnectionPanel({
                       <FileText className="h-6 w-6" />
                     </span>
                     <div>
-                      <p className="text-sm font-black text-slate-950">Article system target saved</p>
+                      <p className="text-sm font-black text-slate-950">Articles/blogs location saved</p>
                       <p className="mt-1 text-sm font-semibold text-slate-500">
-                        Continue to generate and review the article system preview.
+                        Continue to setup review to build and inspect the articles setup preview.
                       </p>
                     </div>
                   </div>
@@ -832,7 +832,7 @@ export default function ArticleSystemConnectionPanel({
                     to="/founder-tools/marketing/create?step=writeCheck"
                     className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700"
                   >
-                    Continue to generate
+                    Generate articles setup preview
                     <ArrowRight className="h-4 w-4" />
                   </Link>
                 </div>
@@ -862,7 +862,7 @@ export default function ArticleSystemConnectionPanel({
                 <div className="flex flex-col justify-center gap-3">
                   <p className="flex items-start gap-2 text-sm font-semibold leading-6 text-slate-600">
                     <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-600" />
-                    Good choice. Content Factory will use this location for the setup preview.
+                    Good choice. Content Factory will use this location for the articles setup preview.
                   </p>
                   <div className="flex flex-col gap-2 sm:flex-row lg:flex-col">
                     <button

--- a/app/components/MarketingRunProgressCard.tsx
+++ b/app/components/MarketingRunProgressCard.tsx
@@ -10,6 +10,16 @@ function labelForStatus(status: string) {
   return status.replace(/_/g, " ");
 }
 
+function labelForWorkflow(workflow: string) {
+  if (workflow === "article_system_setup") return "Articles setup";
+  if (workflow === "repo_scan" || workflow === "content_factory_scan") return "Repository scan";
+  return workflow.replace(/_/g, " ");
+}
+
+function labelForCurrentStep(step: string) {
+  return step.replace(/article_system/g, "articles_setup").replace(/_/g, " ");
+}
+
 function shortErrorMessage(run: VibeMarketingRunSummary, error: string) {
   if (["repo_scan", "content_factory_scan"].includes(run.workflow)) {
     return "Repository scan failed. Retry the scan or choose a different repository.";
@@ -30,9 +40,9 @@ export default function MarketingRunProgressCard({ run }: MarketingRunProgressCa
   const currentStepLabel = isStaleQueuedScan
     ? "The scan worker did not pick up this job. Retry the scan or cancel it and start again."
     : isScanActionNeeded
-    ? "The repository scan finished. Choose the article route, start a new setup preview, or cancel this scan."
+    ? "The repository scan finished. Choose the articles/blogs location, start a new setup preview, or cancel this scan."
     : run.currentStep
-      ? run.currentStep.replace(/_/g, " ")
+      ? labelForCurrentStep(run.currentStep)
       : "Waiting for next update";
   const totalSteps = Math.max(run.steps.length, run.stepOrder.length, 1);
   const completedSteps = run.steps.filter((step) => step.status === "completed" || step.status === "skipped").length;
@@ -50,7 +60,7 @@ export default function MarketingRunProgressCard({ run }: MarketingRunProgressCa
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-base font-black text-gray-950">{run.workflow.replace(/_/g, " ")}</h2>
+            <h2 className="text-base font-black text-gray-950">{labelForWorkflow(run.workflow)}</h2>
             <span className={clsx("rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide", isFailed || isStaleQueuedScan ? "bg-red-100 text-red-700" : "bg-white text-violet-700")}>
               {statusLabel}
             </span>

--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -26,6 +26,7 @@ import type {
 interface MarketingWorkflowShellProps {
   progress?: VibeMarketingWorkflowProgress | null;
   viewedStepId?: string | null;
+  workflowMode?: "article" | "article_setup";
   title?: string;
   titleAs?: "h1" | "h2";
   subtitle?: string;
@@ -81,8 +82,8 @@ const WORKFLOW_DISPLAY_GROUPS: WorkflowDisplayGroupDefinition[] = [
   },
   {
     id: "repo_article_system",
-    label: "Connect repo & article system",
-    summary: "Connect GitHub, scan the repository, and prepare the article system.",
+    label: "Connect repo & articles location",
+    summary: "Connect GitHub, scan the repository, and prepare the articles/blogs location.",
     stepIds: ["repo", "article_system"],
     completionStepId: "article_system",
     icon: CodeBracketIcon,
@@ -108,6 +109,49 @@ const WORKFLOW_DISPLAY_GROUPS: WorkflowDisplayGroupDefinition[] = [
     label: "Publish & automate",
     summary: "Review the package, publish to the site, and enable daily automation.",
     stepIds: ["package", "publish", "automation"],
+    completionStepId: "automation",
+    icon: RocketLaunchIcon,
+  },
+];
+
+const ARTICLE_SETUP_WORKFLOW_DISPLAY_GROUPS: WorkflowDisplayGroupDefinition[] = [
+  {
+    id: "profile_baseline",
+    label: "Startup profile & baseline",
+    summary: "Company details, competitors, seed keywords, and the starting website baseline.",
+    stepIds: ["profile", "baseline"],
+    completionStepId: "baseline",
+    icon: UserCircleIcon,
+  },
+  {
+    id: "repo_article_system",
+    label: "Connect repo & articles location",
+    summary: "Prepare the repo location where future articles will be written.",
+    stepIds: ["repo", "article_system", "generate", "review", "revise", "package", "publish"],
+    completionStepId: "article_system",
+    icon: CodeBracketIcon,
+  },
+  {
+    id: "research_topic",
+    label: "Research & choose topic",
+    summary: "Find topic opportunities and choose the article brief after setup is complete.",
+    stepIds: ["research", "choose_topic"],
+    completionStepId: "choose_topic",
+    icon: MagnifyingGlassIcon,
+  },
+  {
+    id: "article_creation",
+    label: "Generate article",
+    summary: "Generate the first SEO article after the articles location is ready.",
+    stepIds: [],
+    completionStepId: "generate",
+    icon: PencilSquareIcon,
+  },
+  {
+    id: "publish_automation",
+    label: "Publish & automate",
+    summary: "Publish reviewed articles and enable daily automation after setup is complete.",
+    stepIds: [],
     completionStepId: "automation",
     icon: RocketLaunchIcon,
   },
@@ -194,9 +238,10 @@ function groupForStepId(stepId: string | null | undefined, groups: WorkflowDispl
   return groups.find((group) => group.childSteps.some((step) => step.id === stepId));
 }
 
-function buildWorkflowDisplayGroups(steps: VibeMarketingWorkflowStep[]): WorkflowDisplayGroup[] {
+function buildWorkflowDisplayGroups(steps: VibeMarketingWorkflowStep[], workflowMode: MarketingWorkflowShellProps["workflowMode"]): WorkflowDisplayGroup[] {
+  const definitions = workflowMode === "article_setup" ? ARTICLE_SETUP_WORKFLOW_DISPLAY_GROUPS : WORKFLOW_DISPLAY_GROUPS;
   const stepById = new Map(steps.map((step) => [step.id, step]));
-  return WORKFLOW_DISPLAY_GROUPS.map((definition) => {
+  return definitions.map((definition) => {
     const childSteps = definition.stepIds.map((stepId) => stepById.get(stepId)).filter((step): step is VibeMarketingWorkflowStep => Boolean(step));
     const actionableStep = childSteps.find((step) => ACTIONABLE_STATUSES.has(step.status));
     const completionStep = stepById.get(definition.completionStepId) ?? childSteps[childSteps.length - 1] ?? childSteps[0];
@@ -223,6 +268,7 @@ function buildWorkflowDisplayGroups(steps: VibeMarketingWorkflowStep[]): Workflo
 export default function MarketingWorkflowShell({
   progress,
   viewedStepId,
+  workflowMode = "article",
   title = "Article workflow",
   titleAs = "h2",
   subtitle,
@@ -241,7 +287,7 @@ export default function MarketingWorkflowShell({
   if (!steps.length) return null;
   const requiredStep = steps.find((step) => step.id === progress?.currentStepId) ?? steps.find((step) => step.status !== "complete" && step.status !== "locked") ?? steps[0];
   const viewedStep = steps.find((step) => step.id === viewedStepId) ?? requiredStep;
-  const displayGroups = buildWorkflowDisplayGroups(steps);
+  const displayGroups = buildWorkflowDisplayGroups(steps, workflowMode);
   const requiredGroup = groupForStepId(requiredStep.id, displayGroups) ?? displayGroups[0];
   const viewedGroup = groupForStepId(viewedStep.id, displayGroups) ?? requiredGroup;
   const viewingRequiredGroup = viewedGroup.id === requiredGroup.id;

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -907,11 +907,11 @@ const DEV_BOOTSTRAP: VibeMarketingBootstrap = {
       },
       {
         id: "article_system",
-        label: "Article system",
+        label: "Articles location",
         phase: "Setup",
         status: "complete",
         href: "/founder-tools/marketing/create?step=articleSystem",
-        summary: "Detect or prepare the article route, registry, and publish target.",
+        summary: "Detect or prepare the articles/blogs route and repo location.",
         primaryAction: null,
         order: 4,
       },

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -117,11 +117,11 @@ const STEP_EXPLAINERS: Record<VibeMarketingStepKey, StepExplainer> = {
   },
   scan: {
     why: "Repository scanning is only needed for direct website publishing.",
-    next: "The scan records framework, routes, build commands, article components, and publish targets.",
+    next: "The scan records framework, routes, build commands, article components, and publishing details.",
     safety: "The scan does not publish changes.",
   },
   articleSystem: {
-    why: "GitHub access lets Content Factory inspect the website repo and find the exact article route before editing anything.",
+    why: "GitHub access lets Content Factory inspect the website repo and find the exact articles/blogs location before editing anything.",
     next: "Choose the repo and articles URL, scan the structure, then approve a setup preview only if changes are needed.",
     safety: "The agent creates review branches and previews; nothing is merged or published until you explicitly approve.",
   },
@@ -493,7 +493,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (intent === "build-article-system-preview") {
       const scanRunId = stringFromForm(formData, "scanRunId");
       if (!scanRunId) {
-        return { intent, error: "Open the scan result before building the article system preview." };
+        return { intent, error: "Open the scan result before building the articles setup preview." };
       }
       const result = await controlVibeMarketingRun(env, request, scanRunId, "approve", { workflow: "repo_scan" });
       const setupRunId = setupRunIdForRun(result);
@@ -685,6 +685,8 @@ export default function FounderToolsMarketingCreate() {
   const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
   const pendingArticleSystemScan = scanRunHasPendingArticleSystemSetup(latestScan) ? latestScan : null;
   const pendingArticleSystemSetupRunId = pendingArticleSystemScan ? setupRunIdForRun(pendingArticleSystemScan) : "";
+  const pendingSetupStepActive = Boolean(pendingArticleSystemScan && ["writeCheck", "editArticle", "reviewPublish"].includes(activeStep));
+  const articleSetupFlowActive = isRepoArticleStep || pendingSetupStepActive;
   const latestDiscovery = bootstrap.latestRuns.find((run) => ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(run.workflow));
   const latestArticle = bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article"].includes(run.workflow));
   const latestContentPackage = latestArticle?.contentPackage ?? bootstrap.publishEvidence?.contentPackage ?? null;
@@ -794,8 +796,10 @@ export default function FounderToolsMarketingCreate() {
       {!setupStepActive ? (
         <MarketingWorkflowShell
           progress={bootstrap.workflowProgress}
-          viewedStepId={WORKFLOW_STEP_ID_BY_CREATE_STEP[activeStep]}
-          title="Create and publish article"
+          viewedStepId={articleSetupFlowActive ? "article_system" : WORKFLOW_STEP_ID_BY_CREATE_STEP[activeStep]}
+          workflowMode={articleSetupFlowActive ? "article_setup" : "article"}
+          title={articleSetupFlowActive ? "Set up articles/blogs location" : "Create and publish article"}
+          subtitle={articleSetupFlowActive ? "Prepare the repo location where future articles will be written." : undefined}
           isSubmitting={isSubmitting}
           showPrimaryAction={false}
         />
@@ -1009,10 +1013,10 @@ export default function FounderToolsMarketingCreate() {
                 title={
                   pendingArticleSystemScan
                     ? activeStep === "reviewPublish"
-                      ? "Publish article system"
+                      ? "Approve articles setup"
                       : activeStep === "editArticle"
-                        ? "Review articles page preview"
-                        : "Generate article system"
+                        ? "Review articles setup preview"
+                        : "Generate articles setup preview"
                     :
                   activeStep === "editArticle"
                     ? "Edit article"
@@ -1026,7 +1030,7 @@ export default function FounderToolsMarketingCreate() {
                 }
                 description={
                   pendingArticleSystemScan
-                    ? "Build the articles/blog page setup, inspect the Cloudflare preview, then approve the setup PR."
+                    ? "Build the articles/blogs location setup, inspect the Cloudflare preview, then approve the setup PR."
                     : reviewDescription
                 }
                 passed={
@@ -1046,7 +1050,7 @@ export default function FounderToolsMarketingCreate() {
                       to={`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemSetupRunId)}`}
                       className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black"
                     >
-                      Open article system preview
+                      Open articles setup preview
                       <ArrowRightIcon className="h-4 w-4" />
                     </Link>
                   ) : pendingArticleSystemScan.status === "awaiting_confirmation" || pendingArticleSystemScan.status === "awaiting_approval" || pendingArticleSystemScan.status === "approval_required" ? (
@@ -1060,7 +1064,7 @@ export default function FounderToolsMarketingCreate() {
                         className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60"
                       >
                         {buildArticleSystemPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                        {buildArticleSystemPreviewPending ? "Generating preview..." : "Generate article system preview"}
+                        {buildArticleSystemPreviewPending ? "Generating preview..." : "Generate articles setup preview"}
                       </button>
                     </Form>
                   ) : (

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -309,7 +309,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         auto_setup_preview: false,
       });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
-      return { intent, error: result.error || result.errors?.[0] || "Article system setup could not be started." };
+      return { intent, error: result.error || result.errors?.[0] || "Articles setup could not be started." };
     } else if (intent === "build-article-system-preview") {
       const result = await controlVibeMarketingRun(env, request, runId, "approve", { workflow: "repo_scan" });
       const setupRunId = setupRunIdForRun(result);
@@ -760,14 +760,15 @@ function ArticleSystemSetupPreviewPanel({
     .filter(Boolean)
     .slice(0, 8);
   const canApprove = run.status === "awaiting_approval" || run.status === "approval_required";
+  const setupCompleted = run.status === "completed" || run.approvalState === "approved";
 
   return (
     <section className="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h2 className="text-lg font-black text-gray-950">Article system preview</h2>
+          <h2 className="text-lg font-black text-gray-950">Articles setup preview</h2>
           <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-            Review the drafted articles page setup before it is merged into the website repo.
+            Review the drafted articles/blogs setup before it is merged into the website repo.
           </p>
           <div className="mt-3 flex flex-wrap gap-2 text-xs font-black">
             {repo ? <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-700">{repo}</span> : null}
@@ -802,12 +803,12 @@ function ArticleSystemSetupPreviewPanel({
         selectedComponent={selectedComponent}
         onSelectComponent={onSelectComponent}
         previewUrlFallback={previewUrl}
-        previewTitle="Article system setup preview"
-        reviewTitle="Setup review comments"
-        draftNoun="setup pin"
-        emptyDraftText="0 draft setup pins ready for review."
-        submittedRetryText="Submitted setup comments are ready to retry."
-        waitingBridgeText="Waiting for setup comment bridge"
+        previewTitle="Articles setup preview"
+        reviewTitle="Articles setup comments"
+        draftNoun="revision pin"
+        emptyDraftText="0 draft revision pins ready for review."
+        submittedRetryText="Submitted revision comments are ready to retry."
+        waitingBridgeText="Waiting for revision bridge"
         unavailableSlot={<ArticleSystemSetupPreviewUnavailable run={run} previewUrl={previewUrl} />}
         actionSlot={(reviewState) => {
           const needsCommentSubmitFirst = reviewState.draftComments.length > 0 || reviewState.hasPendingRevisionBatch;
@@ -827,7 +828,7 @@ function ArticleSystemSetupPreviewPanel({
                   className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
                 >
                   {submitCommentsPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-                  {submitCommentsPending ? "Sending..." : reviewState.canRetrySubmittedBatch ? "Retry setup comments" : "Send setup comments"}
+                  {submitCommentsPending ? "Sending..." : reviewState.canRetrySubmittedBatch ? "Retry revision comments" : "Send revision comments"}
                 </button>
               </Form>
               {canApprove ? (
@@ -841,7 +842,7 @@ function ArticleSystemSetupPreviewPanel({
                       className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50 sm:w-auto"
                     >
                       {denyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <XCircleIcon className="h-4 w-4" />}
-                      {denyPending ? "Denying..." : "Deny setup"}
+                      {denyPending ? "Rejecting..." : "Reject setup"}
                     </button>
                   </Form>
                   <Form method="POST">
@@ -850,11 +851,11 @@ function ArticleSystemSetupPreviewPanel({
                       name="intent"
                       value="approve"
                       disabled={approveDisabled}
-                      title={needsCommentSubmitFirst ? "Send or clear draft setup comments before approving." : undefined}
+                      title={needsCommentSubmitFirst ? "Send or clear draft revision comments before approving." : undefined}
                       className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
                     >
                       {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                      {approvePending ? "Approving..." : "Approve article system"}
+                      {approvePending ? "Approving..." : "Approve articles setup"}
                     </button>
                   </Form>
                 </>
@@ -863,6 +864,23 @@ function ArticleSystemSetupPreviewPanel({
           );
         }}
       />
+
+      {setupCompleted ? (
+        <div className="flex flex-col gap-3 rounded-xl border border-emerald-100 bg-emerald-50 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-black text-emerald-950">Articles setup approved</p>
+            <p className="mt-1 text-sm font-semibold leading-6 text-emerald-800">
+              Future articles can now be generated into this repo location.
+            </p>
+          </div>
+          <Link
+            to="/founder-tools/marketing/create?step=research"
+            className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700"
+          >
+            Continue to topic research
+          </Link>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -884,7 +902,7 @@ function ArticleSystemSetupPreviewUnavailable({
       "rounded-xl border px-4 py-5 text-sm font-semibold",
       error ? "border-red-200 bg-red-50 text-red-800" : "border-violet-100 bg-violet-50 text-violet-800",
     )}>
-      <p className="font-black">{error ? "Setup preview could not be prepared" : "Hosted setup preview is being built"}</p>
+      <p className="font-black">{error ? "Articles setup preview could not be prepared" : "Articles setup preview is being built"}</p>
       <p className="mt-1">Preview status: {previewStatus}. Refreshing this page is safe.</p>
       {error ? <p className="mt-2 break-words font-mono text-xs">{error}</p> : null}
       {logsUrl ? (
@@ -2666,6 +2684,7 @@ function viewedWorkflowStepIdForRun(run: VibeMarketingRunSummary) {
     return run.status === "awaiting_confirmation" ? "choose_topic" : "research";
   }
   if (SCAN_WORKFLOWS.has(workflow)) return "article_system";
+  if (workflow === "article_system_setup") return "article_system";
   if (workflow === "website_baseline") return "baseline";
   if (workflow === "article_revision") return hasPublishHandoffEvidence(run) ? "publish" : "revise";
   if (isArticleWorkflow(workflow)) {
@@ -2752,6 +2771,7 @@ export default function FounderToolsMarketingRun() {
   const deliveryMode = deliveryModeForRun(run, bootstrap);
   const directPublishMode = deliveryMode === "publish_code";
   const isPublishAutomateView = Boolean(isArticleGenerationRun && (viewedWorkflowStepId === "publish" || viewedWorkflowStepId === "automation"));
+  const isArticleSetupContext = isScanRun || isArticleSystemSetupRun || Boolean(effectiveSetupPreviewRun);
   const isCompletedArticleReviewPage = hasArticlePreview && run.status === "completed" && !isPublishAutomateView;
   const previewStatus = String(run.livePreview?.status ?? "").trim().toLowerCase();
   const previewFailed = isFailedArticlePreview(run.livePreview);
@@ -2864,8 +2884,10 @@ export default function FounderToolsMarketingRun() {
       <MarketingWorkflowShell
         progress={workflowProgress}
         viewedStepId={viewedWorkflowStepId}
-        title={directPublishMode || isPublishAutomateView ? "Create and publish article" : "Create article"}
+        workflowMode={isArticleSetupContext ? "article_setup" : "article"}
+        title={isArticleSetupContext ? "Set up articles/blogs location" : directPublishMode || isPublishAutomateView ? "Create and publish article" : "Create article"}
         titleAs="h1"
+        subtitle={isArticleSetupContext ? "Prepare the repo location where future articles will be written." : undefined}
         isSubmitting={isSubmitting}
         topRightActionSlot={isArticleWorkflowRun ? <ArticleRunActionsMenu run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : undefined}
         primaryActionSlot={isArticleWorkflowRun && directPublishMode && !isPublishAutomateView ? <ArticleWorkflowPrimaryAction run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : undefined}
@@ -2882,7 +2904,7 @@ export default function FounderToolsMarketingRun() {
             />
           ) : undefined
         }
-        activeDetailLabel={isPublishAutomateView ? "Publish & automate progress" : "Generating article progress"}
+        activeDetailLabel={isArticleSetupContext ? "Articles setup progress" : isPublishAutomateView ? "Publish & automate progress" : "Generating article progress"}
       />
 
       {isPublishApproval && directPublishMode ? <PublishApprovalPanel run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : null}

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -1635,7 +1635,7 @@ function FirstArticleSetupPage({
                 />
               </FormField>
 
-              <FormField label="Website domain" help="Connect this company to its website and article system.">
+              <FormField label="Website domain" help="Connect this company to its website and articles setup.">
                 <input
                   name="domain"
                   value={startupValues.domain}


### PR DESCRIPTION
## Summary
- Frame first-run article directory setup as an articles/blogs location prerequisite instead of article creation.
- Reword setup preview, revision, approval, and completion CTAs.
- Add setup-aware workflow shell grouping for scan/setup runs.

## Validation
- bun run typecheck