### PR TITLE
Remove Cloudflare Worker CPU limit

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,9 +30,6 @@
   "observability": {
     "enabled": true
   },
-  "limits": {
-    "cpu_ms": 30000
-  },
   /**
    * Smart Placement
    * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## Summary
- Remove the Wrangler CPU limit from mlai-au so deploys work on the Cloudflare Free plan.
- Let Cloudflare apply the plan default CPU behavior instead of sending an unsupported cpu_ms setting.

## Tests
- bun run build
- bunx --yes wrangler deploy --dry-run --outdir /tmp/mlai-au-remove-cpu-limit-dry-run