### PR TITLE
[codex] Polish founder tools mobile followups

### DIFF
--- a/NEXT-SESSION-HANDOFF.md
+++ b/NEXT-SESSION-HANDOFF.md
@@ -1,0 +1,37 @@
+# Next Session Handoff
+
+## Branch
+
+- Branch: `yichen/founder-tools-mobile-cta-followups`
+- Base: `origin/main` at the time this handoff was written
+
+## What Changed
+
+- Tightened Founder Tools dashboard CTA hierarchy and labels on mobile.
+- Removed extra Founder Tools top-bar chrome on mobile.
+- Softened stepper hover/tap treatment so pills no longer flash white.
+- Simplified the mobile review sticky footer.
+- Hid the mobile data-sources sticky footer until the user scrolls.
+- Simplified manual-input copy on Data Sources.
+- Shortened the manual-only draft tooltip copy.
+- Made the mobile review "How it works" intro show only for first-time users.
+
+## Validation
+
+- `bun run typecheck`
+- Manual browser checks on:
+  - `/founder-tools/updates`
+  - `/founder-tools/updates/create`
+  - `/founder-tools/data-sources`
+
+## Local-Only Files
+
+- Keep these out of commits and PRs:
+  - `context.md`
+  - `scripts/start-mlai-5174.bat`
+
+## Useful Context For Next Session
+
+- The branch was rebuilt from latest `origin/main` after the earlier Founder Tools PR stack landed.
+- The current staged/committed scope is intentionally narrow: mobile, CTA, and review-flow polish only.
+- If more Founder Tools feedback arrives, continue from this branch unless the request is clearly a separate task.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,9 @@
+- [x] Simplify the mobile review sticky footer on Founder Tools create-update
+- [x] Polish Founder Tools dashboard CTA hierarchy for the May 17-18 mobile follow-up branch
+- [x] Improve Create Update AI draft card touch/mobile affordance
+- [x] Reduce Founder Tools mobile chrome clutter and card status density
+- [x] Run `bun run typecheck`
+- [x] Verify Founder Tools dashboard, create-update, and data-sources flows in the local browser
 - [x] Fix GA4 Measurement ID and SPA page-view tracking
 - [x] Update the main-page Slack invite link
 - [x] Update the Vibe Raising relationship callout heading to mention building investor relationships 6 months in advance

--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -2,7 +2,6 @@ import { useState, Fragment } from 'react';
 import { Menu, Dialog, Transition } from '@headlessui/react';
 import {
     Bars3Icon,
-    BellIcon,
     ChartBarSquareIcon,
     ChevronDownIcon,
     HomeIcon,
@@ -434,27 +433,6 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                                 <div />
                             )}
                             <div className="flex shrink-0 items-center gap-x-2 sm:gap-x-4 lg:gap-x-6">
-                                <button
-                                    type="button"
-                                    className={classNames(
-                                        "hidden -m-2.5 p-2.5 sm:block",
-                                        isFounderToolsApp
-                                            ? "text-[var(--vr-color-text-sub)] hover:text-[var(--vr-color-text)]"
-                                            : "text-gray-400 hover:text-gray-500"
-                                    )}
-                                >
-                                    <span className="sr-only">View notifications</span>
-                                    <BellIcon aria-hidden="true" className="h-6 w-6" />
-                                </button>
-
-                                <div
-                                    aria-hidden="true"
-                                    className={classNames(
-                                        "hidden lg:block lg:h-6 lg:w-px",
-                                        isFounderToolsApp ? "lg:bg-[var(--vr-color-border)]" : "lg:bg-gray-900/10"
-                                    )}
-                                />
-
                                 <Menu as="div" className="relative">
                                     <Menu.Button className="-m-1.5 flex items-center p-1.5">
                                         <span className="sr-only">Open user menu</span>

