### PR TITLE
Fix Data Sources mobile reset and topbar width

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,31 @@
 - [x] Regenerate `public/sitemap.xml`
 - [x] Run `bun run typecheck`
 - [x] Run `bun run build`
+- [x] Shorten company setup mobile instructions and add a first-time quick tour
+- [x] Add the same mobile-only first-time quick tour pattern to the Data Sources page
+- [x] Collapse Data Sources sticky-bar status copy on mobile so the footer stays usable
+- [x] Shorten Data Sources privacy and connector guidance copy for mobile
+- [x] Shorten Data Sources connector card descriptions and trust copy for mobile
+- [x] Move Create Update mobile instruction copy into a one-time tutorial and hide the visible card
+- [x] Let the Create Update mobile step chips wrap instead of clipping in a horizontal strip
+- [x] Align the active Founder Tools top-nav chip text color with the shared primary CTA token
+- [x] Replace the draft-page month change CTA with a top back button and static selected-month summary
+- [x] Flatten the Create Update investor-materials upload section to a single card surface
+- [x] Add dashed borders to inactive Create Update metric cards so they read as selectable
+- [x] Remove the passive hover tint from the Create Update upload surface and unify its typography
+- [x] Make Create Update mobile metric cards dismiss by tapping again instead of showing a close button
+- [x] Add a visible hover state to the Data Sources manual-input card and its Open form row
+- [x] Match the Google Analytics placeholder logo border to the other grey inactive source cards
+- [x] Match the Google Analytics placeholder footer spacing to the other source cards
+- [x] Remove the backend-availability warning line from all Data Sources cards
+- [x] Hide the extra Data Sources trust card on mobile so privacy guidance only appears in the one-time tutorial
+- [x] Rename unavailable Data Sources card labels from "Not available yet" to "Coming soon"
+- [x] Normalize Data Sources footer copy height so bottom actions align responsively across cards
+- [x] Make the top Data Sources privacy card first-time-only on mobile, with no persistent follow-up note
+- [x] Increase desktop stepper hover padding so the highlight fully wraps the numbered circle
+- [x] Remove stepper chip borders and switch non-active pills to white across shared variants
+- [x] Use shared design-token typography for stepper titles across the shared component
+- [x] Simplify Data Sources cards on mobile by hiding capability chips and footer helper copy
 - [x] Curl-check legacy redirects and canonical targets
 - [x] Add cleanup redirects for broken internal article CTA URLs
 - [x] Replace broken article CTA hrefs and copy with live destinations

--- a/TODO.md
+++ b/TODO.md
@@ -365,3 +365,8 @@
 - [x] Let Updates metric cards stay highlighted after click
 - [x] Make create-update metric cards activate edit mode from any card click
 - [x] Wrap create-update metric card text responsively and reveal extra mobile rows in 6-card Show more batches
+- [x] Simplify the Manage Companies page on mobile and tighten its company hero layout across breakpoints
+- [x] Remove motion from dashboard metric cards and make metric text wrap cleanly across breakpoints
+- [x] Simplify the expanded update metric summary cards and remove their icon treatment
+- [x] Make the expanded past-update card layout read cleanly on mobile
+- [x] Collapse long expanded-update sections on mobile and let users reveal the full list on demand

--- a/TODO.md
+++ b/TODO.md
@@ -370,3 +370,4 @@
 - [x] Simplify the expanded update metric summary cards and remove their icon treatment
 - [x] Make the expanded past-update card layout read cleanly on mobile
 - [x] Collapse long expanded-update sections on mobile and let users reveal the full list on demand
+- [x] Re-sync the Data Sources mobile tour after localStorage resets and tighten the Founder Tools top bar on mobile

--- a/TODO.md
+++ b/TODO.md
@@ -334,3 +334,9 @@
 - [x] Generate Roo kangaroo base pet art
 - [x] Generate Roo kangaroo animation rows
 - [x] Finalize and package Roo kangaroo pet
+- [x] Update the Connect Data stepper after user interview: hide the progress bar until hover and remove the motion
+- [x] Add visible trust and privacy messaging near Connect Data connector actions
+- [x] Fix Data Sources mobile card badges so they no longer overlap source names
+- [x] Let Updates metric cards stay highlighted after click
+- [x] Make create-update metric cards activate edit mode from any card click
+- [x] Wrap create-update metric card text responsively and reveal extra mobile rows in 6-card Show more batches

--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -421,7 +421,7 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                                                 className={classNames(
                                                     "whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-black uppercase tracking-[0.12em] transition sm:px-4",
                                                     current
-                                                        ? "border-[var(--vr-color-primary)] bg-[var(--vr-color-primary)] text-[var(--vr-color-shell-active-text)] shadow-sm"
+                                                        ? "border-[var(--vr-color-primary)] bg-[var(--vr-color-primary)] text-[var(--vr-color-primary-contrast)] shadow-sm"
                                                         : "border-[var(--vr-color-border)] bg-[rgba(255,255,255,0.72)] text-[var(--vr-color-text-mid)] hover:border-[var(--vr-color-primary)] hover:text-[var(--vr-color-text)]"
                                                 )}
                                             >

--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -408,9 +408,9 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                             )}
                         />
 
