### PR TITLE
Surface content island discovery dispatch failures

### DIFF
--- a/app/lib/vibe-marketing-step-revalidation.ts
+++ b/app/lib/vibe-marketing-step-revalidation.ts
@@ -2,6 +2,7 @@ import type { ShouldRevalidateFunctionArgs } from "react-router";
 
 const CREATE_FLOW_PATH = "/founder-tools/marketing/create";
 const VIEW_ONLY_SEARCH_PARAMS = new Set(["step", "googleBaseline"]);
+const IN_PLACE_ACTION_INTENTS = new Set(["start-content-island-discovery"]);
 
 function normalizePathname(pathname: string) {
   return pathname.replace(/\/+$/, "") || "/";
@@ -44,6 +45,13 @@ export function shouldSkipVibeMarketingCreateRevalidation({
   actionResult,
   actionStatus,
 }: ShouldRevalidateFunctionArgs) {
+  const intent =
+    actionResult && typeof actionResult === "object" && "intent" in actionResult
+      ? String((actionResult as { intent?: unknown }).intent ?? "")
+      : "";
+  if (IN_PLACE_ACTION_INTENTS.has(intent)) {
+    return true;
+  }
   if (formMethod || actionResult !== undefined || actionStatus !== undefined) {
     return false;
   }

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -1,4 +1,5 @@
 import type { Route } from "./+types/founder-tools.marketing";
+import type { ShouldRevalidateFunctionArgs } from "react-router";
 import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useRevalidator } from "react-router";
 import type { KeyboardEvent, ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -575,18 +576,31 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
+    const responseData = error?.data ?? error?.response?.data;
+    const responseErrors = Array.isArray(responseData?.errors)
+      ? responseData.errors.map((item: unknown) => String(item)).filter(Boolean)
+      : [];
     return {
       intent,
       error:
-        error?.data?.detail ??
-        error?.data?.error ??
-        error?.response?.data?.detail ??
+        responseErrors[0] ??
+        responseData?.detail ??
+        responseData?.error ??
+        responseData?.message ??
         error?.message ??
         "That action could not be completed.",
+      errors: responseErrors,
     };
   }
 
   return null;
+}
+
+export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
+  if (actionIntent(args.actionResult) === "start-content-island-discovery") {
+    return false;
+  }
+  return args.defaultShouldRevalidate;
 }
 
 function actionError(data: unknown): string | null {


### PR DESCRIPTION
## Summary
- Preserve backend errors arrays when a marketing action fails
- Stop automatic route revalidation for in-place content island discovery starts
- Surface dispatch failures immediately instead of polling a blocked run after a full bootstrap reload

## Tests
- npm run typecheck -- --pretty false