### PR TITLE
[codex] Unify articles setup progress

### DIFF
--- a/app/components/ArticlesSetupProgressCard.tsx
+++ b/app/components/ArticlesSetupProgressCard.tsx
@@ -1,0 +1,198 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { ArrowPathIcon, CheckCircleIcon, ExclamationTriangleIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import { clsx } from "clsx";
+
+import type { VibeMarketingRunSummary, VibeMarketingStepState } from "~/types/vibe-marketing";
+
+interface ArticlesSetupProgressCardProps {
+  run: VibeMarketingRunSummary;
+  actionSlot?: ReactNode;
+  technicalUrl?: string;
+  className?: string;
+}
+
+const COMPLETE_STEP_STATUSES = new Set(["completed", "skipped"]);
+const FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "denied", "cancelled"]);
+const READY_STATUSES = new Set(["awaiting_confirmation", "awaiting_approval", "approval_required"]);
+const RUNNING_STATUSES = new Set(["queued", "pending", "starting", "running"]);
+
+function humanize(value: string) {
+  const normalized = value
+    .replace(/article_system/g, "articles_setup")
+    .replace(/repo/g, "repository")
+    .replace(/_/g, " ")
+    .trim();
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function setupStepLabel(stepKey: string) {
+  const labels: Record<string, string> = {
+    load_repo_context: "Loading repository context",
+    scan_structure: "Checking articles/blogs location",
+    fetch_org_config: "Loading setup context",
+    synthesize_repository_contract: "Preparing setup instructions",
+    draft_article_system_setup: "Drafting articles setup changes",
+    build_preview: "Building articles setup preview",
+    render_preview: "Rendering articles setup preview",
+    package_preview: "Preparing review assets",
+    finalize: "Finalizing setup preview",
+  };
+  return labels[stepKey] ?? humanize(stepKey);
+}
+
+function normalizedSteps(run: VibeMarketingRunSummary): VibeMarketingStepState[] {
+  if (run.steps.length > 0) return run.steps;
+  return run.stepOrder.map((key) => ({
+    key,
+    name: setupStepLabel(key),
+    required: true,
+    status: key === run.currentStep ? "running" : "pending",
+    attempts: 0,
+    artifacts: [],
+  }));
+}
+
+function activeStepLabel(run: VibeMarketingRunSummary, steps: VibeMarketingStepState[]) {
+  const active =
+    steps.find((step) => RUNNING_STATUSES.has(step.status)) ??
+    steps.find((step) => !COMPLETE_STEP_STATUSES.has(step.status)) ??
+    [...steps].reverse().find((step) => COMPLETE_STEP_STATUSES.has(step.status));
+  const key = active?.key || run.currentStep || "";
+  return key ? setupStepLabel(key) : "Waiting for setup progress";
+}
+
+function setupPhase(run: VibeMarketingRunSummary) {
+  const isSetupPreviewRun = run.workflow === "article_system_setup";
+  const failed = FAILED_STATUSES.has(run.status);
+  const approved = run.status === "completed" || run.approvalState === "approved";
+  const ready = READY_STATUSES.has(run.status);
+
+  if (failed) {
+    return {
+      title: "Articles setup needs attention",
+      description: isSetupPreviewRun
+        ? "The articles setup preview could not be prepared. Review the technical details before retrying."
+        : "The articles setup preparation could not finish. Review the technical details before retrying.",
+      tone: "error" as const,
+    };
+  }
+  if (approved) {
+    return {
+      title: isSetupPreviewRun ? "Articles setup approved" : "Articles/blogs location ready",
+      description: isSetupPreviewRun
+        ? "Future articles can now be generated into this repo location."
+        : "The repository location is ready for future articles.",
+      tone: "success" as const,
+    };
+  }
+  if (ready) {
+    return {
+      title: isSetupPreviewRun ? "Articles setup preview ready" : "Articles setup ready to build",
+      description: isSetupPreviewRun
+        ? "Review the Cloudflare preview, leave revision comments if needed, then approve the setup PR."
+        : "The articles/blogs location is ready. The setup preview can be generated next.",
+      tone: "ready" as const,
+    };
+  }
+  return {
+    title: isSetupPreviewRun ? "Building articles setup preview" : "Preparing articles setup",
+    description: isSetupPreviewRun
+      ? "Creating the setup branch, building the preview, and preparing the visual review."
+      : "Validating the articles/blogs location and preparing setup work for preview.",
+    tone: "running" as const,
+  };
+}
+
+function progressPercent(run: VibeMarketingRunSummary, steps: VibeMarketingStepState[]) {
+  const totalSteps = Math.max(steps.length, run.stepOrder.length, 1);
+  const completedSteps = steps.filter((step) => COMPLETE_STEP_STATUSES.has(step.status)).length;
+  const currentIndex = run.currentStep ? steps.findIndex((step) => step.key === run.currentStep) : -1;
+  const completedUnits = Math.max(completedSteps, currentIndex > 0 ? currentIndex : 0);
+
+  if (run.status === "completed" || run.approvalState === "approved" || READY_STATUSES.has(run.status)) return 100;
+  if (FAILED_STATUSES.has(run.status)) return Math.max(12, Math.min(100, Math.round((completedUnits / totalSteps) * 100)));
+  if (RUNNING_STATUSES.has(run.status)) return Math.max(12, Math.min(95, Math.round((completedUnits / totalSteps) * 100)));
+  return Math.max(5, Math.min(100, Math.round((completedUnits / totalSteps) * 100)));
+}
+
+export default function ArticlesSetupProgressCard({
+  run,
+  actionSlot,
+  technicalUrl,
+  className,
+}: ArticlesSetupProgressCardProps) {
+  const steps = normalizedSteps(run);
+  const phase = setupPhase(run);
+  const totalSteps = Math.max(steps.length, run.stepOrder.length, 1);
+  const completedSteps = steps.filter((step) => COMPLETE_STEP_STATUSES.has(step.status)).length;
+  const percent = progressPercent(run, steps);
+  const failed = phase.tone === "error";
+  const success = phase.tone === "success";
+  const ready = phase.tone === "ready";
+  const Icon = failed ? ExclamationTriangleIcon : success ? CheckCircleIcon : ready ? SparklesIcon : ArrowPathIcon;
+
+  return (
+    <section
+      className={clsx(
+        "rounded-xl border p-5 shadow-sm",
+        failed
+          ? "border-red-200 bg-red-50"
+          : success
+            ? "border-emerald-200 bg-emerald-50"
+            : ready
+              ? "border-violet-200 bg-violet-50"
+              : "border-violet-100 bg-violet-50/70",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex min-w-0 gap-4">
+          <div
+            className={clsx(
+              "flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-white",
+              failed ? "text-red-600" : success ? "text-emerald-700" : "text-violet-700",
+            )}
+          >
+            <Icon className={clsx("h-6 w-6", phase.tone === "running" && "animate-spin")} />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-black text-gray-950">{phase.title}</h2>
+              <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-violet-700">
+                {run.status.replace(/_/g, " ")}
+              </span>
+            </div>
+            <p className="mt-1 text-sm font-semibold leading-6 text-gray-700">{phase.description}</p>
+          </div>
+        </div>
+        {actionSlot ? <div className="flex-shrink-0">{actionSlot}</div> : null}
+      </div>
+
+      <div className="mt-5">
+        <div className="h-2 overflow-hidden rounded-full bg-white">
+          <div className="h-full rounded-full bg-violet-600 transition-all" style={{ width: `${percent}%` }} />
+        </div>
+        <div className="mt-3 flex flex-col gap-2 text-xs font-semibold text-gray-600 sm:flex-row sm:items-center sm:justify-between">
+          <p>{activeStepLabel(run, steps)}</p>
+          <p>
+            {completedSteps} of {totalSteps} setup steps complete
+          </p>
+        </div>
+      </div>
+
+      {run.errors.length > 0 ? (
+        <details className="mt-4 rounded-xl border border-red-200 bg-white/80 px-4 py-3 text-sm text-red-700">
+          <summary className="cursor-pointer font-bold">Setup details</summary>
+          <p className="mt-2 break-words font-mono text-xs leading-5 text-red-600">{run.errors[0]}</p>
+        </details>
+      ) : null}
+
+      {technicalUrl ? (
+        <Link to={technicalUrl} className="mt-4 inline-flex text-xs font-black text-violet-700 transition hover:text-violet-900">
+          View technical details
+        </Link>
+      ) : null}
+    </section>
+  );
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
-import { Form, Link, redirect, useActionData, useLoaderData, useLocation, useNavigation, useSearchParams } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useSearchParams } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 import {
   ArrowLeftIcon,
@@ -15,7 +15,7 @@ import { clsx } from "clsx";
 
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
-import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
+import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
 import {
   CustomTopicDecisionCard,
   TopicDecisionCard,
@@ -95,6 +95,10 @@ const CREATE_STEP_BY_WORKFLOW_STEP_ID: Record<string, VibeMarketingStepKey> = {
   automation: "dailyAutomation",
 };
 
+const SETUP_POLLING_STATUSES = new Set(["queued", "pending", "starting", "running"]);
+const SETUP_READY_STATUSES = new Set(["awaiting_confirmation", "awaiting_approval", "approval_required"]);
+const SETUP_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "denied", "cancelled"]);
+
 type StepExplainer = {
   why: string;
   next: string;
@@ -149,6 +153,22 @@ const STEP_EXPLAINERS: Record<VibeMarketingStepKey, StepExplainer> = {
   dailyAutomation: {
     why: "Automation keeps new topic candidates flowing without removing human review.",
     next: "Daily candidates still need selection, review, revision, and publish approval.",
+  },
+};
+
+const ARTICLE_SETUP_STEP_EXPLAINERS: Partial<Record<VibeMarketingStepKey, StepExplainer>> = {
+  writeCheck: {
+    why: "Setup generation creates the articles/blogs location changes and validates the repo files before review.",
+    next: "When the setup preview is ready, open the Cloudflare preview and inspect the articles/blogs location.",
+  },
+  editArticle: {
+    why: "Review shows the proposed articles/blogs setup as it will render in the target app.",
+    next: "Leave revision comments if needed, then continue once the setup preview is acceptable.",
+  },
+  reviewPublish: {
+    why: "Approval merges the reviewed setup PR so future articles have a known publishing location.",
+    next: "After setup is approved, continue to topic research and generate the first SEO article.",
+    safety: "Nothing is merged or published until you approve the articles setup.",
   },
 };
 
@@ -241,6 +261,44 @@ function scanRunHasPendingArticleSystemSetup(run: VibeMarketingRunSummary | null
     requestedAction === "article_system_setup" ||
     requestedAction === "scaffold_publish_route"
   );
+}
+
+function isArticleSystemSetupRun(run: VibeMarketingRunSummary | null | undefined) {
+  return run?.workflow === "article_system_setup";
+}
+
+function isSetupProgressTerminal(run: VibeMarketingRunSummary | null | undefined) {
+  if (!run) return true;
+  return (
+    SETUP_READY_STATUSES.has(run.status) ||
+    SETUP_FAILED_STATUSES.has(run.status) ||
+    run.status === "completed" ||
+    run.approvalState === "approved"
+  );
+}
+
+function findSetupChildRun(
+  setupRunId: string,
+  parentRunId: string,
+  latestRuns: VibeMarketingRunSummary[],
+  polledChildRun: VibeMarketingRunSummary | null,
+) {
+  if (setupRunId && polledChildRun?.runId === setupRunId) return polledChildRun;
+  if (setupRunId) {
+    const exact = latestRuns.find((run) => run.runId === setupRunId);
+    if (exact) return exact;
+  }
+  return latestRuns.find((run) => isArticleSystemSetupRun(run) && run.sourceRunId === parentRunId) ?? null;
+}
+
+function activeSetupProgressRun(
+  parentScan: VibeMarketingRunSummary | null | undefined,
+  latestRuns: VibeMarketingRunSummary[],
+  polledChildRun: VibeMarketingRunSummary | null,
+) {
+  if (!parentScan) return null;
+  const setupRunId = setupRunIdForRun(parentScan);
+  return findSetupChildRun(setupRunId, parentScan.runId, latestRuns, polledChildRun) ?? parentScan;
 }
 
 type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
@@ -498,8 +556,8 @@ export async function action({ request, context }: Route.ActionArgs) {
         article_surface_url: articleSurfaceUrl,
         sourceScanRunId: stringFromForm(formData, "sourceScanRunId"),
         source_scan_run_id: stringFromForm(formData, "sourceScanRunId"),
-        autoSetupPreview: false,
-        auto_setup_preview: false,
+        autoSetupPreview: true,
+        auto_setup_preview: true,
       });
       return redirect("/founder-tools/marketing/create?step=writeCheck");
     }
@@ -711,10 +769,25 @@ export default function FounderToolsMarketingCreate() {
       : null;
   const navigation = useNavigation();
   const location = useLocation();
+  const setupScanStatusFetcher = useFetcher<VibeMarketingRunSummary>();
+  const setupChildStatusFetcher = useFetcher<VibeMarketingRunSummary>();
   const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
-  const pendingArticleSystemScan = scanRunHasPendingArticleSystemSetup(latestScan) ? latestScan : null;
+  const bootstrapPendingArticleSystemScan = scanRunHasPendingArticleSystemSetup(latestScan) ? latestScan : null;
+  const [polledSetupScan, setPolledSetupScan] = useState<VibeMarketingRunSummary | null>(null);
+  const [polledSetupChildRun, setPolledSetupChildRun] = useState<VibeMarketingRunSummary | null>(null);
+  const pendingArticleSystemScan =
+    polledSetupScan?.runId === bootstrapPendingArticleSystemScan?.runId ? polledSetupScan : bootstrapPendingArticleSystemScan;
   const pendingArticleSystemSetupRunId = pendingArticleSystemScan ? setupRunIdForRun(pendingArticleSystemScan) : "";
-  const pendingSetupStepActive = Boolean(pendingArticleSystemScan && ["writeCheck", "editArticle", "reviewPublish"].includes(activeStep));
+  const setupChildRun = pendingArticleSystemScan
+    ? findSetupChildRun(
+        pendingArticleSystemSetupRunId,
+        pendingArticleSystemScan.runId,
+        bootstrap.latestRuns,
+        polledSetupChildRun?.runId === pendingArticleSystemSetupRunId ? polledSetupChildRun : null,
+      )
+    : null;
+  const setupProgressRun = activeSetupProgressRun(pendingArticleSystemScan, bootstrap.latestRuns, setupChildRun);
+  const pendingSetupStepActive = Boolean(setupProgressRun && ["writeCheck", "editArticle", "reviewPublish"].includes(activeStep));
   const articleSetupFlowActive = isRepoArticleStep || pendingSetupStepActive;
   const latestDiscovery = bootstrap.latestRuns.find((run) => ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(run.workflow));
   const latestArticle = bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article"].includes(run.workflow));
@@ -731,7 +804,9 @@ export default function FounderToolsMarketingCreate() {
       latestScan?.status,
       latestScan?.stale,
       latestScan?.retryAvailable,
-      latestScan ? setupRunIdForRun(latestScan) : "",
+      setupProgressRun?.runId,
+      setupProgressRun?.status,
+      pendingArticleSystemSetupRunId,
       latestDiscovery?.runId,
       latestDiscovery?.status,
       latestArticle?.runId,
@@ -799,6 +874,75 @@ export default function FounderToolsMarketingCreate() {
         : "The run workspace shows generated article copy, image assets, and revision controls for manual publishing.";
 
   useEffect(() => {
+    setPolledSetupScan(null);
+    setPolledSetupChildRun(null);
+  }, [bootstrapPendingArticleSystemScan?.runId]);
+
+  useEffect(() => {
+    if (setupScanStatusFetcher.state !== "idle") return;
+    if (!setupScanStatusFetcher.data?.runId || setupScanStatusFetcher.data.runId !== bootstrapPendingArticleSystemScan?.runId) {
+      return;
+    }
+    setPolledSetupScan(setupScanStatusFetcher.data);
+  }, [bootstrapPendingArticleSystemScan?.runId, setupScanStatusFetcher.data, setupScanStatusFetcher.state]);
+
+  useEffect(() => {
+    if (!pendingArticleSystemScan?.runId || setupScanStatusFetcher.state !== "idle") return;
+    const shouldPollParent =
+      SETUP_POLLING_STATUSES.has(pendingArticleSystemScan.status) ||
+      (!pendingArticleSystemSetupRunId && !isSetupProgressTerminal(pendingArticleSystemScan));
+    if (!shouldPollParent) return;
+    const hasLoadedCurrentRun = setupScanStatusFetcher.data?.runId === pendingArticleSystemScan.runId;
+    const timer = window.setTimeout(
+      () => {
+        setupScanStatusFetcher.load(`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemScan.runId)}/status`);
+      },
+      hasLoadedCurrentRun ? 2500 : 0,
+    );
+    return () => window.clearTimeout(timer);
+  }, [
+    pendingArticleSystemScan?.runId,
+    pendingArticleSystemScan?.status,
+    pendingArticleSystemSetupRunId,
+    setupScanStatusFetcher,
+    setupScanStatusFetcher.data?.runId,
+    setupScanStatusFetcher.state,
+  ]);
+
+  useEffect(() => {
+    setPolledSetupChildRun(null);
+  }, [pendingArticleSystemSetupRunId]);
+
+  useEffect(() => {
+    if (setupChildStatusFetcher.state !== "idle") return;
+    if (!setupChildStatusFetcher.data?.runId || setupChildStatusFetcher.data.runId !== pendingArticleSystemSetupRunId) {
+      return;
+    }
+    setPolledSetupChildRun(setupChildStatusFetcher.data);
+  }, [pendingArticleSystemSetupRunId, setupChildStatusFetcher.data, setupChildStatusFetcher.state]);
+
+  useEffect(() => {
+    if (!pendingArticleSystemSetupRunId || setupChildStatusFetcher.state !== "idle") return;
+    if (setupChildRun && isSetupProgressTerminal(setupChildRun)) return;
+    const hasLoadedCurrentRun = setupChildStatusFetcher.data?.runId === pendingArticleSystemSetupRunId;
+    const timer = window.setTimeout(
+      () => {
+        setupChildStatusFetcher.load(`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemSetupRunId)}/status`);
+      },
+      hasLoadedCurrentRun ? 2500 : 0,
+    );
+    return () => window.clearTimeout(timer);
+  }, [
+    pendingArticleSystemSetupRunId,
+    setupChildRun?.runId,
+    setupChildRun?.status,
+    setupChildRun?.approvalState,
+    setupChildStatusFetcher,
+    setupChildStatusFetcher.data?.runId,
+    setupChildStatusFetcher.state,
+  ]);
+
+  useEffect(() => {
     const selectionStillValid =
       selectedTopicCandidateId === "__custom__" ||
       selectableTopicCandidates.some((candidate) => candidate.id === selectedTopicCandidateId);
@@ -812,6 +956,69 @@ export default function FounderToolsMarketingCreate() {
   }, [selectedGithubRepo]);
 
   const setupStepActive = activeStep === "startupDetails" || activeStep === "baseline";
+  const setupProgressTechnicalUrl = setupProgressRun
+    ? `/founder-tools/marketing/runs/${encodeURIComponent(setupProgressRun.runId)}`
+    : "";
+  const setupPreviewRunId = setupChildRun?.runId || pendingArticleSystemSetupRunId;
+  const setupReadyWithoutPreview = Boolean(
+    pendingArticleSystemScan &&
+      !setupChildRun &&
+      !pendingArticleSystemSetupRunId &&
+      pendingArticleSystemScan.status === "completed",
+  );
+  const setupApproved = Boolean(
+    setupReadyWithoutPreview || (setupChildRun && (setupChildRun.status === "completed" || setupChildRun.approvalState === "approved")),
+  );
+  const setupPreviewReady = Boolean(
+    setupChildRun &&
+      !setupApproved &&
+      (SETUP_READY_STATUSES.has(setupChildRun.status) || setupChildRun.livePreview?.previewUrl || setupChildRun.previewUrl),
+  );
+  const setupLegacyNeedsPreview = Boolean(
+    pendingArticleSystemScan && !pendingArticleSystemSetupRunId && SETUP_READY_STATUSES.has(pendingArticleSystemScan.status),
+  );
+  const setupProgressFailed = Boolean(setupProgressRun && SETUP_FAILED_STATUSES.has(setupProgressRun.status));
+  const setupProgressActionSlot = setupApproved ? (
+    <Link
+      to="/founder-tools/marketing/create?step=research"
+      className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700"
+    >
+      Continue to topic research
+    </Link>
+  ) : setupPreviewReady && setupPreviewRunId ? (
+    <Link
+      to={`/founder-tools/marketing/runs/${encodeURIComponent(setupPreviewRunId)}`}
+      className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black"
+    >
+      Review articles setup preview
+      <ArrowRightIcon className="h-4 w-4" />
+    </Link>
+  ) : setupLegacyNeedsPreview ? (
+    <Form method="POST">
+      <input type="hidden" name="scanRunId" value={pendingArticleSystemScan?.runId ?? ""} />
+      <button
+        type="submit"
+        name="intent"
+        value="build-article-system-preview"
+        disabled={isSubmitting}
+        className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60"
+      >
+        {buildArticleSystemPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
+        {buildArticleSystemPreviewPending ? "Generating preview..." : "Generate articles setup preview"}
+      </button>
+    </Form>
+  ) : setupProgressFailed ? null : setupProgressRun ? (
+    <button
+      type="button"
+      disabled
+      className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white opacity-60 shadow-sm"
+    >
+      <ArrowPathIcon className="h-4 w-4 animate-spin" />
+      {setupProgressRun.workflow === "article_system_setup" || pendingArticleSystemSetupRunId
+        ? "Building preview..."
+        : "Preparing setup..."}
+    </button>
+  ) : null;
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
@@ -1064,48 +1271,19 @@ export default function FounderToolsMarketingCreate() {
                 }
                 passed={
                   pendingArticleSystemScan
-                    ? Boolean(pendingArticleSystemSetupRunId)
+                    ? Boolean(setupPreviewReady || setupApproved)
                     : activeStep === "reviewPublish"
                     ? Boolean(bootstrap.checks.publish?.passed || bootstrap.checks.contentPackage?.passed || contentPackageReady)
                     : Boolean(bootstrap.checks.write?.passed)
                 }
-                explainer={STEP_EXPLAINERS[activeStep]}
+                explainer={pendingArticleSystemScan ? ARTICLE_SETUP_STEP_EXPLAINERS[activeStep] ?? STEP_EXPLAINERS[activeStep] : STEP_EXPLAINERS[activeStep]}
               />
-              {pendingArticleSystemScan ? (
-                <div className="space-y-4">
-                  <MarketingRunProgressCard run={pendingArticleSystemScan} />
-                  {pendingArticleSystemSetupRunId ? (
-                    <Link
-                      to={`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemSetupRunId)}`}
-                      className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black"
-                    >
-                      Open articles setup preview
-                      <ArrowRightIcon className="h-4 w-4" />
-                    </Link>
-                  ) : pendingArticleSystemScan.status === "awaiting_confirmation" || pendingArticleSystemScan.status === "awaiting_approval" || pendingArticleSystemScan.status === "approval_required" ? (
-                    <Form method="POST">
-                      <input type="hidden" name="scanRunId" value={pendingArticleSystemScan.runId} />
-                      <button
-                        type="submit"
-                        name="intent"
-                        value="build-article-system-preview"
-                        disabled={isSubmitting}
-                        className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60"
-                      >
-                        {buildArticleSystemPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                        {buildArticleSystemPreviewPending ? "Generating preview..." : "Generate articles setup preview"}
-                      </button>
-                    </Form>
-                  ) : (
-                    <Link
-                      to={`/founder-tools/marketing/runs/${pendingArticleSystemScan.runId}`}
-                      className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black"
-                    >
-                      Open setup scan
-                      <ArrowRightIcon className="h-4 w-4" />
-                    </Link>
-                  )}
-                </div>
+              {pendingArticleSystemScan && setupProgressRun ? (
+                <ArticlesSetupProgressCard
+                  run={setupProgressRun}
+                  technicalUrl={setupProgressTechnicalUrl}
+                  actionSlot={setupProgressActionSlot}
+                />
               ) : latestArticle ? (
                 <div className="space-y-4">
                   {latestContentPackage ? (

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -271,6 +271,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       const scanPurpose = stringFromForm(formData, "scanPurpose") || "inventory";
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before scanning." };
       if (scanPurpose !== "inventory" && !articleSurfaceUrl) return { intent, error: "Enter the articles or blog URL before scanning." };
+      const autoSetupPreview = scanPurpose === "setup";
       const result = await startVibeMarketingScan(env, request, {
         githubRepo,
         github_repo: githubRepo,
@@ -284,12 +285,18 @@ export async function action({ request, params, context }: Route.ActionArgs) {
               articleSurfaceUrl,
               article_surface_url: articleSurfaceUrl,
             }),
-        autoSetupPreview: false,
-        auto_setup_preview: false,
+        autoSetupPreview,
+        auto_setup_preview: autoSetupPreview,
       });
-      if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      if (result.runId) {
+        throw redirect(
+          scanPurpose === "setup"
+            ? "/founder-tools/marketing/create?step=writeCheck"
+            : `/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`,
+        );
+      }
       return { intent, error: result.error || result.errors?.[0] || "Repository scan could not be started." };
-    } else if (intent === "confirm-article-surface" || intent === "create-article-surface") {
+  } else if (intent === "confirm-article-surface" || intent === "create-article-surface") {
       const githubRepo = stringFromForm(formData, "githubRepo") || stringFromForm(formData, "github_repo");
       const articleSurfaceUrl = stringFromForm(formData, "articleSurfaceUrl") || stringFromForm(formData, "article_surface_url");
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before continuing." };
@@ -305,10 +312,10 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         article_surface_url: articleSurfaceUrl,
         sourceScanRunId: runId,
         source_scan_run_id: runId,
-        autoSetupPreview: false,
-        auto_setup_preview: false,
+        autoSetupPreview: true,
+        auto_setup_preview: true,
       });
-      if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      if (result.runId) throw redirect("/founder-tools/marketing/create?step=writeCheck");
       return { intent, error: result.error || result.errors?.[0] || "Articles setup could not be started." };
     } else if (intent === "build-article-system-preview") {
       const result = await controlVibeMarketingRun(env, request, runId, "approve", { workflow: "repo_scan" });
@@ -1848,7 +1855,8 @@ function PublishAndAutomateDetail({
       (publishChildRunId === run.runId && run.status === "awaiting_confirmation" && !prUrl && !previewUrl),
   );
   const publishChildMissingRemote = Boolean(
-    publishChildRecoverable && /not found in content factory|recorded locally but was not found/i.test(publishChildWaitReason),
+    publishChildRecoverable &&
+      /not found in content factory|recorded locally but was not found|queued but did not start/i.test(publishChildWaitReason),
   );
   const publishChildRunning = Boolean(
     publishChildStatus === "queued" ||
@@ -1895,7 +1903,7 @@ function PublishAndAutomateDetail({
 
   return (
     <div className="space-y-5">
-      <ArticleRunStageProgress run={run} variant="embedded" />
+      {publishChildMissingRemote ? null : <ArticleRunStageProgress run={run} variant="embedded" />}
       <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
@@ -1959,7 +1967,7 @@ function PublishAndAutomateDetail({
                 {publishSourceRunId ? <input type="hidden" name="sourceRunId" value={publishSourceRunId} /> : null}
                 <p className="text-sm font-semibold text-gray-600">
                   {publishChildMissingRemote
-                    ? "The publish run was recorded locally but is missing in Content Factory. Retry will safely recreate the same publish run."
+                    ? "The publish job was queued but did not start. Retry will safely recreate the same PR job."
                     : "The publish run is waiting for confirmation instead of creating a PR. Resume will safely reuse the existing publish run."}
                 </p>
                 <button


### PR DESCRIPTION
## Summary
- replace the first-run setup scan fallback with one articles setup progress card
- auto-start the setup preview after users choose or create an articles/blogs location
- poll setup scan and child preview runs so the create page stays in one continuous setup flow
- route scan-run location selections back to the setup progress page instead of raw scan details

## Validation
- bun run typecheck
- git diff --check HEAD~1..HEAD