-                        <div className="flex flex-1 items-center justify-between gap-x-4 self-stretch lg:gap-x-6">
+                        <div className="flex flex-1 items-center justify-between gap-x-2 self-stretch sm:gap-x-4 lg:gap-x-6">
                             {showVibeRaisingTopNavigation ? (
-                                <nav className="flex min-w-0 items-center gap-2 overflow-x-auto py-2" aria-label="Vibe Raising">
+                                <nav className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-2 pr-1 sm:gap-2" aria-label="Vibe Raising">
                                     {VIBE_RAISING_TOP_NAVIGATION.map((item) => {
                                         const current = pathname === item.href || pathname.startsWith(`${item.href}/`);
 
@@ -419,7 +419,7 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                                                 key={item.name}
                                                 to={item.href}
                                                 className={classNames(
-                                                    "whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-black uppercase tracking-[0.12em] transition sm:px-4",
+                                                    "whitespace-nowrap rounded-full border px-2.5 py-1 text-[11px] font-black uppercase tracking-[0.1em] transition sm:px-4 sm:py-1.5 sm:text-xs sm:tracking-[0.12em]",
                                                     current
                                                         ? "border-[var(--vr-color-primary)] bg-[var(--vr-color-primary)] text-[var(--vr-color-primary-contrast)] shadow-sm"
                                                         : "border-[var(--vr-color-border)] bg-[rgba(255,255,255,0.72)] text-[var(--vr-color-text-mid)] hover:border-[var(--vr-color-primary)] hover:text-[var(--vr-color-text)]"
@@ -433,11 +433,11 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                             ) : (
                                 <div />
                             )}
-                            <div className="flex items-center gap-x-4 lg:gap-x-6">
+                            <div className="flex shrink-0 items-center gap-x-2 sm:gap-x-4 lg:gap-x-6">
                                 <button
                                     type="button"
                                     className={classNames(
-                                        "-m-2.5 p-2.5",
+                                        "hidden -m-2.5 p-2.5 sm:block",
                                         isFounderToolsApp
                                             ? "text-[var(--vr-color-text-sub)] hover:text-[var(--vr-color-text)]"
                                             : "text-gray-400 hover:text-gray-500"

--- a/app/components/MonthlyUpdateStepper.tsx
+++ b/app/components/MonthlyUpdateStepper.tsx
@@ -57,6 +57,7 @@ export default function MonthlyUpdateStepper({
   const progressPercent = ((activeIndex + 1) / MONTHLY_UPDATE_STEPS.length) * 100;
   const enabledStepSet = new Set(enabledSteps ?? MONTHLY_UPDATE_STEPS.map((step) => step.key));
   const canSelectStep = (step: MonthlyUpdateStepKey) => Boolean(onStepClick) && enabledStepSet.has(step);
+  const isLockedStep = (step: MonthlyUpdateStepKey, index: number) => !canSelectStep(step) && index > activeIndex;
 
   if (compact) {
     return (
@@ -81,11 +82,12 @@ export default function MonthlyUpdateStepper({
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+        <div className="mt-3 flex flex-wrap gap-2">
           {MONTHLY_UPDATE_STEPS.map((step, index) => {
             const isActive = index === activeIndex;
             const isComplete = index < activeIndex;
             const canSelect = canSelectStep(step.key);
+            const isLocked = isLockedStep(step.key, index);
             return (
               <button
                 key={step.key}
@@ -94,11 +96,12 @@ export default function MonthlyUpdateStepper({
                 disabled={!canSelect}
                 onClick={() => onStepClick?.(step.key)}
                 className={clsx(
-                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 transition",
-                  canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
-                  isActive && "bg-[var(--vr-color-primary)] text-white ring-[var(--vr-color-primary)]",
-                  isComplete && !isActive && "bg-[rgba(0,255,215,0.16)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]",
-                  !isActive && !isComplete && "bg-[var(--vr-color-neutral-50)] text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
+                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold transition",
+                  canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
+                  isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm",
+                  isComplete && !isActive && "bg-white text-[var(--vr-color-primary)]",
+                  !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)]",
+                  isLocked && "bg-white text-gray-400 opacity-85",
                 )}
               >
                 {step.title}
@@ -128,7 +131,7 @@ export default function MonthlyUpdateStepper({
             <p className="text-xs font-extrabold uppercase tracking-wide text-[var(--vr-color-primary)]">
               Step {activeIndex + 1} of {MONTHLY_UPDATE_STEPS.length}
             </p>
-            <h2 className="mt-1 truncate text-2xl font-black tracking-tight text-[var(--vr-color-text)]">
+            <h2 className="vr-text-page-title mt-1 truncate text-2xl font-black tracking-tight text-[var(--vr-color-text)]">
               {active.title}
             </h2>
           </div>
@@ -161,11 +164,12 @@ export default function MonthlyUpdateStepper({
           )}
         >
           <div className="pt-6">
-            <div className="flex gap-2 overflow-x-auto pb-1 sm:hidden">
+            <div className="flex flex-wrap gap-2 sm:hidden">
               {MONTHLY_UPDATE_STEPS.map((step, index) => {
                 const isActive = index === activeIndex;
                 const isComplete = index < activeIndex;
                 const canSelect = canSelectStep(step.key);
+                const isLocked = isLockedStep(step.key, index);
                 return (
                   <button
                     key={step.key}
@@ -174,12 +178,13 @@ export default function MonthlyUpdateStepper({
                     disabled={!canSelect}
                     onClick={() => onStepClick?.(step.key)}
                     className={clsx(
-                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1",
+                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold",
                       !disableMotion && "transition",
-                      canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
-                      isActive && "bg-[var(--vr-color-primary)] text-white ring-[var(--vr-color-primary)]",
-                      isComplete && !isActive && "bg-[rgba(0,255,215,0.16)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]",
-                      !isActive && !isComplete && "bg-[var(--vr-color-neutral-50)] text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
+                      canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
+                      isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm",
+                      isComplete && !isActive && "bg-white text-[var(--vr-color-primary)]",
+                      !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)]",
+                      isLocked && "bg-white text-gray-400 opacity-85",
                     )}
                   >
                     {step.title}
@@ -193,6 +198,7 @@ export default function MonthlyUpdateStepper({
                 const isActive = index === activeIndex;
                 const isComplete = index < activeIndex;
                 const canSelect = canSelectStep(step.key);
+                const isLocked = isLockedStep(step.key, index);
                 return (
                   <div key={step.key} className="relative min-w-0">
                     {index > 0 ? (
@@ -210,7 +216,7 @@ export default function MonthlyUpdateStepper({
                       disabled={!canSelect}
                       onClick={() => onStepClick?.(step.key)}
                       className={clsx(
-                        "relative flex w-full flex-col items-center rounded-xl px-2 pb-3 text-center",
+                        "relative flex w-full flex-col items-center rounded-xl px-3 pt-2 pb-4 text-center",
                         !disableMotion && "transition",
                         canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.12)]" : "cursor-default",
                       )}
@@ -221,7 +227,8 @@ export default function MonthlyUpdateStepper({
                           !disableMotion && "transition",
                           isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_4px_rgba(0,255,215,0.10)]",
                           isActive && !isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_5px_rgba(0,128,128,0.10)]",
-                          !isActive && !isComplete && "border-[var(--vr-color-border)] text-[var(--vr-color-text-sub)]",
+                          !isActive && !isComplete && !isLocked && "border-[var(--vr-color-border)] text-[var(--vr-color-text-sub)]",
+                          isLocked && "border-gray-200 bg-gray-50 text-gray-400",
                         )}
                       >
                         {index + 1}
@@ -229,7 +236,7 @@ export default function MonthlyUpdateStepper({
                       <p
                         className={clsx(
                           "mt-3 truncate text-base font-black",
-                          (isActive || isComplete) ? "text-[var(--vr-color-text)]" : "text-[var(--vr-color-text-sub)]",
+                          (isActive || isComplete) ? "text-[var(--vr-color-text)]" : isLocked ? "text-gray-400" : "text-[var(--vr-color-text-sub)]",
                         )}
                       >
                         {step.title}
@@ -237,7 +244,7 @@ export default function MonthlyUpdateStepper({
                       <p
                         className={clsx(
                           "mt-1 truncate text-xs font-semibold",
-                          isActive ? "text-[var(--vr-color-primary)]" : "text-[var(--vr-color-text-sub)]",
+                          isActive ? "text-[var(--vr-color-primary)]" : isLocked ? "text-gray-400" : "text-[var(--vr-color-text-sub)]",
                         )}
                       >
                         {step.helper}
@@ -269,7 +276,7 @@ export default function MonthlyUpdateStepper({
             <p className="text-xs font-extrabold uppercase tracking-wide text-[var(--vr-color-primary)]">
               Step {activeIndex + 1} of {MONTHLY_UPDATE_STEPS.length}
             </p>
-            <p className="mt-1 text-base font-black text-[var(--vr-color-text)]">{active.title}</p>
+            <p className="vr-text-card-title mt-1 text-base font-black text-[var(--vr-color-text)]">{active.title}</p>
           </div>
           <span className="rounded-full bg-[var(--vr-color-primary-soft)] px-3 py-1 text-xs font-bold text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,128,128,0.14)]">
             {active.helper}
@@ -281,11 +288,12 @@ export default function MonthlyUpdateStepper({
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
+        <div className="mt-4 flex flex-wrap gap-2">
           {MONTHLY_UPDATE_STEPS.map((step, index) => {
             const isActive = index === activeIndex;
             const isComplete = index < activeIndex;
             const canSelect = canSelectStep(step.key);
+            const isLocked = isLockedStep(step.key, index);
             return (
               <button
                 key={step.key}
@@ -294,11 +302,12 @@ export default function MonthlyUpdateStepper({
                 disabled={!canSelect}
                 onClick={() => onStepClick?.(step.key)}
                 className={clsx(
-                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 transition",
-                  canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
-                  isActive && "bg-[var(--vr-color-primary)] text-white ring-[var(--vr-color-primary)]",
-                  isComplete && !isActive && "bg-[rgba(0,255,215,0.16)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]",
-                  !isActive && !isComplete && "bg-[var(--vr-color-neutral-50)] text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
+                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold transition",
+                  canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
+                  isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm",
+                  isComplete && !isActive && "bg-white text-[var(--vr-color-primary)]",
+                  !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)]",
+                  isLocked && "bg-white text-gray-400 opacity-85",
                 )}
               >
                 {step.title}
@@ -315,7 +324,7 @@ export default function MonthlyUpdateStepper({
           </p>
           <p className="mt-1 text-sm font-bold text-[var(--vr-color-text-sub)]">Monthly update workflow</p>
         </div>
-        <p className="text-sm font-black text-[var(--vr-color-text)]">{active.title}</p>
+        <p className="vr-text-card-title text-sm font-black text-[var(--vr-color-text)]">{active.title}</p>
       </div>
 
       <div className={clsx("hidden sm:grid sm:grid-cols-4", frameless ? "gap-5" : "gap-3")}>
@@ -323,6 +332,7 @@ export default function MonthlyUpdateStepper({
           const isActive = index === activeIndex;
           const isComplete = index < activeIndex;
           const canSelect = canSelectStep(step.key);
+          const isLocked = isLockedStep(step.key, index);
           return (
             <div key={step.key} className="relative min-w-0">
               {index > 0 ? (
@@ -341,8 +351,8 @@ export default function MonthlyUpdateStepper({
                 disabled={!canSelect}
                 onClick={() => onStepClick?.(step.key)}
                   className={clsx(
-                    "relative flex w-full flex-col items-center rounded-xl px-2 text-center transition",
-                    frameless ? "pb-3" : "pb-2",
+                    "relative flex w-full flex-col items-center rounded-xl px-3 pt-2 text-center transition",
+                    frameless ? "pb-4" : "pb-3",
                     canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.12)]" : "cursor-default",
                   )}
                 >
@@ -352,7 +362,8 @@ export default function MonthlyUpdateStepper({
                     frameless ? "h-14 w-14 text-base" : "h-10 w-10 text-sm",
                     isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_4px_rgba(0,255,215,0.10)]",
                     isActive && !isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_5px_rgba(0,128,128,0.10)]",
-                    !isActive && !isComplete && "border-[var(--vr-color-border)] text-[var(--vr-color-text-sub)]",
+                    !isActive && !isComplete && !isLocked && "border-[var(--vr-color-border)] text-[var(--vr-color-text-sub)]",
+                    isLocked && "border-gray-200 bg-gray-50 text-gray-400",
                   )}
                 >
                   {index + 1}
@@ -361,7 +372,7 @@ export default function MonthlyUpdateStepper({
                   className={clsx(
                     "truncate font-black",
                     frameless ? "mt-4 text-base" : "mt-3 text-sm",
-                    (isActive || isComplete) ? "text-[var(--vr-color-text)]" : "text-[var(--vr-color-text-sub)]",
+                    (isActive || isComplete) ? "text-[var(--vr-color-text)]" : isLocked ? "text-gray-400" : "text-[var(--vr-color-text-sub)]",
                   )}
                 >
                   {step.title}
@@ -370,7 +381,7 @@ export default function MonthlyUpdateStepper({
                   className={clsx(
                     "mt-1 truncate font-semibold",
                     frameless ? "text-sm" : "text-xs",
-                    isActive ? "text-[var(--vr-color-primary)]" : "text-[var(--vr-color-text-sub)]",
+                    isActive ? "text-[var(--vr-color-primary)]" : isLocked ? "text-gray-400" : "text-[var(--vr-color-text-sub)]",
                   )}
                 >
                   {step.helper}

--- a/app/components/MonthlyUpdateStepper.tsx
+++ b/app/components/MonthlyUpdateStepper.tsx
@@ -96,12 +96,12 @@ export default function MonthlyUpdateStepper({
                 disabled={!canSelect}
                 onClick={() => onStepClick?.(step.key)}
                 className={clsx(
-                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold transition",
+                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset transition",
                   canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
-                  isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm",
-                  isComplete && !isActive && "bg-white text-[var(--vr-color-primary)]",
-                  !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)]",
-                  isLocked && "bg-white text-gray-400 opacity-85",
+                  isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm ring-[var(--vr-color-primary)]",
+                  isComplete && !isActive && "bg-[var(--vr-color-primary-soft)] text-[var(--vr-color-primary)] ring-[rgba(0,128,128,0.18)]",
+                  !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
+                  isLocked && "bg-white text-gray-400 opacity-85 ring-gray-200",
                 )}
               >
                 {step.title}
@@ -178,13 +178,13 @@ export default function MonthlyUpdateStepper({
                     disabled={!canSelect}
                     onClick={() => onStepClick?.(step.key)}
                     className={clsx(
-                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold",
+                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset",
                       !disableMotion && "transition",
                       canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
-                      isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm",
-                      isComplete && !isActive && "bg-white text-[var(--vr-color-primary)]",
-                      !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)]",
-                      isLocked && "bg-white text-gray-400 opacity-85",
+                      isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm ring-[var(--vr-color-primary)]",
+                      isComplete && !isActive && "bg-[var(--vr-color-primary-soft)] text-[var(--vr-color-primary)] ring-[rgba(0,128,128,0.18)]",
+                      !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
+                      isLocked && "bg-white text-gray-400 opacity-85 ring-gray-200",
                     )}
                   >
                     {step.title}
@@ -302,12 +302,12 @@ export default function MonthlyUpdateStepper({
                 disabled={!canSelect}
                 onClick={() => onStepClick?.(step.key)}
                 className={clsx(
-                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold transition",
+                  "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset transition",
                   canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
-                  isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm",
-                  isComplete && !isActive && "bg-white text-[var(--vr-color-primary)]",
-                  !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)]",
-                  isLocked && "bg-white text-gray-400 opacity-85",
+                  isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm ring-[var(--vr-color-primary)]",
+                  isComplete && !isActive && "bg-[var(--vr-color-primary-soft)] text-[var(--vr-color-primary)] ring-[rgba(0,128,128,0.18)]",
+                  !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
+                  isLocked && "bg-white text-gray-400 opacity-85 ring-gray-200",
                 )}
               >
                 {step.title}

--- a/app/components/MonthlyUpdateStepper.tsx
+++ b/app/components/MonthlyUpdateStepper.tsx
@@ -6,9 +6,11 @@ interface MonthlyUpdateStepperProps {
   activeStep: MonthlyUpdateStepKey;
   className?: string;
   compact?: boolean;
+  disableMotion?: boolean;
   enabledSteps?: MonthlyUpdateStepKey[];
   expandOnHover?: boolean;
   frameless?: boolean;
+  hideProgressUntilHover?: boolean;
   onStepClick?: (step: MonthlyUpdateStepKey) => void;
 }
 
@@ -43,9 +45,11 @@ export default function MonthlyUpdateStepper({
   activeStep,
   className,
   compact = false,
+  disableMotion = false,
   enabledSteps,
   expandOnHover = false,
   frameless = false,
+  hideProgressUntilHover = false,
   onStepClick,
 }: MonthlyUpdateStepperProps) {
   const activeIndex = Math.max(0, MONTHLY_UPDATE_STEPS.findIndex((step) => step.key === activeStep));
@@ -114,7 +118,10 @@ export default function MonthlyUpdateStepper({
       >
         <button
           type="button"
-          className="flex w-full items-center justify-between gap-4 rounded-2xl px-1 py-2 text-left outline-none transition hover:bg-[rgba(0,255,215,0.08)] focus-visible:bg-[rgba(0,255,215,0.08)] focus-visible:ring-2 focus-visible:ring-[rgba(0,128,128,0.18)]"
+          className={clsx(
+            "flex w-full items-center justify-between gap-4 rounded-2xl px-1 py-2 text-left outline-none hover:bg-[rgba(0,255,215,0.08)] focus-visible:bg-[rgba(0,255,215,0.08)] focus-visible:ring-2 focus-visible:ring-[rgba(0,128,128,0.18)]",
+            !disableMotion && "transition",
+          )}
           aria-label="Show monthly update workflow"
         >
           <div className="min-w-0">
@@ -126,18 +133,33 @@ export default function MonthlyUpdateStepper({
             </h2>
           </div>
           <span className="hidden rounded-full bg-[rgba(0,255,215,0.12)] px-3 py-1 text-xs font-bold text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.24)] sm:inline-flex">
-            Hover for steps
+            {disableMotion ? "Steps" : "Hover for steps"}
           </span>
         </button>
 
-        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--vr-color-border)]">
+        <div
+          className={clsx(
+            "mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--vr-color-border)]",
+            hideProgressUntilHover && "opacity-0 group-hover/stepper:opacity-100 group-focus-within/stepper:opacity-100",
+            hideProgressUntilHover && !disableMotion && "transition-opacity duration-150",
+          )}
+        >
           <div
-            className="h-full rounded-full bg-[var(--vr-color-primary)] transition-all duration-300"
+            className={clsx(
+              "h-full rounded-full bg-[var(--vr-color-primary)]",
+              !disableMotion && "transition-all duration-300",
+            )}
             style={{ width: `${progressPercent}%` }}
           />
         </div>
 
-        <div className="max-h-0 overflow-hidden opacity-0 transition-all duration-200 ease-out group-hover/stepper:max-h-64 group-hover/stepper:opacity-100 group-focus-within/stepper:max-h-64 group-focus-within/stepper:opacity-100">
+        <div
+          className={clsx(
+            disableMotion
+              ? "block"
+              : "max-h-0 overflow-hidden opacity-0 transition-all duration-200 ease-out group-hover/stepper:max-h-64 group-hover/stepper:opacity-100 group-focus-within/stepper:max-h-64 group-focus-within/stepper:opacity-100",
+          )}
+        >
           <div className="pt-6">
             <div className="flex gap-2 overflow-x-auto pb-1 sm:hidden">
               {MONTHLY_UPDATE_STEPS.map((step, index) => {
@@ -152,7 +174,8 @@ export default function MonthlyUpdateStepper({
                     disabled={!canSelect}
                     onClick={() => onStepClick?.(step.key)}
                     className={clsx(
-                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 transition",
+                      "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1",
+                      !disableMotion && "transition",
                       canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
                       isActive && "bg-[var(--vr-color-primary)] text-white ring-[var(--vr-color-primary)]",
                       isComplete && !isActive && "bg-[rgba(0,255,215,0.16)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]",
@@ -187,13 +210,15 @@ export default function MonthlyUpdateStepper({
                       disabled={!canSelect}
                       onClick={() => onStepClick?.(step.key)}
                       className={clsx(
-                        "relative flex w-full flex-col items-center rounded-xl px-2 pb-3 text-center transition",
+                        "relative flex w-full flex-col items-center rounded-xl px-2 pb-3 text-center",
+                        !disableMotion && "transition",
                         canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.12)]" : "cursor-default",
                       )}
                     >
                       <div
                         className={clsx(
-                          "z-10 flex h-12 w-12 items-center justify-center rounded-full border-2 bg-white text-base font-black transition",
+                          "z-10 flex h-12 w-12 items-center justify-center rounded-full border-2 bg-white text-base font-black",
+                          !disableMotion && "transition",
                           isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_4px_rgba(0,255,215,0.10)]",
                           isActive && !isComplete && "border-[var(--vr-color-primary)] text-[var(--vr-color-primary)] shadow-[0_0_0_5px_rgba(0,128,128,0.10)]",
                           !isActive && !isComplete && "border-[var(--vr-color-border)] text-[var(--vr-color-text-sub)]",

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -1,5 +1,5 @@
 import { Form, Link, useFetcher, useLocation, useNavigation } from "react-router";
-import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type RefObject } from "react";
 import {
   AlertTriangle,
   ArrowRight,
@@ -57,6 +57,7 @@ const FLOW_STEPS = [
 const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running"]);
 const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "cancelled", "denied"]);
 const RESEARCH_DONE_STATUSES = new Set(["completed", ...RESEARCH_FAILED_STATUSES]);
+const MOBILE_STARTUP_SETUP_TUTORIAL_STORAGE_KEY = "vibe_marketing_startup_setup_mobile_tour_seen_v1";
 
 const stableDateFormatter = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
@@ -106,6 +107,139 @@ type VibeMarketingStartupBaselineSetupProps = {
   showSetupProgress?: boolean;
   collapseCompletedSectionsByDefault?: boolean;
 };
+
+type MobileTutorialStep = {
+  key: string;
+  title: string;
+  body: string;
+  targetRef: RefObject<Element | null>;
+};
+
+function MobileStartupSetupTutorial({
+  open,
+  stepIndex,
+  steps,
+  onClose,
+  onBack,
+  onNext,
+}: {
+  open: boolean;
+  stepIndex: number;
+  steps: MobileTutorialStep[];
+  onClose: () => void;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const titleId = useId();
+  const step = steps[stepIndex];
+  const [targetRect, setTargetRect] = useState<{ top: number; left: number; width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    if (!open || !step) {
+      setTargetRect(null);
+      return;
+    }
+
+    const updateTargetRect = () => {
+      const node = step.targetRef.current;
+      if (!node) {
+        setTargetRect(null);
+        return;
+      }
+
+      const rect = node.getBoundingClientRect();
+      setTargetRect({
+        top: Math.max(rect.top - 8, 12),
+        left: Math.max(rect.left - 8, 12),
+        width: Math.min(rect.width + 16, window.innerWidth - 24),
+        height: rect.height + 16,
+      });
+    };
+
+    const handleViewportChange = () => {
+      window.requestAnimationFrame(updateTargetRect);
+    };
+
+    handleViewportChange();
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+    return () => {
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+    };
+  }, [open, step]);
+
+  if (!open || !step) return null;
+
+  const isLastStep = stepIndex === steps.length - 1;
+
+  return (
+    <div className="fixed inset-0 z-[140] sm:hidden" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+      <button
+        type="button"
+        className="absolute inset-0 bg-slate-950/55"
+        onClick={onClose}
+        aria-label="Close startup setup tour"
+      />
+
+      {targetRect ? (
+        <>
+          <div
+            className="pointer-events-none absolute rounded-[28px] border-2 border-[var(--vr-color-primary)] bg-transparent shadow-[0_0_0_9999px_rgba(15,23,42,0.58)] transition-all duration-200"
+            style={targetRect}
+          />
+          <div
+            className="pointer-events-none absolute rounded-full bg-[var(--vr-color-primary)] px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-white shadow-lg"
+            style={{ left: targetRect.left, top: Math.max(targetRect.top - 34, 10) }}
+          >
+            Step {stepIndex + 1}
+          </div>
+        </>
+      ) : null}
+
+      <section className="absolute inset-x-4 bottom-4 rounded-[28px] bg-white p-5 shadow-2xl shadow-black/20">
+        <p className="text-xs font-black uppercase tracking-[0.14em] text-[var(--vr-color-primary)]">
+          Quick mobile tour
+        </p>
+        <h2 id={titleId} className="mt-2 text-xl font-black text-gray-950">
+          {step.title}
+        </h2>
+        <p className="mt-3 text-sm font-semibold leading-6 text-slate-600">
+          {step.body}
+        </p>
+
+        <div className="mt-5 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center justify-center rounded-xl px-3 py-2 text-sm font-black text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+          >
+            Skip
+          </button>
+
+          <div className="flex items-center gap-2">
+            {stepIndex > 0 ? (
+              <button
+                type="button"
+                onClick={onBack}
+                className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-black text-slate-700 shadow-sm transition hover:bg-slate-50"
+              >
+                Back
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={onNext}
+              className="inline-flex items-center justify-center rounded-xl bg-[var(--vr-color-primary)] px-4 py-2 text-sm font-black text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)]"
+            >
+              {isLastStep ? "Got it" : "Next"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
 
 function listFromText(value: unknown): string[] {
   return String(value ?? "")
@@ -1505,7 +1639,7 @@ export default function VibeMarketingStartupBaselineSetup({
   includeBaseline = true,
   setupEyebrow = "Step 1 of 5",
   setupTitle = "Tell us about your startup",
-  setupDescription = "This helps us understand your business, audience, and what makes you unique.",
+  setupDescription = "Share the basics so we can tailor research and setup to your business.",
   primaryActionLabel,
   showSecondaryAction,
   setupProgressPercent = 20,
@@ -1531,6 +1665,9 @@ export default function VibeMarketingStartupBaselineSetup({
   const googleAutoRefreshSubmittedRef = useRef(false);
   const startupDefaults = useMemo(() => startupSetupDefaultsFromBootstrap(bootstrap), [bootstrap]);
   const startupDefaultsSignature = useMemo(() => JSON.stringify(startupDefaults), [startupDefaults]);
+  const mobileIntroRef = useRef<HTMLDivElement | null>(null);
+  const mobileResearchButtonRef = useRef<HTMLButtonElement | null>(null);
+  const mobileNextStepsRef = useRef<HTMLElement | null>(null);
   const activeCompanyKey = String(
     bootstrap.company.id ||
       bootstrap.company.organizationId ||
@@ -1554,6 +1691,10 @@ export default function VibeMarketingStartupBaselineSetup({
   const [autofillLastPollAt, setAutofillLastPollAt] = useState<number | null>(null);
   const [autofillProgressSignature, setAutofillProgressSignature] = useState("");
   const [autofillClock, setAutofillClock] = useState(() => Date.now());
+  const [isMobileTutorialViewport, setIsMobileTutorialViewport] = useState(false);
+  const [mobileTutorialOpen, setMobileTutorialOpen] = useState(false);
+  const [mobileTutorialStepIndex, setMobileTutorialStepIndex] = useState(0);
+  const [mobileTutorialChecked, setMobileTutorialChecked] = useState(false);
 
   const autofillStartData = autofillStartFetcher.data;
   const autofillRun = autofillRunFetcher.data as VibeMarketingRunSummary | undefined;
@@ -1661,6 +1802,29 @@ export default function VibeMarketingStartupBaselineSetup({
     typeof setupProgressPercent === "number" && Number.isFinite(setupProgressPercent)
       ? Math.max(0, Math.min(100, setupProgressPercent))
       : null;
+  const mobileTutorialSteps = useMemo<MobileTutorialStep[]>(
+    () => [
+      {
+        key: "profile",
+        title: "Start with the basics",
+        body: "Add your company name and website first. The rest can be refined after the essentials are in.",
+        targetRef: mobileIntroRef,
+      },
+      {
+        key: "research",
+        title: "Let AI prep the heavy lifting",
+        body: "Once the basics are filled in, run AI research to prepare company context from public sources without overwriting your profile.",
+        targetRef: mobileResearchButtonRef,
+      },
+      {
+        key: "next",
+        title: "You stay in control",
+        body: "This panel shows what happens next: we prepare context, then you review and approve the output yourself.",
+        targetRef: mobileNextStepsRef,
+      },
+    ],
+    [],
+  );
 
   const inputClass =
     "w-full rounded-lg border border-gray-200 bg-white py-3 pr-4 text-sm font-medium text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500";
@@ -1744,9 +1908,63 @@ export default function VibeMarketingStartupBaselineSetup({
   }, [activeCompanyKey, bootstrap.settings.companyContext, collapseCompletedSectionsByDefault, startupDefaults, startupDefaultsSignature]);
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const syncViewport = () => setIsMobileTutorialViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (mobileTutorialChecked || !isMobileTutorialViewport) return;
+    setMobileTutorialChecked(true);
+
+    if (startupProfileComplete) return;
+
+    try {
+      if (window.localStorage.getItem(MOBILE_STARTUP_SETUP_TUTORIAL_STORAGE_KEY) === "1") return;
+    } catch {
+      // Fall back to showing the tour if storage is unavailable.
+    }
+
+    const timer = window.setTimeout(() => {
+      setMobileTutorialStepIndex(0);
+      setMobileTutorialOpen(true);
+    }, 450);
+
+    return () => window.clearTimeout(timer);
+  }, [isMobileTutorialViewport, mobileTutorialChecked, startupProfileComplete]);
+
+  useEffect(() => {
     if (focusSection !== "baseline") return;
     window.setTimeout(() => baselineRef.current?.scrollIntoView({ block: "start", behavior: "smooth" }), 100);
   }, [focusSection]);
+
+  const closeMobileTutorial = () => {
+    setMobileTutorialOpen(false);
+    try {
+      window.localStorage.setItem(MOBILE_STARTUP_SETUP_TUTORIAL_STORAGE_KEY, "1");
+    } catch {
+      // Ignore storage failures; the tour can still be dismissed for this session.
+    }
+  };
+
+  const openMobileTutorial = () => {
+    setMobileTutorialStepIndex(0);
+    setMobileTutorialOpen(true);
+  };
+
+  const goToNextMobileTutorialStep = () => {
+    if (mobileTutorialStepIndex >= mobileTutorialSteps.length - 1) {
+      closeMobileTutorial();
+      return;
+    }
+    setMobileTutorialStepIndex((current) => current + 1);
+  };
+
+  const goToPreviousMobileTutorialStep = () => {
+    setMobileTutorialStepIndex((current) => Math.max(0, current - 1));
+  };
 
   useEffect(() => {
     if (googleAutoRefreshSubmittedRef.current) return;
@@ -1864,10 +2082,18 @@ export default function VibeMarketingStartupBaselineSetup({
 
       <div className="space-y-6 p-5 sm:p-6 lg:p-8">
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(240px,520px)] lg:items-start">
-          <div>
+          <div ref={mobileIntroRef}>
             <p className="text-sm font-black uppercase tracking-wide text-violet-700">{setupEyebrow}</p>
             <h2 className="mt-3 text-3xl font-black tracking-normal text-gray-950">{setupTitle}</h2>
             <p className="mt-3 max-w-3xl text-sm font-semibold leading-6 text-gray-600">{setupDescription}</p>
+            <button
+              type="button"
+              onClick={openMobileTutorial}
+              className="mt-4 inline-flex items-center gap-2 rounded-full border border-[rgba(0,128,128,0.18)] bg-[rgba(0,255,215,0.08)] px-3 py-1.5 text-xs font-black uppercase tracking-[0.12em] text-[var(--vr-color-primary)] sm:hidden"
+            >
+              Quick tour
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
           </div>
           {showSetupProgress && normalizedSetupProgress !== null ? (
             <div className="pt-2 lg:pt-10">
@@ -1892,7 +2118,8 @@ export default function VibeMarketingStartupBaselineSetup({
                     {startupProfileComplete ? <CompletePill /> : null}
                   </div>
                   <p className="mt-2 text-base font-semibold leading-7 text-gray-600">
-                    Add your company identity and business details once. AI research uses these answers without overwriting them.
+                    <span className="sm:hidden">Add your core details once. AI uses them as source-of-truth without changing them.</span>
+                    <span className="hidden sm:inline">Add your company identity and business details once. AI research uses these answers without overwriting them.</span>
                   </p>
                 </div>
               </div>
@@ -1919,9 +2146,10 @@ export default function VibeMarketingStartupBaselineSetup({
                       <Sparkles className="h-7 w-7" />
                     </span>
                     <div>
-                      <h3 className="text-xl font-black tracking-normal text-violet-800">Save time - let our AI do the heavy lifting</h3>
+                      <h3 className="text-xl font-black tracking-normal text-violet-800">Let AI do the heavy lifting</h3>
                       <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-700">
-                        Add or review your details below, then AI can scan public sources and prepare article-generation context from your answers.
+                        <span className="sm:hidden">Fill the basics, then let AI prep company context from public sources.</span>
+                        <span className="hidden sm:inline">Add or review your details below, then AI can scan public sources and prepare article-generation context from your answers.</span>
                         <span className="ml-2 inline-flex items-center gap-1 font-black text-violet-700">
                           Learn how it works <ArrowRight className="h-4 w-4" />
                         </span>
@@ -2135,6 +2363,7 @@ export default function VibeMarketingStartupBaselineSetup({
                 type="button"
                 onClick={startAutofill}
                 disabled={!canStartAutofill}
+                ref={mobileResearchButtonRef}
                 className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-[var(--vr-color-primary)] px-6 py-5 text-left text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <span className="flex min-w-0 items-center gap-4">
@@ -2173,7 +2402,7 @@ export default function VibeMarketingStartupBaselineSetup({
             </div>
           </section>
 
-          <aside className={clsx("self-start rounded-xl border border-gray-200 bg-white p-6 shadow-sm", !profileContentExpanded && "hidden")}>
+          <aside ref={mobileNextStepsRef} className={clsx("self-start rounded-xl border border-gray-200 bg-white p-6 shadow-sm", !profileContentExpanded && "hidden")}>
             <h3 className="text-base font-black text-gray-950">What happens next?</h3>
             <div className="mt-5 space-y-5">
               <NextStepItem icon={Search} title="We research your company" body="AI reviews your site, LinkedIn page, and trusted public sources using your answers as ground truth." />
@@ -2192,6 +2421,15 @@ export default function VibeMarketingStartupBaselineSetup({
           </aside>
         </div>
       </div>
+
+      <MobileStartupSetupTutorial
+        open={mobileTutorialOpen}
+        stepIndex={mobileTutorialStepIndex}
+        steps={mobileTutorialSteps}
+        onClose={closeMobileTutorial}
+        onBack={goToPreviousMobileTutorialStep}
+        onNext={goToNextMobileTutorialStep}
+      />
 
       {includeBaseline ? (
         <section

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -797,7 +797,7 @@ function FormField({
 }
 
 function RequiredPill() {
-  return <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-[10px] font-black text-emerald-700">Required</span>;
+  return <span className="text-sm font-black leading-none text-red-500" aria-label="required">*</span>;
 }
 
 function CompletePill() {
@@ -2135,13 +2135,13 @@ export default function VibeMarketingStartupBaselineSetup({
                 type="button"
                 onClick={startAutofill}
                 disabled={!canStartAutofill}
-                className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-violet-700 px-6 py-5 text-left text-white shadow-lg shadow-violet-200 transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-[var(--vr-color-primary)] px-6 py-5 text-left text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <span className="flex min-w-0 items-center gap-4">
                   {autofillPending || autofillPolling ? <Loader2 className="h-7 w-7 shrink-0 animate-spin" /> : <Sparkles className="h-7 w-7 shrink-0" />}
                   <span className="min-w-0">
                     <span className="block text-lg font-black">Research my company context</span>
-                    <span className="mt-1 block text-sm font-semibold text-violet-100">AI will use these answers to prepare article context and SEO inputs</span>
+                    <span className="mt-1 block text-sm font-semibold text-white/80">AI will use these answers to prepare article context and SEO inputs</span>
                   </span>
                 </span>
                 <ArrowRight className="h-6 w-6 shrink-0" />
@@ -2305,7 +2305,7 @@ export default function VibeMarketingStartupBaselineSetup({
                   type="button"
                   onClick={startBaseline}
                   disabled={!canStartBaseline}
-                  className="inline-flex items-center gap-2 rounded-xl bg-violet-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-4 py-2.5 text-sm font-black text-white shadow-sm shadow-[rgba(0,128,128,0.16)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <BarChart3 className="h-4 w-4" />}
                   {effectiveBaseline.overallScore === null || effectiveBaseline.status === "missing" ? "Generate baseline" : "Rerun baseline"}
@@ -2546,7 +2546,7 @@ export default function VibeMarketingStartupBaselineSetup({
             name="nextAction"
             value="continue"
             disabled={saveActionPending || researchLocked}
-            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-violet-700 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-800 disabled:cursor-not-allowed disabled:opacity-50 sm:px-7"
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-5 py-3 text-sm font-black text-white shadow-sm shadow-[rgba(0,128,128,0.16)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50 sm:px-7"
           >
             {continuePending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
             {continuePending ? "Continuing..." : primaryActionLabel ?? defaultPrimaryActionLabel}

--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -3,6 +3,7 @@ import { ArrowRightIcon } from "@heroicons/react/24/outline";
 
 type VibeRaisingStickyStepBarProps = {
     className?: string;
+    hideStatusOnMobile?: boolean;
     statusIcon?: ReactNode;
     statusTitle: string;
     statusDetail?: string;
@@ -20,6 +21,7 @@ type VibeRaisingStickyStepBarProps = {
 
 export default function VibeRaisingStickyStepBar({
     className,
+    hideStatusOnMobile = false,
     statusIcon,
     statusTitle,
     statusDetail,
@@ -37,7 +39,7 @@ export default function VibeRaisingStickyStepBar({
     return (
         <div className={["fixed inset-x-4 bottom-4 z-40 lg:left-24", className].filter(Boolean).join(" ")}>
             <div className="mx-auto flex max-w-6xl flex-col gap-4 rounded-2xl border border-[var(--vr-color-border)] bg-white/95 px-4 py-4 shadow-2xl shadow-black/10 backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:px-5">
-                <div className="flex min-w-0 items-center gap-3">
+                <div className={["flex min-w-0 items-center gap-3", hideStatusOnMobile ? "hidden sm:flex" : ""].filter(Boolean).join(" ")}>
                     {statusIcon ? (
                         <div className="flex flex-shrink-0 items-center justify-center">
                             {statusIcon}
@@ -76,7 +78,7 @@ export default function VibeRaisingStickyStepBar({
                         form={primaryForm}
                         onClick={primaryType === "button" ? onPrimary : undefined}
                         disabled={primaryDisabled}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--vr-palette-purple)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(150,73,210,0.25)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0 sm:min-w-44 sm:w-auto"
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0 sm:min-w-44 sm:w-auto"
                     >
                         {primaryLabel}
                         <ArrowRightIcon className="h-4 w-4" />

--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { ArrowRightIcon } from "@heroicons/react/24/outline";
 
 type VibeRaisingStickyStepBarProps = {
+    className?: string;
     statusIcon?: ReactNode;
     statusTitle: string;
     statusDetail?: string;
@@ -18,6 +19,7 @@ type VibeRaisingStickyStepBarProps = {
 };
 
 export default function VibeRaisingStickyStepBar({
+    className,
     statusIcon,
     statusTitle,
     statusDetail,
@@ -33,7 +35,7 @@ export default function VibeRaisingStickyStepBar({
     primaryForm,
 }: VibeRaisingStickyStepBarProps) {
     return (
-        <div className="fixed inset-x-4 bottom-4 z-40 lg:left-24">
+        <div className={["fixed inset-x-4 bottom-4 z-40 lg:left-24", className].filter(Boolean).join(" ")}>
             <div className="mx-auto flex max-w-6xl flex-col gap-4 rounded-2xl border border-[var(--vr-color-border)] bg-white/95 px-4 py-4 shadow-2xl shadow-black/10 backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:px-5">
                 <div className="flex min-w-0 items-center gap-3">
                     {statusIcon ? (
@@ -42,19 +44,19 @@ export default function VibeRaisingStickyStepBar({
                         </div>
                     ) : null}
                     <div className="min-w-0">
-                        <p className="truncate text-sm font-black text-gray-950">{statusTitle}</p>
+                        <p className="text-sm font-black leading-tight text-gray-950 sm:truncate">{statusTitle}</p>
                         {statusDetail ? (
-                            <p className="mt-0.5 truncate text-xs font-semibold text-slate-500">{statusDetail}</p>
+                            <p className="mt-0.5 text-xs font-semibold leading-tight text-slate-500 sm:truncate">{statusDetail}</p>
                         ) : null}
                     </div>
                 </div>
 
-                <div className="flex flex-shrink-0 items-center justify-end gap-3">
+                <div className="flex flex-col gap-3 sm:flex-shrink-0 sm:flex-row sm:items-center sm:justify-end">
                     {onBack ? (
                         <button
                             type="button"
                             onClick={onBack}
-                            className="inline-flex items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950"
+                            className="inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950 sm:w-auto"
                         >
                             {backLabel}
                         </button>
@@ -64,7 +66,7 @@ export default function VibeRaisingStickyStepBar({
                             type="button"
                             onClick={onSecondary}
                             disabled={secondaryDisabled}
-                            className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55"
+                            className="inline-flex w-full items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55 sm:w-auto"
                         >
                             {secondaryLabel}
                         </button>
@@ -74,7 +76,7 @@ export default function VibeRaisingStickyStepBar({
                         form={primaryForm}
                         onClick={primaryType === "button" ? onPrimary : undefined}
                         disabled={primaryDisabled}
-                        className="inline-flex min-w-44 items-center justify-center gap-2 rounded-xl bg-[var(--vr-palette-purple)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(150,73,210,0.25)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0"
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--vr-palette-purple)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(150,73,210,0.25)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0 sm:min-w-44 sm:w-auto"
                     >
                         {primaryLabel}
                         <ArrowRightIcon className="h-4 w-4" />

--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -7,6 +7,9 @@ type VibeRaisingStickyStepBarProps = {
     statusDetail?: string;
     backLabel?: string;
     onBack?: () => void;
+    secondaryLabel?: string;
+    onSecondary?: () => void;
+    secondaryDisabled?: boolean;
     primaryLabel: string;
     onPrimary?: () => void;
     primaryDisabled?: boolean;
@@ -20,6 +23,9 @@ export default function VibeRaisingStickyStepBar({
     statusDetail,
     backLabel = "Back",
     onBack,
+    secondaryLabel,
+    onSecondary,
+    secondaryDisabled = false,
     primaryLabel,
     onPrimary,
     primaryDisabled = false,
@@ -51,6 +57,16 @@ export default function VibeRaisingStickyStepBar({
                             className="inline-flex items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950"
                         >
                             {backLabel}
+                        </button>
+                    ) : null}
+                    {secondaryLabel && onSecondary ? (
+                        <button
+                            type="button"
+                            onClick={onSecondary}
+                            disabled={secondaryDisabled}
+                            className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55"
+                        >
+                            {secondaryLabel}
                         </button>
                     ) : null}
                     <button

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -972,6 +972,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
     const [expandedPastUpdateId, setExpandedPastUpdateId] = useState<string | null>(
         currentUpdate ? null : pastUpdates[0]?.id ?? null
     );
+    const [activeMetricCard, setActiveMetricCard] = useState<string | null>(null);
 
     if (!hasUpdates) {
         return (
@@ -1152,7 +1153,12 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
 
             {/* Dashboard metrics row — prototype .metric-card design, scoped under vr- */}
             <div className="vr-metrics-row">
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "mrr"}
+                    className={clsx("vr-metric-card", activeMetricCard === "mrr" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "mrr" ? null : "mrr")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-primary), var(--vr-color-secondary))" }}
@@ -1165,9 +1171,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         {latestUpdate?.metrics?.revenue?.replace(/\s*MRR$/i, "") || "—"}
                     </div>
                     <div className="vr-metric-delta vr-delta-up">↑ 18% month-on-month</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "active-users"}
+                    className={clsx("vr-metric-card", activeMetricCard === "active-users" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "active-users" ? null : "active-users")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-secondary), var(--vr-color-featured))" }}
@@ -1177,9 +1188,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         {latestUpdate?.metrics?.users?.replace(/\s*active$/i, "") || "—"}
                     </div>
                     <div className="vr-metric-delta vr-delta-up">↑ 220 new this month</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "runway"}
+                    className={clsx("vr-metric-card", activeMetricCard === "runway" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "runway" ? null : "runway")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "var(--vr-color-brand-orange)" }}
@@ -1192,9 +1208,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         {latestUpdate?.metrics?.runway?.replace(/\s*months?$/i, " mo") || "—"}
                     </div>
                     <div className="vr-metric-delta vr-delta-down">↓ 2 months vs forecast</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "raise-committed"}
+                    className={clsx("vr-metric-card", activeMetricCard === "raise-committed" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "raise-committed" ? null : "raise-committed")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-featured), var(--vr-color-brand-teal-light))" }}
@@ -1202,9 +1223,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="vr-metric-eyebrow">Raise Committed</div>
                     <div className="vr-metric-value">62%</div>
                     <div className="vr-metric-delta vr-delta-neutral">$750K of $1.2M</div>
-                </div>
+                </button>
 
-                <div className="vr-metric-card">
+                <button
+                    type="button"
+                    aria-pressed={activeMetricCard === "burn-rate"}
+                    className={clsx("vr-metric-card", activeMetricCard === "burn-rate" && "vr-metric-card-active")}
+                    onClick={() => setActiveMetricCard((current) => current === "burn-rate" ? null : "burn-rate")}
+                >
                     <div
                         className="vr-metric-card-bar"
                         style={{ background: "linear-gradient(90deg, var(--vr-color-brand-orange), var(--vr-color-warning))" }}
@@ -1212,7 +1238,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="vr-metric-eyebrow">Burn Rate</div>
                     <div className="vr-metric-value">$52K/mo</div>
                     <div className="vr-metric-delta vr-delta-down">↑ 8% vs last month</div>
-                </div>
+                </button>
             </div>
 
             {isOverdue && (

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -1,5 +1,5 @@
 import { Link, redirect, useLoaderData, useOutletContext, useNavigate } from "react-router";
-import { format, differenceInDays } from "date-fns";
+import { format } from "date-fns";
 import { useState, useRef, useEffect } from "react";
 import type { Route } from "./+types/vibe-raising-app._index";
 import {
@@ -12,7 +12,6 @@ import { clsx } from "clsx";
 import { getEnv } from "~/lib/env.server";
 import {
     ArrowRightIcon,
-    ClockIcon,
     ChartBarIcon,
     PencilSquareIcon,
     SparklesIcon,
@@ -950,9 +949,6 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
     const hasUpdates = updates.length > 0;
 
     const latestUpdate = hasUpdates ? updates[0] : null;
-    const daysSinceLast = latestUpdate ? differenceInDays(new Date(), new Date(latestUpdate.date)) : 0;
-    const isOverdue = daysSinceLast > 21;
-    const daysOverdue = daysSinceLast - 21;
 
     const now = new Date();
     const currentUpdate = updates.find((update) => {
@@ -1240,36 +1236,6 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="vr-metric-delta vr-delta-down">↑ 8% vs last month</div>
                 </button>
             </div>
-
-            {isOverdue && (
-                <div className="relative overflow-hidden rounded-xl border border-[rgba(0,255,215,0.26)] bg-[rgba(0,255,215,0.12)] p-6 shadow-sm">
-                    <div className="relative z-10 flex flex-col md:flex-row md:items-center justify-between gap-6">
-                        <div className="flex items-start gap-4">
-                            <div className="rounded-full border border-[rgba(0,255,215,0.26)] bg-white p-3 text-[var(--vr-color-primary)] shadow-sm">
-                                <ClockIcon className="w-8 h-8" />
-                            </div>
-                            <div>
-                                <div className="flex items-center gap-3 mb-1">
-                                    <h2 className="text-lg font-bold text-gray-900">Time for Your Monthly Update!</h2>
-                                    <span className="rounded-full bg-[rgba(0,255,215,0.24)] px-2.5 py-0.5 text-xs font-bold text-[var(--vr-color-primary)]">
-                                        {daysOverdue} days overdue
-                                    </span>
-                                </div>
-                                <p className="text-gray-700 mb-4">
-                                    Your last update was on <span className="font-semibold">{format(new Date(latestUpdate!.date), "MMMM d, yyyy")}</span>.
-                                    Keep your investors engaged with your latest progress!
-                                </p>
-                            </div>
-                        </div>
-                        <Link
-                            to="/founder-tools/data-sources"
-                            className="whitespace-nowrap rounded-lg bg-[var(--vr-color-primary)] px-6 py-3 font-bold text-white shadow-sm transition-colors hover:bg-[var(--vr-palette-black)]"
-                        >
-                            Create Update Now
-                        </Link>
-                    </div>
-                </div>
-            )}
 
             {/* Tabs + tab content */}
             <div>

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -160,26 +160,20 @@ function UpdateVideoHero({ update }: { update: { videoUrl?: string | null; video
 }
 
 // Reuseable Components
-function MetricCard({ label, value, icon: Icon, active = true }: { label: string, value: string, icon: any, colorClass?: string, active?: boolean }) {
+function MetricCard({ label, value, icon: _Icon, active = true }: { label: string, value: string, icon: any, colorClass?: string, active?: boolean }) {
     return (
         <div className={clsx(
-            "rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 transition-all",
+            "flex flex-col items-center justify-center rounded-xl border px-3 py-4 text-center",
             active
-                ? "border-[var(--vr-color-primary)] bg-[rgba(0,255,215,0.12)] ring-1 ring-[rgba(0,128,128,0.16)] shadow-sm"
-                : "border-gray-200 bg-gray-50 opacity-40"
+                ? "border-[var(--vr-color-border-md)] bg-white shadow-sm"
+                : "border-gray-200 bg-gray-50/80 opacity-45"
         )}>
-            <div className={clsx(
-                "w-7 h-7 rounded-full flex items-center justify-center mb-1.5",
-                active ? "bg-[rgba(0,255,215,0.18)]" : "bg-white"
-            )}>
-                <Icon className="w-4 h-4 text-gray-400" />
-            </div>
             <p className={clsx(
-                "text-base font-extrabold leading-tight",
+                "text-base font-black leading-tight sm:text-[1.75rem]",
                 active ? "text-gray-900" : "text-gray-300"
             )}>{active ? value : "—"}</p>
             <p className={clsx(
-                "text-xs sm:text-[10px] font-semibold uppercase tracking-wide mt-1",
+                "mt-2 text-[11px] font-bold uppercase tracking-[0.12em]",
                 active ? "text-gray-600" : "text-gray-400"
             )}>{label}</p>
         </div>
@@ -187,34 +181,28 @@ function MetricCard({ label, value, icon: Icon, active = true }: { label: string
 }
 
 // Editable metric input for inline editing
-function EditableMetricCard({ label, value, icon: Icon, active = true, editing, onChange }: { label: string, value: string, icon: any, colorClass?: string, active?: boolean, editing: boolean, onChange: (v: string) => void }) {
-    if (!editing) return <MetricCard label={label} value={value} icon={Icon} active={active} />;
+function EditableMetricCard({ label, value, icon: _Icon, active = true, editing, onChange }: { label: string, value: string, icon: any, colorClass?: string, active?: boolean, editing: boolean, onChange: (v: string) => void }) {
+    if (!editing) return <MetricCard label={label} value={value} icon={_Icon} active={active} />;
     return (
         <div className={clsx(
-            "rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
+            "flex cursor-pointer flex-col items-center justify-center rounded-xl border px-3 py-4 text-center transition-all",
             active
-                ? "border-[var(--vr-color-primary)] bg-[rgba(0,255,215,0.12)] ring-1 ring-[rgba(0,128,128,0.16)] shadow-sm"
+                ? "border-[var(--vr-color-border-md)] bg-white shadow-sm"
                 : "border-gray-200 bg-gray-50 opacity-50 hover:opacity-75 hover:border-gray-300"
         )}>
-            <div className={clsx(
-                "w-7 h-7 rounded-full flex items-center justify-center mb-1.5",
-                active ? "bg-[rgba(0,255,215,0.18)]" : "bg-white"
-            )}>
-                <Icon className="w-4 h-4 text-gray-400" />
-            </div>
             {active ? (
                 <input
                     type="text"
                     value={value}
                     onClick={(e) => e.stopPropagation()}
                     onChange={(e) => onChange(e.target.value)}
-                    className="w-full border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-base font-extrabold text-gray-900 focus:border-[var(--vr-color-primary)] focus:outline-none"
+                    className="w-full border-b-2 border-[rgba(0,128,128,0.18)] bg-transparent py-0.5 text-center text-base font-black text-gray-900 focus:border-[var(--vr-color-primary)] focus:outline-none sm:text-[1.75rem]"
                 />
             ) : (
                 <p className="text-base font-extrabold text-gray-300">—</p>
             )}
             <p className={clsx(
-                "text-xs sm:text-[10px] font-semibold uppercase tracking-wide mt-1",
+                "mt-2 text-[11px] font-bold uppercase tracking-[0.12em]",
                 active ? "text-gray-600" : "text-gray-400"
             )}>{label}</p>
         </div>
@@ -656,7 +644,11 @@ function VRUpdateSection({
     label: string;
     items: string[];
 }) {
+    const [mobileExpanded, setMobileExpanded] = useState(false);
     if (items.length === 0) return null;
+    const shouldClampOnMobile = items.length > 2;
+    const visibleItems = mobileExpanded ? items : items.slice(0, 2);
+
     return (
         <div className="vr-us-block">
             <div className="vr-us-heading">
@@ -666,13 +658,22 @@ function VRUpdateSection({
                 <span className="vr-us-heading-text">{label}</span>
             </div>
             <div className="vr-us-list">
-                {items.map((item, i) => (
+                {visibleItems.map((item, i) => (
                     <div className="vr-us-item" key={i}>
                         <span className="vr-us-item-dot">•</span>
                         <span className="vr-us-item-text">{item.trim()}</span>
                     </div>
                 ))}
             </div>
+            {shouldClampOnMobile ? (
+                <button
+                    type="button"
+                    onClick={() => setMobileExpanded((current) => !current)}
+                    className="mt-2 inline-flex text-xs font-bold text-[var(--vr-color-primary)] sm:hidden"
+                >
+                    {mobileExpanded ? "Show less" : `Show all ${items.length}`}
+                </button>
+            ) : null}
         </div>
     );
 }
@@ -858,15 +859,14 @@ function VRPastUpdateRow({
                         <span>{format(new Date(update.date), "MMMM d, yyyy")}</span>
                         <Link
                             to={`/founder-tools/updates/create?edit=${encodeURIComponent(update.id)}`}
-                            className="inline-flex items-center gap-1.5 text-sm font-medium"
-                            style={{ color: "var(--vr-color-text-mid)" }}
+                            className="vr-past-edit"
                         >
                             <PencilSquareIcon className="h-4 w-4" />
                             Edit
                         </Link>
                     </div>
 
-                    <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+                    <div className="vr-past-metrics-grid">
                         {update.metrics?.revenue ? (
                             <MetricCard label="Revenue" value={update.metrics.revenue} icon={CurrencyDollarIcon} />
                         ) : null}

--- a/app/routes/vibe-raising-app.companies.tsx
+++ b/app/routes/vibe-raising-app.companies.tsx
@@ -12,7 +12,6 @@ import {
     PlusIcon,
     BuildingOffice2Icon,
     CheckCircleIcon,
-    ArrowRightIcon,
     PencilSquareIcon,
     GlobeAltIcon,
     IdentificationIcon,
@@ -78,13 +77,14 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                         className="vr-text-body-small mt-1"
                         style={{ color: "var(--vr-color-text-mid)" }}
                     >
-                        Your active company is front and centre. Add another startup or switch between them any time.
+                        <span className="sm:hidden">Switch companies or add another startup.</span>
+                        <span className="hidden sm:inline">Your active company is front and centre. Add another startup or switch between them any time.</span>
                     </p>
                 </div>
                 <div className="flex items-center gap-2.5 flex-wrap">
                     <Link
                         to="/founder-tools/company-setup?new=true"
-                        className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg transition-all"
+                        className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-black transition-all sm:min-h-0 sm:w-auto sm:justify-start sm:rounded-lg sm:py-2.5"
                         style={{
                             background: "var(--vr-color-primary)",
                             color: "#fff",
@@ -110,20 +110,21 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                     <div className="vr-company-hero-banner relative">
                         <div className="vr-company-hero-banner-bubble-1" />
                         <div className="vr-company-hero-banner-bubble-2" />
-                        <div className="absolute top-4 right-4">
-                            <span className="vr-badge vr-badge-teal inline-flex items-center gap-1">
-                                <CheckCircleIcon className="w-3.5 h-3.5" />
-                                Active
+                        <div className="absolute right-3 top-3 sm:right-4 sm:top-4">
+                            <span className="vr-badge vr-badge-teal inline-flex items-center gap-1 px-2 py-1 text-[10px] sm:px-[10px] sm:py-[3px] sm:text-xs">
+                                <CheckCircleIcon className="hidden h-3.5 w-3.5 sm:block" />
+                                <span className="sm:hidden">Live</span>
+                                <span className="hidden sm:inline">Active</span>
                             </span>
                         </div>
                     </div>
 
                     {/* Showcase body */}
-                    <div className="p-6 sm:p-8 space-y-6">
+                    <div className="space-y-5 p-5 sm:space-y-6 sm:p-8">
                         {/* Title + logo row */}
-                        <div className="flex items-start gap-4 flex-wrap">
+                        <div className="flex flex-wrap items-start gap-3 sm:gap-4">
                             <div
-                                className="w-14 h-14 rounded-xl flex items-center justify-center overflow-hidden flex-shrink-0"
+                                className="flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl sm:h-14 sm:w-14"
                                 style={{
                                     background: "var(--vr-color-surface)",
                                     border: "1px solid var(--vr-color-border)",
@@ -133,11 +134,11 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                                     <img
                                         src={`https://www.google.com/s2/favicons?domain=${activeCompany.domain}&sz=128`}
                                         alt={activeCompany.name}
-                                        className="w-10 h-10 rounded"
+                                        className="h-8 w-8 rounded sm:h-10 sm:w-10"
                                     />
                                 ) : (
                                     <BuildingOffice2Icon
-                                        className="w-7 h-7"
+                                        className="h-6 w-6 sm:h-7 sm:w-7"
                                         style={{ color: "var(--vr-color-text-sub)" }}
                                     />
                                 )}
@@ -145,11 +146,11 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                             <div className="flex-1 min-w-0">
                                 <h2
                                     className="vr-text-card-title"
-                                    style={{ fontSize: "28px", lineHeight: 1.15 }}
+                                    style={{ fontSize: "clamp(22px, 4vw, 28px)", lineHeight: 1.15 }}
                                 >
                                     {activeCompany.name}
                                 </h2>
-                                <div className="flex flex-wrap items-center gap-2 mt-1">
+                                <div className="mt-1 flex flex-wrap items-center gap-2">
                                     <StartupRegionBadge location={activeCompany.location} />
                                     {activeCompany.registered && (
                                         <span
@@ -201,34 +202,23 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
 
                         {/* Actions */}
                         <div
-                            className="flex flex-wrap gap-2.5 pt-2"
+                            className="flex flex-col gap-2.5 pt-2 sm:flex-row sm:flex-wrap"
                             style={{ borderTop: "1px solid var(--vr-color-border)" }}
                         >
                             <Link
                                 to={activeCompanyHasUpdates ? "/founder-tools/updates" : "/founder-tools/updates/create"}
-                                className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold transition-all mt-5"
-                                style={{
-                                    background: "var(--vr-color-primary)",
-                                    color: "#fff",
-                                    borderRadius: "var(--vr-radius-md)",
-                                    boxShadow: "var(--vr-shadow-sm)",
-                                }}
+                                className="mt-4 inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-[var(--vr-color-primary)] px-5 py-3 text-sm font-black text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] sm:mt-5 sm:w-auto"
                             >
-                                Go to Updates
-                                <ArrowRightIcon className="w-4 h-4" />
+                                <span className="sm:hidden">Open updates</span>
+                                <span className="hidden sm:inline">Go to Updates</span>
                             </Link>
                             <Link
                                 to="/founder-tools/company-setup?edit=true&next=/founder-tools/companies"
-                                className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors mt-5"
-                                style={{
-                                    color: "var(--vr-color-text-mid)",
-                                    background: "transparent",
-                                    border: "1px solid var(--vr-color-border-md)",
-                                    borderRadius: "var(--vr-radius-md)",
-                                }}
+                                className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 sm:mt-5 sm:w-auto"
                             >
                                 <PencilSquareIcon className="w-4 h-4" />
-                                Edit Details
+                                <span className="sm:hidden">Edit company</span>
+                                <span className="hidden sm:inline">Edit Details</span>
                             </Link>
                         </div>
                     </div>
@@ -283,10 +273,12 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                                             </div>
                                         )}
                                     </div>
-                                    <ArrowRightIcon
-                                        className="w-4 h-4 flex-shrink-0"
+                                    <span
+                                        className="text-[11px] font-black uppercase tracking-wide"
                                         style={{ color: "var(--vr-color-text-sub)" }}
-                                    />
+                                    >
+                                        Switch
+                                    </span>
                                 </button>
                             </Form>
                         ))}
@@ -297,7 +289,7 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
             {/* Register new company — subtle dashed card at the bottom */}
             <Link
                 to="/founder-tools/company-setup?new=true"
-                className="vr-company-card-add flex items-center justify-center gap-3 p-5 text-center group"
+                className="vr-company-card-add group flex items-center justify-center gap-3 p-4 text-center sm:p-5"
                 style={{ borderRadius: "var(--vr-radius-lg)" }}
             >
                 <div
@@ -313,7 +305,8 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                     />
                 </div>
                 <span className="vr-text-body-small" style={{ color: "var(--vr-color-text-mid)", fontWeight: 500 }}>
-                    Register another company
+                    <span className="sm:hidden">Add another company</span>
+                    <span className="hidden sm:inline">Register another company</span>
                 </span>
             </Link>
         </div>

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -76,6 +76,12 @@ const DATA_PRIVACY_POINTS = [
   "Private drafts stay hidden until you publish",
   "You can disconnect sources and remove cached data anytime",
 ] as const;
+const CONNECTOR_TRUST_ITEMS = [
+  "Only founders and teammates with access to this workspace can see connected source data.",
+  "We only scan the selected source data needed to draft your monthly update.",
+  "We store synced context, generated metrics, and draft materials inside this workspace.",
+  "You can disconnect a source anytime, and connectors with deletion support let you remove stored data from this screen.",
+];
 
 const EMPTY_SOURCES: VibeRaisingInputSourceSummary[] = [
   {
@@ -1343,6 +1349,9 @@ function ConnectorCard({
   const isConnected = source.status === "connected" || source.status === "syncing";
   const displayedStatus = canConnectWhenUnavailable ? "not_connected" : source.status;
   const displayedStatusLabel = canConnectWhenUnavailable ? "Ready to connect" : statusLabel(source.status);
+  const trustMessage = isConnected
+    ? `Only this founder workspace can see synced ${source.label} context. You can manage access here anytime.`
+    : `Only this founder workspace can see synced ${source.label} context. We only scan ${sourceScanSummary(source)}.`;
   const connectClassName = clsx(
     "block w-full rounded-lg px-3 py-2 text-center text-xs font-extrabold transition",
     disabled || !canConnect
@@ -1359,22 +1368,23 @@ function ConnectorCard({
           ? "border-[rgba(0,255,215,0.42)] bg-white ring-1 ring-[rgba(0,128,128,0.12)]"
           : "border-gray-200 bg-white",
     )} tabIndex={0}>
-      <div className="pointer-events-none flex items-start gap-3 pr-20">
-        <SourceLogo sourceKey={source.key} large />
+      <div className="pointer-events-none flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <SourceLogo sourceKey={source.key} large />
+          <span className={clsx(
+            "inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:max-w-[9rem] sm:px-2 sm:text-[10px]",
+            isConnected ? "bg-white text-[var(--vr-color-primary)] ring-white/60" : statusClassName(displayedStatus),
+          )}>
+            {displayedStatusLabel}
+          </span>
+        </div>
         <h3 className={clsx(
-          "pt-2 text-left text-sm font-black sm:text-base",
+          "break-words text-left text-base font-black leading-tight sm:text-lg",
           isConnected ? "text-white" : "text-gray-950",
         )}>
           {source.label}
         </h3>
       </div>
-
-      <span className={clsx(
-        "absolute right-3 top-3 inline-flex max-w-[88px] items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:right-4 sm:top-4 sm:max-w-[112px] sm:px-2 sm:text-[10px]",
-        isConnected ? "bg-white text-[var(--vr-color-primary)] ring-white/60" : statusClassName(displayedStatus),
-      )}>
-        {displayedStatusLabel}
-      </span>
 
       <div className="flex flex-1 flex-col pt-4 sm:pt-5">
         <p className={clsx("mt-1 line-clamp-4 min-h-0 text-[11px] leading-4 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5", isConnected ? "text-white/80" : "text-slate-500")}>
@@ -1444,6 +1454,15 @@ function ConnectorCard({
           {source.warning && source.status !== "coming_soon" ? (
             <p className={clsx("mt-2 line-clamp-2 text-[10px] font-medium leading-4 sm:text-[11px]", isConnected ? "text-white/80" : "text-[var(--vr-color-text)]")}>{source.warning}</p>
           ) : null}
+
+          <p
+            className={clsx(
+              "mt-2 text-[10px] leading-4 sm:text-[11px]",
+              isConnected ? "text-white/80" : "text-slate-500",
+            )}
+          >
+            {trustMessage}
+          </p>
         </div>
       </div>
     </div>
@@ -1456,22 +1475,23 @@ function GoogleAnalyticsPlaceholderCard() {
       className="relative flex min-h-[152px] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white p-3 shadow-sm outline-none sm:min-h-[220px] sm:rounded-2xl sm:p-4"
       aria-label="Google Analytics source coming soon"
     >
-      <div className="pointer-events-none flex items-start gap-3 pr-20">
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
-          <svg viewBox="0 0 36 36" className="h-8 w-8 sm:h-10 sm:w-10" aria-hidden>
-            <rect x="8" y="18" width="6" height="10" rx="3" fill="#f59e0b" />
-            <rect x="16" y="10" width="6" height="18" rx="3" fill="#f97316" />
-            <circle cx="27" cy="12" r="4" fill="#fb923c" />
-          </svg>
+      <div className="pointer-events-none flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
+            <svg viewBox="0 0 36 36" className="h-8 w-8 sm:h-10 sm:w-10" aria-hidden>
+              <rect x="8" y="18" width="6" height="10" rx="3" fill="#f59e0b" />
+              <rect x="16" y="10" width="6" height="18" rx="3" fill="#f97316" />
+              <circle cx="27" cy="12" r="4" fill="#fb923c" />
+            </svg>
+          </div>
+          <span className="inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold text-gray-500 ring-1 ring-gray-200 sm:max-w-[9rem] sm:px-2 sm:text-[10px]">
+            Coming soon
+          </span>
         </div>
-        <h3 className="pt-2 text-left text-sm font-black text-gray-950 sm:text-base">
+        <h3 className="break-words text-left text-base font-black leading-tight text-gray-950 sm:text-lg">
           Google Analytics
         </h3>
       </div>
-
-      <span className="absolute right-3 top-3 inline-flex max-w-[88px] items-center truncate rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold text-gray-500 ring-1 ring-gray-200 sm:right-4 sm:top-4 sm:max-w-[112px] sm:px-2 sm:text-[10px]">
-        Coming soon
-      </span>
 
       <div className="flex flex-1 flex-col pt-4 sm:pt-5">
         <p className="mt-1 line-clamp-4 min-h-0 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5">
@@ -1529,31 +1549,26 @@ function ManualMaterialsCard({
           : "border-gray-200 bg-white",
       )}
     >
-      <div
-        className="pointer-events-none flex items-start gap-3 pr-20"
-      >
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
-          <DocumentTextIcon className="h-6 w-6 sm:h-8 sm:w-8" />
+      <div className="pointer-events-none flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
+            <DocumentTextIcon className="h-6 w-6 sm:h-8 sm:w-8" />
+          </div>
+          <span
+            className={clsx(
+              "inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:max-w-[9rem] sm:px-2 sm:text-[10px]",
+              hasManualMaterials
+                ? "bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]"
+                : "bg-gray-100 text-slate-500 ring-gray-200",
+            )}
+          >
+            {hasManualMaterials ? "Added" : "Optional"}
+          </span>
         </div>
-        <h3
-          className={clsx(
-            "pt-2 text-left text-sm font-black text-gray-950 sm:text-base",
-          )}
-        >
+        <h3 className="break-words text-left text-base font-black leading-tight text-gray-950 sm:text-lg">
           Manual input
         </h3>
       </div>
-
-      <span
-        className={clsx(
-          "absolute right-3 top-3 inline-flex max-w-[88px] items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:right-4 sm:top-4 sm:max-w-[112px] sm:px-2 sm:text-[10px]",
-          hasManualMaterials
-            ? "bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] ring-[rgba(0,255,215,0.26)]"
-            : "bg-gray-100 text-slate-500 ring-gray-200",
-        )}
-      >
-        {hasManualMaterials ? "Added" : "Optional"}
-      </span>
 
       <div className="flex flex-1 flex-col pt-4 sm:pt-5">
         <p className="mt-1 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:text-xs sm:leading-5">
@@ -1602,6 +1617,29 @@ function deletionSummaryText(deleted: {
   if (rawCount > 0) parts.push(`${rawCount} Gmail cache item${rawCount === 1 ? "" : "s"}`);
   if (derivedCount > 0) parts.push(`${derivedCount} generated update item${derivedCount === 1 ? "" : "s"}`);
   return parts.length > 0 ? parts.join(" and ") : "local Gmail access";
+}
+
+function sourceScanSummary(source: VibeRaisingInputSourceSummary) {
+  switch (source.key) {
+    case "gmail":
+      return "recent emails, relevant threads, and attachments that match your drafting filters";
+    case "slack":
+      return "selected channels and messages you choose for update drafting";
+    case "linear":
+      return "selected projects, issues, and status updates relevant to this update";
+    case "stripe":
+      return "subscription and revenue metrics relevant to this reporting period";
+    case "xero":
+      return "invoices, revenue records, and accounting context for this update";
+    case "bank_feed":
+      return "transactions and cash-flow activity connected to this reporting period";
+    case "notion":
+      return "the pages and notes you choose to use as drafting context";
+    case "google_drive":
+      return "the files you choose to use as investor-update context";
+    default:
+      return "the selected source data needed for this update";
+  }
 }
 
 function GmailManagementModal({
@@ -2592,7 +2630,9 @@ export default function ConnectData() {
       <div className="space-y-4">
         <MonthlyUpdateStepper
           activeStep="connect"
+          disableMotion
           enabledSteps={["connect", "draft"]}
+          hideProgressUntilHover
           onStepClick={handleStepperClick}
           expandOnHover
           frameless
@@ -2666,7 +2706,25 @@ export default function ConnectData() {
           ) : null}
         </div>
 
-        <div className="mt-6 grid grid-cols-3 gap-3 lg:grid-cols-4 lg:gap-4">
+        <div className="mt-4 rounded-2xl border border-[rgba(0,255,215,0.22)] bg-[rgba(0,255,215,0.08)] p-4 sm:p-5">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[var(--vr-color-border)]">
+              <ShieldCheckIcon className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="text-sm font-extrabold text-[var(--vr-color-primary)]">Before you connect</h3>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {CONNECTOR_TRUST_ITEMS.map((item) => (
+                  <p key={item} className="rounded-xl bg-white/80 px-3 py-2 text-sm leading-5 text-[var(--vr-color-text)] ring-1 ring-[rgba(0,128,128,0.08)]">
+                    {item}
+                  </p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
           <GoogleAnalyticsPlaceholderCard />
           {prioritySources.map((source) => (
             <ConnectorCard
@@ -2697,7 +2755,7 @@ export default function ConnectData() {
         ) : null}
 
         {showAllSources && moreOptionSources.length > 0 ? (
-          <div id="more-source-options-panel" className="mt-4 grid grid-cols-3 gap-3 lg:grid-cols-4 lg:gap-4">
+          <div id="more-source-options-panel" className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
             {moreOptionSources.map((source) => (
               <ConnectorCard
                 key={source.key}
@@ -2709,13 +2767,12 @@ export default function ConnectData() {
                 onToggle={handleToggle}
               />
             ))}
-          </div>
-        ) : null}
-
-        <div className="mt-4 grid grid-cols-3 gap-3 lg:grid-cols-4 lg:gap-4">
-          <ManualMaterialsCard
-            expanded={manualMaterialsExpanded}
-            hasManualMaterials={hasManualMaterials}
+            </div>
+          ) : null}
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
+            <ManualMaterialsCard
+              expanded={manualMaterialsExpanded}
+              hasManualMaterials={hasManualMaterials}
             summary={manualMaterialsSummary}
             onToggle={() => setManualMaterialsExpanded((value) => !value)}
           />
@@ -2723,7 +2780,7 @@ export default function ConnectData() {
           {manualMaterialsExpanded ? (
             <div
               id="manual-materials-panel"
-              className="col-span-3 space-y-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm lg:col-span-3 lg:p-5"
+              className="col-span-1 space-y-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:col-span-2 lg:col-span-4 lg:p-5"
             >
               <div className="flex items-center justify-between gap-4">
                 <p className="text-sm font-bold text-slate-500">
@@ -3034,7 +3091,14 @@ export default function ConnectData() {
                   <h3 className="text-base font-black text-gray-950">Privacy and security</h3>
                 </div>
                 <ul className="mt-5 space-y-3 text-sm font-semibold text-slate-600">
-                  {["Only you can see connected source data and private drafts", "Read-only access where supported", "You control what stays connected", "Disconnecting can remove cached source data"].map((item) => (
+                  {[
+                    "Only founders and teammates with access to this workspace can see connected data.",
+                    `For ${pendingConnectSource.label}, we only scan ${sourceScanSummary(pendingConnectSource)}.`,
+                    "We store synced context, generated metrics, and draft materials in this workspace so you can keep editing.",
+                    pendingConnectSource.key === "gmail"
+                      ? "You can disconnect Gmail anytime, and this screen can also delete Gmail-derived drafts, events, and metrics."
+                      : "You can disconnect this source anytime, and connectors with deletion support let you remove stored data from this screen.",
+                  ].map((item) => (
                     <li key={item} className="flex items-center gap-3">
                       <CheckCircleIcon className="h-5 w-5 text-[var(--vr-color-primary)]" />
                       {item}

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -1636,9 +1636,6 @@ function GoogleAnalyticsPlaceholderCard({ isMobileView = false }: { isMobileView
               <circle cx="27" cy="12" r="4" fill="#fb923c" />
             </svg>
           </div>
-          <span className="inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full bg-gray-100 px-1.5 py-0.5 text-[9px] font-bold text-gray-500 ring-1 ring-gray-200 sm:max-w-[9rem] sm:px-2 sm:text-[10px]">
-            Coming soon
-          </span>
         </div>
         <h3 className="break-words text-left text-base font-black leading-tight text-gray-950 sm:text-lg">
           Google Analytics
@@ -2085,6 +2082,41 @@ export default function ConnectData() {
 
     return () => window.clearTimeout(timer);
   }, [isMobileTourViewport, mobileTourChecked]);
+
+  useEffect(() => {
+    if (!isMobileTourViewport) return;
+
+    const syncMobileTourState = () => {
+      let hasSeenTour = false;
+
+      try {
+        hasSeenTour = window.localStorage.getItem(DATA_SOURCES_MOBILE_TOUR_STORAGE_KEY) === "1";
+      } catch {
+        hasSeenTour = false;
+      }
+
+      setMobilePrivacyNoteSeen(hasSeenTour);
+
+      if (!hasSeenTour) {
+        setMobileTourChecked(false);
+        setMobileTourStepIndex(0);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        syncMobileTourState();
+      }
+    };
+
+    window.addEventListener("focus", syncMobileTourState);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", syncMobileTourState);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isMobileTourViewport]);
 
   useEffect(() => {
     if (hasManualMaterials) {

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type RefObject } from "react";
 import type { Route } from "./+types/vibe-raising-app.connect-data";
 import { Link, redirect, useLoaderData, useLocation, useNavigate } from "react-router";
 import { clsx } from "clsx";
@@ -71,10 +71,16 @@ const PRIORITY_SOURCE_KEYS: VibeRaisingInputSourceKey[] = ["stripe", "notion", "
 const MORE_SOURCE_KEYS: VibeRaisingInputSourceKey[] = ["gmail", "slack", "linear", "bank_feed", "xero"];
 const SLACK_CHANNEL_PAGE_LIMIT = 100;
 const LINEAR_PROJECT_PAGE_LIMIT = 100;
+const DATA_SOURCES_MOBILE_TOUR_STORAGE_KEY = "vibe_raising_data_sources_mobile_tour_seen_v1";
 const DATA_PRIVACY_POINTS = [
   "Only you can see connected source data in your workspace",
   "Private drafts stay hidden until you publish",
   "You can disconnect sources and remove cached data anytime",
+] as const;
+const MOBILE_DATA_PRIVACY_POINTS = [
+  "Only you can see connected data here",
+  "Drafts stay private until you publish",
+  "Disconnect or remove data anytime",
 ] as const;
 const CONNECTOR_TRUST_ITEMS = [
   "Only founders and teammates with access to this workspace can see connected source data.",
@@ -82,6 +88,11 @@ const CONNECTOR_TRUST_ITEMS = [
   "We store synced context, generated metrics, and draft materials inside this workspace.",
   "You can disconnect a source anytime, and connectors with deletion support let you remove stored data from this screen.",
 ];
+const MOBILE_CONNECTOR_TRUST_ITEMS = [
+  "Only your workspace can see connected source data.",
+  "We only scan the data needed for this draft.",
+  "Disconnect a source or remove stored data anytime.",
+] as const;
 
 const EMPTY_SOURCES: VibeRaisingInputSourceSummary[] = [
   {
@@ -148,6 +159,129 @@ type ManualMaterialsState = {
   documents: VibeRaisingManualDocument[];
 };
 
+type MobileTourStep = {
+  key: string;
+  title: string;
+  body: string;
+  targetRef: RefObject<Element | null>;
+};
+
+function MobileDataSourcesTour({
+  open,
+  stepIndex,
+  steps,
+  onBack,
+  onClose,
+  onNext,
+}: {
+  open: boolean;
+  stepIndex: number;
+  steps: MobileTourStep[];
+  onBack: () => void;
+  onClose: () => void;
+  onNext: () => void;
+}) {
+  const titleId = useId();
+  const step = steps[stepIndex];
+  const [targetRect, setTargetRect] = useState<{ top: number; left: number; width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    if (!open || !step) {
+      setTargetRect(null);
+      return;
+    }
+
+    const updateTargetRect = () => {
+      const node = step.targetRef.current;
+      if (!node) {
+        setTargetRect(null);
+        return;
+      }
+
+      const rect = node.getBoundingClientRect();
+      setTargetRect({
+        top: Math.max(rect.top - 8, 12),
+        left: Math.max(rect.left - 8, 12),
+        width: Math.min(rect.width + 16, window.innerWidth - 24),
+        height: rect.height + 16,
+      });
+    };
+
+    const handleViewportChange = () => window.requestAnimationFrame(updateTargetRect);
+
+    handleViewportChange();
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+    return () => {
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+    };
+  }, [open, step]);
+
+  if (!open || !step) return null;
+
+  return (
+    <div className="fixed inset-0 z-[140] sm:hidden" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+      <button
+        type="button"
+        className="absolute inset-0 bg-slate-950/55"
+        onClick={onClose}
+        aria-label="Close data sources tour"
+      />
+
+      {targetRect ? (
+        <>
+          <div
+            className="pointer-events-none absolute rounded-[28px] border-2 border-[var(--vr-color-primary)] bg-transparent shadow-[0_0_0_9999px_rgba(15,23,42,0.58)] transition-all duration-200"
+            style={targetRect}
+          />
+          <div
+            className="pointer-events-none absolute rounded-full bg-[var(--vr-color-primary)] px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-white shadow-lg"
+            style={{ left: targetRect.left, top: Math.max(targetRect.top - 34, 10) }}
+          >
+            Step {stepIndex + 1}
+          </div>
+        </>
+      ) : null}
+
+      <section className="absolute inset-x-4 bottom-4 rounded-[28px] bg-white p-5 shadow-2xl shadow-black/20">
+        <p className="text-xs font-black uppercase tracking-[0.14em] text-[var(--vr-color-primary)]">Quick mobile tour</p>
+        <h2 id={titleId} className="mt-2 text-xl font-black text-gray-950">{step.title}</h2>
+        <p className="mt-3 text-sm font-semibold leading-6 text-slate-600">{step.body}</p>
+
+        <div className="mt-5 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center justify-center rounded-xl px-3 py-2 text-sm font-black text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+          >
+            Skip
+          </button>
+
+          <div className="flex items-center gap-2">
+            {stepIndex > 0 ? (
+              <button
+                type="button"
+                onClick={onBack}
+                className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-black text-slate-700 shadow-sm transition hover:bg-slate-50"
+              >
+                Back
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={onNext}
+              className="inline-flex items-center justify-center rounded-xl bg-[var(--vr-color-primary)] px-4 py-2 text-sm font-black text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)]"
+            >
+              {stepIndex === steps.length - 1 ? "Got it" : "Next"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
 type OAuthSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "manual_documents">;
 
 function isOAuthSourceKey(key: VibeRaisingInputSourceKey): key is OAuthSourceKey {
@@ -194,41 +328,50 @@ function writeStoredManualMaterials(materials: ManualMaterialsState) {
   window.localStorage.setItem(MANUAL_MATERIALS_STORAGE_KEY, JSON.stringify({ summary, manualDocumentIds, documents }));
 }
 
-const SOURCE_COPY: Record<VibeRaisingInputSourceKey, { description: string; connectedUse: string }> = {
+const SOURCE_COPY: Record<VibeRaisingInputSourceKey, { description: string; mobileDescription: string; connectedUse: string }> = {
   gmail: {
     description: "Scan emails for key updates, investor feedback, and important threads.",
+    mobileDescription: "Scan key emails and investor threads.",
     connectedUse: "Emails, investor threads",
   },
   stripe: {
     description: "Pull revenue, subscriptions, and financial metrics automatically.",
+    mobileDescription: "Pull revenue and subscription metrics.",
     connectedUse: "Revenue, subscriptions",
   },
   xero: {
     description: "Use invoices and recurring revenue records from your accounting workspace.",
+    mobileDescription: "Use invoices and recurring revenue data.",
     connectedUse: "Invoices, accounting",
   },
   bank_feed: {
     description: "Import transactions and cash flow data from your business accounts.",
+    mobileDescription: "Import transactions and cash flow.",
     connectedUse: "Transactions, cash flow",
   },
   notion: {
     description: "Sync notes, docs, and internal updates from your workspace.",
+    mobileDescription: "Sync notes, docs, and updates.",
     connectedUse: "Docs, notes, updates",
   },
   google_drive: {
     description: "Add files, reports, and presentations for deeper context.",
+    mobileDescription: "Add files, reports, and decks.",
     connectedUse: "Files, reports, decks",
   },
   slack: {
     description: "Bring in important team updates and customer conversations.",
+    mobileDescription: "Bring in team updates and conversations.",
     connectedUse: "Team updates, conversations",
   },
   linear: {
     description: "Pull project updates, active workstreams, and key tasks from Linear.",
+    mobileDescription: "Pull project updates and key tasks.",
     connectedUse: "Projects, tasks, updates",
   },
   manual_documents: {
     description: "Use uploaded founder documents as deterministic context.",
+    mobileDescription: "Use uploaded documents as context.",
     connectedUse: "Documents, summary",
   },
 };
@@ -280,7 +423,7 @@ function statusLabel(status: VibeRaisingInputSourceStatus) {
     case "coming_soon":
       return "Coming soon";
     case "unavailable":
-      return "Not available yet";
+      return "Coming soon";
     default:
       return "Not connected";
   }
@@ -1326,6 +1469,7 @@ function ConnectorCard({
   source,
   selected,
   busy,
+  isMobileView = false,
   onConnect,
   onManageGmail,
   onToggle,
@@ -1333,6 +1477,7 @@ function ConnectorCard({
   source: VibeRaisingInputSourceSummary;
   selected: boolean;
   busy: boolean;
+  isMobileView?: boolean;
   onConnect: (source: VibeRaisingInputSourceSummary) => void;
   onManageGmail: (source: VibeRaisingInputSourceSummary) => void;
   onToggle: (source: VibeRaisingInputSourceSummary) => void;
@@ -1349,9 +1494,16 @@ function ConnectorCard({
   const isConnected = source.status === "connected" || source.status === "syncing";
   const displayedStatus = canConnectWhenUnavailable ? "not_connected" : source.status;
   const displayedStatusLabel = canConnectWhenUnavailable ? "Ready to connect" : statusLabel(source.status);
-  const trustMessage = isConnected
-    ? `Only this founder workspace can see synced ${source.label} context. You can manage access here anytime.`
-    : `Only this founder workspace can see synced ${source.label} context. We only scan ${sourceScanSummary(source)}.`;
+  const trustMessage = isMobileView
+    ? isConnected
+      ? `Only this workspace can see synced ${source.label} data.`
+      : `Only this workspace can see synced ${source.label} data.`
+    : isConnected
+      ? `Only this founder workspace can see synced ${source.label} context. You can manage access here anytime.`
+      : `Only this founder workspace can see synced ${source.label} context. We only scan ${sourceScanSummary(source)}.`;
+  const description = isMobileView ? SOURCE_COPY[source.key].mobileDescription : SOURCE_COPY[source.key].description;
+  const shouldShowCapabilities = !isMobileView;
+  const shouldShowTrustMessage = !isMobileView;
   const connectClassName = clsx(
     "block w-full rounded-lg px-3 py-2 text-center text-xs font-extrabold transition",
     disabled || !canConnect
@@ -1386,26 +1538,28 @@ function ConnectorCard({
         </h3>
       </div>
 
-      <div className="flex flex-1 flex-col pt-4 sm:pt-5">
-        <p className={clsx("mt-1 line-clamp-4 min-h-0 text-[11px] leading-4 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5", isConnected ? "text-white/80" : "text-slate-500")}>
-          {SOURCE_COPY[source.key].description}
+      <div className={clsx("flex flex-1 flex-col", isMobileView ? "pt-3" : "pt-4 sm:pt-5")}>
+        <p className={clsx("mt-1 line-clamp-3 min-h-0 text-[11px] leading-4 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5 sm:line-clamp-4", isConnected ? "text-white/80" : "text-slate-500")}>
+          {description}
         </p>
 
-        <div className="mt-2 flex flex-wrap gap-1 sm:mt-3">
-          {source.capabilities.map((capability) => (
-            <span
-              key={capability}
-              className={clsx(
-                "rounded-full px-1.5 py-0.5 text-[9px] font-bold sm:text-[10px]",
-                isConnected ? "bg-white/[0.14] text-white ring-1 ring-white/20" : "bg-gray-50 text-slate-500",
-              )}
-            >
-              {capabilityLabel(capability)}
-            </span>
-          ))}
-        </div>
+        {shouldShowCapabilities ? (
+          <div className="mt-2 flex flex-wrap gap-1 sm:mt-3">
+            {source.capabilities.map((capability) => (
+              <span
+                key={capability}
+                className={clsx(
+                  "rounded-full px-1.5 py-0.5 text-[9px] font-bold sm:text-[10px]",
+                  isConnected ? "bg-white/[0.14] text-white ring-1 ring-white/20" : "bg-gray-50 text-slate-500",
+                )}
+              >
+                {capabilityLabel(capability)}
+              </span>
+            ))}
+          </div>
+        ) : null}
 
-        <div className="mt-auto pt-3 sm:pt-4">
+        <div className={clsx("mt-auto", isMobileView ? "pt-2" : "pt-3 sm:pt-4")}>
           {selectable ? (
             <button
               type="button"
@@ -1449,27 +1603,25 @@ function ConnectorCard({
               <ShieldCheckIcon className="h-4 w-4" />
               Manage Gmail access
             </button>
-          ) : null}
+              ) : null}
 
-          {source.warning && source.status !== "coming_soon" ? (
-            <p className={clsx("mt-2 line-clamp-2 text-[10px] font-medium leading-4 sm:text-[11px]", isConnected ? "text-white/80" : "text-[var(--vr-color-text)]")}>{source.warning}</p>
+          {shouldShowTrustMessage ? (
+            <p
+              className={clsx(
+                "mt-2 min-h-8 line-clamp-2 text-[10px] leading-4 sm:min-h-[2.75rem] sm:text-[11px] sm:line-clamp-none",
+                isConnected ? "text-white/80" : "text-slate-500",
+              )}
+            >
+              {trustMessage}
+            </p>
           ) : null}
-
-          <p
-            className={clsx(
-              "mt-2 text-[10px] leading-4 sm:text-[11px]",
-              isConnected ? "text-white/80" : "text-slate-500",
-            )}
-          >
-            {trustMessage}
-          </p>
         </div>
       </div>
     </div>
   );
 }
 
-function GoogleAnalyticsPlaceholderCard() {
+function GoogleAnalyticsPlaceholderCard({ isMobileView = false }: { isMobileView?: boolean }) {
   return (
     <div
       className="relative flex min-h-[152px] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white p-3 shadow-sm outline-none sm:min-h-[220px] sm:rounded-2xl sm:p-4"
@@ -1477,7 +1629,7 @@ function GoogleAnalyticsPlaceholderCard() {
     >
       <div className="pointer-events-none flex flex-col gap-3">
         <div className="flex items-start justify-between gap-3">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-[rgba(0,255,215,0.24)] sm:h-16 sm:w-16 sm:rounded-2xl">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-gray-200 sm:h-16 sm:w-16 sm:rounded-2xl">
             <svg viewBox="0 0 36 36" className="h-8 w-8 sm:h-10 sm:w-10" aria-hidden>
               <rect x="8" y="18" width="6" height="10" rx="3" fill="#f59e0b" />
               <rect x="16" y="10" width="6" height="18" rx="3" fill="#f97316" />
@@ -1493,23 +1645,27 @@ function GoogleAnalyticsPlaceholderCard() {
         </h3>
       </div>
 
-      <div className="flex flex-1 flex-col pt-4 sm:pt-5">
-        <p className="mt-1 line-clamp-4 min-h-0 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5">
-          Pull website traffic, acquisition, and top-page performance into your monthly update workflow.
+      <div className={clsx("flex flex-1 flex-col", isMobileView ? "pt-3" : "pt-4 sm:pt-5")}>
+        <p className="mt-1 line-clamp-3 min-h-0 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5 sm:line-clamp-4">
+          {isMobileView
+            ? "Pull traffic and acquisition metrics."
+            : "Pull website traffic, acquisition, and top-page performance into your monthly update workflow."}
         </p>
 
-        <div className="mt-2 flex flex-wrap gap-1 sm:mt-3">
-          {["Traffic", "Attribution"].map((capability) => (
-            <span
-              key={capability}
-              className="rounded-full bg-gray-50 px-1.5 py-0.5 text-[9px] font-bold text-slate-500 sm:text-[10px]"
-            >
-              {capability}
-            </span>
-          ))}
-        </div>
+        {!isMobileView ? (
+          <div className="mt-2 flex flex-wrap gap-1 sm:mt-3">
+            {["Traffic", "Attribution"].map((capability) => (
+              <span
+                key={capability}
+                className="rounded-full bg-gray-50 px-1.5 py-0.5 text-[9px] font-bold text-slate-500 sm:text-[10px]"
+              >
+                {capability}
+              </span>
+            ))}
+          </div>
+        ) : null}
 
-        <div className="mt-auto pt-3 sm:pt-4">
+        <div className={clsx("mt-auto", isMobileView ? "pt-2" : "pt-3 sm:pt-4")}>
           <button
             type="button"
             disabled
@@ -1517,6 +1673,11 @@ function GoogleAnalyticsPlaceholderCard() {
           >
             Coming soon
           </button>
+          {!isMobileView ? (
+            <p className="mt-2 min-h-8 line-clamp-2 text-[10px] leading-4 text-slate-500 sm:min-h-[2.75rem] sm:text-[11px] sm:line-clamp-none">
+              Website traffic support is coming soon for founder updates.
+            </p>
+          ) : null}
         </div>
       </div>
     </div>
@@ -1543,10 +1704,10 @@ function ManualMaterialsCard({
       aria-expanded={expanded}
       aria-controls="manual-materials-panel"
       className={clsx(
-        "relative flex min-h-[152px] w-full flex-col overflow-hidden rounded-xl border p-3 text-left shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-[rgba(0,128,128,0.20)] sm:min-h-[220px] sm:rounded-2xl sm:p-4",
+        "group relative flex min-h-[152px] w-full flex-col overflow-hidden rounded-xl border p-3 text-left shadow-sm outline-none transition focus-visible:ring-2 focus-visible:ring-[rgba(0,128,128,0.20)] sm:min-h-[220px] sm:rounded-2xl sm:p-4",
         expanded || hasManualMaterials
           ? "border-[rgba(0,255,215,0.42)] bg-white ring-1 ring-[rgba(0,128,128,0.12)]"
-          : "border-gray-200 bg-white",
+          : "border-gray-200 bg-white hover:border-[rgba(0,128,128,0.28)] hover:shadow-md",
       )}
     >
       <div className="pointer-events-none flex flex-col gap-3">
@@ -1587,7 +1748,7 @@ function ManualMaterialsCard({
         </div>
 
         <div className="mt-auto pt-3 sm:pt-4">
-          <div className="flex w-full items-center justify-center rounded-lg bg-[rgba(0,255,215,0.12)] px-2.5 py-2 text-[11px] font-extrabold text-[var(--vr-color-primary)] sm:px-3 sm:text-xs">
+          <div className="flex w-full items-center justify-center rounded-lg bg-[rgba(0,255,215,0.12)] px-2.5 py-2 text-[11px] font-extrabold text-[var(--vr-color-primary)] transition group-hover:bg-[rgba(0,255,215,0.18)] group-hover:ring-1 group-hover:ring-[rgba(0,128,128,0.18)] sm:px-3 sm:text-xs">
             <span>{expanded ? "Hide form" : "Open form"}</span>
           </div>
 
@@ -1798,9 +1959,17 @@ export default function ConnectData() {
   const [manualDocumentError, setManualDocumentError] = useState<string | null>(null);
   const [manualMaterialsExpanded, setManualMaterialsExpanded] = useState(false);
   const manualDocumentInputRef = useRef<HTMLInputElement | null>(null);
+  const privacyCardRef = useRef<HTMLDivElement | null>(null);
+  const sourcesSectionRef = useRef<HTMLElement | null>(null);
+  const manualMaterialsRef = useRef<HTMLDivElement | null>(null);
   const defaultSelectionAppliedRef = useRef(false);
   const slackSelectionTouchedRef = useRef(false);
   const linearSelectionTouchedRef = useRef(false);
+  const [isMobileTourViewport, setIsMobileTourViewport] = useState(false);
+  const [mobileTourOpen, setMobileTourOpen] = useState(false);
+  const [mobileTourStepIndex, setMobileTourStepIndex] = useState(0);
+  const [mobileTourChecked, setMobileTourChecked] = useState(false);
+  const [mobilePrivacyNoteSeen, setMobilePrivacyNoteSeen] = useState(false);
 
   const sourceByKey = useMemo(() => new Map(sources.map((source) => [source.key, source])), [sources]);
   const prioritySources = useMemo(() => {
@@ -1816,6 +1985,31 @@ export default function ConnectData() {
   const selectedSourceList = useMemo(
     () => sources.filter((source) => selectedSources.has(source.key)),
     [selectedSources, sources],
+  );
+  const privacyPoints = isMobileTourViewport ? MOBILE_DATA_PRIVACY_POINTS : DATA_PRIVACY_POINTS;
+  const connectorTrustItems = isMobileTourViewport ? MOBILE_CONNECTOR_TRUST_ITEMS : CONNECTOR_TRUST_ITEMS;
+  const mobileTourSteps = useMemo<MobileTourStep[]>(
+    () => [
+      {
+        key: "privacy",
+        title: "Start with privacy",
+        body: "This card explains what stays private and links to the policy before you connect anything.",
+        targetRef: privacyCardRef,
+      },
+      {
+        key: "sources",
+        title: "Pick the best sources first",
+        body: "Start with the tools you already use. One connector is enough to begin, and you can add more later.",
+        targetRef: sourcesSectionRef,
+      },
+      {
+        key: "manual",
+        title: "Manual input still works",
+        body: "No connector yet? Upload documents or add a short summary and continue with a manual draft.",
+        targetRef: manualMaterialsRef,
+      },
+    ],
+    [],
   );
   const slackChannels = useMemo(() => Object.values(slackChannelsById), [slackChannelsById]);
   const linearProjects = useMemo(() => Object.values(linearProjectsById), [linearProjectsById]);
@@ -1862,6 +2056,35 @@ export default function ConnectData() {
   useEffect(() => {
     void refreshStatuses();
   }, [backendBaseUrl]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const syncViewport = () => setIsMobileTourViewport(mediaQuery.matches);
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => mediaQuery.removeEventListener("change", syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (mobileTourChecked || !isMobileTourViewport) return;
+    setMobileTourChecked(true);
+
+    try {
+      if (window.localStorage.getItem(DATA_SOURCES_MOBILE_TOUR_STORAGE_KEY) === "1") {
+        setMobilePrivacyNoteSeen(true);
+        return;
+      }
+    } catch {
+      // Ignore storage failures and still show the tour for this session.
+    }
+
+    const timer = window.setTimeout(() => {
+      setMobileTourStepIndex(0);
+      setMobileTourOpen(true);
+    }, 450);
+
+    return () => window.clearTimeout(timer);
+  }, [isMobileTourViewport, mobileTourChecked]);
 
   useEffect(() => {
     if (hasManualMaterials) {
@@ -2625,6 +2848,28 @@ export default function ConnectData() {
     </div>
   );
 
+  const closeMobileTour = () => {
+    setMobileTourOpen(false);
+    setMobilePrivacyNoteSeen(true);
+    try {
+      window.localStorage.setItem(DATA_SOURCES_MOBILE_TOUR_STORAGE_KEY, "1");
+    } catch {
+      // Ignore storage failures.
+    }
+  };
+
+  const goToPreviousMobileTourStep = () => {
+    setMobileTourStepIndex((current) => Math.max(0, current - 1));
+  };
+
+  const goToNextMobileTourStep = () => {
+    if (mobileTourStepIndex >= mobileTourSteps.length - 1) {
+      closeMobileTour();
+      return;
+    }
+    setMobileTourStepIndex((current) => current + 1);
+  };
+
   return (
     <div className="mx-auto max-w-6xl space-y-10 pb-32">
       <div className="space-y-4">
@@ -2639,51 +2884,55 @@ export default function ConnectData() {
           className="mt-8"
         />
 
-        <div className="rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-5 shadow-sm">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex min-w-0 items-center gap-4">
-              <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)]">
-                <ShieldCheckIcon className="h-5 w-5" />
+        {!(isMobileTourViewport && mobilePrivacyNoteSeen) ? (
+          <div ref={privacyCardRef} className="rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-5 shadow-sm">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex min-w-0 items-center gap-4">
+                  <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)]">
+                    <ShieldCheckIcon className="h-5 w-5" />
+                  </div>
+                  <div className="min-w-0">
+                    <h2 className="text-lg font-black text-gray-950">Your data stays private</h2>
+                  </div>
+                </div>
+                <div className="lg:flex lg:justify-end">
+                  <Link
+                    to="/privacy"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center rounded-xl border border-[var(--vr-color-border)] bg-[var(--vr-palette-paper)] px-4 py-2 text-sm font-extrabold text-[var(--vr-color-text)] transition hover:border-[var(--vr-color-primary)] hover:text-[var(--vr-color-primary)]"
+                  >
+                    Privacy Policy
+                  </Link>
+                </div>
               </div>
-              <div className="min-w-0">
-                <h2 className="text-lg font-black text-gray-950">Your data stays private</h2>
-              </div>
-            </div>
-            <div className="lg:flex lg:justify-end">
-              <Link
-                to="/privacy"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center justify-center rounded-xl border border-[var(--vr-color-border)] bg-[var(--vr-palette-paper)] px-4 py-2 text-sm font-extrabold text-[var(--vr-color-text)] transition hover:border-[var(--vr-color-primary)] hover:text-[var(--vr-color-primary)]"
-              >
-                Privacy Policy
-              </Link>
-            </div>
-          </div>
 
-          <ul className="mt-5 space-y-3">
-            {DATA_PRIVACY_POINTS.map((item) => (
-              <li key={item} className="flex items-start gap-3">
-                <CheckCircleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--vr-color-primary)]" />
-                <p className="text-sm font-semibold leading-6 text-slate-600">{item}</p>
-              </li>
-            ))}
-          </ul>
+              <ul className="mt-5 space-y-3">
+                {privacyPoints.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <CheckCircleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--vr-color-primary)]" />
+                    <p className="text-sm font-semibold leading-6 text-slate-600">{item}</p>
+                  </li>
+                ))}
+              </ul>
 
-          <div className="mt-6 border-t border-[var(--vr-color-border)] pt-6">
-            <div className="flex min-w-0 items-start gap-4">
-              <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)]">
-                <SparklesIcon className="h-5 w-5" />
+              <div className="mt-6 border-t border-[var(--vr-color-border)] pt-6">
+                <div className="flex min-w-0 items-start gap-4">
+                  <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)]">
+                    <SparklesIcon className="h-5 w-5" />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="text-lg font-black text-gray-950">How it works</h3>
+                    <p className="mt-1 text-sm leading-6 text-slate-600">
+                      {isMobileTourViewport
+                        ? "Connect a tool or continue with manual input."
+                        : "Connect your tools below. We only use the authorized data needed to help draft your monthly update."}
+                    </p>
+                  </div>
+                </div>
               </div>
-              <div className="min-w-0">
-                <h3 className="text-lg font-black text-gray-950">How it works</h3>
-                <p className="mt-1 text-sm leading-6 text-slate-600">
-                  Connect your tools below. We only use the authorized data needed to help draft your monthly update.
-                </p>
-              </div>
-            </div>
           </div>
-        </div>
+        ) : null}
       </div>
 
       {statusMessage ? (
@@ -2692,7 +2941,7 @@ export default function ConnectData() {
         </div>
       ) : null}
 
-      <section>
+      <section ref={sourcesSectionRef}>
         <div className="flex items-end justify-between gap-4">
           <div>
             <h2 className="text-xl font-black text-gray-950">Popular sources</h2>
@@ -2706,15 +2955,15 @@ export default function ConnectData() {
           ) : null}
         </div>
 
-        <div className="mt-4 rounded-2xl border border-[rgba(0,255,215,0.22)] bg-[rgba(0,255,215,0.08)] p-4 sm:p-5">
+        <div className="mt-4 hidden rounded-2xl border border-[rgba(0,255,215,0.22)] bg-[rgba(0,255,215,0.08)] p-4 sm:block sm:p-5">
           <div className="flex items-start gap-3">
             <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[var(--vr-color-border)]">
               <ShieldCheckIcon className="h-5 w-5" />
             </div>
             <div className="min-w-0">
-              <h3 className="text-sm font-extrabold text-[var(--vr-color-primary)]">Before you connect</h3>
+              <h3 className="text-sm font-extrabold text-[var(--vr-color-primary)]">{isMobileTourViewport ? "Before connecting" : "Before you connect"}</h3>
               <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                {CONNECTOR_TRUST_ITEMS.map((item) => (
+                {connectorTrustItems.map((item) => (
                   <p key={item} className="rounded-xl bg-white/80 px-3 py-2 text-sm leading-5 text-[var(--vr-color-text)] ring-1 ring-[rgba(0,128,128,0.08)]">
                     {item}
                   </p>
@@ -2725,13 +2974,14 @@ export default function ConnectData() {
         </div>
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
-          <GoogleAnalyticsPlaceholderCard />
+          <GoogleAnalyticsPlaceholderCard isMobileView={isMobileTourViewport} />
           {prioritySources.map((source) => (
             <ConnectorCard
               key={source.key}
               source={source}
               selected={selectedSources.has(source.key)}
               busy={busyProvider === source.key}
+              isMobileView={isMobileTourViewport}
               onConnect={requestConnectSource}
               onManageGmail={handleOpenGmailManagement}
               onToggle={handleToggle}
@@ -2762,6 +3012,7 @@ export default function ConnectData() {
                 source={source}
                 selected={selectedSources.has(source.key)}
                 busy={busyProvider === source.key}
+                isMobileView={isMobileTourViewport}
                 onConnect={requestConnectSource}
                 onManageGmail={handleOpenGmailManagement}
                 onToggle={handleToggle}
@@ -2769,7 +3020,7 @@ export default function ConnectData() {
             ))}
             </div>
           ) : null}
-          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
+          <div ref={manualMaterialsRef} className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
             <ManualMaterialsCard
               expanded={manualMaterialsExpanded}
               hasManualMaterials={hasManualMaterials}
@@ -2972,12 +3223,22 @@ export default function ConnectData() {
       </div>
 
       <VibeRaisingStickyStepBar
+        hideStatusOnMobile
         statusIcon={stickyStatusIcon}
         statusTitle={stickyStatusTitle}
         statusDetail={stickyStatusDetail}
         onBack={() => navigate("/founder-tools/companies")}
         primaryLabel="Continue to draft"
         onPrimary={handleManualMaterialsContinue}
+      />
+
+      <MobileDataSourcesTour
+        open={mobileTourOpen}
+        stepIndex={mobileTourStepIndex}
+        steps={mobileTourSteps}
+        onBack={goToPreviousMobileTourStep}
+        onClose={closeMobileTour}
+        onNext={goToNextMobileTourStep}
       />
 
       {showNoSourcesModal ? (

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -1982,6 +1982,8 @@ export default function CreateUpdate() {
         : isManualOnlyDraftFlow
             ? METRIC_OPTIONS
             : metricOptionsFromKeys(["revenue", "activeUsers", "mrr", "burnRate"]);
+    const mobileDraftMetricBatchSize = 6;
+    const [mobileVisibleDraftMetricCount, setMobileVisibleDraftMetricCount] = useState(mobileDraftMetricBatchSize);
     const showLegacyDraftFlow = false;
     const selectedInputSourceLabels = selectedInputSources.map((key) => INPUT_SOURCE_LABELS[key]);
     const selectedInputSourceDescription = selectedInputSourceLabels.length > 0
@@ -2088,6 +2090,12 @@ export default function CreateUpdate() {
             });
         }
     }, [shouldDimMetricsTemplate]);
+
+    const focusMetricInput = useCallback((inputId: string) => {
+        window.requestAnimationFrame(() => {
+            document.getElementById(inputId)?.focus();
+        });
+    }, []);
 
     useEffect(() => {
         if (isEdit) return;
@@ -3313,22 +3321,24 @@ export default function CreateUpdate() {
         }
     };
 
-    const toggleActiveMetric = (key: string) => {
+    const activateActiveMetric = (key: string) => {
         if (isViewingCurrentUpdate) {
-            toggleMetric(key);
+            setSelectedMetrics((previous) => {
+                if (previous.has(key)) return previous;
+                const next = new Set(previous);
+                next.add(key);
+                return next;
+            });
+            focusMetricInput(`active-metric-${key}`);
             return;
         }
 
         if (activePastIndex < 0 || !activePastCard) return;
-        setPastMonthCards(prev => prev.map((card, index) => {
-            if (index !== activePastIndex) return card;
-            const nextMetrics = { ...card.metrics };
-            if (key in nextMetrics) {
-                delete nextMetrics[key];
-                return { ...card, metrics: nextMetrics };
-            }
-            return { ...card, metrics: { ...nextMetrics, [key]: "" } };
+        setPastMonthCards((previous) => previous.map((card, index) => {
+            if (index !== activePastIndex || key in card.metrics) return card;
+            return { ...card, metrics: { ...card.metrics, [key]: "" } };
         }));
+        focusMetricInput(`active-metric-${key}`);
     };
 
     const updateActiveHighlights = (value: string) => {
@@ -3821,7 +3831,9 @@ export default function CreateUpdate() {
             <div className="mx-auto max-w-6xl space-y-10 pb-32">
                 <MonthlyUpdateStepper
                     activeStep={showConfirmPopup ? "publish" : "review"}
+                    disableMotion
                     enabledSteps={["connect", "draft", "review", "publish"]}
+                    hideProgressUntilHover
                     onStepClick={handleReviewStepperClick}
                     expandOnHover
                     frameless
@@ -3836,7 +3848,7 @@ export default function CreateUpdate() {
                         <div className="min-w-0">
                             <h2 className="text-lg font-black text-gray-950">How it works</h2>
                             <p className="mt-1 text-sm leading-6 text-slate-600">
-                                Preview page shows exactly what investors will see before you publish this monthly update.
+                                Review shows exactly what investors will see before you publish this monthly update.
                             </p>
                         </div>
                     </div>
@@ -4205,6 +4217,43 @@ export default function CreateUpdate() {
                                 This update is saved privately in <Link to="/founder-tools/drafts" className="font-black text-[var(--vr-color-primary)] hover:text-[var(--vr-palette-black)]">My Drafts</Link> until you publish it.
                             </p>
                         </div>
+
+                        {/* Your Audience Block */}
+                        {(() => {
+                            const d = data as any;
+                            const text = [(d.highlights || ''), (d.challenges || ''), (d.learnings || ''), (d.next30Days || ''), (d.asks || '')].join(" ").toLowerCase();
+                            
+                            const criteria = [];
+                            if (text.includes("saas") || text.includes("software")) criteria.push("B2B SaaS");
+                            if (text.includes("health") || text.includes("medtech") || text.includes("medical")) criteria.push("MedTech");
+                            if (text.includes("agri") || text.includes("farm") || text.includes("agriculture")) criteria.push("AgTech");
+                            if (text.includes("ai") || text.includes("machine learning") || text.includes("artificial intelligence")) criteria.push("AI/ML");
+                            if (text.includes("enterprise") || text.includes("b2b") || text.includes("fortune 500")) criteria.push("Enterprise");
+                            if (text.includes("fintech") || text.includes("finance") || text.includes("payment")) criteria.push("FinTech");
+                            if (text.includes("consumer") || text.includes("b2c")) criteria.push("Consumer Tech");
+                            if (criteria.length === 0) criteria.push("Sector Agnostic", "Early Stage");
+
+                            const count = 18 + (criteria.length * 14);
+
+                            return (
+                                <div className="mt-6 rounded-xl border border-[rgba(76,110,245,0.22)] bg-[rgba(76,110,245,0.08)] p-5 shadow-sm">
+                                    <h3 className="mb-2 flex items-center gap-2 text-sm font-bold text-[var(--vr-color-text)]">
+                                        <UsersIcon className="h-4 w-4 text-[var(--vr-palette-blue)]" />
+                                        Your Audience
+                                    </h3>
+                                    <p className="mb-3 text-sm text-[var(--vr-color-text-mid)]">
+                                        We found <strong className="font-extrabold text-[var(--vr-palette-blue)]">{count} investors</strong> on Vibe Raising actively looking for updates matching your criteria:
+                                    </p>
+                                    <div className="flex flex-wrap gap-2">
+                                        {criteria.map(c => (
+                                            <span key={c} className="rounded-lg border border-[rgba(76,110,245,0.24)] bg-white px-2.5 py-1 text-xs font-semibold text-[var(--vr-palette-blue)] shadow-sm">
+                                                {c}
+                                            </span>
+                                        ))}
+                                    </div>
+                                </div>
+                                );
+                            })()}
                     </div>
 
                     {showReviewLinkedInPopup ? (
@@ -4302,7 +4351,9 @@ export default function CreateUpdate() {
                                 <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full p-8 text-center relative overflow-hidden animate-in fade-in zoom-in duration-300">
                                     <MonthlyUpdateStepper
                                         activeStep="publish"
+                                        disableMotion
                                         enabledSteps={["connect", "draft", "review", "publish"]}
+                                        hideProgressUntilHover
                                         onStepClick={handleReviewStepperClick}
                                         expandOnHover
                                         frameless
@@ -4311,6 +4362,9 @@ export default function CreateUpdate() {
                                     <h2 className="text-2xl font-black text-gray-900 mb-2 tracking-tight">Ready to send? 🚀</h2>
                                     <p className="text-gray-600 mb-6 text-sm leading-relaxed">
                                         Your update is about to go live on Vibe Raising. We will send it directly to <strong className="font-bold text-gray-900">{reviewAudienceCount} investors</strong> matching your criteria: {reviewAudienceCriteria.join(", ")}.
+                                    </p>
+                                    <p className="mb-6 rounded-xl border border-[rgba(0,255,215,0.24)] bg-[rgba(0,255,215,0.10)] px-4 py-3 text-left text-sm leading-relaxed text-[var(--vr-color-text)]">
+                                        You do not need to send this yet. Save it locally first if you want to come back and keep refining the earlier steps.
                                     </p>
 
                                     <Form 
@@ -4352,7 +4406,7 @@ export default function CreateUpdate() {
                                             onClick={() => setShowConfirmPopup(false)}
                                             className="w-full px-5 py-3 text-sm font-bold text-gray-600 bg-gray-100 rounded-xl hover:bg-gray-200 transition-all active:scale-95"
                                         >
-                                            Wait, go back
+                                            Save it locally
                                         </button>
                                     </Form>
                                 </div>
@@ -4434,8 +4488,11 @@ export default function CreateUpdate() {
                         </div>
                     }
                     statusTitle={`Review ${reviewMonth} ${reviewYear} update`}
-                    statusDetail="Preview is ready. Publish when the story feels right."
+                    statusDetail="Review is ready. Publish when the story feels right."
                     onBack={() => setDismissedFeedback(true)}
+                    secondaryLabel={draftSaved ? "Draft saved!" : "Save as draft"}
+                    onSecondary={handlePersistDraft}
+                    secondaryDisabled={saveDraftFetcher.state !== "idle"}
                     primaryLabel="Publish and Send"
                     onPrimary={() => setShowConfirmPopup(true)}
                 />
@@ -4449,7 +4506,9 @@ export default function CreateUpdate() {
             <div className="space-y-4">
                 <MonthlyUpdateStepper
                     activeStep="draft"
+                    disableMotion
                     enabledSteps={isEdit ? ["draft"] : ["connect", "draft"]}
+                    hideProgressUntilHover
                     onStepClick={handleDraftStepperClick}
                     expandOnHover
                     frameless
@@ -4611,21 +4670,27 @@ export default function CreateUpdate() {
                                                 Click any metric card to start editing.
                                             </p>
                                         ) : null}
-                                        <div className="grid gap-3 transition duration-200 sm:grid-cols-2 lg:grid-cols-4">
-                                        {draftMetricOptions.map((metric) => (
+                                        <div className="grid grid-cols-2 gap-3 transition duration-200 lg:grid-cols-4">
+                                        {draftMetricOptions.map((metric, metricIndex) => (
                                                 (() => {
                                                     const hasMetricValue = String(metricValues[metric.key] || "").trim().length > 0;
                                                     const isMetricCardAwake = !shouldDimMetricsTemplate || awakeMetricCards.has(metric.key) || hasMetricValue;
+                                                    const isHiddenOnMobile = metricIndex >= mobileVisibleDraftMetricCount;
                                                     return (
                                                 <label
                                                     key={metric.key}
                                                     className={clsx(
-                                                        "relative rounded-2xl border p-4 transition duration-200",
+                                                        "relative min-w-0 rounded-2xl border p-3 transition duration-200 sm:p-4",
+                                                        isHiddenOnMobile ? "hidden sm:block" : null,
                                                         isMetricCardAwake
                                                             ? "border-gray-200 bg-[var(--vr-palette-paper)]"
                                                             : "cursor-pointer border-gray-200/80 bg-[rgba(247,246,242,0.65)] opacity-45 saturate-0",
                                                     )}
-                                                    onClick={() => wakeMetricCard(metric.key)}
+                                                    onClick={(event) => {
+                                                        if ((event.target as HTMLElement).closest("button")) return;
+                                                        wakeMetricCard(metric.key);
+                                                        focusMetricInput(`draft-metric-${metric.key}`);
+                                                    }}
                                                 >
                                                     {shouldDimMetricsTemplate && isMetricCardAwake ? (
                                                         <button
@@ -4648,10 +4713,10 @@ export default function CreateUpdate() {
                                                         )}>
                                                             {metric.icon}
                                                         </span>
-                                                        <div className="min-w-0">
-                                                            <div className="group/metric-heading relative inline-flex max-w-full items-center">
+                                                        <div className="min-w-0 flex-1">
+                                                            <div className="group/metric-heading relative flex max-w-full flex-wrap items-center gap-1">
                                                                 <span className={clsx(
-                                                                    "cursor-help text-xs font-black uppercase tracking-wide transition duration-200",
+                                                                    "min-w-0 cursor-help break-words text-left text-[11px] font-black uppercase leading-tight tracking-wide transition duration-200 sm:text-xs",
                                                                     isMetricCardAwake ? "text-gray-500" : "text-gray-400",
                                                                 )}>
                                                                     {metric.label}
@@ -4666,6 +4731,7 @@ export default function CreateUpdate() {
                                                         </div>
                                                     </div>
                                                     <input
+                                                        id={`draft-metric-${metric.key}`}
                                                         type="text"
                                                         name={metric.key}
                                                         value={metricValues[metric.key] || ""}
@@ -4676,7 +4742,7 @@ export default function CreateUpdate() {
                                                         }}
                                                         placeholder={metric.prefix ? `${metric.prefix}${metric.placeholder}` : metric.placeholder}
                                                         className={clsx(
-                                                            "mt-4 w-full border-b-2 bg-transparent py-1 text-lg font-black outline-none transition",
+                                                            "mt-4 w-full min-w-0 border-b-2 bg-transparent py-1 text-base font-black outline-none transition placeholder:text-sm sm:text-lg",
                                                             isMetricCardAwake
                                                                 ? "border-[rgba(0,128,128,0.26)] text-gray-950 focus:border-[var(--vr-color-primary)]"
                                                                 : "border-gray-300 text-gray-400 focus:border-[var(--vr-color-primary)]",
@@ -4687,6 +4753,19 @@ export default function CreateUpdate() {
                                                 })()
                                         ))}
                                         </div>
+                                        {mobileVisibleDraftMetricCount < draftMetricOptions.length ? (
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    setMobileVisibleDraftMetricCount((previous) =>
+                                                        Math.min(previous + mobileDraftMetricBatchSize, draftMetricOptions.length),
+                                                    );
+                                                }}
+                                                className="inline-flex w-full items-center justify-center rounded-xl border border-[var(--vr-color-border)] bg-white px-4 py-2.5 text-xs font-black uppercase tracking-wide text-gray-700 transition hover:border-[var(--vr-color-primary)] hover:text-[var(--vr-color-primary)] sm:hidden"
+                                            >
+                                                Show more
+                                            </button>
+                                        ) : null}
                                     </div>
 
                                     <div className="space-y-5">
@@ -5255,7 +5334,10 @@ export default function CreateUpdate() {
 	                                        return (
 	                                            <div
 	                                                key={m.key}
-	                                                onClick={() => toggleActiveMetric(m.key)}
+	                                                onClick={(event) => {
+	                                                    if ((event.target as HTMLElement).closest("input,button,a,textarea,select")) return;
+	                                                    activateActiveMetric(m.key);
+	                                                }}
                                                 className={clsx(
                                                     "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
                                                     active
@@ -5272,19 +5354,20 @@ export default function CreateUpdate() {
                                                 </div>
                                                 {active ? (
                                                     <input
+	                                                        id={`active-metric-${m.key}`}
 	                                                        type="text"
 	                                                        name={isViewingCurrentUpdate ? m.key : undefined}
 	                                                        value={activeMetricValues[m.key] || ""}
 	                                                        onClick={(e) => e.stopPropagation()}
 	                                                        onChange={(e) => updateActiveMetric(m.key, e.target.value)}
                                                         placeholder={m.prefix ? `${m.prefix}${m.placeholder}` : m.placeholder}
-                                                        className="w-full border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-base font-extrabold text-gray-900 focus:border-[var(--vr-color-primary)] focus:outline-none"
+                                                        className="w-full min-w-0 border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-sm font-extrabold text-gray-900 placeholder:text-xs focus:border-[var(--vr-color-primary)] focus:outline-none sm:text-base"
                                                     />
                                                 ) : (
                                                     <p className="text-base font-extrabold text-gray-300">—</p>
                                                 )}
                                                 <p className={clsx(
-                                                    "text-[10px] font-semibold uppercase tracking-wide mt-1",
+                                                    "mt-1 max-w-full break-words text-[10px] font-semibold uppercase leading-tight tracking-wide",
                                                     active ? "text-gray-600" : "text-gray-400"
                                                 )}>{m.label}</p>
                                             </div>
@@ -5365,7 +5448,16 @@ export default function CreateUpdate() {
                                     return (
                                         <div
                                             key={m.key}
-                                            onClick={() => toggleMetric(m.key)}
+                                            onClick={(event) => {
+                                                if ((event.target as HTMLElement).closest("input,button,a,textarea,select")) return;
+                                                setSelectedMetrics((previous) => {
+                                                    if (previous.has(m.key)) return previous;
+                                                    const next = new Set(previous);
+                                                    next.add(m.key);
+                                                    return next;
+                                                });
+                                                focusMetricInput(`default-metric-${m.key}`);
+                                            }}
                                             className={clsx(
                                                 "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
                                                 active
@@ -5382,19 +5474,20 @@ export default function CreateUpdate() {
                                             </div>
                                             {active ? (
                                                 <input
+                                                    id={`default-metric-${m.key}`}
                                                     type="text"
                                                     name={m.key}
                                                     value={metricValues[m.key] || ""}
                                                     onClick={(e) => e.stopPropagation()}
                                                     onChange={(e) => setMetricValues(prev => ({ ...prev, [m.key]: e.target.value }))}
                                                     placeholder={m.prefix ? `${m.prefix}${m.placeholder}` : m.placeholder}
-                                                    className="w-full border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-base font-extrabold text-gray-900 focus:border-[var(--vr-color-primary)] focus:outline-none"
+                                                    className="w-full min-w-0 border-b-2 border-[rgba(0,128,128,0.26)] bg-transparent py-0.5 text-center text-sm font-extrabold text-gray-900 placeholder:text-xs focus:border-[var(--vr-color-primary)] focus:outline-none sm:text-base"
                                                 />
                                             ) : (
                                                 <p className="text-base font-extrabold text-gray-300">—</p>
                                             )}
                                             <p className={clsx(
-                                                "text-[10px] font-semibold uppercase tracking-wide mt-1",
+                                                "mt-1 max-w-full break-words text-[10px] font-semibold uppercase leading-tight tracking-wide",
                                                 active ? "text-gray-600" : "text-gray-400"
                                             )}>{m.label}</p>
                                         </div>

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -4848,6 +4848,7 @@ export default function CreateUpdate() {
             </section>
 
             <VibeRaisingStickyStepBar
+                className={!monthConfirmed ? "hidden sm:block" : undefined}
                 statusIcon={draftStickyStatusIcon}
                 statusTitle={draftStickyBar.statusTitle}
                 statusDetail={draftStickyBar.statusDetail}

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -1,5 +1,5 @@
 import { Form, Link, useActionData, useFetcher, useLocation, useNavigate, useNavigation, useLoaderData, redirect } from "react-router";
-import React, { startTransition, useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import React, { startTransition, useCallback, useEffect, useEffectEvent, useId, useMemo, useRef, useState, type RefObject } from "react";
 import type { Route } from "./+types/vibe-raising-app.create-update";
 import { getEnv } from "~/lib/env.server";
 import {
@@ -34,6 +34,7 @@ import {
     ChartBarIcon,
     UsersIcon,
     FireIcon,
+    ArrowLeftIcon,
     ArrowRightIcon,
     BanknotesIcon,
     InformationCircleIcon,
@@ -84,8 +85,16 @@ const INPUT_SOURCE_LABELS: Record<VibeRaisingInputSourceKey, string> = {
 
 const DEFAULT_BACKEND_BASE_URL = "https://api.mlai.au";
 const MANUAL_MATERIALS_STORAGE_KEY = "vibe_raising_manual_materials";
+const CREATE_UPDATE_MOBILE_TOUR_STORAGE_KEY = "vibe_raising_create_update_mobile_tour_seen_v1";
 const SHOW_AI_REVIEW_FEEDBACK = false;
 const DRAFT_REVIEW_FORM_ID = "vibe-raising-draft-review-form";
+
+type CreateUpdateMobileTourStep = {
+    key: string;
+    title: string;
+    body: string;
+    targetRef: RefObject<Element | null>;
+};
 
 function readStoredManualMaterials(): {
     summary: string;
@@ -1832,6 +1841,122 @@ function GrowthChart({
     );
 }
 
+function CreateUpdateMobileTour({
+    open,
+    stepIndex,
+    steps,
+    onBack,
+    onClose,
+    onNext,
+}: {
+    open: boolean;
+    stepIndex: number;
+    steps: CreateUpdateMobileTourStep[];
+    onBack: () => void;
+    onClose: () => void;
+    onNext: () => void;
+}) {
+    const titleId = useId();
+    const step = steps[stepIndex];
+    const [targetRect, setTargetRect] = useState<{ top: number; left: number; width: number; height: number } | null>(null);
+
+    useEffect(() => {
+        if (!open || !step) {
+            setTargetRect(null);
+            return;
+        }
+
+        const updateTargetRect = () => {
+            const node = step.targetRef.current;
+            if (!node) {
+                setTargetRect(null);
+                return;
+            }
+
+            const rect = node.getBoundingClientRect();
+            setTargetRect({
+                top: Math.max(rect.top - 8, 12),
+                left: Math.max(rect.left - 8, 12),
+                width: Math.min(rect.width + 16, window.innerWidth - 24),
+                height: rect.height + 16,
+            });
+        };
+
+        const handleViewportChange = () => window.requestAnimationFrame(updateTargetRect);
+
+        handleViewportChange();
+        window.addEventListener("resize", handleViewportChange);
+        window.addEventListener("scroll", handleViewportChange, true);
+        return () => {
+            window.removeEventListener("resize", handleViewportChange);
+            window.removeEventListener("scroll", handleViewportChange, true);
+        };
+    }, [open, step]);
+
+    if (!open || !step) return null;
+
+    return (
+        <div className="fixed inset-0 z-[140] sm:hidden" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+            <button
+                type="button"
+                className="absolute inset-0 bg-slate-950/55"
+                onClick={onClose}
+                aria-label="Close create update tour"
+            />
+
+            {targetRect ? (
+                <>
+                    <div
+                        className="pointer-events-none absolute rounded-[28px] border-2 border-[var(--vr-color-primary)] bg-transparent shadow-[0_0_0_9999px_rgba(15,23,42,0.58)] transition-all duration-200"
+                        style={targetRect}
+                    />
+                    <div
+                        className="pointer-events-none absolute rounded-full bg-[var(--vr-color-primary)] px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-white shadow-lg"
+                        style={{ left: targetRect.left, top: Math.max(targetRect.top - 34, 10) }}
+                    >
+                        Step {stepIndex + 1}
+                    </div>
+                </>
+            ) : null}
+
+            <section className="absolute inset-x-4 bottom-4 rounded-[28px] bg-white p-5 shadow-2xl shadow-black/20">
+                <p className="text-xs font-black uppercase tracking-[0.14em] text-[var(--vr-color-primary)]">Quick mobile tour</p>
+                <h2 id={titleId} className="mt-2 text-xl font-black text-gray-950">{step.title}</h2>
+                <p className="mt-3 text-sm font-semibold leading-6 text-slate-600">{step.body}</p>
+
+                <div className="mt-5 flex items-center justify-between gap-3">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="inline-flex items-center justify-center rounded-xl px-3 py-2 text-sm font-black text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+                    >
+                        Skip
+                    </button>
+
+                    <div className="flex items-center gap-2">
+                        {stepIndex > 0 ? (
+                            <button
+                                type="button"
+                                onClick={onBack}
+                                className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-black text-slate-700 shadow-sm transition hover:bg-slate-50"
+                            >
+                                Back
+                            </button>
+                        ) : null}
+                        <button
+                            type="button"
+                            onClick={onNext}
+                            className="inline-flex items-center justify-center rounded-xl bg-[var(--vr-color-primary)] px-4 py-2 text-sm font-black text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)]"
+                        >
+                            {stepIndex === steps.length - 1 ? "Got it" : "Next"}
+                        </button>
+                    </div>
+                </div>
+            </section>
+        </div>
+    );
+}
+
 export default function CreateUpdate() {
     const {
         user,
@@ -1984,6 +2109,10 @@ export default function CreateUpdate() {
             : metricOptionsFromKeys(["revenue", "activeUsers", "mrr", "burnRate"]);
     const mobileDraftMetricBatchSize = 6;
     const [mobileVisibleDraftMetricCount, setMobileVisibleDraftMetricCount] = useState(mobileDraftMetricBatchSize);
+    const [isMobileTourViewport, setIsMobileTourViewport] = useState(false);
+    const [mobileTourOpen, setMobileTourOpen] = useState(false);
+    const [mobileTourStepIndex, setMobileTourStepIndex] = useState(0);
+    const [mobileTourChecked, setMobileTourChecked] = useState(false);
     const showLegacyDraftFlow = false;
     const selectedInputSourceLabels = selectedInputSources.map((key) => INPUT_SOURCE_LABELS[key]);
     const selectedInputSourceDescription = selectedInputSourceLabels.length > 0
@@ -2077,8 +2206,12 @@ export default function CreateUpdate() {
     const pitchDeckPreviewObjectUrlRef = useRef<string | null>(null);
     const loadedExistingUpdateKeyRef = useRef<string | null>(null);
     const editorMonthKeyRef = useRef<string>(selectedMonthUpdateKey);
+    const draftStepperRef = useRef<HTMLDivElement | null>(null);
+    const monthSelectorRef = useRef<HTMLDivElement | null>(null);
+    const draftStickyTriggerRef = useRef<HTMLDivElement | null>(null);
     const shouldDimMetricsTemplate = isManualOnlyDraftFlow && draftMetricOptions.length >= 12;
     const [awakeMetricCards, setAwakeMetricCards] = useState<Set<string>>(new Set());
+    const [showDraftStickyOnMobile, setShowDraftStickyOnMobile] = useState(false);
 
     const wakeMetricCard = useCallback((metricKey: string) => {
         if (shouldDimMetricsTemplate) {
@@ -2464,6 +2597,71 @@ export default function CreateUpdate() {
     useEffect(() => {
         setIsClientMounted(true);
     }, []);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia("(max-width: 639px)");
+        const syncViewport = () => setIsMobileTourViewport(mediaQuery.matches);
+        syncViewport();
+        mediaQuery.addEventListener("change", syncViewport);
+        return () => mediaQuery.removeEventListener("change", syncViewport);
+    }, []);
+
+    useEffect(() => {
+        if (mobileTourChecked || !isMobileTourViewport || monthConfirmed || selectedDraftStage === "reporting") return;
+        setMobileTourChecked(true);
+
+        try {
+            if (window.localStorage.getItem(CREATE_UPDATE_MOBILE_TOUR_STORAGE_KEY) === "1") return;
+        } catch {
+            // Ignore storage failures and still show the tour for this session.
+        }
+
+        const timer = window.setTimeout(() => {
+            setMobileTourStepIndex(0);
+            setMobileTourOpen(true);
+        }, 450);
+
+        return () => window.clearTimeout(timer);
+    }, [isMobileTourViewport, mobileTourChecked, monthConfirmed, selectedDraftStage]);
+
+    const closeMobileTour = () => {
+        setMobileTourOpen(false);
+        try {
+            window.localStorage.setItem(CREATE_UPDATE_MOBILE_TOUR_STORAGE_KEY, "1");
+        } catch {
+            // Ignore storage failures.
+        }
+    };
+
+    const goToPreviousMobileTourStep = () => {
+        setMobileTourStepIndex((current) => Math.max(0, current - 1));
+    };
+
+    const goToNextMobileTourStep = () => {
+        if (mobileTourStepIndex >= 1) {
+            closeMobileTour();
+            return;
+        }
+        setMobileTourStepIndex((current) => current + 1);
+    };
+
+    const mobileTourSteps = useMemo<CreateUpdateMobileTourStep[]>(
+        () => [
+            {
+                key: "stepper",
+                title: "Keep your materials together",
+                body: "Bring in your raw materials first. We keep the selected month, inputs, and draft fields together through review and publish.",
+                targetRef: draftStepperRef,
+            },
+            {
+                key: "month",
+                title: "Pick a month, then draft",
+                body: "Choose the update month first. Early stage? No worries. A selfie video or short presentation can still tell the investor story well.",
+                targetRef: monthSelectorRef,
+            },
+        ],
+        [],
+    );
 
     const hydrateCompletedEmailDraft = useEffectEvent(async (runId?: string | null) => {
         const results = await getVibeRaisingStartupUpdateDraftResults(backendBaseUrl, runId);
@@ -2977,6 +3175,31 @@ export default function CreateUpdate() {
         metricsConfirmed &&
         (!isAutoDrafting || canContinueDraftManually) &&
         !showEmailWizard;
+    useEffect(() => {
+        if (!isMobileTourViewport || selectedDraftStage !== "reporting" || !hasDraftTemplate) {
+            setShowDraftStickyOnMobile(false);
+            return;
+        }
+
+        const updateStickyVisibility = () => {
+            const trigger = draftStickyTriggerRef.current;
+            if (!trigger) {
+                setShowDraftStickyOnMobile(false);
+                return;
+            }
+
+            const rect = trigger.getBoundingClientRect();
+            setShowDraftStickyOnMobile(rect.top <= window.innerHeight - 140);
+        };
+
+        updateStickyVisibility();
+        window.addEventListener("scroll", updateStickyVisibility, true);
+        window.addEventListener("resize", updateStickyVisibility);
+        return () => {
+            window.removeEventListener("scroll", updateStickyVisibility, true);
+            window.removeEventListener("resize", updateStickyVisibility);
+        };
+    }, [hasDraftTemplate, isMobileTourViewport, selectedDraftStage]);
     const hasAnyMetricValue = Object.values(metricValues).some((value) => String(value || "").trim().length > 0);
     const qualitativeDraftText = [highlights, challenges, learnings, next30Days, asks].join("\n");
     const hasQualitativeDraftText =
@@ -3020,6 +3243,15 @@ export default function CreateUpdate() {
             window.setTimeout(() => setHighlightMaterialsSection(false), 2400);
         }, 80);
     }, [dismissStoryMaterialsSuggestion]);
+
+    const returnToMonthSelection = useCallback(() => {
+        setMonthConfirmed(false);
+        setSelectedDraftStage(null);
+        setMetricsConfirmed(false);
+        if (typeof window !== "undefined") {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+    }, []);
 
     const draftStickyStatusIcon = (
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.26)]">
@@ -3502,26 +3734,26 @@ export default function CreateUpdate() {
             </div>
             <div className="relative mt-6">
                 <fieldset disabled={isEmailDraftBusy} className={clsx(isEmailDraftBusy && "opacity-80")}>
-                    <div className="rounded-[2rem] border border-[var(--vr-color-border)] bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+                    <div className="contents">
                         <div
                             {...getMaterialsRootProps()}
                             className={clsx(
-                                "relative flex flex-col items-center justify-center rounded-2xl border p-6 text-center transition-all sm:p-12",
+                                "relative flex flex-col items-center justify-center rounded-[2rem] border p-6 text-center shadow-sm transition-all sm:p-8 lg:p-10",
                                 isMaterialsDragActive
                                     ? "scale-[1.01] border-[var(--vr-color-primary)] bg-[rgba(0,255,215,0.12)]"
-                                    : "border-[var(--vr-color-border)] bg-white hover:bg-[var(--vr-color-neutral-50)]",
+                                    : "border-[var(--vr-color-border)] bg-white",
                             )}
                         >
                             <input {...getMaterialsInputProps()} />
                             <div className="w-full max-w-4xl">
                                 <div className="mb-8 flex flex-col items-center text-center">
-                                    <div className="mb-4 h-12 w-12 text-gray-400">
+                                    <div className="mb-4 h-12 w-12 text-slate-400">
                                         <CloudArrowUpIcon className="h-full w-full stroke-1" />
                                     </div>
-                                    <p className="text-lg font-bold text-gray-900">
+                                    <p className="text-xl font-black text-gray-950">
                                         {isMaterialsDragActive ? "Drop your file here" : "Drag your pitch deck or video here"}
                                     </p>
-                                    <p className="mt-2 max-w-md text-sm text-gray-500">
+                                    <p className="mt-2 max-w-md text-sm font-semibold leading-6 text-slate-600">
                                         Choose the format that tells the investor story best. Final upload limit: 50 MB.
                                     </p>
                                 </div>
@@ -3532,10 +3764,10 @@ export default function CreateUpdate() {
                                             Pitch deck
                                         </p>
                                         <h3 className="mt-2 text-xl font-black text-gray-950">Upload the deck</h3>
-                                        <p className="mt-3 text-sm leading-6 text-slate-500">
+                                        <p className="mt-3 text-sm font-semibold leading-6 text-slate-600">
                                             Best for slides, founder bio, market story, and early traction notes.
                                         </p>
-                                        <p className="mt-2 text-xs font-semibold text-slate-400">
+                                        <p className="mt-2 text-xs font-black uppercase tracking-[0.08em] text-slate-400">
                                             PDF, PPT, or PPTX
                                         </p>
                                     </div>
@@ -3547,10 +3779,10 @@ export default function CreateUpdate() {
                                             Walkthrough video
                                         </p>
                                         <h3 className="mt-2 text-xl font-black text-gray-950">Record the founder story</h3>
-                                        <p className="mt-3 text-sm leading-6 text-slate-500">
+                                        <p className="mt-3 text-sm font-semibold leading-6 text-slate-600">
                                             Best when metrics are light and investors need to hear the founder thinking.
                                         </p>
-                                        <p className="mt-2 text-xs font-semibold text-slate-400">
+                                        <p className="mt-2 text-xs font-black uppercase tracking-[0.08em] text-slate-400">
                                             MP4, MOV, WebM and more
                                         </p>
                                     </div>
@@ -4503,19 +4735,34 @@ export default function CreateUpdate() {
     // 3. Create/Edit Form View
     return (
         <div className="mx-auto max-w-6xl space-y-10 pb-32">
-            <div className="space-y-4">
-                <MonthlyUpdateStepper
-                    activeStep="draft"
-                    disableMotion
-                    enabledSteps={isEdit ? ["draft"] : ["connect", "draft"]}
-                    hideProgressUntilHover
-                    onStepClick={handleDraftStepperClick}
-                    expandOnHover
-                    frameless
-                    className="mt-8"
-                />
+            {monthConfirmed ? (
+                <div className="pt-6">
+                    <button
+                        type="button"
+                        onClick={returnToMonthSelection}
+                        className="inline-flex items-center gap-2 rounded-xl border border-[var(--vr-color-border)] bg-white px-4 py-2 text-sm font-black text-[var(--vr-color-text)] shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-[var(--vr-color-primary-soft)]"
+                    >
+                        <ArrowLeftIcon className="h-4 w-4" />
+                        Back to month selection
+                    </button>
+                </div>
+            ) : null}
 
-                <div className="rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-5 shadow-sm">
+            <div className="space-y-4">
+                <div ref={draftStepperRef}>
+                    <MonthlyUpdateStepper
+                        activeStep="draft"
+                        disableMotion
+                        enabledSteps={isEdit ? ["draft"] : ["connect", "draft"]}
+                        hideProgressUntilHover
+                        onStepClick={handleDraftStepperClick}
+                        expandOnHover
+                        frameless
+                        className="mt-8"
+                    />
+                </div>
+
+                <div className="hidden rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-5 shadow-sm sm:block">
                     <div className="flex min-w-0 items-start gap-4">
                         <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)]">
                             <SparklesIcon className="h-5 w-5" />
@@ -4535,25 +4782,24 @@ export default function CreateUpdate() {
             <section>
                 <div className="space-y-4">
                     {monthConfirmed ? (
-                        <button
-                            type="button"
-                            onClick={() => {
-                                setMonthConfirmed(false);
-                                setSelectedDraftStage(null);
-                                setMetricsConfirmed(false);
-                            }}
-                            className="group flex w-full items-center rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-3 text-left shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-[rgba(0,255,215,0.08)] focus:outline-none focus:ring-4 focus:ring-[rgba(0,255,215,0.24)] sm:px-6 sm:py-4"
-                            aria-label={`Change selected update month, currently ${selectedMonthLabel}`}
+                        <div
+                            className="w-full rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-3 shadow-sm sm:px-6 sm:py-4"
+                            aria-label={`Selected update month: ${selectedMonthLabel}`}
                         >
                             <div className="flex min-w-0 flex-1 items-center gap-3">
-                                <span className="h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[var(--vr-palette-mint)] ring-4 ring-[rgba(0,255,215,0.14)] transition group-hover:ring-[rgba(0,255,215,0.28)]" />
-                                <p className="truncate text-base font-black text-gray-950">
-                                    {selectedMonthLabel}
-                                </p>
+                                <span className="h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[var(--vr-palette-mint)] ring-4 ring-[rgba(0,255,215,0.14)]" />
+                                <div className="min-w-0">
+                                    <p className="text-[11px] font-black uppercase tracking-[0.14em] text-slate-500">
+                                        Selected month
+                                    </p>
+                                    <p className="truncate text-base font-black text-gray-950">
+                                        {selectedMonthLabel}
+                                    </p>
+                                </div>
                             </div>
-                        </button>
+                        </div>
                     ) : (
-                        <div className="space-y-3">
+                        <div ref={monthSelectorRef} className="space-y-3">
                             <p className="px-1 text-sm font-black text-gray-950">Select month</p>
                             <div className="overflow-visible rounded-[2rem] border border-[var(--vr-color-border)] bg-white p-5 shadow-sm transition-all sm:p-8 lg:p-10">
                                 <div className="grid gap-4 lg:grid-cols-4 lg:items-stretch">
@@ -4688,6 +4934,10 @@ export default function CreateUpdate() {
                                                     )}
                                                     onClick={(event) => {
                                                         if ((event.target as HTMLElement).closest("button")) return;
+                                                        if (isMobileTourViewport && shouldDimMetricsTemplate && isMetricCardAwake) {
+                                                            dismissMetricCard(metric.key);
+                                                            return;
+                                                        }
                                                         wakeMetricCard(metric.key);
                                                         focusMetricInput(`draft-metric-${metric.key}`);
                                                     }}
@@ -4700,7 +4950,7 @@ export default function CreateUpdate() {
                                                                 event.stopPropagation();
                                                                 dismissMetricCard(metric.key);
                                                             }}
-                                                            className="absolute right-2 top-2 rounded-full p-1 text-gray-400 transition hover:bg-white hover:text-gray-700"
+                                                            className="absolute right-2 top-2 hidden rounded-full p-1 text-gray-400 transition hover:bg-white hover:text-gray-700 sm:inline-flex"
                                                             aria-label={`Dismiss ${metric.label}`}
                                                         >
                                                             <XMarkIcon className="h-3.5 w-3.5" />
@@ -4838,6 +5088,7 @@ export default function CreateUpdate() {
                                         </button>
                                     </div>
                                 </div>
+                                <div ref={draftStickyTriggerRef} aria-hidden className="h-1 w-full" />
                                 </div>
                             ) : null}
                             {materialsSection}
@@ -4848,7 +5099,10 @@ export default function CreateUpdate() {
             </section>
 
             <VibeRaisingStickyStepBar
-                className={!monthConfirmed ? "hidden sm:block" : undefined}
+                className={clsx(
+                    !monthConfirmed && "hidden sm:block",
+                    isMobileTourViewport && selectedDraftStage === "reporting" && hasDraftTemplate && !showDraftStickyOnMobile && "hidden sm:block",
+                )}
                 statusIcon={draftStickyStatusIcon}
                 statusTitle={draftStickyBar.statusTitle}
                 statusDetail={draftStickyBar.statusDetail}
@@ -5232,7 +5486,7 @@ export default function CreateUpdate() {
                                                                 "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-1.5 cursor-pointer transition-all",
                                                                 active
                                                                     ? "border-[var(--vr-color-primary)] bg-[rgba(0,255,215,0.12)] ring-1 ring-[rgba(0,128,128,0.16)] shadow-sm"
-                                                                    : "border-gray-200 bg-gray-50 opacity-50 hover:opacity-75 hover:border-gray-300"
+                                                                    : "border-[3px] border-dashed border-gray-400 bg-gray-50 opacity-80 hover:opacity-100 hover:border-gray-500"
                                                             )}
 	                                                        >
                                                             <MetricInfoBadge info={m.info} />
@@ -5343,7 +5597,7 @@ export default function CreateUpdate() {
                                                     "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
                                                     active
                                                         ? "border-[var(--vr-color-primary)] bg-[rgba(0,255,215,0.12)] ring-1 ring-[rgba(0,128,128,0.16)] shadow-sm"
-                                                        : "border-gray-200 bg-gray-50 opacity-50 hover:opacity-75 hover:border-gray-300"
+                                                        : "border-[3px] border-dashed border-gray-400 bg-gray-50 opacity-80 hover:opacity-100 hover:border-gray-500"
                                                 )}
 	                                            >
                                                 <MetricInfoBadge info={m.info} />
@@ -5463,7 +5717,7 @@ export default function CreateUpdate() {
                                                 "relative rounded-xl border-2 flex flex-col items-center justify-center text-center py-3 px-2 cursor-pointer transition-all",
                                                 active
                                                     ? "border-[var(--vr-color-primary)] bg-[rgba(0,255,215,0.12)] ring-1 ring-[rgba(0,128,128,0.16)] shadow-sm"
-                                                    : "border-gray-200 bg-gray-50 opacity-50 hover:opacity-75 hover:border-gray-300"
+                                                    : "border-[3px] border-dashed border-gray-400 bg-gray-50 opacity-80 hover:opacity-100 hover:border-gray-500"
                                             )}
 	                                        >
                                             <MetricInfoBadge info={m.info} />
@@ -5560,6 +5814,14 @@ export default function CreateUpdate() {
                     companyDomain={user.domain}
                 />
             ) : null}
+            <CreateUpdateMobileTour
+                open={mobileTourOpen}
+                stepIndex={mobileTourStepIndex}
+                steps={mobileTourSteps}
+                onBack={goToPreviousMobileTourStep}
+                onClose={closeMobileTour}
+                onNext={goToNextMobileTourStep}
+            />
             </>
             ) : null}
         </div>

--- a/app/styles/vibe-raising-components.css
+++ b/app/styles/vibe-raising-components.css
@@ -39,13 +39,13 @@
   cursor: pointer;
   text-align: left;
   width: 100%;
-  transition: box-shadow 0.15s, transform 0.15s;
+  min-width: 0;
+  transition: box-shadow 0.15s, border-color 0.15s, background-color 0.15s;
 }
 
 .vr-scope .vr-metric-card:hover,
 .vr-scope .vr-metric-card:focus-visible {
   box-shadow: var(--vr-shadow-md);
-  transform: translateY(-2px);
 }
 
 .vr-scope .vr-metric-card:focus-visible {
@@ -56,7 +56,6 @@
 .vr-scope .vr-metric-card-active {
   border-color: var(--vr-color-primary);
   box-shadow: var(--vr-shadow-md), 0 0 0 3px rgba(0, 255, 215, 0.16);
-  transform: translateY(-2px);
 }
 
 .vr-scope .vr-metric-card-bar {
@@ -76,26 +75,54 @@
   color: var(--vr-color-text-sub);
   margin-bottom: 10px;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
 .vr-scope .vr-metric-value {
   font-family: var(--vr-font-title);
   font-weight: var(--vr-font-weight-bold);
-  font-size: 30px;
+  font-size: clamp(24px, 2.6vw, 30px);
   color: var(--vr-color-text);
-  line-height: 1;
+  line-height: 1.08;
   margin-bottom: 6px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  text-wrap: balance;
 }
 
 .vr-scope .vr-metric-delta {
   font-size: var(--vr-font-size-sm);
   font-weight: var(--vr-font-weight-medium);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 4px;
+  flex-wrap: wrap;
+  line-height: 1.35;
+}
+
+@media (max-width: 1023px) {
+  .vr-scope .vr-metric-card {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 640px) {
+  .vr-scope .vr-metric-card {
+    padding: 16px;
+  }
+
+  .vr-scope .vr-metric-value {
+    font-size: clamp(20px, 7vw, 26px);
+    text-wrap: pretty;
+  }
+
+  .vr-scope .vr-metric-delta {
+    font-size: var(--vr-font-size-xs);
+  }
 }
 
 .vr-scope .vr-delta-up    { color: var(--vr-color-success); }
@@ -481,11 +508,15 @@
   margin-bottom: 16px;
 }
 
+.vr-scope .vr-us-block:last-child {
+  margin-bottom: 0;
+}
+
 .vr-scope .vr-us-heading {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .vr-scope .vr-us-heading-icon {
@@ -497,8 +528,8 @@
 
 .vr-scope .vr-us-heading-text {
   font-family: var(--vr-font-body);
-  font-size: var(--vr-font-size-sm);
-  font-weight: var(--vr-font-weight-bold);
+  font-size: var(--vr-font-size-base);
+  font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--vr-color-text);
@@ -660,6 +691,47 @@
   color: var(--vr-color-text-sub);
   font-size: var(--vr-font-size-sm);
   flex-wrap: wrap;
+}
+
+.vr-scope .vr-past-edit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--vr-color-border);
+  background: var(--vr-color-surface);
+  color: var(--vr-color-text-mid);
+  font-size: var(--vr-font-size-sm);
+  font-weight: var(--vr-font-weight-semibold);
+  transition: background-color 0.15s ease-out, color 0.15s ease-out, border-color 0.15s ease-out;
+}
+
+.vr-scope .vr-past-edit:hover {
+  background: rgba(0, 255, 215, 0.08);
+  color: var(--vr-color-text);
+  border-color: rgba(0, 128, 128, 0.18);
+}
+
+.vr-scope .vr-past-metrics-grid {
+  margin-bottom: 24px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (min-width: 640px) {
+  .vr-scope .vr-past-metrics-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .vr-scope .vr-past-metrics-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 }
 
 .vr-scope .vr-past-footer {
@@ -905,9 +977,34 @@
   gap: 16px;
 }
 
+@media (max-width: 900px) {
+  .vr-scope .vr-company-info-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 @media (max-width: 640px) {
+  .vr-scope .vr-company-hero-banner {
+    min-height: 96px;
+  }
+
+  .vr-scope .vr-company-hero-banner-bubble-1 {
+    top: -34px;
+    right: 18px;
+    width: 128px;
+    height: 128px;
+  }
+
+  .vr-scope .vr-company-hero-banner-bubble-2 {
+    bottom: -22px;
+    right: -14px;
+    width: 76px;
+    height: 76px;
+  }
+
   .vr-scope .vr-company-info-grid {
     grid-template-columns: 1fr;
+    gap: 12px;
   }
 }
 
@@ -996,6 +1093,61 @@
   .vr-scope .vr-past-row {
     padding: 12px 14px;
   }
+
+  .vr-scope .vr-us-block {
+    margin-bottom: 14px;
+  }
+
+  .vr-scope .vr-us-heading {
+    gap: 6px;
+    margin-bottom: 8px;
+  }
+
+  .vr-scope .vr-us-heading-text {
+    font-size: var(--vr-font-size-sm);
+    letter-spacing: 0.06em;
+  }
+
+  .vr-scope .vr-us-item {
+    gap: 8px;
+    margin-bottom: 6px;
+    padding-left: 8px;
+  }
+
+  .vr-scope .vr-us-item-text {
+    font-size: var(--vr-font-size-sm);
+    line-height: 1.5;
+  }
+
+  .vr-scope .vr-past-body {
+    padding: 16px 14px 18px;
+  }
+
+  .vr-scope .vr-past-meta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  .vr-scope .vr-past-edit {
+    width: 100%;
+  }
+
+  .vr-scope .vr-past-metrics-grid {
+    margin-bottom: 18px;
+    gap: 10px;
+  }
+
+  .vr-scope .vr-past-footer {
+    margin-top: 18px;
+    padding-top: 14px;
+  }
+
+  .vr-scope .vr-ucf-left {
+    width: 100%;
+  }
+
   .vr-scope .vr-past-preview {
     display: none;
   }

--- a/app/styles/vibe-raising-components.css
+++ b/app/styles/vibe-raising-components.css
@@ -35,11 +35,27 @@
   position: relative;
   overflow: hidden;
   box-shadow: var(--vr-shadow-sm);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
   transition: box-shadow 0.15s, transform 0.15s;
 }
 
-.vr-scope .vr-metric-card:hover {
+.vr-scope .vr-metric-card:hover,
+.vr-scope .vr-metric-card:focus-visible {
   box-shadow: var(--vr-shadow-md);
+  transform: translateY(-2px);
+}
+
+.vr-scope .vr-metric-card:focus-visible {
+  outline: 2px solid rgba(0, 128, 128, 0.22);
+  outline-offset: 3px;
+}
+
+.vr-scope .vr-metric-card-active {
+  border-color: var(--vr-color-primary);
+  box-shadow: var(--vr-shadow-md), 0 0 0 3px rgba(0, 255, 215, 0.16);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- make the Data Sources mobile tour re-check local state after localStorage resets
- keep the mobile privacy/tour experience in sync when the page regains focus
- tighten the Founder Tools top bar on small screens by shrinking nav pills and hiding the mobile bell

## Testing
- bun run typecheck