--- a/app/components/MonthlyUpdateStepper.tsx
+++ b/app/components/MonthlyUpdateStepper.tsx
@@ -97,7 +97,7 @@ export default function MonthlyUpdateStepper({
                 onClick={() => onStepClick?.(step.key)}
                 className={clsx(
                   "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset transition",
-                  canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
+                  canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
                   isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm ring-[var(--vr-color-primary)]",
                   isComplete && !isActive && "bg-[var(--vr-color-primary-soft)] text-[var(--vr-color-primary)] ring-[rgba(0,128,128,0.18)]",
                   !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
@@ -179,7 +179,7 @@ export default function MonthlyUpdateStepper({
                     className={clsx(
                       "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset",
                       !disableMotion && "transition",
-                      canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
+                      canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
                       isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm ring-[var(--vr-color-primary)]",
                       isComplete && !isActive && "bg-[var(--vr-color-primary-soft)] text-[var(--vr-color-primary)] ring-[rgba(0,128,128,0.18)]",
                       !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",
@@ -302,7 +302,7 @@ export default function MonthlyUpdateStepper({
                 onClick={() => onStepClick?.(step.key)}
                 className={clsx(
                   "whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset transition",
-                  canSelect ? "cursor-pointer hover:bg-white" : "cursor-default",
+                  canSelect ? "cursor-pointer hover:bg-[rgba(0,255,215,0.16)]" : "cursor-default",
                   isActive && "bg-[var(--vr-color-primary)] text-white shadow-sm ring-[var(--vr-color-primary)]",
                   isComplete && !isActive && "bg-[var(--vr-color-primary-soft)] text-[var(--vr-color-primary)] ring-[rgba(0,128,128,0.18)]",
                   !isActive && !isComplete && !isLocked && "bg-white text-[var(--vr-color-text-sub)] ring-[var(--vr-color-border)]",

--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -4,15 +4,20 @@ import { ArrowRightIcon } from "@heroicons/react/24/outline";
 type VibeRaisingStickyStepBarProps = {
     className?: string;
     hideStatusOnMobile?: boolean;
+    hideBackOnMobile?: boolean;
+    compactOnMobile?: boolean;
     statusIcon?: ReactNode;
     statusTitle: string;
     statusDetail?: string;
     backLabel?: string;
+    mobileBackLabel?: string;
     onBack?: () => void;
     secondaryLabel?: string;
+    mobileSecondaryLabel?: string;
     onSecondary?: () => void;
     secondaryDisabled?: boolean;
     primaryLabel: string;
+    mobilePrimaryLabel?: string;
     onPrimary?: () => void;
     primaryDisabled?: boolean;
     primaryType?: "button" | "submit";
@@ -22,23 +27,37 @@ type VibeRaisingStickyStepBarProps = {
 export default function VibeRaisingStickyStepBar({
     className,
     hideStatusOnMobile = false,
+    hideBackOnMobile = false,
+    compactOnMobile = false,
     statusIcon,
     statusTitle,
     statusDetail,
     backLabel = "Back",
+    mobileBackLabel,
     onBack,
     secondaryLabel,
+    mobileSecondaryLabel,
     onSecondary,
     secondaryDisabled = false,
     primaryLabel,
+    mobilePrimaryLabel,
     onPrimary,
     primaryDisabled = false,
     primaryType = "button",
     primaryForm,
 }: VibeRaisingStickyStepBarProps) {
+    const resolvedBackLabel = mobileBackLabel ?? backLabel;
+    const resolvedSecondaryLabel = mobileSecondaryLabel ?? secondaryLabel;
+    const resolvedPrimaryLabel = mobilePrimaryLabel ?? primaryLabel;
+
     return (
         <div className={["fixed inset-x-4 bottom-4 z-40 lg:left-24", className].filter(Boolean).join(" ")}>
-            <div className="mx-auto flex max-w-6xl flex-col gap-4 rounded-2xl border border-[var(--vr-color-border)] bg-white/95 px-4 py-4 shadow-2xl shadow-black/10 backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:px-5">
+            <div
+                className={[
+                    "mx-auto flex max-w-6xl flex-col rounded-2xl border border-[var(--vr-color-border)] bg-white/95 shadow-2xl shadow-black/10 backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:px-5 sm:py-4",
+                    compactOnMobile ? "gap-3 px-3 py-3" : "gap-4 px-4 py-4",
+                ].join(" ")}
+            >
                 <div className={["flex min-w-0 items-center gap-3", hideStatusOnMobile ? "hidden sm:flex" : ""].filter(Boolean).join(" ")}>
                     {statusIcon ? (
                         <div className="flex flex-shrink-0 items-center justify-center">
@@ -53,14 +72,24 @@ export default function VibeRaisingStickyStepBar({
                     </div>
                 </div>
 
-                <div className="flex flex-col gap-3 sm:flex-shrink-0 sm:flex-row sm:items-center sm:justify-end">
-                    {onBack ? (
+                <div
+                    className={[
+                        compactOnMobile
+                            ? "grid grid-cols-2 gap-2 sm:flex sm:flex-shrink-0 sm:flex-row sm:items-center sm:justify-end"
+                            : "flex flex-col gap-3 sm:flex-shrink-0 sm:flex-row sm:items-center sm:justify-end",
+                    ].join(" ")}
+                >
+                    {onBack && !hideBackOnMobile ? (
                         <button
                             type="button"
                             onClick={onBack}
-                            className="inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950 sm:w-auto"
+                            className={[
+                                "inline-flex items-center justify-center rounded-xl px-4 py-3 text-sm font-extrabold text-slate-500 transition hover:bg-gray-50 hover:text-gray-950",
+                                compactOnMobile ? "w-full sm:w-auto" : "w-full sm:w-auto",
+                            ].join(" ")}
                         >
-                            {backLabel}
+                            <span className="sm:hidden">{resolvedBackLabel}</span>
+                            <span className="hidden sm:inline">{backLabel}</span>
                         </button>
                     ) : null}
                     {secondaryLabel && onSecondary ? (
@@ -68,9 +97,13 @@ export default function VibeRaisingStickyStepBar({
                             type="button"
                             onClick={onSecondary}
                             disabled={secondaryDisabled}
-                            className="inline-flex w-full items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55 sm:w-auto"
+                            className={[
+                                "inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55",
+                                compactOnMobile ? "w-full sm:w-auto" : "w-full sm:w-auto",
+                            ].join(" ")}
                         >
-                            {secondaryLabel}
+                            <span className="sm:hidden">{resolvedSecondaryLabel}</span>
+                            <span className="hidden sm:inline">{secondaryLabel}</span>
                         </button>
                     ) : null}
                     <button
@@ -78,9 +111,13 @@ export default function VibeRaisingStickyStepBar({
                         form={primaryForm}
                         onClick={primaryType === "button" ? onPrimary : undefined}
                         disabled={primaryDisabled}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0 sm:min-w-44 sm:w-auto"
+                        className={[
+                            "inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-5 py-3 text-sm font-extrabold text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:-translate-y-0.5 hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:translate-y-0",
+                            compactOnMobile ? "col-span-1 w-full sm:min-w-44 sm:w-auto" : "w-full sm:min-w-44 sm:w-auto",
+                        ].join(" ")}
                     >
-                        {primaryLabel}
+                        <span className="sm:hidden">{resolvedPrimaryLabel}</span>
+                        <span className="hidden sm:inline">{primaryLabel}</span>
                         <ArrowRightIcon className="h-4 w-4" />
                     </button>
                 </div>

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -648,8 +648,8 @@ function VRUpdateSection({
 }) {
     const [mobileExpanded, setMobileExpanded] = useState(false);
     if (items.length === 0) return null;
-    const shouldClampOnMobile = items.length > 2;
-    const visibleItems = mobileExpanded ? items : items.slice(0, 2);
+    const shouldClampOnMobile = items.length > 1;
+    const visibleItems = mobileExpanded ? items : items.slice(0, 1);
 
     return (
         <div className="vr-us-block">
@@ -986,35 +986,20 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     <div className="flex items-center gap-2.5 flex-wrap">
                         <Link
                             to="/founder-tools/overview"
-                            className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border transition-colors"
-                            style={{
-                                color: "var(--vr-color-text-mid)",
-                                borderColor: "var(--vr-color-border-md)",
-                                background: "transparent",
-                            }}
+                            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-white hover:text-gray-950"
                         >
                             View Overview
                         </Link>
                         <Link
                             to="/founder-tools/drafts"
-                            className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border transition-colors"
-                            style={{
-                                color: "var(--vr-color-text-mid)",
-                                borderColor: "var(--vr-color-border-md)",
-                                background: "transparent",
-                            }}
+                            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-white hover:text-gray-950"
                         >
-                            My Draft
+                            My Drafts
                         </Link>
                         <button
                             type="button"
                             onClick={() => triggerAnnouncement(() => navigate("/founder-tools/data-sources"))}
-                            className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg transition-all"
-                            style={{
-                                background: "var(--vr-color-primary)",
-                                color: "#fff",
-                                boxShadow: "var(--vr-shadow-sm)",
-                            }}
+                            className="inline-flex items-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-4 py-3 text-sm font-black text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)]"
                         >
                             <PlusIcon className="w-4 h-4" />
                             Create Update
@@ -1045,19 +1030,14 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                                 <button
                                     type="button"
                                     onClick={() => triggerAnnouncement(() => navigate("/founder-tools/data-sources"))}
-                                    className="inline-flex items-center gap-3 rounded-xl bg-[var(--vr-color-text-strong)] px-6 py-3 font-bold text-white transition-all hover:opacity-95"
+                                    className="inline-flex items-center gap-3 rounded-xl bg-[var(--vr-color-primary)] px-6 py-3 font-bold text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)]"
                                 >
                                     Create Your First Update
                                     <ArrowRightIcon className="h-5 w-5" />
                                 </button>
                                 <Link
                                     to="/founder-tools/overview"
-                                    className="inline-flex items-center gap-2 rounded-xl border px-6 py-3 font-semibold"
-                                    style={{
-                                        borderColor: "var(--vr-color-border-md)",
-                                        color: "var(--vr-color-text-strong)",
-                                        background: "rgba(255,255,255,0.9)",
-                                    }}
+                                    className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-6 py-3 font-semibold text-[var(--vr-color-text-strong)] shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-white"
                                 >
                                     Revisit Overview
                                 </Link>
@@ -1106,12 +1086,7 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     {showDiscover ? (
                         <button
                             type="button"
-                            className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border transition-colors"
-                            style={{
-                                color: "var(--vr-color-text-mid)",
-                                borderColor: "var(--vr-color-border-md)",
-                                background: "transparent",
-                            }}
+                            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-white hover:text-gray-950"
                             onClick={() => navigate("/founder-tools/discover")}
                         >
                             Discover Investors
@@ -1119,23 +1094,13 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     ) : null}
                     <Link
                         to="/founder-tools/drafts"
-                        className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border transition-colors"
-                        style={{
-                            color: "var(--vr-color-text-mid)",
-                            borderColor: "var(--vr-color-border-md)",
-                            background: "transparent",
-                        }}
+                        className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-black text-slate-700 shadow-sm transition hover:border-[var(--vr-color-primary)] hover:bg-white hover:text-gray-950"
                     >
-                        My Draft
+                        My Drafts
                     </Link>
                     <Link
                         to="/founder-tools/data-sources"
-                        className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg transition-all"
-                        style={{
-                            background: "var(--vr-color-primary)",
-                            color: "#fff",
-                            boxShadow: "var(--vr-shadow-sm)",
-                        }}
+                        className="inline-flex items-center gap-2 rounded-xl bg-[var(--vr-color-primary)] px-4 py-3 text-sm font-black text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)]"
                     >
                         <PlusIcon className="w-4 h-4" />
                         Create Update

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -1494,6 +1494,7 @@ function ConnectorCard({
   const isConnected = source.status === "connected" || source.status === "syncing";
   const displayedStatus = canConnectWhenUnavailable ? "not_connected" : source.status;
   const displayedStatusLabel = canConnectWhenUnavailable ? "Ready to connect" : statusLabel(source.status);
+  const shouldShowHeaderStatus = displayedStatus !== "coming_soon" && displayedStatus !== "unavailable";
   const trustMessage = isMobileView
     ? isConnected
       ? `Only this workspace can see synced ${source.label} data.`
@@ -1508,7 +1509,7 @@ function ConnectorCard({
     "block w-full rounded-lg px-3 py-2 text-center text-xs font-extrabold transition",
     disabled || !canConnect
       ? "cursor-not-allowed bg-gray-100 text-gray-400"
-      : "bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] hover:bg-[rgba(0,255,215,0.18)]",
+      : "bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)] hover:bg-[rgba(0,255,215,0.18)] hover:ring-1 hover:ring-[rgba(0,128,128,0.18)]",
   );
 
   return (
@@ -1521,14 +1522,16 @@ function ConnectorCard({
           : "border-gray-200 bg-white",
     )} tabIndex={0}>
       <div className="pointer-events-none flex flex-col gap-3">
-        <div className="flex items-start justify-between gap-3">
+        <div className={clsx("flex items-start gap-3", shouldShowHeaderStatus && "justify-between")}>
           <SourceLogo sourceKey={source.key} large />
-          <span className={clsx(
-            "inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:max-w-[9rem] sm:px-2 sm:text-[10px]",
-            isConnected ? "bg-white text-[var(--vr-color-primary)] ring-white/60" : statusClassName(displayedStatus),
-          )}>
-            {displayedStatusLabel}
-          </span>
+          {shouldShowHeaderStatus ? (
+            <span className={clsx(
+              "inline-flex max-w-[8rem] flex-shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-[9px] font-bold ring-1 sm:max-w-[9rem] sm:px-2 sm:text-[10px]",
+              isConnected ? "bg-white text-[var(--vr-color-primary)] ring-white/60" : statusClassName(displayedStatus),
+            )}>
+              {displayedStatusLabel}
+            </span>
+          ) : null}
         </div>
         <h3 className={clsx(
           "break-words text-left text-base font-black leading-tight sm:text-lg",
@@ -1692,7 +1695,7 @@ function ManualMaterialsCard({
   summary: string;
   onToggle: () => void;
 }) {
-  const cardCaption = "Upload private documents or add a short written summary for context outside your connected tools.";
+  const cardCaption = "Upload document or add a short written summary for context outside your connected tools.";
 
   return (
     <button
@@ -1963,6 +1966,7 @@ export default function ConnectData() {
   const slackSelectionTouchedRef = useRef(false);
   const linearSelectionTouchedRef = useRef(false);
   const [isMobileTourViewport, setIsMobileTourViewport] = useState(false);
+  const [showStickyBarOnMobile, setShowStickyBarOnMobile] = useState(false);
   const [mobileTourOpen, setMobileTourOpen] = useState(false);
   const [mobileTourStepIndex, setMobileTourStepIndex] = useState(0);
   const [mobileTourChecked, setMobileTourChecked] = useState(false);
@@ -2017,7 +2021,7 @@ export default function ConnectData() {
       manualMaterials.manualDocumentIds.length > 0 ? `${manualMaterials.manualDocumentIds.length} document${manualMaterials.manualDocumentIds.length === 1 ? "" : "s"} selected` : null,
       manualMaterials.summary.trim() ? "summary added" : null,
     ].filter((value): value is string => Boolean(value)).join(" and ")
-    : "Upload private documents or add a short written summary when you want extra context in the draft.";
+    : "Upload document or add a short written summary when you want extra context in the draft.";
   const gmailSource = sourceByKey.get("gmail");
   const shouldShowGmailPreview = gmailSource?.status === "connected" || gmailSource?.status === "syncing" || gmailSource?.status === "error";
   const bankFeedSource = sourceByKey.get("bank_feed");
@@ -2115,6 +2119,25 @@ export default function ConnectData() {
     return () => {
       window.removeEventListener("focus", syncMobileTourState);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isMobileTourViewport]);
+
+  useEffect(() => {
+    if (!isMobileTourViewport) {
+      setShowStickyBarOnMobile(false);
+      return;
+    }
+
+    const updateStickyVisibility = () => {
+      setShowStickyBarOnMobile(window.scrollY > 120);
+    };
+
+    updateStickyVisibility();
+    window.addEventListener("scroll", updateStickyVisibility, true);
+    window.addEventListener("resize", updateStickyVisibility);
+    return () => {
+      window.removeEventListener("scroll", updateStickyVisibility, true);
+      window.removeEventListener("resize", updateStickyVisibility);
     };
   }, [isMobileTourViewport]);
 
@@ -2943,7 +2966,7 @@ export default function ConnectData() {
                 {privacyPoints.map((item) => (
                   <li key={item} className="flex items-start gap-3">
                     <CheckCircleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--vr-color-primary)]" />
-                    <p className="text-sm font-semibold leading-6 text-slate-600">{item}</p>
+                    <p className="text-[11px] font-semibold leading-4 text-slate-600 sm:text-sm sm:leading-6">{item}</p>
                   </li>
                 ))}
               </ul>
@@ -3067,7 +3090,7 @@ export default function ConnectData() {
             >
               <div className="flex items-center justify-between gap-4">
                 <p className="text-sm font-bold text-slate-500">
-                  Upload documents or add a short written summary for extra context.
+                  Upload document or add a short written summary for extra context.
                 </p>
                 {hasManualMaterials ? (
                   <button
@@ -3255,6 +3278,7 @@ export default function ConnectData() {
       </div>
 
       <VibeRaisingStickyStepBar
+        className={clsx(isMobileTourViewport && !showStickyBarOnMobile && "hidden sm:block")}
         hideStatusOnMobile
         statusIcon={stickyStatusIcon}
         statusTitle={stickyStatusTitle}

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -2113,6 +2113,7 @@ export default function CreateUpdate() {
     const [mobileTourOpen, setMobileTourOpen] = useState(false);
     const [mobileTourStepIndex, setMobileTourStepIndex] = useState(0);
     const [mobileTourChecked, setMobileTourChecked] = useState(false);
+    const [mobileReviewHowItWorksSeen, setMobileReviewHowItWorksSeen] = useState(false);
     const showLegacyDraftFlow = false;
     const selectedInputSourceLabels = selectedInputSources.map((key) => INPUT_SOURCE_LABELS[key]);
     const selectedInputSourceDescription = selectedInputSourceLabels.length > 0
@@ -2209,6 +2210,7 @@ export default function CreateUpdate() {
     const draftStepperRef = useRef<HTMLDivElement | null>(null);
     const monthSelectorRef = useRef<HTMLDivElement | null>(null);
     const draftStickyTriggerRef = useRef<HTMLDivElement | null>(null);
+    const generateDraftSwipeStartRef = useRef<{ x: number; y: number } | null>(null);
     const shouldDimMetricsTemplate = isManualOnlyDraftFlow && draftMetricOptions.length >= 12;
     const [awakeMetricCards, setAwakeMetricCards] = useState<Set<string>>(new Set());
     const [showDraftStickyOnMobile, setShowDraftStickyOnMobile] = useState(false);
@@ -2607,6 +2609,29 @@ export default function CreateUpdate() {
     }, []);
 
     useEffect(() => {
+        if (!isMobileTourViewport) {
+            setMobileReviewHowItWorksSeen(false);
+            return;
+        }
+
+        const syncMobileReviewIntro = () => {
+            try {
+                setMobileReviewHowItWorksSeen(window.localStorage.getItem(CREATE_UPDATE_MOBILE_TOUR_STORAGE_KEY) === "1");
+            } catch {
+                setMobileReviewHowItWorksSeen(false);
+            }
+        };
+
+        syncMobileReviewIntro();
+        window.addEventListener("focus", syncMobileReviewIntro);
+        document.addEventListener("visibilitychange", syncMobileReviewIntro);
+        return () => {
+            window.removeEventListener("focus", syncMobileReviewIntro);
+            document.removeEventListener("visibilitychange", syncMobileReviewIntro);
+        };
+    }, [isMobileTourViewport]);
+
+    useEffect(() => {
         if (mobileTourChecked || !isMobileTourViewport || monthConfirmed || selectedDraftStage === "reporting") return;
         setMobileTourChecked(true);
 
@@ -2872,6 +2897,25 @@ export default function CreateUpdate() {
     const handleGenerateDraftFromEmailClick = useCallback(() => {
         handleGenerateSelectedMonthUpdate();
     }, [handleGenerateSelectedMonthUpdate]);
+    const handleGenerateDraftCardTouchStart = useCallback((event: React.TouchEvent<HTMLButtonElement>) => {
+        const touch = event.touches[0];
+        if (!touch) return;
+        generateDraftSwipeStartRef.current = { x: touch.clientX, y: touch.clientY };
+    }, []);
+    const handleGenerateDraftCardTouchEnd = useCallback((event: React.TouchEvent<HTMLButtonElement>) => {
+        const start = generateDraftSwipeStartRef.current;
+        generateDraftSwipeStartRef.current = null;
+        if (!start || !isMobileTourViewport || isSelectedMonthInFuture || emailDraftActionBusy) return;
+
+        const touch = event.changedTouches[0];
+        if (!touch) return;
+
+        const deltaX = touch.clientX - start.x;
+        const deltaY = Math.abs(touch.clientY - start.y);
+        if (deltaX >= 72 && deltaY <= 40) {
+            void handleGenerateDraftFromEmailClick();
+        }
+    }, [emailDraftActionBusy, handleGenerateDraftFromEmailClick, isMobileTourViewport, isSelectedMonthInFuture]);
 
     const handleConfirmRegenerateDraft = useCallback(() => {
         const request = pendingDraftRequest ?? {};
@@ -3124,6 +3168,9 @@ export default function CreateUpdate() {
     const emailDraftButtonTitle = emailDraftActionBusy
         ? `Generating ${selectedMonthLabel} update`
         : `${selectedMonthGenerationVerb} ${selectedMonthLabel} update`;
+    const emailDraftButtonAriaLabel = isMobileTourViewport
+        ? `${emailDraftButtonTitle}. Swipe right on mobile to ${selectedMonthGenerationVerb.toLowerCase()} this update.`
+        : emailDraftButtonTitle;
     const emailDraftButtonDescription = emailDraftActionBusy
         ? "Contacting the MLAI backend and preparing the selected sources for drafting."
         : isSelectedMonthInFuture
@@ -3304,7 +3351,7 @@ export default function CreateUpdate() {
             statusDetail: selectedMetricOptions.length > 0
                 ? `AI selected ${selectedMetricOptions.length} metric${selectedMetricOptions.length === 1 ? "" : "s"} for ${selectedMonthLabel}.`
                 : isManualOnlyDraftFlow
-                    ? `Start with the full 16-metric template for ${selectedMonthLabel}, then trim or fill what matters.`
+                    ? `Use the full 16-metric template for ${selectedMonthLabel}.`
                     : `AI drafted ${selectedMonthLabel}; core metrics are ready to edit below.`,
             primaryLabel: isSubmitting ? "Reviewing..." : "Review draft",
             primaryType: "submit" as const,
@@ -4072,7 +4119,10 @@ export default function CreateUpdate() {
                     className="mt-8"
                 />
 
-                <div className="rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-5 shadow-sm">
+                <div className={clsx(
+                    "rounded-2xl border border-[var(--vr-color-border)] bg-white px-5 py-5 shadow-sm",
+                    isMobileTourViewport && mobileReviewHowItWorksSeen && "hidden sm:block",
+                )}>
                     <div className="flex min-w-0 items-start gap-4">
                         <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] shadow-sm ring-1 ring-[rgba(0,255,215,0.24)]">
                             <SparklesIcon className="h-5 w-5" />
@@ -4718,6 +4768,9 @@ export default function CreateUpdate() {
                 </div>
 
                 <VibeRaisingStickyStepBar
+                    hideStatusOnMobile
+                    hideBackOnMobile
+                    compactOnMobile
                     statusIcon={
                         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.26)]">
                             <CheckCircleIcon className="h-5 w-5" />
@@ -4727,9 +4780,11 @@ export default function CreateUpdate() {
                     statusDetail="Review is ready. Publish when the story feels right."
                     onBack={() => setDismissedFeedback(true)}
                     secondaryLabel={draftSaved ? "Draft saved!" : "Save as draft"}
+                    mobileSecondaryLabel={draftSaved ? "Draft saved" : "Save draft"}
                     onSecondary={handlePersistDraft}
                     secondaryDisabled={saveDraftFetcher.state !== "idle"}
                     primaryLabel="Publish and Send"
+                    mobilePrimaryLabel="Publish"
                     onPrimary={() => setShowConfirmPopup(true)}
                 />
             </div>
@@ -4836,12 +4891,15 @@ export default function CreateUpdate() {
                                         onClick={() => {
                                             void handleGenerateDraftFromEmailClick();
                                         }}
+                                        onTouchStart={handleGenerateDraftCardTouchStart}
+                                        onTouchEnd={handleGenerateDraftCardTouchEnd}
                                         className={clsx(
-                                            "group flex w-full flex-col justify-between rounded-3xl border px-5 py-5 text-left shadow-sm transition focus:outline-none focus:ring-4 lg:col-span-1 lg:min-h-[132px]",
+                                            "group flex w-full flex-col justify-between rounded-3xl border px-5 py-5 text-left shadow-sm transition [touch-action:pan-y] focus:outline-none focus:ring-4 lg:col-span-1 lg:min-h-[132px]",
                                             isSelectedMonthInFuture || emailDraftActionBusy
                                                 ? "cursor-not-allowed border-[var(--vr-color-border)] bg-[var(--vr-palette-paper)] text-slate-400"
-                                                : "cursor-pointer border-[var(--vr-palette-black)] bg-[var(--vr-palette-black)] text-white hover:-translate-y-0.5 hover:bg-[var(--vr-palette-purple)] focus:ring-[rgba(150,73,210,0.24)]",
+                                                : "cursor-pointer border-[var(--vr-color-primary)] bg-[var(--vr-color-primary)] text-white hover:-translate-y-0.5 hover:border-[var(--vr-palette-black)] hover:bg-[var(--vr-palette-black)] focus:ring-[rgba(0,128,128,0.2)]",
                                         )}
+                                        aria-label={emailDraftButtonAriaLabel}
                                     >
                                         <div>
                                             <p
@@ -4861,7 +4919,7 @@ export default function CreateUpdate() {
                                             {emailDraftActionBusy ? (
                                                 <ArrowPathIcon className="h-5 w-5 animate-spin" />
                                             ) : (
-                                                <ArrowRightIcon className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                                                <ArrowRightIcon className="h-4 w-4" />
                                             )}
                                         </div>
                                     </button>


### PR DESCRIPTION
## What changed
- tightened Founder Tools mobile CTA hierarchy and labels across dashboard, data sources, and review flows
- refined shared mobile stepper and sticky action behaviors to reduce noise and improve touch interactions
- simplified mobile-only helper copy and intro surfaces, including first-time-only review guidance
- added `NEXT-SESSION-HANDOFF.md` with branch context and follow-up notes for the next session

## Why
The earlier Founder Tools PR stack landed on `main`, and this branch carries the smaller follow-up polish pass that should sit on top of that merged baseline without reintroducing the integration branch history.

## Validation
- `bun run typecheck`
- manual browser checks on `/founder-tools/updates`, `/founder-tools/updates/create`, and `/founder-tools/data-sources`