### PR TITLE
[codex] Fix first repo scan auto advance

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -49,6 +49,18 @@ const SCAN_RUNNING_STATUSES = new Set(["queued", "running", "pending", "starting
 const SCAN_POLLING_STATUSES = SCAN_RUNNING_STATUSES;
 const SCAN_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "denied"]);
 const SCAN_ACTION_NEEDED_STATUSES = new Set(["awaiting_confirmation", "awaiting_approval", "approval_required"]);
+const SCAN_TERMINAL_REVALIDATE_STATUSES = new Set([
+  "completed",
+  "awaiting_confirmation",
+  "awaiting_approval",
+  "approval_required",
+  "failed",
+  "blocked",
+  "blocked_verification",
+  "denied",
+  "cancelled",
+  "canceled",
+]);
 
 function isGithubPublishingReady(bootstrap: VibeMarketingBootstrap) {
   return Boolean(bootstrap.checks.github?.passed && bootstrap.settings.githubRepo);
@@ -165,9 +177,27 @@ function scanPurposeForRun(run: VibeMarketingRunSummary | null | undefined) {
   ).trim();
 }
 
+function hasConcreteArticleSurfaceHint(value: unknown) {
+  if (typeof value === "string") return Boolean(value.trim());
+  const hint = resultObject(value);
+  return [
+    "route",
+    "route_path",
+    "routePath",
+    "path",
+    "public_url",
+    "publicUrl",
+    "listing_url",
+    "listingUrl",
+    "article_surface_url",
+    "articleSurfaceUrl",
+    "url",
+  ].some((key) => typeof hint[key] === "string" && Boolean((hint[key] as string).trim()));
+}
+
 function scanHasArticleSurfaceHint(run: VibeMarketingRunSummary | null | undefined) {
   if (!run) return false;
-  return Boolean(resultValue(run, "article_surface_hint") || run.result?.["articleSurfaceHint"]);
+  return hasConcreteArticleSurfaceHint(resultValue(run, "article_surface_hint")) || hasConcreteArticleSurfaceHint(run.result?.["articleSurfaceHint"]);
 }
 
 function isInventoryScan(run: VibeMarketingRunSummary | null | undefined) {
@@ -448,6 +478,7 @@ export default function ArticleSystemConnectionPanel({
   const [createNewPath, setCreateNewPath] = useState(articleSurfaceDefault || "/articles");
   const lastScanProgressSignatureRef = useRef("");
   const lastScanProgressAtRef = useRef(Date.now());
+  const lastTerminalRevalidationRef = useRef("");
   const [pageVisible, setPageVisible] = useState(true);
   const [githubAuthWaiting, setGithubAuthWaiting] = useState(() =>
     typeof window !== "undefined" && window.sessionStorage.getItem("vibe-marketing:github-auth-open") === "true",
@@ -534,8 +565,7 @@ export default function ArticleSystemConnectionPanel({
     if (!pageVisible) return;
     const shouldPollScan =
       !effectiveScanRun ||
-      (!setupTargetScan &&
-        SCAN_POLLING_STATUSES.has(effectiveScanRun.status) &&
+      (SCAN_POLLING_STATUSES.has(effectiveScanRun.status) &&
         !SCAN_ACTION_NEEDED_STATUSES.has(effectiveScanRun.status) &&
         !scanStale);
     if (!shouldPollScan) return;
@@ -569,6 +599,16 @@ export default function ArticleSystemConnectionPanel({
     runStatusFetcher.state,
     scanStale,
   ]);
+
+  useEffect(() => {
+    if (!effectiveScanRun?.runId) return;
+    const terminalStatus = scanStale ? "stale" : effectiveScanRun.status;
+    if (!scanStale && !SCAN_TERMINAL_REVALIDATE_STATUSES.has(effectiveScanRun.status)) return;
+    const key = [effectiveScanRun.runId, terminalStatus, effectiveScanRun.updatedAt ?? ""].join("|");
+    if (lastTerminalRevalidationRef.current === key) return;
+    lastTerminalRevalidationRef.current = key;
+    revalidator.revalidate();
+  }, [effectiveScanRun?.runId, effectiveScanRun?.status, effectiveScanRun?.updatedAt, revalidator, scanStale]);
 
   useEffect(() => {
     if (!autoStartInventoryScan || !connected || !selectedRepo || currentScanRunId || inventoryFetcher.state !== "idle") return;

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -248,17 +248,55 @@ function runResultValue(run: VibeMarketingRunSummary | null | undefined, key: st
   if (!run) return undefined;
   if (run.result?.[key] !== undefined) return run.result[key];
   const nested = resultObject(run.result?.result);
-  return nested[key];
+  if (nested[key] !== undefined) return nested[key];
+  const latestControl = resultObject(run.result?.latest_control_response);
+  return latestControl[key];
+}
+
+function hasMeaningfulPayload(value: unknown) {
+  if (typeof value === "string") return Boolean(value.trim());
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === "object") return Object.keys(value as Record<string, unknown>).length > 0;
+  return Boolean(value);
+}
+
+function hasConcreteArticleSurfaceHint(value: unknown) {
+  if (typeof value === "string") return Boolean(value.trim());
+  const hint = resultObject(value);
+  return [
+    "route",
+    "route_path",
+    "routePath",
+    "path",
+    "public_url",
+    "publicUrl",
+    "listing_url",
+    "listingUrl",
+    "article_surface_url",
+    "articleSurfaceUrl",
+    "url",
+  ].some((key) => typeof hint[key] === "string" && Boolean((hint[key] as string).trim()));
+}
+
+function scanRunHasArticleSurfaceHint(run: VibeMarketingRunSummary | null | undefined) {
+  return Boolean(
+    run &&
+      (hasConcreteArticleSurfaceHint(runResultValue(run, "article_surface_hint")) ||
+        hasConcreteArticleSurfaceHint(runResultValue(run, "articleSurfaceHint"))),
+  );
 }
 
 function scanRunHasPendingArticleSystemSetup(run: VibeMarketingRunSummary | null | undefined) {
   if (!run || !["repo_scan", "content_factory_scan"].includes(run.workflow)) return false;
-  const purpose = String(runResultValue(run, "scan_purpose") ?? runResultValue(run, "scanPurpose") ?? "").trim();
+  const request = resultObject(run.result?.run_request ?? run.result?.request);
+  const purpose = String(
+    runResultValue(run, "scan_purpose") ?? runResultValue(run, "scanPurpose") ?? request.scan_purpose ?? request.scanPurpose ?? "",
+  ).trim();
   const requestedAction = stringResultValue(run, "requested_action", "setup_requested_action");
   return (
     purpose === "setup" ||
-    Boolean(runResultValue(run, "pending_article_system_setup")) ||
-    Boolean(runResultValue(run, "article_surface_hint")) ||
+    hasMeaningfulPayload(runResultValue(run, "pending_article_system_setup")) ||
+    scanRunHasArticleSurfaceHint(run) ||
     requestedAction === "article_system_setup" ||
     requestedAction === "scaffold_publish_route"
   );

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -2777,6 +2777,40 @@ function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
   return "";
 }
 
+function resultObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function resultValue(run: VibeMarketingRunSummary, key: string): unknown {
+  if (run.result?.[key] !== undefined) return run.result[key];
+  const nestedResult = resultObject(run.result?.result);
+  if (nestedResult[key] !== undefined) return nestedResult[key];
+  const latestControl = resultObject(run.result?.latest_control_response);
+  return latestControl[key];
+}
+
+function hasConcreteArticleSurfaceHint(value: unknown) {
+  if (typeof value === "string") return Boolean(value.trim());
+  const hint = resultObject(value);
+  return [
+    "route",
+    "route_path",
+    "routePath",
+    "path",
+    "public_url",
+    "publicUrl",
+    "listing_url",
+    "listingUrl",
+    "article_surface_url",
+    "articleSurfaceUrl",
+    "url",
+  ].some((key) => typeof hint[key] === "string" && Boolean((hint[key] as string).trim()));
+}
+
+function scanHasArticleSurfaceHint(run: VibeMarketingRunSummary) {
+  return hasConcreteArticleSurfaceHint(resultValue(run, "article_surface_hint")) || hasConcreteArticleSurfaceHint(resultValue(run, "articleSurfaceHint"));
+}
+
 function setupRunIdForRun(run: VibeMarketingRunSummary) {
   const direct = stringResultValue(run, "setup_run_id", "setupRunId", "scaffold_job_id", "scaffoldJobId");
   if (direct) return direct;
@@ -2833,7 +2867,7 @@ function isPublishApprovalGate(run: VibeMarketingRunSummary) {
 function isSetupScanRun(run: VibeMarketingRunSummary) {
   if (!SCAN_WORKFLOWS.has(run.workflow)) return false;
   const scanPurpose = stringResultValue(run, "scan_purpose", "scanPurpose");
-  return scanPurpose === "setup" || Boolean(setupRunIdForRun(run)) || Boolean(run.result?.["article_surface_hint"]);
+  return scanPurpose === "setup" || Boolean(setupRunIdForRun(run)) || scanHasArticleSurfaceHint(run);
 }
 
 function setupWorkflowStepIdForRun(run: VibeMarketingRunSummary) {


### PR DESCRIPTION
## Summary
- keep first-time inventory scans polling until terminal status
- treat empty article surface hints as non-setup so inventory scans can show route selection
- revalidate bootstrap/latest runs when scan polling reaches terminal or stale states

## Validation
- npm run typecheck -- --pretty false