### PR TITLE
Gate first-time articles setup before research

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -421,6 +421,7 @@ export default function ArticleSystemConnectionPanel({
   const selectedRepo = selectedRepoName({ bootstrap, githubRepos, repos, repoSelection });
   const repoUrl = selectedRepo.includes("/") ? `https://github.com/${selectedRepo}` : "";
   const scaffoldReady = Boolean(bootstrap.checks.scaffold?.passed);
+  const setupBlocked = Boolean(bootstrap.checks.scaffold?.setupBlocked);
   const requestedScanRunId = new URLSearchParams(location.search).get("scanRunId")?.trim() ?? "";
   const currentScanRunId = requestedScanRunId || scanRun?.runId || "";
   const scanRunForCurrentId = !requestedScanRunId || scanRun?.runId === requestedScanRunId ? scanRun : null;
@@ -433,7 +434,8 @@ export default function ArticleSystemConnectionPanel({
   const setupRunId = effectiveScanRun ? setupRunIdForRun(effectiveScanRun) : "";
   const inventoryScan = isInventoryScan(effectiveScanRun);
   const setupTargetScan = isSetupTargetScan(effectiveScanRun);
-  const inventoryReady = Boolean(effectiveScanRun && inventoryScan && effectiveScanRun.status === "completed");
+  const inventoryProgressRun = effectiveScanRun && inventoryScan && !setupTargetScan ? effectiveScanRun : null;
+  const inventoryReady = Boolean(inventoryProgressRun?.status === "completed");
   const setupTargetReady = Boolean(effectiveScanRun && setupTargetScan && (scanNeedsSetupApproval || setupRunId));
   const scanStartPending = actionPending("start-scan") || inventoryFetcher.state !== "idle";
   const retryScanPending = actionPending("retry-scan");
@@ -532,7 +534,8 @@ export default function ArticleSystemConnectionPanel({
     if (!pageVisible) return;
     const shouldPollScan =
       !effectiveScanRun ||
-      (SCAN_POLLING_STATUSES.has(effectiveScanRun.status) &&
+      (!setupTargetScan &&
+        SCAN_POLLING_STATUSES.has(effectiveScanRun.status) &&
         !SCAN_ACTION_NEEDED_STATUSES.has(effectiveScanRun.status) &&
         !scanStale);
     if (!shouldPollScan) return;
@@ -769,20 +772,20 @@ export default function ArticleSystemConnectionPanel({
           </FlowStep>
         ) : null}
 
-        {effectiveScanRun && inventoryScan ? (
+        {inventoryProgressRun ? (
           <FlowStep number={2} title="Scanning repository" description="Looking for article pages and content locations">
-            <MarketingRunProgressCard run={effectiveScanRun} />
+            <MarketingRunProgressCard run={inventoryProgressRun} />
             {scanRunning || scanFailed || scanStale ? (
               <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <Link
-                  to={`/founder-tools/marketing/runs/${encodeURIComponent(effectiveScanRun.runId)}`}
+                  to={`/founder-tools/marketing/runs/${encodeURIComponent(inventoryProgressRun.runId)}`}
                   className="inline-flex text-xs font-black text-violet-700 transition hover:text-violet-900"
                 >
                   View scan run
                 </Link>
                 <Form method="POST" className="flex flex-col gap-2 sm:flex-row">
-                  <input type="hidden" name="scanRunId" value={effectiveScanRun.runId} />
-                  {effectiveScanRun.retryAvailable || effectiveScanRun.stale ? (
+                  <input type="hidden" name="scanRunId" value={inventoryProgressRun.runId} />
+                  {inventoryProgressRun.retryAvailable || inventoryProgressRun.stale ? (
                     <button
                       type="submit"
                       name="intent"
@@ -1013,7 +1016,7 @@ export default function ArticleSystemConnectionPanel({
           </div>
         ) : null}
 
-        {connected && scaffoldReady && !setupTargetReady && !inventoryReady ? (
+        {connected && scaffoldReady && !setupBlocked && !setupTargetReady && !inventoryReady ? (
           <Link
             to="/founder-tools/marketing/create?step=research"
             className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700"

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1330,12 +1330,14 @@ async function startMarketingRun(env: Env, request: Request, path: string, body:
   const client = createApiClient(env, request);
   const response = await client.post(`${BASE_PATH}/${path}`, body);
   const runId = asNullableString(response.data?.runId) ?? asNullableString(response.data?.run_id);
+  const setupRunId = asNullableString(response.data?.setupRunId) ?? asNullableString(response.data?.setup_run_id);
   const error =
     asNullableString(response.data?.error) ??
     asNullableString(response.data?.detail) ??
     asNullableString(response.data?.message);
   return {
     runId,
+    setupRunId,
     status: asNullableString(response.data?.status) ?? "queued",
     error,
     errors: asStringList(response.data?.errors ?? (error ? [error] : [])),
@@ -1344,6 +1346,10 @@ async function startMarketingRun(env: Env, request: Request, path: string, body:
 
 export function startVibeMarketingScan(env: Env, request: Request, body: Record<string, unknown>) {
   return startMarketingRun(env, request, "scan", body);
+}
+
+export function startVibeMarketingArticleSystemSetup(env: Env, request: Request, body: Record<string, unknown>) {
+  return startMarketingRun(env, request, "article-system-setup", body);
 }
 
 export function startVibeMarketingDiscovery(env: Env, request: Request, body: Record<string, unknown>) {

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -39,6 +39,7 @@ import {
   saveVibeMarketingSettings,
   skipVibeMarketingBaseline,
   startVibeMarketingArticle,
+  startVibeMarketingArticleSystemSetup,
   startVibeMarketingAutofill,
   startVibeMarketingBaseline,
   startVibeMarketingDiscovery,
@@ -318,11 +319,23 @@ function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap): Articl
   return isGithubPublishingReady(bootstrap) ? "review_draft" : "content_only";
 }
 
+function isArticleSystemSetupBlocked(bootstrap: VibeMarketingBootstrap) {
+  return Boolean(bootstrap.checks.scaffold?.setupBlocked);
+}
+
+function isArticleSystemPublished(bootstrap: VibeMarketingBootstrap) {
+  const scaffold = bootstrap.checks.scaffold;
+  return Boolean(scaffold?.published || (scaffold?.passed && !scaffold?.setupBlocked));
+}
+
 function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMarketingBootstrap): VibeMarketingStepKey {
   const requiredStep =
     createStepForWorkflowStep(bootstrap.workflowProgress?.currentStepId) ??
     normalizeStep(bootstrap.currentGuidedStep, "startupDetails");
   const requested = normalizeStep(value, requiredStep);
+  if (isArticleSystemSetupBlocked(bootstrap) && ["research", "chooseArticle"].includes(requested)) {
+    return "articleSystem";
+  }
   const requestedWorkflowStepId = WORKFLOW_STEP_ID_BY_CREATE_STEP[requested];
   const requestedWorkflowStep = bootstrap.workflowProgress?.steps?.find((step) => step.id === requestedWorkflowStepId);
   const contentOnlyAllowedStep = ["research", "chooseArticle"].includes(requested);
@@ -353,6 +366,10 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
   const requestedStep = normalizeStep(url.searchParams.get("step"), "startupDetails");
+  if (isArticleSystemSetupBlocked(bootstrap) && ["research", "chooseArticle"].includes(requestedStep)) {
+    url.searchParams.set("step", "articleSystem");
+    throw redirect(`${url.pathname}?${url.searchParams.toString()}`);
+  }
   if (["writeCheck", "editArticle", "reviewPublish"].includes(requestedStep)) {
     const latestSetupScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
     if (scanRunHasPendingArticleSystemSetup(latestSetupScan)) {
@@ -566,7 +583,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       const articleSurfaceUrl = stringFromForm(formData, "articleSurfaceUrl");
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before continuing." };
       if (!articleSurfaceUrl) return { intent, error: "Choose or enter an article/blog route before continuing." };
-      const result = await startVibeMarketingScan(env, request, {
+      const result = await startVibeMarketingArticleSystemSetup(env, request, {
         githubRepo,
         github_repo: githubRepo,
         scanPurpose: "setup",
@@ -580,6 +597,10 @@ export async function action({ request, context }: Route.ActionArgs) {
         autoSetupPreview: true,
         auto_setup_preview: true,
       });
+      const setupRunId = result.setupRunId || result.runId;
+      if (setupRunId) {
+        return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
+      }
       if (result.runId) {
         return redirect(`/founder-tools/marketing/create?step=articleSystem&scanRunId=${encodeURIComponent(result.runId)}`);
       }
@@ -613,6 +634,13 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-discovery") {
+      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      if (isArticleSystemSetupBlocked(bootstrap)) {
+        return {
+          intent,
+          error: "Finish approving, merging, and verifying the articles directory setup before researching topics.",
+        };
+      }
       const result = await startVibeMarketingDiscovery(env, request, {});
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       return redirect("/founder-tools/marketing/create?step=research");
@@ -620,6 +648,12 @@ export async function action({ request, context }: Route.ActionArgs) {
 
     if (intent === "start-article") {
       const bootstrap = await getVibeMarketingBootstrap(env, request);
+      if (isArticleSystemSetupBlocked(bootstrap)) {
+        return {
+          intent,
+          error: "Finish approving, merging, and verifying the articles directory setup before generating articles.",
+        };
+      }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
       const selectedCandidate =
         topicCandidateId && topicCandidateId !== "__custom__"
@@ -931,6 +965,7 @@ export default function FounderToolsMarketingCreate() {
   useEffect(() => {
     if (!pendingArticleSystemScan?.runId || setupScanStatusFetcher.state !== "idle") return;
     if (!pageVisible) return;
+    if (pendingArticleSystemSetupRunId) return;
     const shouldPollParent =
       SETUP_POLLING_STATUSES.has(pendingArticleSystemScan.status) ||
       (!pendingArticleSystemSetupRunId && !isSetupProgressTerminal(pendingArticleSystemScan));
@@ -1025,30 +1060,57 @@ export default function FounderToolsMarketingCreate() {
     ? `/founder-tools/marketing/runs/${encodeURIComponent(setupProgressRun.runId)}`
     : "";
   const setupPreviewRunId = setupChildRun?.runId || pendingArticleSystemSetupRunId;
+  const setupBlocked = isArticleSystemSetupBlocked(bootstrap);
+  const setupPublished = isArticleSystemPublished(bootstrap);
+  const setupChildStatus = setupChildRun
+    ? stringResultValue(setupChildRun, "status", "setupStatus", "setup_status") || setupChildRun.currentStep || setupChildRun.status
+    : "";
+  const setupManualMergeRequired = Boolean(setupBlocked && setupChildStatus === "manual_merge_required");
+  const setupVerifying = Boolean(
+    setupBlocked &&
+      (bootstrap.checks.scaffold?.rescanRunId ||
+        ["completed", "merged", "merged_verifying", "verifying"].includes(setupChildStatus)),
+  );
   const setupReadyWithoutPreview = Boolean(
     pendingArticleSystemScan &&
       !setupChildRun &&
       !pendingArticleSystemSetupRunId &&
       pendingArticleSystemScan.status === "completed",
   );
-  const setupApproved = Boolean(
-    setupReadyWithoutPreview || (setupChildRun && (setupChildRun.status === "completed" || setupChildRun.approvalState === "approved")),
-  );
   const setupPreviewReady = Boolean(
     setupChildRun &&
-      !setupApproved &&
+      !setupPublished &&
+      !setupVerifying &&
+      !setupManualMergeRequired &&
       (SETUP_READY_STATUSES.has(setupChildRun.status) || setupChildRun.livePreview?.previewUrl || setupChildRun.previewUrl),
   );
   const setupLegacyNeedsPreview = Boolean(
     pendingArticleSystemScan && !pendingArticleSystemSetupRunId && SETUP_READY_STATUSES.has(pendingArticleSystemScan.status),
   );
   const setupProgressFailed = Boolean(setupProgressRun && SETUP_FAILED_STATUSES.has(setupProgressRun.status));
-  const setupProgressActionSlot = setupApproved ? (
+  const setupProgressActionSlot = setupPublished ? (
     <Link
       to="/founder-tools/marketing/create?step=research"
       className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700"
     >
       Continue to topic research
+    </Link>
+  ) : setupVerifying ? (
+    <button
+      type="button"
+      disabled
+      className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-5 py-3 text-sm font-bold text-white opacity-60 shadow-sm"
+    >
+      <ArrowPathIcon className="h-4 w-4 animate-spin" />
+      Verifying merged articles directory...
+    </button>
+  ) : setupManualMergeRequired ? (
+    <Link
+      to={setupPreviewRunId ? `/founder-tools/marketing/runs/${encodeURIComponent(setupPreviewRunId)}` : "/founder-tools/marketing/create?step=articleSystem"}
+      className="inline-flex items-center justify-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-5 py-3 text-sm font-bold text-amber-800 shadow-sm transition hover:bg-amber-100"
+    >
+      Manual merge required
+      <ArrowRightIcon className="h-4 w-4" />
     </Link>
   ) : setupPreviewReady && setupPreviewRunId ? (
     <Link
@@ -1345,7 +1407,7 @@ export default function FounderToolsMarketingCreate() {
                 }
                 passed={
                   pendingArticleSystemScan
-                    ? Boolean(setupPreviewReady || setupApproved)
+                    ? Boolean(setupPreviewReady || setupPublished)
                     : activeStep === "reviewPublish"
                     ? Boolean(bootstrap.checks.publish?.passed || bootstrap.checks.contentPackage?.passed || contentPackageReady)
                     : Boolean(bootstrap.checks.write?.passed)

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -135,10 +135,6 @@ function hasActiveLivePreview(preview: VibeMarketingRunSummary["livePreview"] | 
   return LIVE_PREVIEW_ACTIVE_STATUSES.has(previewStatus) || LIVE_PREVIEW_ACTIVE_STATUSES.has(platformStatus);
 }
 
-function isTerminalAttentionStatus(status: string | null | undefined) {
-  return RESUMABLE_ATTENTION_STATUSES.has(String(status ?? "").trim().toLowerCase());
-}
-
 function hasPendingArticlePreview(run: VibeMarketingRunSummary) {
   if (!isArticleWorkflow(run.workflow) || !run.componentManifest || hasReadyArticlePreview(run)) {
     return false;
@@ -170,8 +166,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
   const run = await getVibeMarketingRun(env, request, runId);
   let githubRepos: VibeMarketingGithubReposResponse = { status: "unavailable", repos: [], repositories: [] };
-  const shouldLoadGithubRepos =
-    ["repo_scan", "content_factory_scan", "article_system_setup"].includes(run.workflow) || Boolean(setupRunIdForRun(run));
+  const shouldLoadGithubRepos = ["repo_scan", "content_factory_scan"].includes(run.workflow) && !setupRunIdForRun(run);
   if (shouldLoadGithubRepos) {
     try {
       githubRepos = await getVibeMarketingGithubRepos(env, request);
@@ -362,6 +357,9 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       });
     } else if (intent === "start-article") {
       const bootstrap = await getVibeMarketingBootstrap(env, request);
+      if (bootstrap.checks.scaffold?.setupBlocked) {
+        return { intent, error: "Finish approving, merging, and verifying the articles directory setup before generating articles." };
+      }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
       const selectedCandidate =
         topicCandidateId && topicCandidateId !== "__custom__"
@@ -775,6 +773,16 @@ function ArticleSystemSetupPreviewPanel({
     stringResultValue(run, "preview_url", "previewUrl") ||
     stringResultValue(source, "preview_url", "previewUrl");
   const setupRunId = setupRunIdForRun(run) || setupRunIdForRun(source) || run.runId;
+  const setupStatus = (
+    stringResultValue(run, "status", "setupStatus", "setup_status") ||
+    String(setup.status ?? "") ||
+    run.currentStep ||
+    run.status ||
+    ""
+  ).trim().toLowerCase();
+  const rescanRunId = stringResultValue(run, "rescan_run_id", "rescanRunId") || String(setup.rescan_run_id ?? setup.rescanRunId ?? "");
+  const manualMergeRequired = setupStatus === "manual_merge_required" || run.currentStep === "manual_merge_required";
+  const setupMerged = !manualMergeRequired && run.status === "completed";
   const changedFiles = [
     ...arrayResultValue(run, "changed_files_preview"),
     ...(Array.isArray(setup.changed_files_preview) ? setup.changed_files_preview : []),
@@ -783,9 +791,9 @@ function ArticleSystemSetupPreviewPanel({
     .filter(Boolean)
     .slice(0, 8);
   const canApprove = run.status === "awaiting_approval" || run.status === "approval_required";
-  const setupCompleted = run.status === "completed" || run.approvalState === "approved";
+  const setupCompleted = setupMerged;
   const previewReady = Boolean(previewUrl || (run.livePreview?.available && run.livePreview.previewUrl));
-  const previewActive = !isTerminalAttentionStatus(run.status) && hasActiveLivePreview(run.livePreview);
+  const previewActive = hasActiveLivePreview(run.livePreview);
   const previewFailed =
     !previewActive && (isFailedArticlePreview(run.livePreview) || (["blocked", "failed"].includes(run.status) && Boolean(run.livePreview?.error || run.errors.length)));
 
@@ -883,7 +891,7 @@ function ArticleSystemSetupPreviewPanel({
                         className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
                       >
                         {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                        {approvePending ? "Approving..." : "Approve articles setup"}
+                        {approvePending ? "Approving..." : "Approve and merge setup PR"}
                       </button>
                     </Form>
                   </>
@@ -906,20 +914,41 @@ function ArticleSystemSetupPreviewPanel({
         </div>
       ) : null}
 
-      {setupCompleted ? (
-        <div className="flex flex-col gap-3 rounded-xl border border-emerald-100 bg-emerald-50 p-4 sm:flex-row sm:items-center sm:justify-between">
+      {manualMergeRequired ? (
+        <div className="flex flex-col gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-sm font-black text-emerald-950">Articles setup approved</p>
-            <p className="mt-1 text-sm font-semibold leading-6 text-emerald-800">
-              Future articles can now be generated into this repo location.
+            <p className="text-sm font-black text-amber-950">Manual merge required</p>
+            <p className="mt-1 text-sm font-semibold leading-6 text-amber-800">
+              Merge the setup PR in GitHub, then the verification scan can confirm the articles directory before topic research unlocks.
             </p>
           </div>
-          <Link
-            to="/founder-tools/marketing/create?step=research"
-            className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700"
-          >
-            Continue to topic research
-          </Link>
+          {prUrl ? (
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center rounded-xl bg-amber-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-amber-700"
+            >
+              Open setup PR
+            </a>
+          ) : null}
+        </div>
+      ) : setupCompleted ? (
+        <div className="flex flex-col gap-3 rounded-xl border border-emerald-100 bg-emerald-50 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-black text-emerald-950">Verifying merged articles directory</p>
+            <p className="mt-1 text-sm font-semibold leading-6 text-emerald-800">
+              The setup PR was merged. Topic research unlocks after the verification scan confirms the directory on the default branch.
+            </p>
+          </div>
+          {rescanRunId ? (
+            <Link
+              to={`/founder-tools/marketing/runs/${encodeURIComponent(rescanRunId)}`}
+              className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700"
+            >
+              View verification scan
+            </Link>
+          ) : null}
         </div>
       ) : null}
     </section>
@@ -939,17 +968,25 @@ function ArticleSystemSetupPreviewUnavailable({
 }) {
   const preview = run.livePreview;
   const previewStatus = String(preview?.status || run.status || "building").replace(/_/g, " ");
-  const previewActive = !isTerminalAttentionStatus(run.status) && hasActiveLivePreview(preview);
+  const previewActive = hasActiveLivePreview(preview);
   const error = previewActive ? "" : String(preview?.error || run.errors?.[0] || "").trim();
   const logsUrl = preview?.logsUrl || preview?.builderRunUrl;
-  const retryPreviewPending = previewActive || (isActionPending?.("start-live-preview") ?? isSubmitting);
+  const setupRetryable = Boolean(run.stale || run.retryAvailable || run.resumeAvailable);
+  const retryIntent = setupRetryable ? "resume" : "start-live-preview";
+  const retryPreviewPending = previewActive || (isActionPending?.(retryIntent) ?? isSubmitting);
   if (previewUrl) return null;
   return (
     <div className={clsx(
       "rounded-xl border px-4 py-5 text-sm font-semibold",
       error ? "border-red-200 bg-red-50 text-red-800" : "border-violet-100 bg-violet-50 text-violet-800",
     )}>
-      <p className="font-black">{error ? "Articles setup preview could not be prepared" : "Articles setup preview is being built"}</p>
+      <p className="font-black">
+        {error
+          ? setupRetryable
+            ? "Articles setup build did not advance"
+            : "Articles setup preview could not be prepared"
+          : "Articles setup preview is being built"}
+      </p>
       <p className="mt-1">{previewActive ? "Waiting for GitHub Actions to finish. Refreshing this page is safe." : `Preview status: ${previewStatus}. Refreshing this page is safe.`}</p>
       {error ? <p className="mt-2 break-words font-mono text-xs">{error}</p> : null}
       <div className="mt-4 flex flex-col gap-2 sm:flex-row">
@@ -965,16 +1002,16 @@ function ArticleSystemSetupPreviewUnavailable({
         ) : null}
         {error ? (
           <Form method="POST">
-            <input type="hidden" name="force" value="true" />
+            {setupRetryable ? null : <input type="hidden" name="force" value="true" />}
             <button
               type="submit"
               name="intent"
-              value="start-live-preview"
+              value={retryIntent}
               disabled={retryPreviewPending}
               className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-red-700 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-red-800 disabled:opacity-50 sm:w-auto"
             >
               {retryPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
-              {retryPreviewPending ? "Starting preview..." : "Retry preview build"}
+              {retryPreviewPending ? "Retrying..." : setupRetryable ? "Retry setup build" : "Retry preview build"}
             </button>
           </Form>
         ) : null}
@@ -2755,7 +2792,8 @@ function isSetupScanRun(run: VibeMarketingRunSummary) {
 }
 
 function setupWorkflowStepIdForRun(run: VibeMarketingRunSummary) {
-  if (run.status === "completed" || run.approvalState === "approved") return "publish";
+  const setupStatus = (stringResultValue(run, "status", "setupStatus", "setup_status") || run.currentStep || run.status || "").toLowerCase();
+  if (run.status === "completed" || setupStatus === "manual_merge_required") return "publish";
   if (run.livePreview?.available && run.livePreview.previewUrl) return "review";
   if (run.previewUrl || run.status === "awaiting_approval" || run.status === "approval_required") return "review";
   return "generate";
@@ -2787,10 +2825,11 @@ function workflowProgressForRunPage(
   const progress = run.workflowProgress ?? fallbackProgress ?? null;
   if (progress && run.workflow === "article_system_setup") {
     const activeStepId = setupWorkflowStepIdForRun(run);
-    const setupTerminal = isTerminalAttentionStatus(run.status);
-    const setupPreviewActive = !setupTerminal && hasActiveLivePreview(run.livePreview);
-    const setupFailed = !setupPreviewActive && (isFailedArticlePreview(run.livePreview) || setupTerminal);
-    const setupComplete = run.status === "completed" || run.approvalState === "approved";
+    const setupStatus = (stringResultValue(run, "status", "setupStatus", "setup_status") || run.currentStep || run.status || "").toLowerCase();
+    const manualMergeRequired = setupStatus === "manual_merge_required";
+    const setupPreviewActive = hasActiveLivePreview(run.livePreview);
+    const setupFailed = !setupPreviewActive && (isFailedArticlePreview(run.livePreview) || run.status === "blocked" || run.status === "failed");
+    const setupComplete = run.status === "completed" && !manualMergeRequired;
     const reviewReady = activeStepId === "review" || setupComplete;
     return {
       ...progress,
@@ -2823,8 +2862,10 @@ function workflowProgressForRunPage(
             ...step,
             label: step.id === "publish" ? "Publish setup PR" : "Setup PR ready",
             href: `/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}`,
-            summary: "Approve and merge the setup pull request to main.",
-            status: setupComplete ? "complete" : "locked",
+            summary: setupComplete
+              ? "Merged setup PR is being verified on the default branch."
+              : "Approve and merge the setup pull request to main.",
+            status: manualMergeRequired ? "needs_action" : setupComplete ? "running" : "locked",
           };
         }
         if (step.id === "research" || step.id === "choose_topic" || step.id === "automation") {
@@ -2881,8 +2922,7 @@ export default function FounderToolsMarketingRun() {
   const isRunActionNeeded = ["awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const isArticleSystemSetupRun = workflow === "article_system_setup";
-  const setupRunTerminal = isArticleSystemSetupRun && isTerminalAttentionStatus(run.status);
-  const setupPreviewActive = isArticleSystemSetupRun && !setupRunTerminal && hasActiveLivePreview(run.livePreview);
+  const setupPreviewActive = isArticleSystemSetupRun && hasActiveLivePreview(run.livePreview);
   const setupPreviewFailed = isArticleSystemSetupRun && !setupPreviewActive && isFailedArticlePreview(run.livePreview);
   const shouldPoll =
     (POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
@@ -2893,9 +2933,11 @@ export default function FounderToolsMarketingRun() {
   const isArticleWorkflowRun = isArticleWorkflow(workflow);
   const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
   const hasArticlePreview = hasReadyArticlePreview(run);
+  const setupBlocked = Boolean(bootstrap.checks.scaffold?.setupBlocked);
   const isDiscoveryConfirmation =
     ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(workflow) &&
-    run.status === "awaiting_confirmation";
+    run.status === "awaiting_confirmation" &&
+    !setupBlocked;
   const isPublishApproval = isPublishApprovalGate(run);
   const effectiveSetupPreviewRun = setupRun?.livePreview?.previewUrl || setupRun?.previewUrl ? setupRun : isScanRun && setupRunIdForRun(run) ? run : setupRun;
   const showRunAttentionBanner = RESUMABLE_ATTENTION_STATUSES.has(run.status);
@@ -2916,7 +2958,7 @@ export default function FounderToolsMarketingRun() {
   const isPublishAutomateView = Boolean(isArticleGenerationRun && (viewedWorkflowStepId === "publish" || viewedWorkflowStepId === "automation"));
   const isArticleSetupContext = isSetupScanContext || isArticleSystemSetupRun || Boolean(effectiveSetupPreviewRun);
   const isCompletedArticleReviewPage = hasArticlePreview && run.status === "completed" && !isPublishAutomateView;
-  const previewActive = isArticleSystemSetupRun ? setupPreviewActive : hasActiveLivePreview(run.livePreview);
+  const previewActive = hasActiveLivePreview(run.livePreview);
   const previewFailed = isFailedArticlePreview(run.livePreview);
   const shouldAutoStartPreview = Boolean(
     isArticleGenerationRun &&

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -73,6 +73,7 @@ const FLOW_STEPS = [
   { label: "You review & publish", icon: Send },
   { label: "Drive more traffic & grow", icon: BarChart3 },
 ] as const;
+const DRAFT_DELETE_CONFIRMATION_STORAGE_KEY = "vibe-marketing:skip-draft-delete-confirmation";
 
 function listFromForm(value: FormDataEntryValue | null) {
   return String(value ?? "")
@@ -99,6 +100,10 @@ function founderNamesFromForm(formData: FormData) {
 
 function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
+}
+
+function isArticleSystemSetupBlocked(bootstrap: VibeMarketingBootstrap) {
+  return Boolean(bootstrap.checks.scaffold?.setupBlocked);
 }
 
 type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
@@ -393,6 +398,10 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-discovery" || intent === "discovery") {
+      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      if (isArticleSystemSetupBlocked(bootstrap)) {
+        return { intent, error: "Finish approving, merging, and verifying the articles directory setup before researching topics." };
+      }
       const run = await startVibeMarketingDiscovery(env, request, {});
       if (run.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}`);
     }
@@ -423,6 +432,9 @@ export async function action({ request, context }: Route.ActionArgs) {
 
     if (intent === "start-article") {
       const bootstrap = await getVibeMarketingBootstrap(env, request);
+      if (isArticleSystemSetupBlocked(bootstrap)) {
+        return { intent, error: "Finish approving, merging, and verifying the articles directory setup before generating articles." };
+      }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
       const selectedCandidate =
         topicCandidateId && topicCandidateId !== "__custom__"
@@ -2222,9 +2234,15 @@ function draftActionVariant(actionKind: string) {
 function DraftArticleRow({
   draft,
   submitting,
+  deleting,
+  skipDeleteConfirmation,
+  onDeleteRequest,
 }: {
   draft: VibeMarketingDraftArticle;
   submitting: boolean;
+  deleting: boolean;
+  skipDeleteConfirmation: boolean;
+  onDeleteRequest: (draft: { runId: string; title: string }) => void;
 }) {
   const tone = draftStatusTone(draft);
   const href = `/founder-tools/marketing/runs/${encodeURIComponent(draft.runId)}`;
@@ -2257,15 +2275,15 @@ function DraftArticleRow({
             type="submit"
             disabled={submitting}
             onClick={(event) => {
-              if (!confirm(`Delete "${title}"? This cancels the article run and removes generated content for this draft.`)) {
-                event.preventDefault();
-              }
+              if (skipDeleteConfirmation) return;
+              event.preventDefault();
+              onDeleteRequest({ runId: draft.runId, title });
             }}
             title={`Delete draft: ${title}`}
             aria-label={`Delete draft: ${title}`}
             className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 focus:outline-none focus:ring-4 focus:ring-rose-100 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            <Trash2 className="h-4 w-4" />
+            {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
           </button>
         </Form>
         {canPostAction ? (
@@ -2304,9 +2322,15 @@ function DraftArticleRow({
 function DraftArticlesCard({
   drafts,
   submitting,
+  deletingRunId,
+  skipDeleteConfirmation,
+  onDeleteRequest,
 }: {
   drafts: VibeMarketingDraftArticle[];
   submitting: boolean;
+  deletingRunId: string | null;
+  skipDeleteConfirmation: boolean;
+  onDeleteRequest: (draft: { runId: string; title: string }) => void;
 }) {
   if (!drafts.length) return null;
   return (
@@ -2320,10 +2344,78 @@ function DraftArticlesCard({
       </div>
       <div className="mt-5">
         {drafts.slice(0, 5).map((draft) => (
-          <DraftArticleRow key={draft.runId} draft={draft} submitting={submitting} />
+          <DraftArticleRow
+            key={draft.runId}
+            draft={draft}
+            submitting={submitting}
+            deleting={deletingRunId === draft.runId}
+            skipDeleteConfirmation={skipDeleteConfirmation}
+            onDeleteRequest={onDeleteRequest}
+          />
         ))}
       </div>
     </section>
+  );
+}
+
+function DraftDeleteConfirmationModal({
+  draft,
+  submitting,
+  onClose,
+  onRememberSkip,
+}: {
+  draft: { runId: string; title: string };
+  submitting: boolean;
+  onClose: () => void;
+  onRememberSkip: () => void;
+}) {
+  const [dontAskAgain, setDontAskAgain] = useState(false);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-8 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="draft-delete-confirmation-title">
+      <div className="w-full max-w-md rounded-2xl border border-rose-100 bg-white p-5 shadow-2xl">
+        <h2 id="draft-delete-confirmation-title" className="text-lg font-black text-slate-950">Delete draft article?</h2>
+        <p className="mt-2 text-sm font-semibold leading-6 text-slate-600">
+          This cancels the article run and removes generated content for &quot;{draft.title}&quot;.
+        </p>
+        <label className="mt-4 flex items-center gap-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-3 text-sm font-bold text-slate-600">
+          <input
+            type="checkbox"
+            checked={dontAskAgain}
+            onChange={(event) => setDontAskAgain(event.target.checked)}
+            className="h-4 w-4 rounded border-slate-300 text-violet-700 focus:ring-violet-200"
+          />
+          Don&apos;t ask me again
+        </label>
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={onClose}
+            className="inline-flex justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 transition hover:bg-slate-50 disabled:opacity-50"
+          >
+            Keep draft
+          </button>
+          <Form
+            method="POST"
+            onSubmit={() => {
+              if (dontAskAgain) onRememberSkip();
+            }}
+          >
+            <input type="hidden" name="intent" value="delete-draft" />
+            <input type="hidden" name="runId" value={draft.runId} />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-rose-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-50 sm:w-auto"
+            >
+              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+              {submitting ? "Deleting..." : "Delete draft"}
+            </button>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -2447,9 +2539,13 @@ function ReturningTopicPickerPage({
   const isSubmitting = pendingActions.isAnyPending;
   const articleSubmitting = pendingActions.isPending("start-article");
   const discoverySubmitting = pendingActions.isPending("start-discovery", "discovery");
+  const deleteDraftSubmitting = pendingActions.isPending("delete-draft");
   const restoreBusy = restoreFetcher.state !== "idle";
   const visibleTopics = topics.slice(0, visibleCount);
   const [declineRequests, setDeclineRequests] = useState<Record<string, VibeMarketingTopicCandidate>>({});
+  const [draftDeleteRequest, setDraftDeleteRequest] = useState<{ runId: string; title: string } | null>(null);
+  const [skipDeleteConfirmation, setSkipDeleteConfirmation] = useState(false);
+  const [deletingDraftRunId, setDeletingDraftRunId] = useState<string | null>(null);
 
   const submitSelectedTopic = useCallback(() => {
     if (articleSubmitting || !selectedTopic) return;
@@ -2462,6 +2558,15 @@ function ReturningTopicPickerPage({
     formData.set("feedbackId", feedbackId);
     restoreFetcher.submit(formData, { method: "POST" });
   }, [restoreFetcher]);
+
+  const rememberSkipDeleteConfirmation = useCallback(() => {
+    setSkipDeleteConfirmation(true);
+    try {
+      window.localStorage.setItem(DRAFT_DELETE_CONFIRMATION_STORAGE_KEY, "1");
+    } catch {
+      // Ignore storage failures. The current delete should still submit normally.
+    }
+  }, []);
 
   function handleDeclineTopic(topic: VibeMarketingTopicCandidate) {
     setPendingDeclines((current) => ({ ...current, [topic.id]: topic }));
@@ -2491,6 +2596,32 @@ function ReturningTopicPickerPage({
   function handleRestoreFeedback(feedback: VibeMarketingTopicFeedback) {
     submitRestoreFeedback(feedback.id);
   }
+
+  useEffect(() => {
+    try {
+      setSkipDeleteConfirmation(window.localStorage.getItem(DRAFT_DELETE_CONFIRMATION_STORAGE_KEY) === "1");
+    } catch {
+      setSkipDeleteConfirmation(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (navigation.state === "idle") return;
+    if (String(navigation.formData?.get("intent") ?? "") !== "delete-draft") return;
+    const runId = String(navigation.formData?.get("runId") ?? "").trim();
+    setDeletingDraftRunId(runId || null);
+  }, [navigation.formData, navigation.state]);
+
+  useEffect(() => {
+    if (deleteDraftSubmitting) return;
+    setDeletingDraftRunId(null);
+  }, [deleteDraftSubmitting]);
+
+  useEffect(() => {
+    if (!draftDeleteRequest) return;
+    const stillPresent = (bootstrap.draftArticles ?? []).some((draft) => draft.runId === draftDeleteRequest.runId);
+    if (!stillPresent) setDraftDeleteRequest(null);
+  }, [bootstrap.draftArticles, draftDeleteRequest]);
 
   useEffect(() => {
     if (!topics.length) {
@@ -2793,7 +2924,13 @@ function ReturningTopicPickerPage({
             </div>
           </section>
 
-          <DraftArticlesCard drafts={bootstrap.draftArticles ?? []} submitting={isSubmitting} />
+          <DraftArticlesCard
+            drafts={bootstrap.draftArticles ?? []}
+            submitting={isSubmitting}
+            deletingRunId={deleteDraftSubmitting ? deletingDraftRunId : null}
+            skipDeleteConfirmation={skipDeleteConfirmation}
+            onDeleteRequest={setDraftDeleteRequest}
+          />
 
           <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <div className="flex items-center justify-between gap-4">
@@ -2850,6 +2987,14 @@ function ReturningTopicPickerPage({
           </section>
         </aside>
       </div>
+      {draftDeleteRequest ? (
+        <DraftDeleteConfirmationModal
+          draft={draftDeleteRequest}
+          submitting={deleteDraftSubmitting}
+          onClose={() => setDraftDeleteRequest(null)}
+          onRememberSkip={rememberSkipDeleteConfirmation}
+        />
+      ) : null}
     </div>
   );
 }
@@ -2859,7 +3004,8 @@ export default function FounderToolsMarketing() {
   const actionData = useActionData<typeof action>();
   const error = actionError(actionData);
   const errorIntent = actionIntent(actionData);
-  const shouldShowTopicPicker = bootstrap.startPageMode === "topic_picker" || Boolean(bootstrap.hasCompletedArticleFlow);
+  const setupBlocked = Boolean(bootstrap.checks.scaffold?.setupBlocked);
+  const shouldShowTopicPicker = !setupBlocked && (bootstrap.startPageMode === "topic_picker" || Boolean(bootstrap.hasCompletedArticleFlow));
 
   return (
     <div className="min-h-screen bg-[#fbfaf8]">

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -202,6 +202,13 @@ export interface VibeMarketingCheck {
   connectionState?: string | null;
   repoSet?: boolean;
   articleSystem?: Record<string, unknown>;
+  published?: boolean;
+  setupBlocked?: boolean;
+  setupRunId?: string | null;
+  setupStatus?: string | null;
+  rescanRunId?: string | null;
+  prUrl?: string | null;
+  previewUrl?: string | null;
 }
 
 export interface VibeMarketingTopicCandidate {


### PR DESCRIPTION
## Summary
- Gate create and run screens on scaffold.published/setupBlocked instead of treating approved/completed setup as research-ready.
- Redirect research/chooseArticle attempts back to article system setup while first-time setup is pending.
- Show preview, merge, manual merge, and verification states instead of topic research CTAs.

## Tests
- npm run typecheck -- --pretty false