### PR TITLE
Polish Vibe Raising stepper and draft interactions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -334,3 +334,9 @@
 - [x] Generate Roo kangaroo base pet art
 - [x] Generate Roo kangaroo animation rows
 - [x] Finalize and package Roo kangaroo pet
+- [x] Update the Connect Data stepper after user interview: hide the progress bar until hover and remove the motion
+- [x] Add visible trust and privacy messaging near Connect Data connector actions
+- [x] Fix Data Sources mobile card badges so they no longer overlap source names
+- [x] Let Updates metric cards stay highlighted after click
+- [x] Make create-update metric cards activate edit mode from any card click
+- [x] Wrap create-update metric card text responsively and reveal extra mobile rows in 6-card Show more batches

--- a/app/components/MonthlyUpdateStepper.tsx
+++ b/app/components/MonthlyUpdateStepper.tsx
@@ -6,9 +6,11 @@ interface MonthlyUpdateStepperProps {
   activeStep: MonthlyUpdateStepKey;
   className?: string;
   compact?: boolean;
+  disableMotion?: boolean;
   enabledSteps?: MonthlyUpdateStepKey[];
   expandOnHover?: boolean;
   frameless?: boolean;
+  hideProgressUntilHover?: boolean;
   onStepClick?: (step: MonthlyUpdateStepKey) => void;
 }
 
