### PR TITLE
[codex] Optimize Vibe Marketing navigation payloads

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1,6 +1,6 @@
 import { Form, Link, useFetcher, useLocation, useRevalidator } from "react-router";
 import { clsx } from "clsx";
-import { useEffect, useMemo, useState, type ChangeEvent, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from "react";
 import {
   ArrowRight,
   CheckCircle2,
@@ -444,6 +444,9 @@ export default function ArticleSystemConnectionPanel({
   const [manualArticleRoute, setManualArticleRoute] = useState("");
   const [manualRouteError, setManualRouteError] = useState("");
   const [createNewPath, setCreateNewPath] = useState(articleSurfaceDefault || "/articles");
+  const lastScanProgressSignatureRef = useRef("");
+  const lastScanProgressAtRef = useRef(Date.now());
+  const [pageVisible, setPageVisible] = useState(true);
   const [githubAuthWaiting, setGithubAuthWaiting] = useState(() =>
     typeof window !== "undefined" && window.sessionStorage.getItem("vibe-marketing:github-auth-open") === "true",
   );
@@ -498,6 +501,22 @@ export default function ArticleSystemConnectionPanel({
   }, [currentScanRunId]);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
+    const updateVisibility = () => setPageVisible(document.visibilityState !== "hidden");
+    updateVisibility();
+    document.addEventListener("visibilitychange", updateVisibility);
+    return () => document.removeEventListener("visibilitychange", updateVisibility);
+  }, []);
+
+  useEffect(() => {
+    if (!githubAuthWaiting || (!connected && !connectionError && !githubRepos.error)) return;
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem("vibe-marketing:github-auth-open");
+    }
+    setGithubAuthWaiting(false);
+  }, [connected, connectionError, githubAuthWaiting, githubRepos.error]);
+
+  useEffect(() => {
     if (
       runStatusFetcher.state !== "idle" ||
       !runStatusFetcher.data?.runId ||
@@ -510,6 +529,7 @@ export default function ArticleSystemConnectionPanel({
 
   useEffect(() => {
     if (!currentScanRunId || runStatusFetcher.state !== "idle") return;
+    if (!pageVisible) return;
     const shouldPollScan =
       !effectiveScanRun ||
       (SCAN_POLLING_STATUSES.has(effectiveScanRun.status) &&
@@ -517,16 +537,30 @@ export default function ArticleSystemConnectionPanel({
         !scanStale);
     if (!shouldPollScan) return;
     const hasLoadedCurrentRun = runStatusFetcher.data?.runId === currentScanRunId;
+    const signature = [
+      effectiveScanRun?.runId,
+      effectiveScanRun?.status,
+      effectiveScanRun?.currentStep,
+      effectiveScanRun?.updatedAt,
+      effectiveScanRun?.steps.map((step) => `${step.key}:${step.status}:${step.completedAt ?? ""}`).join(","),
+    ].join("|");
+    if (lastScanProgressSignatureRef.current !== signature) {
+      lastScanProgressSignatureRef.current = signature;
+      lastScanProgressAtRef.current = Date.now();
+    }
+    const idleMs = Date.now() - lastScanProgressAtRef.current;
+    const pollDelay = !hasLoadedCurrentRun ? 0 : idleMs > 60_000 ? 15_000 : idleMs > 10_000 ? 5_000 : 2_500;
     const timer = window.setTimeout(
       () => {
         void runStatusFetcher.load(`/founder-tools/marketing/runs/${encodeURIComponent(currentScanRunId)}/status`);
       },
-      hasLoadedCurrentRun ? 2500 : 0,
+      pollDelay,
     );
     return () => window.clearTimeout(timer);
   }, [
     currentScanRunId,
     effectiveScanRun,
+    pageVisible,
     runStatusFetcher,
     runStatusFetcher.data?.runId,
     runStatusFetcher.state,
@@ -619,12 +653,10 @@ export default function ArticleSystemConnectionPanel({
               </div>
               <h4 className="mt-4 text-lg font-black text-slate-950">Connect your GitHub repository</h4>
               <p className="mx-auto mt-2 max-w-2xl text-sm font-semibold leading-6 text-slate-500">
-                GitHub opens in a new tab. This page will refresh when the connection is ready.
+                GitHub will open securely, then return you here when the connection is ready.
               </p>
               <a
                 href={githubConnectHref()}
-                target="_blank"
-                rel="noopener noreferrer"
                 onClick={markGithubAuthOpen}
                 className="mt-5 inline-flex items-center justify-center gap-3 rounded-xl bg-slate-950 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-black"
               >
@@ -638,7 +670,7 @@ export default function ArticleSystemConnectionPanel({
               </div>
               {githubAuthWaiting ? (
                 <div className="mx-auto mt-4 max-w-3xl rounded-xl border border-violet-100 bg-violet-50 px-4 py-3 text-left text-sm font-semibold text-violet-800">
-                  Finish authorising in the GitHub tab, then return here.
+                  Finish authorising in GitHub, then you will return here.
                 </div>
               ) : null}
               {connectionError ? (

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1165,11 +1165,19 @@ function devAutofillResultFromSnapshot(runId: string, snapshot: Record<string, u
   });
 }
 
-export async function getVibeMarketingBootstrap(env: Env, request: Request, companyId?: string | null) {
+export async function getVibeMarketingBootstrap(
+  env: Env,
+  request: Request,
+  companyId?: string | null,
+  view?: "summary" | "full",
+) {
   if (shouldUseDevBackendStub()) return DEV_BOOTSTRAP;
   try {
     const client = createApiClient(env, request);
-    const query = companyId ? `?company_id=${encodeURIComponent(companyId)}` : "";
+    const params = new URLSearchParams();
+    if (companyId) params.set("company_id", companyId);
+    if (view && view !== "full") params.set("view", view);
+    const query = params.toString() ? `?${params.toString()}` : "";
     const response = await client.get(`${BASE_PATH}/bootstrap/${query}`);
     return normalizeBootstrap(response.data);
   } catch (error) {
@@ -1454,7 +1462,13 @@ export function replayVibeMarketingDaily(env: Env, request: Request, body: Recor
   return startMarketingRun(env, request, "daily/replay", body);
 }
 
-export async function getVibeMarketingRun(env: Env, request: Request, runId: string, companyId?: string | null) {
+export async function getVibeMarketingRun(
+  env: Env,
+  request: Request,
+  runId: string,
+  companyId?: string | null,
+  view?: "status" | "full",
+) {
   if (shouldUseDevBackendStub()) {
     if (runId.includes("autofill")) {
       return devAutofillResultFromSnapshot(runId, DEV_RUN_SNAPSHOTS.get(runId));
@@ -1480,7 +1494,10 @@ export async function getVibeMarketingRun(env: Env, request: Request, runId: str
     });
   }
   const client = createApiClient(env, request);
-  const query = companyId ? `?company_id=${encodeURIComponent(companyId)}` : "";
+  const params = new URLSearchParams();
+  if (companyId) params.set("company_id", companyId);
+  if (view && view !== "full") params.set("view", view);
+  const query = params.toString() ? `?${params.toString()}` : "";
   const response = await client.get(`${BASE_PATH}/runs/${encodeURIComponent(runId)}${query}`);
   return normalizeMarketingRun(response.data);
 }

--- a/app/routes/founder-tools.marketing.autofill-run.tsx
+++ b/app/routes/founder-tools.marketing.autofill-run.tsx
@@ -53,7 +53,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
   try {
-    return await getVibeMarketingRun(env, request, runId);
+    return await getVibeMarketingRun(env, request, runId, null, "status");
   } catch (error) {
     return blockedRunPayload(runId, error);
   }

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigate, useNavigation, useSearchParams } from "react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
@@ -351,7 +351,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     throw redirect(`${url.pathname}?${url.searchParams.toString()}`);
   }
 
-  const bootstrap = await getVibeMarketingBootstrap(env, request);
+  const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
   const requestedStep = normalizeStep(url.searchParams.get("step"), "startupDetails");
   if (["writeCheck", "editArticle", "reviewPublish"].includes(requestedStep)) {
     const latestSetupScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
@@ -368,15 +368,18 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     repos: [],
     repositories: [],
   };
-  try {
-    githubRepos = await getVibeMarketingGithubRepos(env, request);
-  } catch (error) {
-    githubRepos = {
-      status: "unavailable",
-      repos: [],
-      repositories: [],
-      error: error instanceof Error ? error.message : "Unable to load repositories.",
-    };
+  const activeStep = resolveActiveStep(url.searchParams.get("step"), bootstrap);
+  if (activeStep === "articleSystem" || requestedStep === "articleSystem") {
+    try {
+      githubRepos = await getVibeMarketingGithubRepos(env, request);
+    } catch (error) {
+      githubRepos = {
+        status: "unavailable",
+        repos: [],
+        repositories: [],
+        error: error instanceof Error ? error.message : "Unable to load repositories.",
+      };
+    }
   }
   return { bootstrap, githubRepos };
 }
@@ -797,6 +800,11 @@ export default function FounderToolsMarketingCreate() {
   const location = useLocation();
   const setupScanStatusFetcher = useFetcher<VibeMarketingRunSummary>();
   const setupChildStatusFetcher = useFetcher<VibeMarketingRunSummary>();
+  const setupParentProgressAtRef = useRef(Date.now());
+  const setupParentProgressSignatureRef = useRef("");
+  const setupChildProgressAtRef = useRef(Date.now());
+  const setupChildProgressSignatureRef = useRef("");
+  const [pageVisible, setPageVisible] = useState(true);
   const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
   const bootstrapPendingArticleSystemScan = scanRunHasPendingArticleSystemSetup(latestScan) ? latestScan : null;
   const [polledSetupScan, setPolledSetupScan] = useState<VibeMarketingRunSummary | null>(null);
@@ -905,6 +913,14 @@ export default function FounderToolsMarketingCreate() {
   }, [bootstrapPendingArticleSystemScan?.runId]);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
+    const updateVisibility = () => setPageVisible(document.visibilityState !== "hidden");
+    updateVisibility();
+    document.addEventListener("visibilitychange", updateVisibility);
+    return () => document.removeEventListener("visibilitychange", updateVisibility);
+  }, []);
+
+  useEffect(() => {
     if (setupScanStatusFetcher.state !== "idle") return;
     if (!setupScanStatusFetcher.data?.runId || setupScanStatusFetcher.data.runId !== bootstrapPendingArticleSystemScan?.runId) {
       return;
@@ -914,22 +930,31 @@ export default function FounderToolsMarketingCreate() {
 
   useEffect(() => {
     if (!pendingArticleSystemScan?.runId || setupScanStatusFetcher.state !== "idle") return;
+    if (!pageVisible) return;
     const shouldPollParent =
       SETUP_POLLING_STATUSES.has(pendingArticleSystemScan.status) ||
       (!pendingArticleSystemSetupRunId && !isSetupProgressTerminal(pendingArticleSystemScan));
     if (!shouldPollParent) return;
     const hasLoadedCurrentRun = setupScanStatusFetcher.data?.runId === pendingArticleSystemScan.runId;
+    const signature = `${pendingArticleSystemScan.runId}:${pendingArticleSystemScan.status}:${pendingArticleSystemScan.currentStep ?? ""}:${pendingArticleSystemScan.updatedAt ?? ""}`;
+    if (setupParentProgressSignatureRef.current !== signature) {
+      setupParentProgressSignatureRef.current = signature;
+      setupParentProgressAtRef.current = Date.now();
+    }
+    const idleMs = Date.now() - setupParentProgressAtRef.current;
+    const pollDelay = !hasLoadedCurrentRun ? 0 : idleMs > 60_000 ? 15_000 : idleMs > 10_000 ? 5_000 : 2_500;
     const timer = window.setTimeout(
       () => {
         setupScanStatusFetcher.load(`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemScan.runId)}/status`);
       },
-      hasLoadedCurrentRun ? 2500 : 0,
+      pollDelay,
     );
     return () => window.clearTimeout(timer);
   }, [
     pendingArticleSystemScan?.runId,
     pendingArticleSystemScan?.status,
     pendingArticleSystemSetupRunId,
+    pageVisible,
     setupScanStatusFetcher,
     setupScanStatusFetcher.data?.runId,
     setupScanStatusFetcher.state,
@@ -949,17 +974,26 @@ export default function FounderToolsMarketingCreate() {
 
   useEffect(() => {
     if (!pendingArticleSystemSetupRunId || setupChildStatusFetcher.state !== "idle") return;
+    if (!pageVisible) return;
     if (setupChildRun && isSetupProgressTerminal(setupChildRun)) return;
     const hasLoadedCurrentRun = setupChildStatusFetcher.data?.runId === pendingArticleSystemSetupRunId;
+    const signature = `${setupChildRun?.runId ?? pendingArticleSystemSetupRunId}:${setupChildRun?.status ?? ""}:${setupChildRun?.currentStep ?? ""}:${setupChildRun?.updatedAt ?? ""}`;
+    if (setupChildProgressSignatureRef.current !== signature) {
+      setupChildProgressSignatureRef.current = signature;
+      setupChildProgressAtRef.current = Date.now();
+    }
+    const idleMs = Date.now() - setupChildProgressAtRef.current;
+    const pollDelay = !hasLoadedCurrentRun ? 0 : idleMs > 60_000 ? 15_000 : idleMs > 10_000 ? 5_000 : 2_500;
     const timer = window.setTimeout(
       () => {
         setupChildStatusFetcher.load(`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemSetupRunId)}/status`);
       },
-      hasLoadedCurrentRun ? 2500 : 0,
+      pollDelay,
     );
     return () => window.clearTimeout(timer);
   }, [
     pendingArticleSystemSetupRunId,
+    pageVisible,
     setupChildRun?.runId,
     setupChildRun?.status,
     setupChildRun?.approvalState,

--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -35,7 +35,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   await requireVibeRaisingFounder(env, request);
-  let run = await getVibeMarketingRun(env, request, runId);
+  let run = await getVibeMarketingRun(env, request, runId, null, "status");
   if (shouldRefreshSetupLivePreview(run)) {
     try {
       run = await refreshVibeMarketingLivePreview(env, request, runId);

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/founder-tools.marketing.run";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useRevalidator } from "react-router";
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
@@ -150,17 +150,34 @@ function hasPendingArticlePreview(run: VibeMarketingRunSummary) {
   return run.status === "completed" || hasActiveLivePreview(preview);
 }
 
+function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
+  if (run.status === "awaiting_confirmation" || run.status === "awaiting_approval" || run.status === "approval_required") {
+    return true;
+  }
+  if (["completed", "failed", "blocked", "denied", "cancelled"].includes(run.status)) {
+    return true;
+  }
+  if (run.previewUrl || run.prUrl || run.livePreview?.previewUrl || run.livePreview?.error) {
+    return true;
+  }
+  return false;
+}
+
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
-  const bootstrap = await getVibeMarketingBootstrap(env, request);
+  const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
   const run = await getVibeMarketingRun(env, request, runId);
   let githubRepos: VibeMarketingGithubReposResponse = { status: "unavailable", repos: [], repositories: [] };
-  try {
-    githubRepos = await getVibeMarketingGithubRepos(env, request);
-  } catch {
-    githubRepos = { status: "unavailable", repos: [], repositories: [], error: "Repository list is unavailable." };
+  const shouldLoadGithubRepos =
+    ["repo_scan", "content_factory_scan", "article_system_setup"].includes(run.workflow) || Boolean(setupRunIdForRun(run));
+  if (shouldLoadGithubRepos) {
+    try {
+      githubRepos = await getVibeMarketingGithubRepos(env, request);
+    } catch {
+      githubRepos = { status: "unavailable", repos: [], repositories: [], error: "Repository list is unavailable." };
+    }
   }
   const setupRunId = setupRunIdForRun(run);
   let setupRun: VibeMarketingRunSummary | null = null;
@@ -2844,10 +2861,15 @@ export default function FounderToolsMarketingRun() {
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const location = useLocation();
+  const revalidator = useRevalidator();
   const runStatusFetcher = useFetcher<VibeMarketingRunSummary>();
   const previewStartFetcher = useFetcher<typeof action>();
   const previewStartRunRef = useRef("");
+  const statusRefreshRef = useRef("");
+  const lastProgressSignatureRef = useRef("");
+  const lastProgressAtRef = useRef(Date.now());
   const [polledRun, setPolledRun] = useState<VibeMarketingRunSummary | null>(null);
+  const [pageVisible, setPageVisible] = useState(true);
   const run = polledRun ?? loaderRun;
   const [selectedComponent, setSelectedComponent] = useState<VibeMarketingComponentManifestItem | null>(null);
   const statusUrl = `/founder-tools/marketing/runs/${encodeURIComponent(loaderRun.runId)}/status`;
@@ -2856,13 +2878,14 @@ export default function FounderToolsMarketingRun() {
   const isSetupScanContext = isScanRun && isSetupScanRun(run);
   const isStaleScan = isScanRun && Boolean(run.stale || run.staleReason === "scan_queue_not_started");
   const isScanActionNeeded = isScanRun && ["awaiting_confirmation", "awaiting_approval", "approval_required"].includes(run.status);
+  const isRunActionNeeded = ["awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const isArticleSystemSetupRun = workflow === "article_system_setup";
   const setupRunTerminal = isArticleSystemSetupRun && isTerminalAttentionStatus(run.status);
   const setupPreviewActive = isArticleSystemSetupRun && !setupRunTerminal && hasActiveLivePreview(run.livePreview);
   const setupPreviewFailed = isArticleSystemSetupRun && !setupPreviewActive && isFailedArticlePreview(run.livePreview);
   const shouldPoll =
-    (POLLING_STATUSES.has(run.status) && !isScanActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
+    (POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
     setupPreviewActive ||
     hasPendingArticlePreview(run) ||
     hasPublishHandoffEvidence(run);
@@ -2935,7 +2958,15 @@ export default function FounderToolsMarketingRun() {
 
   useEffect(() => {
     setPolledRun(null);
-  }, [loaderRun.runId]);
+  }, [loaderRun.currentStep, loaderRun.runId, loaderRun.status, loaderRun.updatedAt]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const updateVisibility = () => setPageVisible(document.visibilityState !== "hidden");
+    updateVisibility();
+    document.addEventListener("visibilitychange", updateVisibility);
+    return () => document.removeEventListener("visibilitychange", updateVisibility);
+  }, []);
 
   useEffect(() => {
     if (
@@ -2945,8 +2976,17 @@ export default function FounderToolsMarketingRun() {
     ) {
       return;
     }
+    if (statusPollNeedsFullRefresh(runStatusFetcher.data)) {
+      const refreshKey = `${runStatusFetcher.data.runId}:${runStatusFetcher.data.status}:${runStatusFetcher.data.updatedAt ?? ""}:${runStatusFetcher.data.currentStep ?? ""}`;
+      if (statusRefreshRef.current !== refreshKey) {
+        statusRefreshRef.current = refreshKey;
+        setPolledRun(null);
+        revalidator.revalidate();
+      }
+      return;
+    }
     setPolledRun(runStatusFetcher.data);
-  }, [loaderRun.runId, runStatusFetcher.data, runStatusFetcher.state]);
+  }, [loaderRun.runId, revalidator, runStatusFetcher.data, runStatusFetcher.state]);
 
   useEffect(() => {
     const data = previewStartFetcher.data;
@@ -2974,16 +3014,37 @@ export default function FounderToolsMarketingRun() {
   }, [previewStartFetcher, run.runId, shouldAutoStartPreview]);
 
   useEffect(() => {
+    const signature = [
+      run.runId,
+      run.status,
+      run.currentStep,
+      run.updatedAt,
+      run.steps.map((step) => `${step.key}:${step.status}:${step.completedAt ?? ""}`).join(","),
+      run.livePreview?.status,
+      run.livePreview?.previewUrl,
+      run.previewUrl,
+      run.prUrl,
+    ].join("|");
+    if (lastProgressSignatureRef.current !== signature) {
+      lastProgressSignatureRef.current = signature;
+      lastProgressAtRef.current = Date.now();
+    }
+  }, [run]);
+
+  useEffect(() => {
     if (!shouldPoll || !loaderRun.runId || runStatusFetcher.state !== "idle") return;
+    if (!pageVisible) return;
     const hasLoadedCurrentRun = runStatusFetcher.data?.runId === loaderRun.runId;
+    const idleMs = Date.now() - lastProgressAtRef.current;
+    const pollDelay = !hasLoadedCurrentRun ? 0 : idleMs > 60_000 ? 15_000 : idleMs > 10_000 ? 5_000 : 2_500;
     const timer = window.setTimeout(
       () => {
         void runStatusFetcher.load(statusUrl);
       },
-      hasLoadedCurrentRun ? 5000 : 0,
+      pollDelay,
     );
     return () => window.clearTimeout(timer);
-  }, [loaderRun.runId, runStatusFetcher, runStatusFetcher.data?.runId, runStatusFetcher.state, shouldPoll, statusUrl]);
+  }, [loaderRun.runId, pageVisible, runStatusFetcher, runStatusFetcher.data?.runId, runStatusFetcher.state, shouldPoll, statusUrl]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -228,7 +228,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     return { bootstrap: emptyBootstrapFromProfile(vibeContext.profile), hasFounderCompany: false };
   }
 
-  const bootstrap = await getVibeMarketingBootstrap(env, request);
+  const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
   return { bootstrap, hasFounderCompany: true };
 }
 


### PR DESCRIPTION
## Summary
- Use summary bootstrap payloads for Vibe Marketing dashboard/create/run shell navigation.
- Use compact run status payloads for polling instead of full run detail payloads.
- Lazy-load GitHub repository lists only when the articles-location/setup UI needs them.
- Back off polling, pause polling in hidden tabs, and clear stale GitHub auth revalidation state.

## Why
Loaded Vibe Marketing accounts were forcing the Cloudflare Worker to normalize and render large bootstrap/run payloads during normal navigation and polling, which contributed to slow page transitions and CPU limit errors.

## Validation
- `bun run typecheck`
