### PR TITLE
[codex] Stop polling terminal setup previews

### DIFF
--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -6,6 +6,8 @@ import { getVibeMarketingRun, refreshVibeMarketingLivePreview } from "~/lib/vibe
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
 import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
+const TERMINAL_ATTENTION_STATUSES = new Set(["blocked", "blocked_verification", "failed", "cancelled", "canceled"]);
+
 function isDocumentNavigation(request: Request) {
   const fetchDest = request.headers.get("Sec-Fetch-Dest")?.toLowerCase();
   const fetchMode = request.headers.get("Sec-Fetch-Mode")?.toLowerCase();
@@ -16,6 +18,7 @@ function isDocumentNavigation(request: Request) {
 
 function shouldRefreshSetupLivePreview(run: VibeMarketingRunSummary) {
   if (run.workflow !== "article_system_setup") return false;
+  if (TERMINAL_ATTENTION_STATUSES.has(String(run.status || "").trim().toLowerCase())) return false;
   if (run.livePreview?.previewUrl || run.livePreview?.error) return false;
   const status = String(run.livePreview?.status || run.status || "").trim().toLowerCase();
   const platformStatus = String(run.livePreview?.platformStatus || "").trim().toLowerCase();

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -135,6 +135,10 @@ function hasActiveLivePreview(preview: VibeMarketingRunSummary["livePreview"] | 
   return LIVE_PREVIEW_ACTIVE_STATUSES.has(previewStatus) || LIVE_PREVIEW_ACTIVE_STATUSES.has(platformStatus);
 }
 
+function isTerminalAttentionStatus(status: string | null | undefined) {
+  return RESUMABLE_ATTENTION_STATUSES.has(String(status ?? "").trim().toLowerCase());
+}
+
 function hasPendingArticlePreview(run: VibeMarketingRunSummary) {
   if (!isArticleWorkflow(run.workflow) || !run.componentManifest || hasReadyArticlePreview(run)) {
     return false;
@@ -764,7 +768,7 @@ function ArticleSystemSetupPreviewPanel({
   const canApprove = run.status === "awaiting_approval" || run.status === "approval_required";
   const setupCompleted = run.status === "completed" || run.approvalState === "approved";
   const previewReady = Boolean(previewUrl || (run.livePreview?.available && run.livePreview.previewUrl));
-  const previewActive = hasActiveLivePreview(run.livePreview);
+  const previewActive = !isTerminalAttentionStatus(run.status) && hasActiveLivePreview(run.livePreview);
   const previewFailed =
     !previewActive && (isFailedArticlePreview(run.livePreview) || (["blocked", "failed"].includes(run.status) && Boolean(run.livePreview?.error || run.errors.length)));
 
@@ -918,7 +922,7 @@ function ArticleSystemSetupPreviewUnavailable({
 }) {
   const preview = run.livePreview;
   const previewStatus = String(preview?.status || run.status || "building").replace(/_/g, " ");
-  const previewActive = hasActiveLivePreview(preview);
+  const previewActive = !isTerminalAttentionStatus(run.status) && hasActiveLivePreview(preview);
   const error = previewActive ? "" : String(preview?.error || run.errors?.[0] || "").trim();
   const logsUrl = preview?.logsUrl || preview?.builderRunUrl;
   const retryPreviewPending = previewActive || (isActionPending?.("start-live-preview") ?? isSubmitting);
@@ -2766,8 +2770,9 @@ function workflowProgressForRunPage(
   const progress = run.workflowProgress ?? fallbackProgress ?? null;
   if (progress && run.workflow === "article_system_setup") {
     const activeStepId = setupWorkflowStepIdForRun(run);
-    const setupPreviewActive = hasActiveLivePreview(run.livePreview);
-    const setupFailed = !setupPreviewActive && (isFailedArticlePreview(run.livePreview) || run.status === "blocked" || run.status === "failed");
+    const setupTerminal = isTerminalAttentionStatus(run.status);
+    const setupPreviewActive = !setupTerminal && hasActiveLivePreview(run.livePreview);
+    const setupFailed = !setupPreviewActive && (isFailedArticlePreview(run.livePreview) || setupTerminal);
     const setupComplete = run.status === "completed" || run.approvalState === "approved";
     const reviewReady = activeStepId === "review" || setupComplete;
     return {
@@ -2853,7 +2858,8 @@ export default function FounderToolsMarketingRun() {
   const isScanActionNeeded = isScanRun && ["awaiting_confirmation", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const isArticleSystemSetupRun = workflow === "article_system_setup";
-  const setupPreviewActive = isArticleSystemSetupRun && hasActiveLivePreview(run.livePreview);
+  const setupRunTerminal = isArticleSystemSetupRun && isTerminalAttentionStatus(run.status);
+  const setupPreviewActive = isArticleSystemSetupRun && !setupRunTerminal && hasActiveLivePreview(run.livePreview);
   const setupPreviewFailed = isArticleSystemSetupRun && !setupPreviewActive && isFailedArticlePreview(run.livePreview);
   const shouldPoll =
     (POLLING_STATUSES.has(run.status) && !isScanActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
@@ -2887,7 +2893,7 @@ export default function FounderToolsMarketingRun() {
   const isPublishAutomateView = Boolean(isArticleGenerationRun && (viewedWorkflowStepId === "publish" || viewedWorkflowStepId === "automation"));
   const isArticleSetupContext = isSetupScanContext || isArticleSystemSetupRun || Boolean(effectiveSetupPreviewRun);
   const isCompletedArticleReviewPage = hasArticlePreview && run.status === "completed" && !isPublishAutomateView;
-  const previewActive = hasActiveLivePreview(run.livePreview);
+  const previewActive = isArticleSystemSetupRun ? setupPreviewActive : hasActiveLivePreview(run.livePreview);
   const previewFailed = isFailedArticlePreview(run.livePreview);
   const shouldAutoStartPreview = Boolean(
     isArticleGenerationRun &&


### PR DESCRIPTION
## Summary
- stop treating blocked article-system setup runs as active just because stale livePreview fields say building
- avoid refreshing setup live-preview status for terminal attention states
- keep retry/progress UI consistent with the latest run status

## Tests
- bun run typecheck -- --pretty false