@@ -43,9 +45,11 @@ export default function MonthlyUpdateStepper({
   activeStep,
   className,
   compact = false,
+  disableMotion = false,
   enabledSteps,
   expandOnHover = false,
   frameless = false,
+  hideProgressUntilHover = false,
   onStepClick,
 }: MonthlyUpdateStepperProps) {
   const activeIndex = Math.max(0, MONTHLY_UPDATE_STEPS.findIndex((step) => step.key === activeStep));
@@ -114,7 +118,10 @@ export default function MonthlyUpdateStepper({
       >
         <button
           type="button"
-          className="flex w-full items-center justify-between gap-4 rounded-2xl px-1 py-2 text-left outline-none transition hover:bg-[rgba(0,255,215,0.08)] focus-visible:bg-[rgba(0,255,215,0.08)] focus-visible:ring-2 focus-visible:ring-[rgba(0,128,128,0.18)]"
+          className={clsx(
+            "flex w-full items-center justify-between gap-4 rounded-2xl px-1 py-2 text-left outline-none hover:bg-[rgba(0,255,215,0.08)] focus-visible:bg-[rgba(0,255,215,0.08)] focus-visible:ring-2 focus-visible:ring-[rgba(0,128,128,0.18)]",
+            !disableMotion && "transition",
+          )}
           aria-label="Show monthly update workflow"
         >
           <div className="min-w-0">
@@ -126,18 +133,33 @@ export default function MonthlyUpdateStepper({
             </h2>
           </div>
           <span className="hidden rounded-full bg-[rgba(0,255,215,0.12)] px-3 py-1 text-xs font-bold text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.24)] sm:inline-flex">
-            Hover for steps
+            {disableMotion ? "Steps" : "Hover for steps"}
           </span>
         </button>
 
-        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--vr-color-border)]">
+        <div
+          className={clsx(
+            "mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--vr-color-border)]",
+            hideProgressUntilHover && "opacity-0 group-hover/stepper:opacity-100 group-focus-within/stepper:opacity-100",
+            hideProgressUntilHover && !disableMotion && "transition-opacity duration-150",
+          )}
+        >
           <div
-            className="h-full rounded-full bg-[var(--vr-color-primary)] transition-all duration-300"
+            className={clsx(
+              "h-full rounded-full bg-[var(--vr-color-primary)]",
+              !disableMotion && "transition-all duration-300",
+            )}
             style={{ width: `${progressPercent}%` }}
           />
         </div>
 
-        <div className="max-h-0 overflow-hidden opacity-0 transition-all duration-200 ease-out group-hover/stepper:max-h-64 group-hover/stepper:opacity-100 group-focus-within/stepper:max-h-64 group-focus-within/stepper:opacity-100">
+        <div
+          className={clsx(
+            disableMotion
+              ? "block"
+              : "max-h-0 overflow-hidden opacity-0 transition-all duration-200 ease-out group-hover/stepper:max-h-64 group-hover/stepper:opacity-100 group-focus-within/stepper:max-h-64 group-focus-within/stepper:opacity-100",
+          )}
+        >
           <div className="pt-6">
             <div className="flex gap-2 overflow-x-auto pb-1 sm:hidden">
               {MONTHLY_UPDATE_STEPS.map((step, index) => {
@@ -152,7 +174,8 @@ export default function MonthlyUpdateStepper({
                     disabled={!canSelect}
                     onClick={() => onStepClick?.(step.key)}
                     className={clsx(
-                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 transition",
+                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1",
+                      !disableMotion && "transition",
                       canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
                       isActive && "bg-[var(--vr-color-primary)] text-white ring-[var(--vr-color-primary)]",
                       isComplete && !isActive && "bg-[rgba(0,255,215,0.16)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]",
@@ -187,13 +210,15 @@ export default function MonthlyUpdateStepper({
                       disabled={!canSelect}
                       onClick={() => onStepClick?.(step.key)}
                       className={clsx(
-                        "relative flex w-full flex-col items-center rounded-xl px-2 pb-3 text-center transition",
+                        "relative flex w-full flex-col items-center rounded-xl px-2 pb-3 text-center",
+                        !disableMotion && "transition",
                         canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.12)]" : "cursor-default",
                       )}
                     >
                       <div
                         className={clsx(
-                          "z-10 flex h-12 w-12 items-center justify-center rounded-full border-2 bg-white text-base font-black transition",
+                          "z-10 flex h-12 w-12 items-center justify-center rounded-full border-2 bg-white text-base font-black",
+                          !disableMotion && "transition",
                           isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_4px_rgba(0,255,215,0.10)]",
                           isActive && !isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_5px_rgba(0,128,128,0.10)]",
                           !isActive && !isComplete && "border-[var(--vr-color-border)] text-[var(--vr-color-text-sub)]",

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -797,7 +797,7 @@ function FormField({
 }
 
 function RequiredPill() {
-  return <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-[10px] font-black text-emerald-700">Required</span>;
+  return <span className="text-sm font-black leading-none text-red-500" aria-label="required">*</span>;
 }
 
 function CompletePill() {
@@ -2135,13 +2135,13 @@ export default function VibeMarketingStartupBaselineSetup({
                 type="button"
                 onClick={startAutofill}
                 disabled={!canStartAutofill}
-                className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-violet-700 px-6 py-5 text-left text-white shadow-lg shadow-violet-200 transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-[var(--vr-color-primary)] px-6 py-5 text-left text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <span className="flex min-w-0 items-center gap-4">
                   {autofillPending || autofillPolling ? <Loader2 className="h-7 w-7 shrink-0 animate-spin" /> : <Sparkles className="h-7 w-7 shrink-0" />}
                   <span className="min-w-0">
                     <span className="block text-lg font-black">Research my company context</span>
-                    <span className="mt-1 block text-sm font-semibold text-violet-100">AI will use these answers to prepare article context and SEO inputs</span>
+                    <span className="mt-1 block text-sm font-semibold text-white/80">AI will use these answers to prepare article context and SEO inputs</span>
                   </span>
                 </span>
                 <ArrowRight className="h-6 w-6 shrink-0" />
@@ -2305,7 +2305,7 @@ export default function VibeMarketingStartupBaselineSetup({
                   type="button"
                   onClick={startBaseline}
                   disabled={!canStartBaseline}
-                  className="inline-flex items-center gap-2 rounded-xl bg-violet-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-4 py-2.5 text-sm font-black text-white shadow-sm shadow-[rgba(0,128,128,0.16)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <BarChart3 className="h-4 w-4" />}
                   {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Generate baseline" : "Rerun baseline"}
@@ -2546,7 +2546,7 @@ export default function VibeMarketingStartupBaselineSetup({
             name="nextAction"
             value="continue"
             disabled={saveActionPending || researchLocked}
-            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-violet-700 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50 sm:px-7"
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-5 py-3 text-sm font-black text-white shadow-sm shadow-[rgba(0,128,128,0.16)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50 sm:px-7"
           >
             {continuePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
             {continuePending ? "Continuing..." : primaryActionLabel ?? defaultPrimaryActionLabel}

--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { ArrowRightIcon } from "@heroicons/react/24/outline";
 
 type VibeRaisingStickyStepBarProps = {
+    className?: string;
     statusIcon?: ReactNode;
     statusTitle: string;
     statusDetail?: string;
@@ -18,6 +19,7 @@ type VibeRaisingStickyStepBarProps = {
 };
 
 export default function VibeRaisingStickyStepBar({
+    className,
     statusIcon,
     statusTitle,
     statusDetail,
@@ -33,7 +35,7 @@ export default function VibeRaisingStickyStepBar({
     primaryForm,
 }: VibeRaisingStickyStepBarProps) {
     return (
-        <div className="fixed inset-x-4 bottom-4 z-40 lg:left-24">
+        <div className={["fixed inset-x-4 bottom-4 z-40 lg:left-24", className].filter(Boolean).join(" ")}>
             <div className="mx-auto flex max-w-6xl flex-col gap-4 rounded-2xl border border-[var(--vr-color-border)] bg-white/95 px-4 py-4 shadow-2xl shadow-black/10 backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:px-5">
                 <div className="flex min-w-0 items-center gap-3">
                     {statusIcon ? (
@@ -42,19 +44,19 @@ export default function VibeRaisingStickyStepBar({
                         </div>
                     ) : null}
                     <div className="min-w-0">
-                        <p className="truncate text-sm font-black text-gray-950">{statusTitle}</p>
+                        <p className="text-sm font-black leading-tight text-gray-950 sm:truncate">{statusTitle}</p>
                         {statusDetail ? (
-                            <p className="mt-0.5 truncate text-xs font-semibold text-slate-500">{statusDetail}</p>
+                            <p className="mt-0.5 text-xs font-semibold leading-tight text-slate-500 sm:truncate">{statusDetail}</p>
                         ) : null}
                     </div>
                 </div>
 
-                <div className="flex flex-shrink-0 items-center justify-end gap-3">
+                <div className="flex flex-col gap-3 sm:flex-shrink-0 sm:flex-row sm:items-center sm:justify-end">
                     {onBack ? (
                         <button
                             type="button"
                             onClick={onBack}
-                            className="inline-flex items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950"
+                            className="inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950 sm:w-auto"
                         >
                             {backLabel}
                         </button>
@@ -64,7 +66,7 @@ export default function VibeRaisingStickyStepBar({
                             type="button"
                             onClick={onSecondary}
                             disabled={secondaryDisabled}
-                            className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55"
+                            className="inline-flex w-full items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55 sm:w-auto"
                         >
                             {secondaryLabel}
                         </button>
@@ -74,7 +76,7 @@ export default function VibeRaisingStickyStepBar({
                         form={primaryForm}
                         onClick={primaryType === "button" ? onPrimary : undefined}
                         disabled={primaryDisabled}
-                        className="inline-flex min-w-44 items-center justify-center gap-2 rounded-xl bg-[var(--vr-palette-purple)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(150,73,210,0.25)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0"
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--vr-palette-purple)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(150,73,210,0.25)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0 sm:min-w-44 sm:w-auto"
                     >
                         {primaryLabel}
                         <ArrowRightIcon className="h-4 w-4" />

--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -7,6 +7,9 @@ type VibeRaisingStickyStepBarProps = {
     statusDetail?: string;
     backLabel?: string;
     onBack?: () => void;
+    secondaryLabel?: string;
+    onSecondary?: () => void;
+    secondaryDisabled?: boolean;
     primaryLabel: string;
     onPrimary?: () => void;
     primaryDisabled?: boolean;
@@ -20,6 +23,9 @@ export default function VibeRaisingStickyStepBar({
     statusDetail,
     backLabel = "Back",
     onBack,
+    secondaryLabel,
+    onSecondary,
+    secondaryDisabled = false,
     primaryLabel,
     onPrimary,
     primaryDisabled = false,
@@ -51,6 +57,16 @@ export default function VibeRaisingStickyStepBar({
                             className="inline-flex items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950"
                         >
                             {backLabel}
+                        </button>
+                    ) : null}
+                    {secondaryLabel && onSecondary ? (
+                        <button
+                            type="button"
+                            onClick={onSecondary}
+                            disabled={secondaryDisabled}
+                            className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55"
+                        >
+                            {secondaryLabel}
                         </button>
                     ) : null}
                     <button

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -972,6 +972,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
     const [expandedPastUpdateId, setExpandedPastUpdateId] = useState<string | null>(
         currentUpdate ? null : pastUpdates[0]?.id ?? null
     );
+    const [activeMetricCard, setActiveMetricCard] = useState<string | null>(null);
 
     if (!hasUpdates) {
         return (
@@ -1152,7 +1153,12 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
 
             {/* Dashboard metrics row — prototype .metric-card design, scoped under vr- */}
             <div className="vr-metrics-row">
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "mrr"}
+                    className={clsx("vr-metric-card", activeMetricCard === "mrr" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "mrr" ? null : "mrr")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-primary), var(--vr-color-secondary))" }}
@@ -1165,9 +1171,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         {latestUpdate?.metrics?.revenue?.replace(/\s*MRR$/i, "") || "—"}
                     </div>
                     <div className="vr-metric-delta vr-delta-up">↑ 18% month-on-month</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "active-users"}
+                    className={clsx("vr-metric-card", activeMetricCard === "active-users" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "active-users" ? null : "active-users")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-secondary), var(--vr-color-featured))" }}
@@ -1177,9 +1188,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         {latestUpdate?.metrics?.users?.replace(/\s*active$/i, "") || "—"}
                     </div>
                     <div className="vr-metric-delta vr-delta-up">↑ 220 new this month</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "runway"}
+                    className={clsx("vr-metric-card", activeMetricCard === "runway" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "runway" ? null : "runway")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "var(--vr-color-brand-orange)" }}
@@ -1192,9 +1208,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         {latestUpdate?.metrics?.runway?.replace(/\s*months?$/i, " mo") || "—"}
                     </div>
                     <div className="vr-metric-delta vr-delta-down">↓ 2 months vs forecast</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "raise-committed"}
+                    className={clsx("vr-metric-card", activeMetricCard === "raise-committed" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "raise-committed" ? null : "raise-committed")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-featured), var(--vr-color-brand-teal-light))" }}
@@ -1202,9 +1223,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="vr-metric-eyebrow">Raise Committed</div>
                     <div className="vr-metric-value">62%</div>
                     <div className="vr-metric-delta vr-delta-neutral">$750K of $1.2M</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "burn-rate"}
+                    className={clsx("vr-metric-card", activeMetricCard === "burn-rate" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "burn-rate" ? null : "burn-rate")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-brand-orange), var(--vr-color-warning))" }}
@@ -1212,7 +1238,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="vr-metric-eyebrow">Burn Rate</div>
                     <div className="vr-metric-value">$52K/mo</div>
                     <div className="vr-metric-delta vr-delta-down">↑ 8% vs last month</div>
-                </div>
+                </button>
             </div>
 
             {isOverdue && (

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -1,5 +1,5 @@
 import { Link, redirect, useLoaderData, useOutletContext, useNavigate } from "react-router";
-import { format, differenceInDays } from "date-fns";
+import { format } from "date-fns";
 import { useState, useRef, useEffect } from "react";
 import type { Route } from "./+types/vibe-raising-app._index";
 import {
@@ -12,7 +12,6 @@ import { clsx } from "clsx";
 import { getEnv } from "~/lib/env.server";
 import {
     ArrowRightIcon,
-    ClockIcon,
     ChartBarIcon,
     PencilSquareIcon,
     SparklesIcon,
@@ -950,9 +949,6 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
     const hasUpdates = updates.length > 0;
 
     const latestUpdate = hasUpdates ? updates[0] : null;
-    const daysSinceLast = latestUpdate ? differenceInDays(new Date(), new Date(latestUpdate.date)) : 0;
-    const isOverdue = daysSinceLast > 21;
-    const daysOverdue = daysSinceLast - 21;
 
     const now = new Date();
     const currentUpdate = updates.find((update) => {
@@ -1240,36 +1236,6 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="vr-metric-delta vr-delta-down">↑ 8% vs last month</div>
                 </button>
             </div>
-
-            {isOverdue && (
-                <div className="relative overflow-hidden rounded-xl border border-[rgba(0,255,215,0.26)] bg-[rgba(0,255,215,0.12)] p-6 shadow-sm">
-                    <div className="relative z-10 flex flex-col md:flex-row md:items-center justify-between gap-6">
-                        <div className="flex items-start gap-4">
-                            <div className="rounded-full border border-[rgba(0,255,215,0.26)] bg-white p-3 text-[var(--vr-color-primary)] shadow-sm">
-                                <ClockIcon className="w-8 h-8" />
-                            </div>
-                            <div>
-                                <div className="flex items-center gap-3 mb-1">
-                                    <h2 className="text-lg font-bold text-gray-900">Time for Your Monthly Update!</h2>
-                                    <span className="rounded-full bg-[rgba(0,255,215,0.24)] px-2.5 py-0.5 text-xs font-bold text-[var(--vr-color-primary)]">
-                                        {daysOverdue} days overdue
-                                    </span>
-                                </div>
-                                <p className="text-gray-700 mb-4">
-                                    Your last update was on <span className="font-semibold">{format(new Date(latestUpdate!.date), "MMMM d, yyyy")}</span>.
-                                    Keep your investors engaged with your latest progress!
-                                </p>
-                            </div>
-                        </div>
-                        <Link
-                            to="/founder-tools/data-sources"
-                            className="whitespace-nowrap rounded-lg bg-[var(--vr-color-primary)] px-6 py-3 font-bold text-white shadow-sm transition-colors hover:bg-[var(--vr-palette-black)]"
-                        >
-                            Create Update Now
-                        </Link>
-                    </div>
-                </div>
-            )}
 
             {/* Tabs + tab content */}
             <div>

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -76,6 +76,12 @@ const DATA_PRIVACY_POINTS = [
   "Private drafts stay hidden until you publish",
   "You can disconnect sources and remove cached data anytime",
 ] as const;
+const CONNECTOR_TRUST_ITEMS = [
+  "Only founders and teammates with access to this workspace can see connected source data.",
+  "We only scan the selected source data needed to draft your monthly update.",
+  "We store synced context, generated metrics, and draft materials inside this workspace.",
+  "You can disconnect a source anytime, and connectors with deletion support let you remove stored data from this screen.",
+];
 
 const EMPTY_SOURCES: VibeRaisingInputSourceSummary[] = [
   {
@@ -1343,6 +1349,9 @@ function ConnectorCard({
   const isConnected = source.status === "connected" || source.status === "syncing";
   const displayedStatus = canConnectWhenUnavailable ? "not_connected" : source.status;
   const displayedStatusLabel = canConnectWhenUnavailable ? "Ready to connect" : statusLabel(source.status);
+  const trustMessage = isConnected
+    ? `Only this founder workspace can see synced ${source.label} context. You can manage access here anytime.`
+    : `Only this founder workspace can see synced ${source.label} context. We only scan ${sourceScanSummary(source)}.`;
   const connectClassName = clsx(
     "block w-full rounded-lg px-3 py-2 text-center text-xs font-extrabold transition",
     disabled || !canConnect
@@ -1359,22 +1368,23 @@ function ConnectorCard({
           ? "border-[rgba(0,255,215,0.42)] bg-white ring-1 ring-[rgba(0,128,128,0.12)]"
           : "border-gray-200 bg-white",
     )} tabIndex={0}>
-      <div className="pointer-events-none flex items-start gap-3 pr-20">
-        <SourceLogo sourceKey={source.key} large />
+      <div className="pointer-events-none flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <SourceLogo sourceKey={source.key} large />
+          <span className={clsx(
+            "inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:max-w-[9rem] sm:px-2 sm:text-[10px]",
+            isConnected ? "bg-white text-[var(--vr-color-primary)] ring-white/60" : statusClassName(displayedStatus),
+          )}>
+            {displayedStatusLabel}
+          </span>
+        </div>
         <h3 className={clsx(
-          "pt-2 text-left text-sm font-black sm:text-base",
+          "break-words text-left text-base font-black leading-tight sm:text-lg",
           isConnected ? "text-white" : "text-gray-950",
         )}>
           {source.label}
         </h3>
       </div>
-
-      <span className={clsx(
-        "absolute right-3 top-3 inline-flex max-w-[88px] items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:right-4 sm:top-4 sm:max-w-[112px] sm:px-2 sm:text-[10px]",
-        isConnected ? "bg-white text-[var(--vr-color-primary)] ring-white/60" : statusClassName(displayedStatus),
-      )}>
-        {displayedStatusLabel}
-      </span>
 
       <div className="flex flex-1 flex-col pt-4 sm:pt-5">
         <p className={clsx("mt-1 line-clamp-4 min-h-0 text-[11px] leading-4 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5", isConnected ? "text-white/80" : "text-slate-500")}>
@@ -1444,6 +1454,15 @@ function ConnectorCard({
           {source.warning && source.status !== "coming_soon" ? (
             <p className={clsx("mt-2 line-clamp-2 text-[10px] font-medium leading-4 sm:text-[11px]", isConnected ? "text-white/80" : "text-[var(--vr-color-text)]")}>{source.warning}</p>
           ) : null}
+
+          <p
+            className={clsx(
+              "mt-2 text-[10px] leading-4 sm:text-[11px]",
+              isConnected ? "text-white/80" : "text-slate-500",
+            )}
+          >
+            {trustMessage}
+          </p>
         </div>
       </div>
     </div>
@@ -1456,22 +1475,23 @@ function GoogleAnalyticsPlaceholderCard() {
       className="relative flex min-h-[152px] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white p-3 shadow-sm outline-none sm:min-h-[220px] sm:rounded-2xl sm:p-4"
       aria-label="Google Analytics source coming soon"
     >
-      <div className="pointer-events-none flex items-start gap-3 pr-20">
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
-          <svg viewBox="0 0 36 36" className="h-8 w-8 sm:h-10 sm:w-10" aria-hidden>
-            <rect x="8" y="18" width="6" height="10" rx="3" fill="#f59e0b" />
-            <rect x="16" y="10" width="6" height="18" rx="3" fill="#f97316" />
-            <circle cx="27" cy="12" r="4" fill="#fb923c" />
-          </svg>
+      <div className="pointer-events-none flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
+            <svg viewBox="0 0 36 36" className="h-8 w-8 sm:h-10 sm:w-10" aria-hidden>
+              <rect x="8" y="18" width="6" height="10" rx="3" fill="#f59e0b" />
+              <rect x="16" y="10" width="6" height="18" rx="3" fill="#f97316" />
+              <circle cx="27" cy="12" r="4" fill="#fb923c" />
+            </svg>
+          </div>
+          <span className="inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold text-gray-500 ring-1 ring-gray-200 sm:max-w-[9rem] sm:px-2 sm:text-[10px]">
+            Coming soon
+          </span>
         </div>
-        <h3 className="pt-2 text-left text-sm font-black text-gray-950 sm:text-base">
+        <h3 className="break-words text-left text-base font-black leading-tight text-gray-950 sm:text-lg">
           Google Analytics
         </h3>
       </div>
-
-      <span className="absolute right-3 top-3 inline-flex max-w-[88px] items-center truncate rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold text-gray-500 ring-1 ring-gray-200 sm:right-4 sm:top-4 sm:max-w-[112px] sm:px-2 sm:text-[10px]">
-        Coming soon
-      </span>
 
       <div className="flex flex-1 flex-col pt-4 sm:pt-5">
         <p className="mt-1 line-clamp-4 min-h-0 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5">
@@ -1529,31 +1549,26 @@ function ManualMaterialsCard({
           : "border-gray-200 bg-white",
       )}
     >
-      <div
-        className="pointer-events-none flex items-start gap-3 pr-20"
-      >
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
-          <DocumentTextIcon className="h-6 w-6 sm:h-8 sm:w-8" />
+      <div className="pointer-events-none flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
+            <DocumentTextIcon className="h-6 w-6 sm:h-8 sm:w-8" />
+          </div>
+          <span
+            className={clsx(
+              "inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:max-w-[9rem] sm:px-2 sm:text-[10px]",
+              hasManualMaterials
+                ? "bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]"
+                : "bg-gray-100 text-slate-500 ring-gray-200",
+            )}
+          >
+            {hasManualMaterials ? "Added" : "Optional"}
+          </span>
         </div>
-        <h3
-          className={clsx(
-            "pt-2 text-left text-sm font-black text-gray-950 sm:text-base",
-          )}
-        >
+        <h3 className="break-words text-left text-base font-black leading-tight text-gray-950 sm:text-lg">
           Manual input
         </h3>
       </div>
-
-      <span
-        className={clsx(
-          "absolute right-3 top-3 inline-flex max-w-[88px] items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:right-4 sm:top-4 sm:max-w-[112px] sm:px-2 sm:text-[10px]",
-          hasManualMaterials
-            ? "bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]"
-            : "bg-gray-100 text-slate-500 ring-gray-200",
-        )}
-      >
-        {hasManualMaterials ? "Added" : "Optional"}
-      </span>
 
       <div className="flex flex-1 flex-col pt-4 sm:pt-5">
         <p className="mt-1 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:text-xs sm:leading-5">
@@ -1602,6 +1617,29 @@ function deletionSummaryText(deleted: {
   if (rawCount > 0) parts.push(`${rawCount} Gmail cache item${rawCount === 1 ? "" : "s"}`);
   if (derivedCount > 0) parts.push(`${derivedCount} generated update item${derivedCount === 1 ? "" : "s"}`);
   return parts.length > 0 ? parts.join(" and ") : "local Gmail access";
+}
+
+function sourceScanSummary(source: VibeRaisingInputSourceSummary) {
+  switch (source.key) {
+    case "gmail":
+      return "recent emails, relevant threads, and attachments that match your drafting filters";
+    case "slack":
+      return "selected channels and messages you choose for update drafting";
+    case "linear":
+      return "selected projects, issues, and status updates relevant to this update";
+    case "stripe":
+      return "subscription and revenue metrics relevant to this reporting period";
+    case "xero":
+      return "invoices, revenue records, and accounting context for this update";
+    case "bank_feed":
+      return "transactions and cash-flow activity connected to this reporting period";
+    case "notion":
+      return "the pages and notes you choose to use as drafting context";
+    case "google_drive":
+      return "the files you choose to use as investor-update context";
+    default:
+      return "the selected source data needed for this update";
+  }
 }
 
 function GmailManagementModal({
@@ -2592,7 +2630,9 @@ export default function ConnectData() {
       <div className="space-y-4">
         <MonthlyUpdateStepper
           activeStep="connect"
+          disableMotion
           enabledSteps={["connect", "draft"]}
+          hideProgressUntilHover
           onStepClick={handleStepperClick}
           expandOnHover
           frameless
@@ -2666,7 +2706,25 @@ export default function ConnectData() {
           ) : null}
         </div>
 
-        <div className="mt-6 grid grid-cols-3 gap-3 lg:grid-cols-4 lg:gap-4">
+        <div className="mt-4 rounded-2xl border border-[rgba(0,255,215,0.22)] bg-[rgba(0,255,215,0.08)] p-4 sm:p-5">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[var(--vr-color-border)]">
+              <ShieldCheckIcon className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="text-sm font-extrabold text-[var(--vr-color-primary)]">Before you connect</h3>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {CONNECTOR_TRUST_ITEMS.map((item) => (
+                  <p key={item} className="rounded-xl bg-white/80 px-3 py-2 text-sm leading-5 text-[var(--vr-color-text)] ring-1 ring-[rgba(0,128,128,0.08)]">
+                    {item}
+                  </p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
           <GoogleAnalyticsPlaceholderCard />
           {prioritySources.map((source) => (
             <ConnectorCard
@@ -2697,7 +2755,7 @@ export default function ConnectData() {
         ) : null}
 
         {showAllSources && moreOptionSources.length > 0 ? (
-          <div id="more-source-options-panel" className="mt-4 grid grid-cols-3 gap-3 lg:grid-cols-4 lg:gap-4">
+          <div id="more-source-options-panel" className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
             {moreOptionSources.map((source) => (
               <ConnectorCard
                 key={source.key}
@@ -2709,13 +2767,12 @@ export default function ConnectData() {
                 onToggle={handleToggle}
               />
             ))}
-          </div>
-        ) : null}
-
-        <div className="mt-4 grid grid-cols-3 gap-3 lg:grid-cols-4 lg:gap-4">
-          <ManualMaterialsCard
-            expanded={manualMaterialsExpanded}
-            hasManualMaterials={hasManualMaterials}
+            </div>
+          ) : null}
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
+            <ManualMaterialsCard
+              expanded={manualMaterialsExpanded}
+              hasManualMaterials={hasManualMaterials}
             summary={manualMaterialsSummary}
             onToggle={() => setManualMaterialsExpanded((value) => !value)}
           />
@@ -2723,7 +2780,7 @@ export default function ConnectData() {
           {manualMaterialsExpanded ? (
             <div
               id="manual-materials-panel"
-              className="col-span-3 space-y-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm lg:col-span-3 lg:p-5"
+              className="col-span-1 space-y-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:col-span-2 lg:col-span-4 lg:p-5"
             >
               <div className="flex items-center justify-between gap-4">
                 <p className="text-sm font-bold text-slate-500">
@@ -3034,7 +3091,14 @@ export default function ConnectData() {
                   <h3 className="text-base font-black text-gray-950">Privacy and security</h3>
                 </div>
                 <ul className="mt-5 space-y-3 text-sm font-semibold text-slate-600">
-                  {["Only you can see connected source data and private drafts", "Read-only access where supported", "You control what stays connected", "Disconnecting can remove cached source data"].map((item) => (
+                  {[
+                    "Only founders and teammates with access to this workspace can see connected data.",
+                    `For ${pendingConnectSource.label}, we only scan ${sourceScanSummary(pendingConnectSource)}.`,
+                    "We store synced context, generated metrics, and draft materials in this workspace so you can keep editing.",
+                    pendingConnectSource.key === "gmail"
+                      ? "You can disconnect Gmail anytime, and this screen can also delete Gmail-derived drafts, events, and metrics."
+                      : "You can disconnect this source anytime, and connectors with deletion support let you remove stored data from this screen.",
+                  ].map((item) => (
                     <li key={item} className="flex items-center gap-3">
                       <CheckCircleIcon className="h-5 w-5 text-[var(--vr-color-primary)]" />
                       {item}

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -1982,6 +1982,8 @@ export default function CreateUpdate() {
         : isManualOnlyDraftFlow
             ? METRIC_OPTIONS
             : metricOptionsFromKeys(["revenue", "activeUsers", "mrr", "burnRate"]);
+    const mobileDraftMetricBatchSize = 6;
+    const [mobileVisibleDraftMetricCount, setMobileVisibleDraftMetricCount] = useState(mobileDraftMetricBatchSize);
     const showLegacyDraftFlow = false;
     const selectedInputSourceLabels = selectedInputSources.map((key) => INPUT_SOURCE_LABELS[key]);
     const selectedInputSourceDescription = selectedInputSourceLabels.length > 0
@@ -2088,6 +2090,12 @@ export default function CreateUpdate() {
             });
         }
     }, [shouldDimMetricsTemplate]);
+
+    const focusMetricInput = useCallback((inputId: string) => {
+        window.requestAnimationFrame(() => {
+            document.getElementById(inputId)?.focus();
+        });
+    }, []);
 
     useEffect(() => {
         if (isEdit) return;
@@ -3313,22 +3321,24 @@ export default function CreateUpdate() {
         }
     };
 
-    const toggleActiveMetric = (key: string) => {
+    const activateActiveMetric = (key: string) => {
         if (isViewingCurrentUpdate) {
-            toggleMetric(key);
+            setSelectedMetrics((previous) => {
+                if (previous.has(key)) return previous;
+                const next = new Set(previous);
+                next.add(key);
+                return next;
+            });
+            focusMetricInput(`active-metric-${key}`);
             return;
         }
 
         if (activePastIndex < 0 || !activePastCard) return;
-        setPastMonthCards(prev => prev.map((card, index) => {
-            if (index !== activePastIndex) return card;
-            const nextMetrics = { ...card.metrics };
-            if (key in nextMetrics) {
-                delete nextMetrics[key];
-                return { ...card, metrics: nextMetrics };
-            }
-            return { ...card, metrics: { ...nextMetrics, [key]: "" } };
+        setPastMonthCards((previous) => previous.map((card, index) => {
+            if (index !== activePastIndex || key in card.metrics) return card;
+            return { ...card, metrics: { ...card.metrics, [key]: "" } };
         }));
+        focusMetricInput(`active-metric-${key}`);
     };
 
     const updateActiveHighlights = (value: string) => {
@@ -3821,7 +3831,9 @@ export default function CreateUpdate() {
             <div className="mx-auto max-w-6xl space-y-10 pb-32">
                 <MonthlyUpdateStepper
                     activeStep={showConfirmPopup ? "publish" : "review"}
+                    disableMotion
                     enabledSteps={["connect", "draft", "review", "publish"]}
+                    hideProgressUntilHover
                     onStepClick={handleReviewStepperClick}
                     expandOnHover
                     frameless
@@ -3836,7 +3848,7 @@ export default function CreateUpdate() {
                         <div className="min-w-0">
                             <h2 className="text-lg font-black text-gray-950">How it works</h2>
                             <p className="mt-1 text-sm leading-6 text-slate-600">
-                                Preview page shows exactly what investors will see before you publish this monthly update.
+                                Review shows exactly what investors will see before you publish this monthly update.
                             </p>
                         </div>
                     </div>
@@ -4205,6 +4217,43 @@ export default function CreateUpdate() {
                                 This update is saved privately in <Link to="/founder-tools/drafts" className="font-black text-[var(--vr-color-primary)] hover:text-[var(--vr-palette-black)]">My Drafts</Link> until you publish it.
                             </p>
                         </div>
+
+                        {/* Your Audience Block */}
+                        {(() => {
+                            const d = data as any;
+                            const text = [(d.highlights || ''), (d.challenges || ''), (d.learnings || ''), (d.next30Days || ''), (d.asks || '')].join(" ").toLowerCase();
+                            
+                            const criteria = [];
+                            if (text.includes("saas") || text.includes("software")) criteria.push("B2B SaaS");
+                            if (text.includes("health") || text.includes("medtech") || text.includes("medical")) criteria.push("MedTech");
+                            if (text.includes("agri") || text.includes("farm") || text.includes("agriculture")) criteria.push("AgTech");
+                            if (text.includes("ai") || text.includes("machine learning") || text.includes("artificial intelligence")) criteria.push("AI/ML");
+                            if (text.includes("enterprise") || text.includes("b2b") || text.includes("fortune 500")) criteria.push("Enterprise");
+                            if (text.includes("fintech") || text.includes("finance") || text.includes("payment")) criteria.push("FinTech");
+                            if (text.includes("consumer") || text.includes("b2c")) criteria.push("Consumer Tech");
+                            if (criteria.length === 0) criteria.push("Sector Agnostic", "Early Stage");
+
+                            const count = 18 + (criteria.length * 14);
+
+                            return (
+                                <div className="mt-6 rounded-xl border border-[rgba(76,110,245,0.22)] bg-[rgba(76,110,245,0.08)] p-5 shadow-sm">
+                                    <h3 className="mb-2 flex items-center gap-2 text-sm font-bold text-[var(--vr-color-text)]">
+                                        <UsersIcon className="h-4 w-4 text-[var(--vr-palette-blue)]" />
+                                        Your Audience
+                                    </h3>
+                                    <p className="mb-3 text-sm text-[var(--vr-color-text-mid)]">
+                                        We found <strong className="font-extrabold text-[var(--vr-palette-blue)]">{count} investors</strong> on Vibe Raising actively looking for updates matching your criteria:
+                                    </p>
+                                    <div className="flex flex-wrap gap-2">
+                                        {criteria.map(c => (
+                                            <span key={c} className="rounded-lg border border-[rgba(76,110,245,0.24)] bg-white px-2.5 py-1 text-xs font-semibold text-[var(--vr-palette-blue)] shadow-sm">
+                                                {c}
+                                            </span>
+                                        ))}
+                                    </div>
+                                </div>
+                                );
+                            })()}
                     </div>
 
                     {showReviewLinkedInPopup ? (
@@ -4302,7 +4351,9 @@ export default function CreateUpdate() {
                                 <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full p-8 text-center relative overflow-hidden animate-in fade-in zoom-in duration-300">
                                     <MonthlyUpdateStepper
                                         activeStep="publish"
+                                        disableMotion
                                         enabledSteps={["connect", "draft", "review", "publish"]}
+                                        hideProgressUntilHover
                                         onStepClick={handleReviewStepperClick}
                                         expandOnHover
                                         frameless
@@ -4311,6 +4362,9 @@ export default function CreateUpdate() {
                                     <h2 className="text-2xl font-black text-gray-900 mb-2 tracking-tight">Ready to send? 🚀</h2>
                                     <p className="text-gray-600 mb-6 text-sm leading-relaxed">
                                         Your update is about to go live on Vibe Raising. We will send it directly to <strong className="font-bold text-gray-900">{reviewAudienceCount} investors</strong> matching your criteria: {reviewAudienceCriteria.join(", ")}.
+                                    </p>
+                                    <p className="mb-6 rounded-xl border border-[rgba(0,255,215,0.24)] bg-[rgba(0,255,215,0.10)] px-4 py-3 text-left text-sm leading-relaxed text-[var(--vr-color-text)]">
+                                        You do not need to send this yet. Save it locally first if you want to come back and keep refining the earlier steps.
                                     </p>
 
                                     <Form 
@@ -4352,7 +4406,7 @@ export default function CreateUpdate() {
                                             onClick={() => setShowConfirmPopup(false)}
                                             className="w-full px-5 py-3 text-sm font-bold text-gray-600 bg-gray-100 rounded-xl hover:bg-gray-200 transition-all active:scale-95"
                                         >
-                                            Wait, go back
+                                            Save it locally
                                         </button>
                                     </Form>
                                 </div>
@@ -4434,8 +4488,11 @@ export default function CreateUpdate() {
                         </div>
                     }
                     statusTitle={`Review ${reviewMonth} ${reviewYear} update`}
-                    statusDetail="Preview is ready. Publish when the story feels right."
+                    statusDetail="Review is ready. Publish when the story feels right."
                     onBack={() => setDismissedFeedback(true)}
+                    secondaryLabel={draftSaved ? "Draft saved!" : "Save as draft"}
+                    onSecondary={handlePersistDraft}
+                    secondaryDisabled={saveDraftFetcher.state !== "idle"}
                     primaryLabel="Publish and Send"
                     onPrimary={() => setShowConfirmPopup(true)}
                 />
@@ -4449,7 +4506,9 @@ export default function CreateUpdate() {
             <div className="space-y-4">
                 <MonthlyUpdateStepper
                     activeStep="draft"
+                    disableMotion
                     enabledSteps={isEdit ? ["draft"] : ["connect", "draft"]}
+                    hideProgressUntilHover
                     onStepClick={handleDraftStepperClick}
                     expandOnHover
                     frameless
@@ -4611,21 +4670,27 @@ export default function CreateUpdate() {
                                                 Click any metric card to start editing.
                                             </p>
                                         ) : null}
-                                        <div className="grid gap-3 transition duration-200 sm:grid-cols-2 lg:grid-cols-4">
-                                        {draftMetricOptions.map((metric) => (
+                                        <div className="grid grid-cols-2 gap-3 transition duration-200 lg:grid-cols-4">
+                                        {draftMetricOptions.map((metric, metricIndex) => (
                                                 (() => {
                                                     const hasMetricValue = String(metricValues[metric.key] || "").trim().length > 0;
                                                     const isMetricCardAwake = !shouldDimMetricsTemplate || awakeMetricCards.has(metric.key) || hasMetricValue;
+                                                    const isHiddenOnMobile = metricIndex >= mobileVisibleDraftMetricCount;
                                                     return (
                                                 <label
                                                     key={metric.key}
                                                     className={clsx(
-                                                        "relative rounded-2xl border p-4 transition duration-200",
+                                                        "relative min-w-0 rounded-2xl border p-3 transition duration-200 sm:p-4",
+                                                        isHiddenOnMobile ? "hidden sm:block" : null,
                                                         isMetricCardAwake
                                                             ? "border-gray-200 bg-[var(--vr-palette-paper)]"
                                                             : "cursor-pointer border-gray-200/80 bg-[rgba(247,246,242,0.65)] opacity-45 saturate-0",
                                                     )}
-                                                    onClick={() => wakeMetricCard(metric.key)}
+                                                    onClick={(event) => {
+                                                        if ((event.target as HTMLElement).closest("button")) return;
+                                                        wakeMetricCard(metric.key);
+                                                        focusMetricInput(`draft-metric-${metric.key}`);
+                                                    }}
                                                 >
                                                     {shouldDimMetricsTemplate && isMetricCardAwake ? (
                                                         <button
@@ -4648,10 +4713,10 @@ export default function CreateUpdate() {
                                                         )}>
                                                             {metric.icon}
                                                         </span>
-                                                        <div className="min-w-0">
-                                                            <div className="group/metric-heading relative inline-flex max-w-full items-center">
+                                                        <div className="min-w-0 flex-1">
+                                                            <div className="group/metric-heading relative flex max-w-full flex-wrap items-center gap-1">
                                                                 <span className={clsx(
-                                                                    "cursor-help text-xs font-black uppercase tracking-wide transition duration-200",
+                                                                    "min-w-0 cursor-help break-words text-left text-[11px] font-black uppercase leading-tight tracking-wide transition duration-200 sm:text-xs",
                                                                     isMetricCardAwake ? "text-gray-500" : "text-gray-400",
                                                                 )}>
                                                                     {metric.label}
@@ -4666,6 +4731,7 @@ export default function CreateUpdate() {
                                                         </div>
                                                     </div>
                                                     <input
+                                                        id={`draft-metric-${metric.key}`}
                                                         type="text"
                                                         name={metric.key}
                                                         value={metricValues[metric.key] || ""}
@@ -4676,7 +4742,7 @@ export default function CreateUpdate() {
                                                         }}
                                                         placeholder={metric.prefix ? `${metric.prefix}${metric.placeholder}` : metric.placeholder}
                                                         className={clsx(
-                                                            "mt-4 w-full border-b-2 bg-transparent py-1 text-lg font-black outline-none transition",
+                                                            "mt-4 w-full min-w-0 border-b-2 bg-transparent py-1 text-base font-black outline-none transition placeholder:text-sm sm:text-lg",
                                                             isMetricCardAwake
                                                                 ? "border-[rgba(0,128,128,0.26)] text-gray-950 focus:border-[var(--vr-color-primary)]"
                                                                 : "border-gray-300 text-gray-400 focus:border-[var(--vr-color-primary)]",
@@ -4687,6 +4753,19 @@ export default function CreateUpdate() {
                                                 })()
                                         ))}
                                         </div>
+                                        {mobileVisibleDraftMetricCount < draftMetricOptions.length ? (
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    setMobileVisibleDraftMetricCount((previous) =>
+                                                        Math.min(previous + mobileDraftMetricBatchSize, draftMetricOptions.length),
+                                                    );
+                                                }}
+                                                className="inline-flex w-full items-center justify-center rounded-xl border border-[var(--vr-color-border)] bg-white px-4 py-2.5 text-xs font-black uppercase tracking-wide text-gray-700 transition hover:border-[var(--vr-color-primary)] hover:text-[var(--vr-color-primary)] sm:hidden"
+                                            >
+                                                Show more
+                                            </button>
+                                        ) : null}
                                     </div>
 
                                     <div className="space-y-5">
@@ -5255,7 +5334,10 @@ export default function CreateUpdate() {
 	                                        return (
 	                                            <div
 	                                                key={m.key}
-	                                                onClick={() => toggleActiveMetric(m.key)}
+	                                                onClick={(event) => {
+	                                                    if ((event.target as HTMLElement).closest("input,button,a,textarea,select")) return;
+	                                                    activateActiveMetric(m.key);
+	                                                }}
                                                 className={clsx(
                                                     "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
                                                     active
@@ -5272,19 +5354,20 @@ export default function CreateUpdate() {
                                                 </div>
                                                 {active ? (
                                                     <input
+	                                                        id={`active-metric-${m.key}`}
 	                                                        type="text"
 	                                                        name={isViewingCurrentUpdate ? m.key : undefined}
 	                                                        value={activeMetricValues[m.key] || ""}
 	                                                        onClick={(e) => e.stopPropagation()}
 	                                                        onChange={(e) => updateActiveMetric(m.key, e.target.value)}
                                                         placeholder={m.prefix ? `${m.prefix}${m.placeholder}` : m.placeholder}
-                                                        className="w-full border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-base font-extrabold text-gray-900 focus:border-[var(--vr-color-primary)] focus:outline-none"
+                                                        className="w-full min-w-0 border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-sm font-extrabold text-gray-900 placeholder:text-xs focus:border-[var(--vr-color-primary)] focus:outline-none sm:text-base"
                                                     />
                                                 ) : (
                                                     <p className="text-base font-extrabold text-gray-300">—</p>
                                                 )}
                                                 <p className={clsx(
-                                                    "text-[10px] font-semibold uppercase tracking-wide mt-1",
+                                                    "mt-1 max-w-full break-words text-[10px] font-semibold uppercase leading-tight tracking-wide",
                                                     active ? "text-gray-600" : "text-gray-400"
                                                 )}>{m.label}</p>
                                             </div>
@@ -5365,7 +5448,16 @@ export default function CreateUpdate() {
                                     return (
                                         <div
                                             key={m.key}
-                                            onClick={() => toggleMetric(m.key)}
+                                            onClick={(event) => {
+                                                if ((event.target as HTMLElement).closest("input,button,a,textarea,select")) return;
+                                                setSelectedMetrics((previous) => {
+                                                    if (previous.has(m.key)) return previous;
+                                                    const next = new Set(previous);
+                                                    next.add(m.key);
+                                                    return next;
+                                                });
+                                                focusMetricInput(`default-metric-${m.key}`);
+                                            }}
                                             className={clsx(
                                                 "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
                                                 active
@@ -5382,19 +5474,20 @@ export default function CreateUpdate() {
                                             </div>
                                             {active ? (
                                                 <input
+                                                    id={`default-metric-${m.key}`}
                                                     type="text"
                                                     name={m.key}
                                                     value={metricValues[m.key] || ""}
                                                     onClick={(e) => e.stopPropagation()}
                                                     onChange={(e) => setMetricValues(prev => ({ ...prev, [m.key]: e.target.value }))}
                                                     placeholder={m.prefix ? `${m.prefix}${m.placeholder}` : m.placeholder}
-                                                    className="w-full border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-base font-extrabold text-gray-900 focus:border-[var(--vr-color-primary)] focus:outline-none"
+                                                    className="w-full min-w-0 border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-sm font-extrabold text-gray-900 placeholder:text-xs focus:border-[var(--vr-color-primary)] focus:outline-none sm:text-base"
                                                 />
                                             ) : (
                                                 <p className="text-base font-extrabold text-gray-300">—</p>
                                             )}
                                             <p className={clsx(
-                                                "text-[10px] font-semibold uppercase tracking-wide mt-1",
+                                                "mt-1 max-w-full break-words text-[10px] font-semibold uppercase leading-tight tracking-wide",
                                                 active ? "text-gray-600" : "text-gray-400"
                                             )}>{m.label}</p>
                                         </div>

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -4848,6 +4848,7 @@ export default function CreateUpdate() {
             </section>
 
             <VibeRaisingStickyStepBar
+                className={!monthConfirmed ? "hidden sm:block" : undefined}
                 statusIcon={draftStickyStatusIcon}
                 statusTitle={draftStickyBar.statusTitle}
                 statusDetail={draftStickyBar.statusDetail}

--- a/app/styles/vibe-raising-components.css
+++ b/app/styles/vibe-raising-components.css
@@ -35,11 +35,27 @@
   position: relative;
   overflow: hidden;
   box-shadow: var(--vr-shadow-sm);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
   transition: box-shadow 0.15s, transform 0.15s;
 }
 
-.vr-scope .vr-metric-card:hover {
+.vr-scope .vr-metric-card:hover,
+.vr-scope .vr-metric-card:focus-visible {
   box-shadow: var(--vr-shadow-md);
+  transform: translateY(-2px);
+}
+
+.vr-scope .vr-metric-card:focus-visible {
+  outline: 2px solid rgba(0, 128, 128, 0.22);
+  outline-offset: 3px;
+}
+
+.vr-scope .vr-metric-card-active {
+  border-color: var(--vr-color-primary);
+  box-shadow: var(--vr-shadow-md), 0 0 0 3px rgba(0, 255, 215, 0.16);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- calm the Vibe Raising stepper by supporting motion-free hover expansion and hiding the progress bar until hover
- add stronger trust and privacy messaging plus a better mobile connector-card layout on Connect Data
- improve create-update and dashboard metric-card interactions, including mobile wrapping, click-to-edit behavior, and a secondary save-as-draft action in the sticky bar
- replace Required pills in company setup with simple required asterisks and move shared company-setup CTAs onto the Founder Tools primary token styling
- remove the overdue reminder banner from the founder updates dashboard and hide the duplicate pre-draft sticky CTA on mobile

## Testing
- previewed the MLAI Vibe Raising flow locally on the clean dev server port
- rechecked company setup and create-update in the in-app browser after the follow-up UI changes