### PR TITLE
[codex] Update MLAI legal policies

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,8 @@
+- [x] Restyle `/terms` and `/privacy` to match the main MLAI brutalist page shell
+- [x] Verify styled legal pages in the local browser
+- [x] Rewrite `/terms` as MLAI-wide Terms of Service with product schedules
+- [x] Rewrite `/privacy` as MLAI-wide Privacy Policy with Google and product-specific sections
+- [x] Run `bun run typecheck`
 - [x] Simplify the mobile review sticky footer on Founder Tools create-update
 - [x] Polish Founder Tools dashboard CTA hierarchy for the May 17-18 mobile follow-up branch
 - [x] Improve Create Update AI draft card touch/mobile affordance

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -1,290 +1,570 @@
+import type { ReactNode } from "react";
 import type { MetaFunction } from "react-router";
-import { Container } from "~/components/ui/Container";
+import SectionDivider from "~/components/SectionDivider";
 
-const LAST_UPDATED = "13 May 2026";
+const LAST_UPDATED = "20 May 2026";
 
 export const meta: MetaFunction = () => {
   return [
-    { title: "MLAI Vibe Raising Privacy Policy | Google and Gmail Data Use" },
+    { title: "MLAI Privacy Policy" },
     {
       name: "description",
       content:
-        "Privacy Policy for MLAI Vibe Raising, including Google OAuth, Gmail data access, connected sources, AI-assisted monthly founder updates, retention, deletion, and Limited Use commitments.",
+        "MLAI Privacy Policy covering MLAI websites, events, community programs, Vibe Raising, Vibe Marketing, MLAI Studio, grants, project services, software, Google OAuth, Gmail, Drive, Analytics, Search Console, connected services, AI processing, retention, deletion, and Limited Use commitments.",
     },
     {
       name: "keywords",
       content:
-        "MLAI Vibe Raising privacy policy, Gmail integration, Slack integration, Xero integration, Google OAuth, Google user data, Limited Use, data deletion",
+        "MLAI privacy policy, Google user data, Gmail data, Google Drive, Google Analytics, Search Console, Vibe Raising privacy, Vibe Marketing privacy, AI processing, data deletion, Limited Use",
     },
   ];
 };
 
+function Section({ id, title, children }: { id: string; title: string; children: ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-28 border-t border-[var(--brutalist-border)]/15 pt-8">
+      <h2 className="flex items-start gap-3 text-2xl font-black leading-8 tracking-tight text-[var(--brutalist-black)] sm:text-3xl">
+        <span className="mt-3 h-2 w-10 shrink-0 rounded-full bg-[var(--brutalist-blue)]" aria-hidden="true" />
+        <span>{title}</span>
+      </h2>
+      <div className="mt-5 space-y-4 text-base leading-7 text-[var(--brutalist-black)]/75">{children}</div>
+    </section>
+  );
+}
+
+function Subsection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="space-y-4">
+      <h3 className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-orange)]">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function List({ children }: { children: ReactNode }) {
+  return <ul className="list-disc space-y-2 pl-5 marker:text-[var(--brutalist-blue)]">{children}</ul>;
+}
+
+function PolicyLink({
+  href,
+  children,
+  className = "text-[var(--brutalist-blue)]",
+}: {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <a href={href} className={`font-black underline underline-offset-4 ${className}`}>
+      {children}
+    </a>
+  );
+}
+
 export default function Privacy() {
   return (
-    <>
-      <Container className="bg-white pt-32">
-        <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-1 lg:grid-rows-[auto_1fr] lg:gap-y-12">
-          <div className="lg:order-first lg:row-span-2">
-            <h1 className="text-4xl pt-12 font-bold tracking-tight text-[#3b82f6] sm:text-5xl dark:text-[#3b82f6]">
-              MLAI Vibe Raising Privacy Policy
-            </h1>
-            <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
-              <h2 className="text-xl font-semibold leading-7 text-gray-900">
-                Last updated: {LAST_UPDATED}
-              </h2>
-
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                MLAI Aus Inc ("MLAI", "we", "our", or "us") provides MLAI
-                Vibe Raising, a founder tool that helps startups draft monthly
-                investor updates from information the founder chooses to provide
-                or connect. This Privacy Policy explains how we collect, use,
-                store, share, protect, retain, and delete information, including
-                Google user data and Gmail data.
-              </p>
-
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                By using MLAI websites, applications, and services, including
-                MLAI Vibe Raising, you acknowledge the practices described in
-                this Privacy Policy.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Information We Collect
-              </h2>
-
-              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Account, Contact, and Support Information
-              </h3>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We may collect information you provide when you create an
-                account, contact us, register for events, subscribe to updates,
-                request support, or otherwise interact with MLAI. This may
-                include your name, email address, company name, role, support
-                requests, and communication preferences.
-              </p>
-
-              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Startup and Founder Update Information
-              </h3>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                MLAI Vibe Raising may process startup information that you enter,
-                upload, generate, or approve in the product. This may include
-                company profile information, goals, metrics, milestones,
-                customer conversations, investor asks, risks, blockers, draft
-                updates, final updates, notes, files, and other materials you
-                choose to use for monthly founder or investor updates.
-              </p>
-
-              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Optional Connected Data Sources
-              </h3>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                You may choose to connect third-party services so MLAI Vibe
-                Raising can use relevant context for the update workflow.
-                Connected sources may include Google services such as Gmail and
-                Google Drive, Slack, Xero, Linear, Notion, manual materials, and
-                other data sources that are available in the product from time to
-                time. You should only connect accounts, workspaces, files,
-                channels, and data that you own or are authorized to use.
-              </p>
-
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                Depending on the connector and permissions you choose, MLAI may
-                process:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li><strong>Slack:</strong> workspace and channel identifiers, selected channel names, public or private channel indicators, message text, thread context, timestamps, and related metadata.</li>
-                <li><strong>Xero:</strong> organization, tenant, invoice, payment, contact, account, report, profit and loss, balance sheet, and metric information permitted by granted scopes.</li>
-                <li><strong>Linear:</strong> workspace, project, issue, comment, status, assignee, cycle, label, and delivery context where a Linear integration is enabled.</li>
-                <li><strong>Notion and Google Drive:</strong> page, file, document, folder, metadata, and extracted text where enabled and authorized.</li>
-                <li><strong>Manual materials:</strong> source URLs, short summaries, recorded notes, uploaded files, pasted text, and other materials you add directly.</li>
-                <li><strong>Generated outputs:</strong> monthly update drafts, generated sections, extracted events, metrics, evidence, recommendations, review results, and final updates.</li>
-              </ul>
-
-              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Google and Gmail Data We Access
-              </h3>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you choose to connect your Google account, Google will show
-                the exact permissions requested before you grant access. Depending
-                on the feature you enable, MLAI may access or process:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Google account identifiers such as your email address and profile information.</li>
-                <li>OAuth access tokens and refresh tokens needed to maintain the connection.</li>
-                <li>Gmail message and thread identifiers, history identifiers, labels, headers, dates, and other metadata.</li>
-                <li>Email subjects, sender and recipient fields, snippets, body text, cleaned or extracted text, and previews.</li>
-                <li>Attachment metadata and attachment content when processed for the update workflow.</li>
-                <li>Derived artifacts such as relevance scores, summaries, extracted events, metrics, asks, risks, and generated drafts.</li>
-              </ul>
-
-              <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                Automatically Collected Information
-              </h3>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                When you use our website or services, we may collect technical
-                and usage information such as IP address, browser type, device
-                information, pages visited, referral source, timestamps, log
-                data, product events, and error diagnostics.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                How We Use Information
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We use information to provide, maintain, secure, and improve MLAI
-                services. For MLAI Vibe Raising, we use connected and provided
-                data to:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>Generate monthly founder and investor update drafts requested by you.</li>
-                <li>Identify relevant update signals such as milestones, metrics, investor feedback, customer conversations, risks, asks, and follow-ups.</li>
-                <li>Show previews, summaries, source context, and derived outputs in the product.</li>
-                <li>Maintain your connected account status and refresh authorized data when needed for the requested workflow.</li>
-                <li>Provide support, troubleshoot issues, prevent abuse, protect security, and comply with legal obligations.</li>
-                <li>Send service, transactional, and account-related communications.</li>
-              </ul>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                AI Processing
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                MLAI Vibe Raising may use automated systems and AI models to
-                analyze founder-provided data and optional connected data,
-                including Gmail, Slack, Xero, Linear, Notion, Google Drive, and
-                manual materials, for the purpose of producing the user-facing
-                monthly update workflow you requested. We do not use Google
-                Workspace API data, including Gmail data, to create, train, or
-                improve generalized AI or machine learning models.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Google User Data and Limited Use Commitments
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                MLAI's use and transfer of information received from Google APIs
-                will adhere to the Google API Services User Data Policy,
-                including the Limited Use requirements. In particular:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>We use Google user data only to provide or improve user-facing features that are visible in MLAI Vibe Raising.</li>
-                <li>We do not sell Google user data or Gmail data.</li>
-                <li>We do not use Google user data for advertising, retargeting, personalized advertising, data broker services, credit-worthiness, or lending purposes.</li>
-                <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
-                <li>We do not transfer Google user data except as needed to provide or improve the user-facing feature with your consent, comply with law, protect security, or as otherwise permitted by Google policy.</li>
-                <li>We do not allow humans to read Google user data unless you have given explicit permission, it is necessary for security or legal compliance, or the data has been aggregated and anonymized for permitted internal operations.</li>
-              </ul>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Sharing and Disclosure
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We do not sell your personal information, Google user data,
-                Gmail data, or connected-source data. We may disclose
-                information only in the following limited circumstances:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>To service providers that help us operate, host, secure, support, or provide MLAI services, subject to confidentiality and data protection obligations.</li>
-                <li>To AI infrastructure providers only as needed to provide the user-facing feature you requested, and not for generalized model training on Google Workspace API data.</li>
-                <li>When you direct us to share an output, send an update, invite a collaborator, connect a third-party service, or otherwise disclose information through the product.</li>
-                <li>When required by law, regulation, legal process, or to protect rights, safety, security, and prevent abuse.</li>
-                <li>In connection with a merger, acquisition, financing, reorganization, or sale of assets, subject to applicable law and required user consent where Google policy requires it.</li>
-              </ul>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Data Security
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We use technical and organizational safeguards designed to protect
-                information from unauthorized access, alteration, disclosure, or
-                destruction. These safeguards include HTTPS for data transmitted
-                over external networks, encryption for stored sensitive data where
-                applicable, access controls, token protection, and internal
-                restrictions on who may access production systems. No system is
-                perfectly secure, but we work to maintain a secure operating
-                environment for user data and credentials.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Retention and Deletion
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We retain information only for as long as needed to provide MLAI
-                services, comply with legal obligations, resolve disputes,
-                enforce agreements, maintain security, and support legitimate
-                business purposes. For MLAI Vibe Raising:
-              </p>
-              <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                <li>OAuth tokens and connected account identifiers are retained while your Google connection is active.</li>
-                <li>Selected Gmail message and thread artifacts, extracted text, metadata, relevance signals, and derived outputs may be retained while needed to generate, display, troubleshoot, and improve the user-facing update workflow.</li>
-                <li>Generated drafts, monthly updates, summaries, metrics, and other derived outputs may be retained while your account is active or until you delete them or request deletion.</li>
-                <li>Non-Google connected-source artifacts, selected channel or project settings, uploaded files, source URLs, and extracted text may be retained while needed to provide, display, troubleshoot, secure, and improve the requested workflow.</li>
-                <li>When you disconnect Google, revoke access, delete your account, or request deletion, we will delete or de-identify associated Google tokens, Gmail artifacts, and derived outputs within a reasonable time unless retention is required or permitted by law, security, or legitimate operational needs.</li>
-                <li>When you disconnect another connector, future sync for that connector stops, but historical generated outputs or cached source artifacts may remain until you delete them where product controls are available or request deletion.</li>
-              </ul>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Your Choices and Controls
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                You may choose not to connect Gmail or any other source. If you
-                connect a source, you may disconnect it in MLAI account settings
-                where available, revoke MLAI&apos;s access from the third-party
-                provider, or email us at hi@mlai.au. You may also request
-                access, correction, deletion, export, or restriction of your
-                personal information, subject to applicable law and verification
-                of your request.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Email Communications and Newsletter
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you subscribe to MLAI emails, we may send updates about MLAI
-                activities, events, product information, and service notices. You
-                can unsubscribe from marketing emails by using the unsubscribe
-                link in those emails or by contacting hi@mlai.au. We may still
-                send transactional or account-related messages.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Children's Privacy
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                Our services are not directed to children under 13 years of age.
-                We do not knowingly collect personal information from children
-                under 13.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Changes to This Privacy Policy
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                We may update this Privacy Policy from time to time. If we change
-                how MLAI uses Google user data in a material way, we will update
-                this Privacy Policy and provide notice or seek consent where
-                required before using Google user data for the new purpose.
-              </p>
-
-              <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                Contact Us
-              </h2>
-              <p className="mt-4 text-base leading-7 text-zinc-600">
-                If you have questions about this Privacy Policy, our privacy
-                practices, or a deletion request, contact us at:
-              </p>
-
-              <div className="mt-4 bg-gray-50 p-6 rounded-lg">
-                <p className="mb-2 text-base leading-7 text-zinc-600">
-                  <strong>MLAI Aus Inc</strong>
-                </p>
-                <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
-                <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
-              </div>
+    <main className="min-h-screen bg-[var(--brutalist-beige)] pb-16 pt-20 text-[var(--brutalist-black)]">
+      <SectionDivider color="#3537dc" label="Privacy" />
+      <section className="bg-[var(--brutalist-beige)] p-2 lg:p-3">
+        <article className="w-full rounded-2xl border border-gray-400 bg-[linear-gradient(180deg,var(--brutalist-beige)_0%,#fffaf1_100%)] p-4 shadow-[0_24px_80px_rgba(26,26,26,0.08)] sm:rounded-[2.5rem] sm:p-8 lg:p-12">
+          <header className="border-b border-[var(--brutalist-border)]/20 pb-10">
+            <div className="flex flex-wrap items-center gap-3 text-xs font-black uppercase tracking-[0.24em] text-[var(--brutalist-blue)]">
+              <span>Privacy</span>
+              <span className="h-1 w-8 rounded-full bg-[var(--brutalist-blue)]" aria-hidden="true" />
+              <span>MLAI Aus Inc</span>
             </div>
-          </div>
-        </div>
-      </Container>
-    </>
+
+            <h1
+              className="mt-6 max-w-5xl text-[var(--brutalist-black)]"
+              style={{
+                fontFamily: "'Oswald', sans-serif",
+                fontSize: "clamp(3.25rem, 10vw, 8.5rem)",
+                fontWeight: 700,
+                lineHeight: 0.9,
+              }}
+            >
+              MLAI Privacy Policy
+            </h1>
+
+            <p className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-orange)]">
+              Last updated: {LAST_UPDATED}
+            </p>
+
+            <div className="mt-8 grid gap-5 text-lg leading-8 text-[var(--brutalist-black)]/78 lg:grid-cols-2">
+              <p>
+                MLAI Aus Inc ("MLAI", "we", "our", or "us") is a
+                not-for-profit community based in Australia. This Privacy Policy
+                explains how we collect, use, store, share, protect, retain, and
+                delete information when you use MLAI websites, events, community
+                programs, founder tools, connected-account products, project
+                services, software, workshops, and related services.
+              </p>
+
+              <p>
+                This policy covers MLAI generally, Vibe Raising, Vibe Marketing,
+                MLAI Studio, MLAI Grants and project work, educational software,
+                paid workshops, community activities, volunteers, sponsors, and
+                connected services such as Google, Gmail, Google Drive, Google
+                Analytics, Search Console, Slack, Xero, Linear, and Notion where
+                enabled.
+              </p>
+            </div>
+
+            <div className="mt-8 rounded-[1.5rem] bg-[var(--brutalist-black)] p-5 text-white sm:p-6">
+              <p className="text-xs font-black uppercase tracking-[0.24em] text-[var(--brutalist-mint)]">
+                Policy sections
+              </p>
+              <nav className="mt-4 grid gap-2 text-sm font-semibold leading-6 sm:grid-cols-2 lg:grid-cols-4">
+                  <PolicyLink href="#information-we-collect" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Information We Collect</PolicyLink>
+                  <PolicyLink href="#product-data" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Product-Specific Data</PolicyLink>
+                  <PolicyLink href="#google-data" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Google User Data</PolicyLink>
+                  <PolicyLink href="#ai-processing" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">AI Processing</PolicyLink>
+                  <PolicyLink href="#cross-product" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Cross-Product Data Use</PolicyLink>
+                  <PolicyLink href="#limited-use" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Google Limited Use Commitments</PolicyLink>
+                  <PolicyLink href="#retention-deletion" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Retention, Deletion, and Disconnecting</PolicyLink>
+                  <PolicyLink href="#rights" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Your Rights and Choices</PolicyLink>
+                </nav>
+              </div>
+
+            </header>
+
+            <div className="mt-10 space-y-10">
+
+              <Section id="who-we-are" title="1. Who We Are and How to Contact Us">
+                <p>
+                  MLAI Aus Inc operates MLAI websites, community programs, events,
+                  founder tools, software, project services, educational programs,
+                  and related services. We may act as a community operator, service
+                  provider, software provider, project delivery partner, event
+                  organiser, sponsor or partner contact point, and platform operator,
+                  depending on the service you use.
+                </p>
+                <p>
+                  Contact us at hi@mlai.au for privacy questions, access requests,
+                  correction requests, deletion requests, complaints, or questions
+                  about connected accounts.
+                </p>
+              </Section>
+
+              <Section id="scope" title="2. Scope of This Policy">
+                <p>This Privacy Policy applies to information MLAI handles through:</p>
+                <List>
+                  <li>MLAI websites, landing pages, articles, forms, analytics, and newsletters.</li>
+                  <li>Events, hackathons, workshops, meetups, community spaces, Slack or Discord groups, member directories, and volunteer programs.</li>
+                  <li>Founder tools, including Vibe Raising and Vibe Marketing.</li>
+                  <li>MLAI Studio, builder-hour services, subscriptions, retainers, scoped project delivery, and product support.</li>
+                  <li>MLAI Grants, sponsored projects, educational software, client projects, research, innovation programs, and software licences.</li>
+                  <li>Optional connected services, including Google services and other third-party platforms that you choose to connect.</li>
+                </List>
+                <p>
+                  Third-party websites, platforms, venues, payment processors,
+                  ticketing providers, and connected services have their own privacy
+                  policies. You should review those policies before using them.
+                </p>
+              </Section>
+
+              <Section id="information-we-collect" title="3. Information We Collect">
+                <Subsection title="Account, Contact, and Support Information">
+                  <p>
+                    We may collect your name, email address, phone number, company
+                    name, role, organisation, profile information, login details,
+                    account settings, preferences, support messages, contact forms,
+                    communications, and authentication information.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Website, Analytics, and Usage Information">
+                  <p>
+                    We may collect IP address, browser type, device information,
+                    referral source, pages viewed, timestamps, product events,
+                    approximate location, cookies or similar identifiers, error
+                    diagnostics, logs, and performance information. We may use
+                    analytics tools to understand website and product usage.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Community, Event, Workshop, and Volunteer Information">
+                  <p>
+                    We may collect event registrations, ticketing details, attendance
+                    records, dietary or accessibility information you provide,
+                    speaker and organiser details, hackathon submissions, team
+                    details, judging records, prize eligibility information, workshop
+                    participation, community profile information, Slack or Discord
+                    profile information, volunteer applications, volunteer role
+                    information, sponsor and partner contact details, newsletter
+                    subscriptions, photos, video, recordings, and feedback.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Startup, Founder, Client, and Project Information">
+                  <p>
+                    We may collect startup profiles, company descriptions, website
+                    URLs, stage, sector, goals, metrics, milestones, investor asks,
+                    customer themes, team details, traction, funding context,
+                    uploaded files, product screenshots, brand assets, project
+                    briefs, grants information, curriculum materials, client
+                    requirements, SOW details, support tickets, deliverables,
+                    invoices, purchase orders, and project communications.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Connected-Account and Source Data">
+                  <p>
+                    If you choose to connect a third-party service or data source, we
+                    may collect account identifiers, workspace identifiers, OAuth
+                    tokens, permission details, selected files, selected messages,
+                    metadata, extracted text, analytics reports, project records,
+                    finance records, source URLs, uploaded materials, generated
+                    outputs, and other data permitted by the access you grant and the
+                    feature you enable.
+                  </p>
+                </Subsection>
+              </Section>
+
+              <Section id="product-data" title="4. Product-Specific Data">
+                <Subsection title="Vibe Raising">
+                  <p>
+                    Vibe Raising helps founders prepare monthly founder and investor
+                    updates. We may process startup profile data, monthly update
+                    drafts, final updates, metrics, milestones, highlights, risks,
+                    blockers, asks, investor relationship notes, customer or partner
+                    conversations, uploaded materials, source URLs, and optional
+                    connected-source data from services such as Gmail, Google Drive,
+                    Slack, Xero, Linear, Notion, Google Analytics, and Search Console
+                    where enabled.
+                  </p>
+                  <p>
+                    We may also create derived outputs such as relevance scores,
+                    summaries, extracted events, extracted metrics, source context,
+                    suggested asks, draft updates, review notes, and final updates.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Vibe Marketing">
+                  <p>
+                    Vibe Marketing may process startup profiles, public website
+                    content, website URLs, product descriptions, approved founder
+                    updates, approved Vibe Raising outputs, brand assets, customer
+                    personas, topic ideas, keyword research, content templates,
+                    generated drafts, metadata, schema suggestions, internal-linking
+                    suggestions, sitemap information, Google Analytics reports,
+                    Search Console reports, and performance data where connected.
+                  </p>
+                  <p>
+                    Vibe Marketing is designed to use approved outputs and
+                    user-provided marketing inputs by default, not raw Gmail messages
+                    or broad Google Drive content, unless that raw-source use is
+                    clearly disclosed in-product, you choose to enable it, and the
+                    use is permitted by applicable platform policies and law.
+                  </p>
+                </Subsection>
+
+                <Subsection title="MLAI Studio and Project Services">
+                  <p>
+                    MLAI Studio and project services may process project briefs,
+                    business requirements, design files, code repositories, API keys
+                    or credentials you provide, tickets, product analytics, support
+                    logs, documents, meeting notes, client content, third-party
+                    account details, deliverables, invoices, and communications
+                    needed to deliver scoped work, subscriptions, retainers, builder
+                    hours, support, and maintenance.
+                  </p>
+                </Subsection>
+
+                <Subsection title="MLAI Grants, Educational Software, and Client Programs">
+                  <p>
+                    Grant-funded and educational programs may involve participant
+                    registrations, teacher or facilitator information, student or
+                    team submissions, school or partner details, project reports,
+                    curriculum inputs, assessment or judging records, usage logs,
+                    support records, simulated data, de-identified datasets, and
+                    software licence information. Where a program involves children
+                    or students, MLAI aims to collect the minimum information needed
+                    for the educational purpose and to follow applicable school,
+                    partner, consent, and legal requirements.
+                  </p>
+                </Subsection>
+              </Section>
+
+              <Section id="google-data" title="5. Google User Data">
+                <p>
+                  If you connect a Google account, Google will show the exact
+                  permissions requested before you grant access. The Google data MLAI
+                  accesses depends on the product, feature, scopes, consent screen,
+                  and in-product choices you use.
+                </p>
+
+                <Subsection title="Google Account and OAuth Data">
+                  <List>
+                    <li>Google account identifiers such as email address, profile information, and account ID.</li>
+                    <li>OAuth access tokens, refresh tokens, scope grants, token expiry details, and connection status.</li>
+                    <li>Account, property, file, message, thread, label, or service identifiers needed to operate the connected feature.</li>
+                  </List>
+                </Subsection>
+
+                <Subsection title="Gmail Data">
+                  <p>
+                    If you enable a Gmail-powered feature, MLAI may access or process
+                    Gmail data permitted by the scopes you approve, which may include
+                    message and thread identifiers, history identifiers, labels,
+                    headers, dates, subjects, sender and recipient fields, snippets,
+                    body text, cleaned or extracted text, previews, attachment
+                    metadata, attachment content where required for the feature, and
+                    derived artifacts such as relevance scores, summaries, extracted
+                    events, metrics, asks, risks, and generated drafts.
+                  </p>
+                  <p>
+                    Gmail access is used for disclosed user-facing workflows such as
+                    finding relevant context for a founder update that you request.
+                    We do not use Gmail data for advertising, retargeting, data
+                    broker services, credit-worthiness, lending, or generalized AI
+                    model training.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Google Drive Data">
+                  <p>
+                    If you enable Google Drive features, MLAI may access selected
+                    files, file identifiers, folder or permission metadata, document
+                    names, MIME types, modified dates, extracted text, comments or
+                    content where authorised, and derived outputs needed for the
+                    user-facing feature. Where practicable, MLAI prefers selected
+                    file access, file-picker flows, app-created files, or per-file
+                    access rather than broad Drive-wide access.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Google Analytics and Search Console Data">
+                  <p>
+                    If you connect Google Analytics or Search Console, MLAI may
+                    process account, property, site, query, page, landing page,
+                    impressions, clicks, click-through rate, rankings, traffic,
+                    source, medium, conversion, engagement, device, geography, and
+                    reporting data permitted by the scopes you approve. We use this
+                    data for user-facing reporting, marketing insights, content
+                    measurement, and optimisation workflows you enable.
+                  </p>
+                </Subsection>
+              </Section>
+
+              <Section id="other-connected-services" title="6. Other Connected Services">
+                <p>Depending on the features you enable, MLAI may process:</p>
+                <List>
+                  <li><strong>Slack:</strong> workspace identifiers, channel identifiers, selected channel names, public or private channel indicators, messages, threads, timestamps, and metadata.</li>
+                  <li><strong>Xero:</strong> organisation, tenant, invoice, payment, contact, account, report, profit and loss, balance sheet, and metric information permitted by granted scopes.</li>
+                  <li><strong>Linear:</strong> workspace, project, issue, comment, status, assignee, cycle, label, and delivery context.</li>
+                  <li><strong>Notion:</strong> selected pages, databases, blocks, titles, metadata, extracted text, and related content.</li>
+                  <li><strong>Manual materials:</strong> uploaded files, source URLs, notes, pasted text, recorded walkthroughs, pitch decks, screenshots, summaries, and supporting documents.</li>
+                </List>
+              </Section>
+
+              <Section id="ai-processing" title="7. AI Processing">
+                <p>
+                  MLAI may use AI systems and AI infrastructure providers to assist
+                  with drafting, summarisation, extraction, classification, coding,
+                  testing, search, marketing, analytics, education, simulation,
+                  research, review, automation, and support. We may send relevant
+                  inputs and context to those providers only as needed to provide the
+                  user-facing feature, service, project, or support you request.
+                </p>
+                <p>
+                  We do not use Google Workspace API data, including Gmail data or
+                  Google Drive file content, to create, train, or improve generalized
+                  AI or machine learning models. AI-assisted outputs may be retained
+                  as part of your account, project, support, or product history as
+                  described in this policy.
+                </p>
+              </Section>
+
+              <Section id="how-we-use" title="8. How We Use Information">
+                <p>We use information to:</p>
+                <List>
+                  <li>Provide, operate, personalise, maintain, secure, troubleshoot, and improve MLAI Services.</li>
+                  <li>Run events, workshops, hackathons, community programs, volunteer programs, sponsorships, and partnerships.</li>
+                  <li>Create founder updates, marketing drafts, summaries, analytics reports, product recommendations, educational materials, software deliverables, and project outputs you request.</li>
+                  <li>Maintain account access, connected account status, OAuth tokens, product settings, and service records.</li>
+                  <li>Process payments, invoices, refunds, subscriptions, sponsorships, grants, licences, and workshop fees.</li>
+                  <li>Communicate with you about services, support, security, products, events, newsletters, and community activity.</li>
+                  <li>Prevent abuse, protect security, debug issues, enforce terms, comply with law, and protect MLAI, users, partners, and the public.</li>
+                  <li>Prepare de-identified, aggregated, or statistical insights for operations, reporting, community impact, sponsor reporting, grant reporting, and service improvement.</li>
+                </List>
+              </Section>
+
+              <Section id="cross-product" title="9. Cross-Product Data Use">
+                <p>
+                  Where you use multiple MLAI products, we may use your account
+                  information, startup profile, approved outputs, and product
+                  settings across those products to provide a connected experience.
+                  We do not use raw Google Workspace API data, including Gmail
+                  messages or Google Drive file content, for a different MLAI product
+                  unless that use is clearly disclosed in the product, is part of a
+                  user-facing feature you choose to enable, and is permitted by
+                  Google policy and applicable law.
+                </p>
+                <List>
+                  <li><strong>Account data</strong> such as name, email, company, and role may be used across MLAI services.</li>
+                  <li><strong>Startup profile data</strong> such as company description, website, stage, sector, and goals may be used across Vibe Raising and Vibe Marketing with notice.</li>
+                  <li><strong>Approved outputs</strong> such as final founder updates, approved summaries, approved metrics, and approved themes may be used by Vibe Marketing if you opt in or approve that use.</li>
+                  <li><strong>Restricted source data</strong> such as raw Gmail, Google Drive file content, private Slack, Xero, Linear, OAuth tokens, and other connected-source data is not used across products by default.</li>
+                </List>
+              </Section>
+
+              <Section id="sharing" title="10. Sharing and Disclosure">
+                <p>
+                  We do not sell personal information, Google user data, Gmail data,
+                  Google Drive content, or connected-source data. We may disclose
+                  information only in limited circumstances:
+                </p>
+                <List>
+                  <li>To service providers that help us host, operate, secure, analyse, support, communicate, process payments, deliver events, manage email, provide AI infrastructure, or provide the Services.</li>
+                  <li>To AI infrastructure providers only as needed to provide the user-facing feature, service, support, or project you request.</li>
+                  <li>When you direct us to share an output, send an update, invite a collaborator, publish content, submit a project, join an event, or connect a third-party service.</li>
+                  <li>With venues, event partners, sponsors, mentors, judges, facilitators, co-organisers, schools, clients, grant providers, or project partners where needed for the relevant program and disclosed or reasonably expected.</li>
+                  <li>When required by law, regulation, legal process, grant reporting requirement, safety need, security incident response, or to protect rights and prevent abuse.</li>
+                  <li>In connection with a merger, acquisition, financing, reorganisation, or sale of assets, subject to applicable law and any user consent required by Google policy.</li>
+                </List>
+              </Section>
+
+              <Section id="limited-use" title="11. Google Limited Use Commitments">
+                <p>
+                  MLAI's use and transfer of information received from Google APIs
+                  will adhere to the Google API Services User Data Policy, including
+                  the Limited Use requirements. In particular:
+                </p>
+                <List>
+                  <li>We use Google user data only to provide or improve user-facing features that are visible in the requesting MLAI product.</li>
+                  <li>We request Google permissions only where needed for implemented features and aim to use the narrowest practical scopes.</li>
+                  <li>We do not sell Google user data.</li>
+                  <li>We do not use Google user data for advertising, retargeting, personalised advertising, data broker services, credit-worthiness, or lending purposes.</li>
+                  <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
+                  <li>We do not transfer Google user data except as needed to provide or improve a visible user-facing feature with your consent, comply with law, protect security, or as otherwise permitted by Google policy.</li>
+                  <li>We do not allow humans to read Google user data unless you have given affirmative permission for specific data, it is necessary for security or legal compliance, or the data has been aggregated and anonymised for permitted internal operations.</li>
+                </List>
+              </Section>
+
+              <Section id="international" title="12. International Providers and Transfers">
+                <p>
+                  MLAI is based in Australia, but some service providers, hosting
+                  providers, analytics providers, AI infrastructure providers,
+                  payment processors, email tools, and support tools may process
+                  information in other countries. Where we disclose personal
+                  information to overseas providers, we take reasonable steps to use
+                  providers with appropriate privacy, security, confidentiality, and
+                  contractual protections.
+                </p>
+              </Section>
+
+              <Section id="security" title="13. Data Security">
+                <p>
+                  We use technical and organisational safeguards designed to protect
+                  information from unauthorised access, alteration, disclosure, or
+                  destruction. Safeguards may include HTTPS, encryption for sensitive
+                  stored data where applicable, access controls, token protection,
+                  logging, internal access restrictions, least-privilege practices,
+                  and security review of systems that handle connected-source data.
+                  No system is perfectly secure, and you should use care when
+                  choosing what to upload, connect, or share.
+                </p>
+              </Section>
+
+              <Section id="retention-deletion" title="14. Retention, Deletion, and Disconnecting Accounts">
+                <p>
+                  We retain information only for as long as needed to provide the
+                  Services, operate MLAI, comply with legal obligations, resolve
+                  disputes, enforce agreements, maintain security, complete grant or
+                  project reporting, and support legitimate operational purposes.
+                </p>
+                <List>
+                  <li><strong>OAuth tokens</strong> are retained while the relevant connection is active. If you disconnect or revoke access, we delete or invalidate stored tokens within a reasonable time.</li>
+                  <li><strong>Gmail artifacts and Google source context</strong> are retained only while needed for the user-facing workflow, support, security, troubleshooting, legal compliance, or your account history, unless you request deletion or law permits or requires longer retention.</li>
+                  <li><strong>Generated outputs</strong> such as drafts, summaries, reports, marketing content, and final updates may be retained while your account, project, or product history remains active or until deleted or requested for deletion.</li>
+                  <li><strong>Event, workshop, volunteer, sponsor, grant, project, licence, and payment records</strong> may be retained for operational, accounting, legal, tax, grant reporting, insurance, and governance purposes.</li>
+                  <li><strong>Backups and logs</strong> may retain limited data for a reasonable period before deletion cycles complete.</li>
+                </List>
+                <p>
+                  You may disconnect connected accounts in product settings where
+                  available, revoke access directly with the third-party provider, or
+                  email hi@mlai.au. After disconnecting, connector-powered features
+                  may stop working. Historical generated outputs or cached artifacts
+                  may remain until deleted through product controls or by request,
+                  unless retention is required or permitted by law, security, or
+                  legitimate operational needs.
+                </p>
+              </Section>
+
+              <Section id="rights" title="15. Your Rights and Choices">
+                <p>
+                  You may request access, correction, deletion, export, restriction,
+                  or information about how MLAI handles your personal information,
+                  subject to verification, applicable law, technical feasibility,
+                  safety, security, legal, and operational requirements.
+                </p>
+                <List>
+                  <li>You can choose not to connect optional services such as Gmail, Google Drive, Google Analytics, Search Console, Slack, Xero, Linear, or Notion.</li>
+                  <li>You can revoke Google access from your Google Account permissions and disconnect in MLAI settings where available.</li>
+                  <li>You can unsubscribe from marketing emails using the unsubscribe link or by contacting hi@mlai.au.</li>
+                  <li>You can request deletion of account data, connected-source data, generated outputs, or support records by emailing hi@mlai.au with enough detail to verify and action the request.</li>
+                </List>
+              </Section>
+
+              <Section id="marketing" title="16. Marketing Communications">
+                <p>
+                  If you subscribe to MLAI emails, register for an event, join a
+                  community program, use a product, or otherwise engage with MLAI, we
+                  may send service, transactional, product, event, community,
+                  sponsor, or newsletter communications. You can unsubscribe from
+                  marketing emails, but we may still send transactional, security,
+                  account, legal, or service-related messages.
+                </p>
+              </Section>
+
+              <Section id="children-students" title="17. Children and Students">
+                <p>
+                  MLAI's general websites and founder tools are not directed to
+                  children under 13. Some MLAI educational programs, hackathons, or
+                  school software may involve students or young people through a
+                  school, parent, guardian, client, partner, or facilitator. In those
+                  settings, MLAI aims to collect only what is reasonably needed for
+                  the educational program, use simulated or de-identified data where
+                  appropriate, and follow applicable consent, school, partner, and
+                  legal requirements.
+                </p>
+              </Section>
+
+              <Section id="changes-contact" title="18. Changes, Contact, and Complaints">
+                <p>
+                  We may update this Privacy Policy from time to time. We will post
+                  the updated policy on this page and update the "Last updated" date.
+                  If we change how MLAI uses Google user data in a material way, we
+                  will update this Privacy Policy and provide notice or seek consent
+                  where required before using Google user data for the new purpose.
+                </p>
+                <p>
+                  If you have questions, requests, or complaints about this Privacy
+                  Policy or MLAI's privacy practices, contact us at hi@mlai.au. We
+                  will assess privacy complaints and respond within a reasonable
+                  period. If you are not satisfied with our response, you may be able
+                  to contact the Office of the Australian Information Commissioner or
+                  another applicable regulator.
+                </p>
+                <p>
+                  Our <PolicyLink href="/terms">Terms of Service</PolicyLink>{" "}
+                  explain the terms that apply to MLAI websites, events, community
+                  programs, founder tools, connected-account products, project
+                  services, software, workshops, and related services.
+                </p>
+
+                <div className="mt-6 rounded-[1.5rem] bg-[var(--brutalist-black)] p-6 text-white">
+                  <p className="mb-2 text-base leading-7 text-white">
+                    <strong>MLAI Aus Inc</strong>
+                  </p>
+                  <p className="mb-2 text-base leading-7 text-white/80">Email: hi@mlai.au</p>
+                  <p className="text-base leading-7 text-white/80">Website: https://mlai.au</p>
+                </div>
+              </Section>
+            </div>
+          </article>
+        </section>
+      </main>
   );
 }

--- a/app/routes/terms.tsx
+++ b/app/routes/terms.tsx
@@ -1,314 +1,649 @@
+import type { ReactNode } from "react";
 import type { MetaFunction } from "react-router";
-import { Container } from "~/components/ui/Container";
+import SectionDivider from "~/components/SectionDivider";
 
-const LAST_UPDATED = "13 May 2026";
+const LAST_UPDATED = "20 May 2026";
 
 export const meta: MetaFunction = () => {
-    return [
-        { title: "MLAI Vibe Raising Terms of Service" },
-        {
-            name: "description",
-            content:
-                "Terms of Service for MLAI services, including MLAI Vibe Raising, Google/Gmail connections, connected sources, AI-generated monthly updates, retention, and data deletion.",
-        },
-        {
-            name: "keywords",
-            content:
-                "terms of service, MLAI Vibe Raising, Gmail integration, Slack integration, Xero integration, Google OAuth, AI summaries, retention, data deletion",
-        },
-    ];
+  return [
+    { title: "MLAI Terms of Service" },
+    {
+      name: "description",
+      content:
+        "MLAI Terms of Service for MLAI websites, events, community programs, founder tools, Vibe Raising, Vibe Marketing, MLAI Studio, project services, grants, software licences, workshops, connected accounts, AI outputs, payments, acceptable use, and Google API data commitments.",
+    },
+    {
+      name: "keywords",
+      content:
+        "MLAI terms of service, Vibe Raising terms, Vibe Marketing terms, MLAI Studio, software licence, project services, grants, Google OAuth, Gmail integration, AI outputs, Australian Consumer Law",
+    },
+  ];
 };
 
+function Section({ id, title, children }: { id: string; title: string; children: ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-28 border-t border-[var(--brutalist-border)]/15 pt-8">
+      <h2 className="flex items-start gap-3 text-2xl font-black leading-8 tracking-tight text-[var(--brutalist-black)] sm:text-3xl">
+        <span className="mt-3 h-2 w-10 shrink-0 rounded-full bg-[var(--brutalist-orange)]" aria-hidden="true" />
+        <span>{title}</span>
+      </h2>
+      <div className="mt-5 space-y-4 text-base leading-7 text-[var(--brutalist-black)]/75">{children}</div>
+    </section>
+  );
+}
+
+function Subsection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="space-y-4">
+      <h3 className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-blue)]">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function List({ children }: { children: ReactNode }) {
+  return <ul className="list-disc space-y-2 pl-5 marker:text-[var(--brutalist-orange)]">{children}</ul>;
+}
+
+function PolicyLink({
+  href,
+  children,
+  className = "text-[var(--brutalist-blue)]",
+}: {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <a href={href} className={`font-black underline underline-offset-4 ${className}`}>
+      {children}
+    </a>
+  );
+}
+
 export default function TermsOfService() {
-    return (
-        <>
-            <Container className="bg-white pt-32">
-                <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-1 lg:grid-rows-[auto_1fr] lg:gap-y-12">
-                    <div className="lg:order-first lg:row-span-2">
-                        <h1 className="text-4xl pt-12 font-bold tracking-tight text-[#3b82f6] sm:text-5xl dark:text-[#3b82f6]">
-                            MLAI Vibe Raising Terms of Service
-                        </h1>
+  return (
+    <main className="min-h-screen bg-[var(--brutalist-beige)] pb-16 pt-20 text-[var(--brutalist-black)]">
+      <SectionDivider color="#ff3d00" label="Legal" />
+      <section className="bg-[var(--brutalist-beige)] p-2 lg:p-3">
+        <article className="w-full rounded-2xl border border-gray-400 bg-[linear-gradient(180deg,var(--brutalist-beige)_0%,#fffaf1_100%)] p-4 shadow-[0_24px_80px_rgba(26,26,26,0.08)] sm:rounded-[2.5rem] sm:p-8 lg:p-12">
+          <header className="border-b border-[var(--brutalist-border)]/20 pb-10">
+            <div className="flex flex-wrap items-center gap-3 text-xs font-black uppercase tracking-[0.24em] text-[var(--brutalist-orange)]">
+              <span>Legal</span>
+              <span className="h-1 w-8 rounded-full bg-[var(--brutalist-orange)]" aria-hidden="true" />
+              <span>MLAI Aus Inc</span>
+            </div>
 
-                        <div className="mt-16 mb-24 space-y-7 text-base text-zinc-600 dark:text-gray-900">
-                            <h2 className="text-xl font-semibold leading-7 text-gray-900">
-                                Last updated: {LAST_UPDATED}
-                            </h2>
+            <h1
+              className="mt-6 max-w-5xl text-[var(--brutalist-black)]"
+              style={{
+                fontFamily: "'Oswald', sans-serif",
+                fontSize: "clamp(3.25rem, 10vw, 8.5rem)",
+                fontWeight: 700,
+                lineHeight: 0.9,
+              }}
+            >
+              MLAI Terms of Service
+            </h1>
 
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                These Terms of Service ("Terms") govern your access to and use
-                                of MLAI websites, applications, and services, including MLAI
-                                Vibe Raising (collectively, the "Services") provided by MLAI
-                                Aus Inc ("MLAI", "we", "our", or "us").
-                            </p>
+            <p className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-blue)]">
+              Last updated: {LAST_UPDATED}
+            </p>
 
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                By accessing or using the Services, you agree to be bound by
-                                these Terms. If you do not agree, do not use the Services.
-                            </p>
+            <div className="mt-8 grid gap-5 text-lg leading-8 text-[var(--brutalist-black)]/78 lg:grid-cols-2">
+              <p>
+                These Terms of Service ("Terms") govern your access to and use of
+                the websites, applications, events, community programs, founder
+                tools, project services, software, workshops, and other services
+                provided by MLAI Aus Inc ("MLAI", "we", "our", or "us").
+              </p>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                1. The Services
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                MLAI provides community, educational, and software-based tools.
-                                MLAI Vibe Raising helps founders draft monthly startup and
-                                investor updates from information the founder chooses to enter,
-                                upload, generate, or connect. Some features allow you to
-                                connect third-party accounts, including Google, Gmail,
-                                Google Drive, Slack, Xero, Linear, and Notion, or upload
-                                manual materials, so MLAI can process relevant context for
-                                user-requested summaries, drafts, metrics, asks, risks,
-                                and follow-ups.
-                            </p>
+              <p>
+                These Terms apply to MLAI websites, events, community programs,
+                Vibe Raising, Vibe Marketing, MLAI Studio, MLAI Grants and project
+                work, software licensing, paid workshops, subscriptions, builder
+                hours, connected-account products, and related services
+                (collectively, the "Services"). By accessing or using the Services,
+                you agree to be bound by these Terms. If you do not agree, do not
+                use the Services.
+              </p>
+            </div>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                2. Eligibility and Accounts
-                            </h2>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>You must be able to form a legally binding contract to use the Services.</li>
-                                <li>You are responsible for maintaining the confidentiality of your account credentials and for all activity under your account.</li>
-                                <li>You agree to provide accurate, current, and complete information and keep it updated.</li>
-                            </ul>
+            <div className="mt-8 rounded-[1.5rem] bg-[var(--brutalist-black)] p-5 text-white sm:p-6">
+              <p className="text-xs font-black uppercase tracking-[0.24em] text-[var(--brutalist-mint)]">
+                Product schedules
+              </p>
+              <nav className="mt-4 grid gap-2 text-sm font-semibold leading-6 sm:grid-cols-2 lg:grid-cols-3">
+                  <PolicyLink href="#community" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule A - General MLAI Community Terms</PolicyLink>
+                  <PolicyLink href="#vibe-raising" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule B - Vibe Raising Terms</PolicyLink>
+                  <PolicyLink href="#vibe-marketing" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule C - Vibe Marketing Terms</PolicyLink>
+                  <PolicyLink href="#grants-projects" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule D - MLAI Grants and Project Delivery Terms</PolicyLink>
+                  <PolicyLink href="#studio" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule E - MLAI Studio Terms</PolicyLink>
+                  <PolicyLink href="#software-licence" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule F - Software Licence Terms</PolicyLink>
+                  <PolicyLink href="#workshops" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule G - Paid Workshops and Organiser Terms</PolicyLink>
+                </nav>
+              </div>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                3. Connected Accounts, OAuth, and Source Analysis
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Connector use is optional. If you choose to connect an
-                                account, workspace, channel, file store, or project system,
-                                you authorize MLAI to access the data you explicitly grant
-                                through the relevant consent screen, API authorization, or
-                                in-product selection flow for the purpose of providing the
-                                MLAI Vibe Raising feature you requested.
-                            </p>
+            </header>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.1 What you are authorizing
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Depending on the feature you enable, MLAI may access data from
-                                connected services such as Gmail messages and attachments,
-                                Slack channels and threads, Xero invoices, payments, contacts,
-                                accounts and reports, Linear projects and issues, Notion
-                                pages, Google Drive files, manual materials, and related
-                                metadata. The exact permissions are shown on the relevant
-                                consent screen or connector UI before you grant access.
-                            </p>
+            <div className="mt-10 space-y-10">
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.2 What we do with connected-source data
-                            </h3>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>We use connected-source data only to provide or improve the user-facing MLAI Vibe Raising workflow you requested.</li>
-                                <li>We use source context to identify relevant update signals such as investor feedback, customer conversations, milestones, risks, asks, metrics, financial changes, delivery progress, and follow-ups.</li>
-                                <li>We may process connected-source data using automated systems and AI models to produce requested drafts, summaries, extracted facts, metrics, evidence, and related outputs.</li>
-                                <li>We may store OAuth tokens, connected account identifiers, selected source artifacts, extracted text, and derived outputs while needed to provide the Services.</li>
-                            </ul>
+              <Section id="who-we-are" title="1. Who We Are">
+                <p>
+                  MLAI Aus Inc is a not-for-profit community based in Australia
+                  that aims to empower the Australian AI community through events,
+                  education, learning-by-doing programs, founder tools, software,
+                  project delivery, sponsorships, partnerships, and community
+                  programs.
+                </p>
+                <p>
+                  These Terms are intended to operate as MLAI's standard terms for
+                  general community participation, software tools, licences, project
+                  services, grants, events, workshops, and related deliverables
+                  unless MLAI and a counterparty have signed a separate written
+                  agreement that says otherwise.
+                </p>
+              </Section>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.3 Google API data use commitments
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                MLAI's use and transfer of information received from Google
-                                APIs will adhere to the Google API Services User Data Policy,
-                                including the Limited Use requirements. In particular:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>We do not sell Google user data or Gmail data.</li>
-                                <li>We do not use Google user data or Gmail data for advertising, retargeting, credit-worthiness, lending, data broker, or information reseller purposes.</li>
-                                <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
-                                <li>We limit access, transfer, and human review of Google user data to what is permitted by our Privacy Policy, your consent, applicable law, security needs, and Google policy.</li>
-                            </ul>
+              <Section id="services-covered" title="2. Services Covered">
+                <p>The Services may include:</p>
+                <List>
+                  <li>MLAI websites, articles, resources, guides, newsletters, and public content.</li>
+                  <li>Events, hackathons, workshops, meetups, community programs, and member spaces.</li>
+                  <li>Founder tools, including Vibe Raising and Vibe Marketing.</li>
+                  <li>MLAI Studio services, builder hours, subscriptions, retainers, and scoped delivery work.</li>
+                  <li>Grant-funded, sponsored, educational, software, research, innovation, and project delivery work.</li>
+                  <li>Software licences, hosted tools, educational simulations, maintenance, support, configuration, and feature enhancements.</li>
+                  <li>Paid workshops, organiser services, sponsorship packages, and related attendee or sponsor deliverables.</li>
+                </List>
+              </Section>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.4 What we store
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Our goal is to minimize the source data we store while still
-                                providing the MLAI Vibe Raising workflow you requested. We may
-                                store:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li><strong>Connection data:</strong> OAuth tokens, refresh tokens, and basic account or workspace identifiers while your connection is active.</li>
-                                <li><strong>Selected Gmail artifacts:</strong> message and thread metadata, extracted or cleaned text, attachment information, relevance signals, and source context needed to generate, display, troubleshoot, and improve the requested update workflow.</li>
-                                <li><strong>Other source artifacts:</strong> selected Slack messages, Xero records, Linear issues, Notion pages, Google Drive documents, uploaded files, source URLs, extracted text, and related metadata needed for the requested workflow.</li>
-                                <li><strong>Derived outputs:</strong> monthly update drafts, summaries, insights, events, metrics, evidence, recommendations, asks, follow-ups, and other outputs associated with your account.</li>
-                            </ul>
+              <Section id="eligibility-accounts" title="3. Eligibility and Accounts">
+                <List>
+                  <li>You must be able to form a legally binding contract to use the Services.</li>
+                  <li>You must provide accurate, current, and complete information and keep it updated.</li>
+                  <li>You are responsible for maintaining the confidentiality of your account credentials and for activity under your account.</li>
+                  <li>You must only use accounts, workspaces, API keys, files, datasets, platforms, content, or third-party services that you own, administer, or are authorised to use.</li>
+                  <li>If you use the Services on behalf of an organisation, you represent that you have authority to bind that organisation to these Terms.</li>
+                </List>
+              </Section>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.5 Data retention
-                            </h3>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li><strong>OAuth tokens:</strong> We retain tokens while your Gmail connection is active. If you disconnect Google/Gmail, revoke access, or delete your account, we will delete or invalidate stored tokens within a reasonable time.</li>
-                                <li><strong>Gmail artifacts and source context:</strong> We retain selected artifacts only while needed to provide, display, troubleshoot, secure, and improve the user-facing update workflow, unless you request deletion or a longer period is required or permitted by law.</li>
-                                <li><strong>Other connected-source artifacts:</strong> We retain selected artifacts, uploaded materials, extracted text, evidence, and connector settings only while needed for the requested workflow, unless you request deletion or a longer period is required or permitted by law.</li>
-                                <li><strong>Derived outputs:</strong> We retain generated drafts and reports while your account remains active or until you delete them or request deletion, subject to legal, security, and operational requirements.</li>
-                            </ul>
+              <Section id="community" title="4. Schedule A - General MLAI Community Terms">
+                <Subsection title="Events, Hackathons, and Workshops">
+                  <List>
+                    <li>MLAI may run in-person, online, hybrid, public, private, free, paid, sponsored, or grant-funded events, workshops, hackathons, and education programs.</li>
+                    <li>Registration, ticketing, refunds, cancellations, rescheduling, venue rules, eligibility, judging, prizes, and workshop materials may be governed by event-specific terms in addition to these Terms.</li>
+                    <li>MLAI may cancel, postpone, reschedule, change venues, change speakers, modify formats, or refuse entry where reasonably necessary.</li>
+                    <li>Unless required by law or stated in event-specific terms, ticket refunds and transfers are handled at MLAI's discretion.</li>
+                    <li>You are responsible for your own travel, accommodation, equipment, dietary requirements, allergy management, health needs, and participation decisions.</li>
+                    <li>MLAI does not guarantee jobs, funding, investment, introductions, prizes, rankings, commercial outcomes, technical outcomes, or business success from any event or program.</li>
+                  </List>
+                </Subsection>
 
-                            <h3 className="mt-6 text-lg font-semibold leading-7 text-gray-900">
-                                3.6 Disconnecting, deleting data, and revoking access
-                            </h3>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You can disconnect connected accounts from MLAI in account
-                                settings where available, revoke MLAI&apos;s access directly
-                                with the relevant third-party provider, or email hi@mlai.au.
-                                After you disconnect or revoke access, connector-powered
-                                features may stop working.
-                            </p>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you want MLAI to delete data associated with a connector,
-                                generated updates, or AI outputs, you can use the settings
-                                area where available or email hi@mlai.au with your request.
-                                Please include the MLAI account email and, where relevant, the
-                                third-party account or workspace you connected. We will action
-                                deletion requests within a reasonable time and confirm where
-                                applicable.
-                            </p>
+                <Subsection title="Community Spaces and Conduct">
+                  <List>
+                    <li>MLAI may provide community spaces such as Slack, Discord, mailing lists, member directories, event groups, forums, and other collaboration channels.</li>
+                    <li>You must participate respectfully, lawfully, and consistently with any code of conduct or moderation rules published by MLAI.</li>
+                    <li>MLAI may moderate, remove, suspend, restrict, or terminate access to community spaces or events if conduct creates risk, disrupts the community, breaches these Terms, or is otherwise inappropriate.</li>
+                    <li>Community posts, jobs, opportunities, sponsor content, member profiles, and third-party offers are not endorsed by MLAI unless expressly stated.</li>
+                  </List>
+                </Subsection>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                4. Your Responsibilities
-                            </h2>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>You may only connect accounts, workspaces, channels, files, and data that you own, administer, or are authorized to use.</li>
-                                <li>You are responsible for ensuring that your use of the Services complies with applicable laws, regulations, confidentiality obligations, and contracts with third parties.</li>
-                                <li>You are responsible for reviewing any generated update, summary, metric, ask, or other output before relying on it or sharing it with investors or other recipients.</li>
-                            </ul>
+                <Subsection title="Photos, Video, and Recordings">
+                  <p>
+                    MLAI events may be photographed, filmed, livestreamed, or
+                    recorded. By attending an event, you consent to MLAI capturing
+                    and using event media that may include your image, likeness, or
+                    voice for event operations, community updates, education,
+                    archives, reporting, and promotion, unless you notify MLAI in
+                    advance or at the event that you do not want to be featured
+                    where reasonably practicable.
+                  </p>
+                </Subsection>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                5. Acceptable Use
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You agree not to misuse the Services. You must not, and must
-                                not attempt to:
-                            </p>
-                            <ul className="mt-4 list-disc pl-5 space-y-2 text-base leading-7 text-zinc-600">
-                                <li>Access or use the Services in a way that violates any law or infringes the rights of others.</li>
-                                <li>Connect accounts, emails, files, or other data that you are not authorized to use.</li>
-                                <li>Attempt to gain unauthorized access to any accounts, systems, or networks.</li>
-                                <li>Reverse engineer, decompile, or attempt to extract the source code of the Services except to the extent permitted by law.</li>
-                                <li>Upload or transmit malware or interfere with the operation or security of the Services.</li>
-                                <li>Use the Services to send spam, deceptive communications, unlawful content, or unsolicited commercial mail.</li>
-                            </ul>
+                <Subsection title="Volunteers, Sponsors, and Partners">
+                  <List>
+                    <li>Volunteer participation does not create an employment relationship unless separately agreed in writing.</li>
+                    <li>Volunteer reimbursements are payable only if MLAI approves them in advance.</li>
+                    <li>Volunteers must protect confidential information, use MLAI systems responsibly, follow access rules, and disclose conflicts of interest.</li>
+                    <li>Sponsor recognition, event involvement, brand use, speaker slots, attendee-list access, content rights, and sponsorship deliverables must be agreed with MLAI.</li>
+                    <li>Sponsorship or partnership does not mean MLAI endorses a sponsor, product, service, investment opportunity, or job listing unless expressly stated.</li>
+                  </List>
+                </Subsection>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                6. AI Outputs and Disclaimers
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                The Services may produce outputs generated by automated systems
-                                or AI models. AI-generated outputs may be inaccurate,
-                                incomplete, outdated, or misleading. You must review outputs
-                                before relying on them. Outputs are not professional advice,
-                                including legal, financial, tax, investment, medical, or
-                                security advice.
-                            </p>
+                <Subsection title="Educational Content">
+                  <p>
+                    MLAI articles, guides, talks, workshops, templates, resources,
+                    hackathon materials, and educational programs are provided for
+                    general educational and community purposes. They are not legal,
+                    financial, tax, investment, medical, engineering, energy-market,
+                    environmental, public policy, cyber security, or other
+                    professional advice unless MLAI expressly agrees otherwise in a
+                    separate written engagement with a qualified professional.
+                  </p>
+                </Subsection>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                7. Intellectual Property
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We and our licensors own all rights, title, and interest in and
-                                to the Services, including all intellectual property rights. You
-                                retain ownership of your content. You grant MLAI a limited
-                                license to process your content solely to provide, operate,
-                                secure, support, and improve the Services in accordance with
-                                these Terms and our Privacy Policy.
-                            </p>
+              <Section id="connected-accounts" title="5. Connected Accounts and OAuth">
+                <p>
+                  Some Services allow you to connect third-party accounts,
+                  workspaces, analytics properties, file stores, communication
+                  systems, project systems, finance systems, or other data sources.
+                  Connector use is optional unless a specific project or SOW requires
+                  it.
+                </p>
+                <List>
+                  <li>You authorise MLAI to access and process the data you grant through the relevant consent screen, API authorisation, in-product disclosure, file picker, account setting, or connector UI.</li>
+                  <li>The exact permissions requested should be shown before you grant access. You should not connect a service unless you understand and accept the requested access.</li>
+                  <li>You may disconnect connected accounts where product controls are available, revoke access directly with the third-party provider, or contact MLAI at hi@mlai.au.</li>
+                  <li>Connector features may stop working if you revoke access, scopes change, a provider changes its API or policy, tokens expire, the third-party service is unavailable, or you no longer have permissions.</li>
+                </List>
+                <Subsection title="Google API Data Commitments">
+                  <p>
+                    MLAI's use and transfer of information received from Google APIs
+                    will adhere to the Google API Services User Data Policy,
+                    including the Limited Use requirements. In particular:
+                  </p>
+                  <List>
+                    <li>We do not sell Google user data or Gmail data.</li>
+                    <li>We do not use Google user data for advertising, retargeting, personalised advertising, data broker services, credit-worthiness, or lending purposes.</li>
+                    <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
+                    <li>We use Google user data only for disclosed user-facing features that you choose to enable and as otherwise permitted by Google policy and applicable law.</li>
+                    <li>We limit human access to Google user data to cases permitted by Google policy, such as your affirmative agreement, support, security, legal compliance, or aggregated internal operations.</li>
+                  </List>
+                </Subsection>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                8. Third-Party Services
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                The Services may integrate with third-party services,
-                                including Google, Gmail, Google Drive, Slack, Xero, Linear,
-                                Notion, OpenAI, and infrastructure providers. Third-party
-                                services are governed by their own terms and policies. MLAI is
-                                not responsible for third-party services. Connector features
-                                may be affected by third-party API outages, rate limits,
-                                revoked scopes, expired tokens, permission changes, product
-                                changes, policy changes, or account restrictions.
-                            </p>
+              <Section id="ai-outputs" title="6. AI Outputs and User Review">
+                <p>
+                  The Services may use automated systems and AI models to assist with
+                  drafting, summarisation, coding, analysis, marketing, education,
+                  research, extraction, recommendations, simulation, and support.
+                  AI-generated or AI-assisted outputs may be inaccurate, incomplete,
+                  outdated, biased, unsafe, unsuitable, or misleading.
+                </p>
+                <List>
+                  <li>You must review outputs before relying on them, publishing them, sending them, deploying them, presenting them, or using them in decisions.</li>
+                  <li>You are responsible for the accuracy, legality, suitability, approvals, permissions, and third-party rights associated with your content and your use of outputs.</li>
+                  <li>MLAI does not guarantee that AI outputs will be error-free, original, secure, compliant, production-ready, commercially effective, or suitable for any particular purpose.</li>
+                  <li>Outputs are not professional advice unless MLAI expressly agrees otherwise in a separate written engagement.</li>
+                </List>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                9. Suspension and Termination
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We may suspend or terminate your access to the Services if we
-                                reasonably believe you have violated these Terms, pose a risk to
-                                the Services, or where required by law. You may stop using the
-                                Services at any time and may revoke connected account access as
-                                described above.
-                            </p>
+              <Section id="user-content-ip" title="7. User Content, MLAI IP, and Licences">
+                <Subsection title="Your Content">
+                  <p>
+                    You retain ownership of content, data, materials, files,
+                    prompts, instructions, brand assets, business information, and
+                    other inputs that you provide to MLAI ("User Content"). You grant
+                    MLAI a limited licence to host, copy, process, transmit, analyse,
+                    display, transform, and use User Content as needed to provide,
+                    operate, secure, support, troubleshoot, improve, and document the
+                    Services, subject to these Terms and our{" "}
+                    <PolicyLink href="/privacy">Privacy Policy</PolicyLink>.
+                  </p>
+                </Subsection>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                10. Disclaimer of Warranties
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                To the maximum extent permitted by law, the Services are
-                                provided on an "as is" and "as available" basis. We disclaim all
-                                warranties, express or implied, including implied warranties of
-                                merchantability, fitness for a particular purpose, and
-                                non-infringement.
-                            </p>
+                <Subsection title="MLAI Intellectual Property">
+                  <p>
+                    MLAI and its licensors retain ownership of MLAI websites,
+                    software, source code, platform code, game systems, simulations,
+                    templates, reusable components, educational materials, tools,
+                    libraries, automations, prompts, workflows, designs, models,
+                    processes, documentation, know-how, improvements, and other
+                    pre-existing or reusable materials unless a signed written
+                    agreement expressly transfers ownership.
+                  </p>
+                </Subsection>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                11. Limitation of Liability
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                To the maximum extent permitted by law, MLAI will not be liable
-                                for any indirect, incidental, special, consequential, or punitive
-                                damages, or any loss of profits, revenue, data, goodwill, or
-                                business opportunity arising from or related to your use of the
-                                Services.
-                            </p>
+                <Subsection title="Community and Workshop Contributions">
+                  <p>
+                    If you contribute ideas, feedback, code, content, designs,
+                    prompts, examples, workshop materials, hackathon submissions, or
+                    suggestions to MLAI, you grant MLAI a non-exclusive, worldwide,
+                    royalty-free licence to use, reproduce, adapt, publish, display,
+                    distribute, and improve those contributions for community,
+                    educational, product, operational, and promotional purposes,
+                    unless MLAI has agreed different written terms.
+                  </p>
+                </Subsection>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                12. Indemnity
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                You agree to indemnify and hold harmless MLAI from and against
-                                any claims, liabilities, damages, losses, and expenses arising
-                                out of or related to your use of the Services, your content,
-                                connected accounts or data, or your violation of these Terms.
-                            </p>
+              <Section id="confidentiality" title="8. Confidentiality">
+                <p>
+                  If a project, workshop, founder workflow, grant, studio engagement,
+                  or community role gives you access to non-public information, you
+                  must keep that information confidential and use it only for the
+                  purpose for which it was provided. MLAI will use reasonable care to
+                  protect confidential information you provide, subject to these
+                  Terms, our Privacy Policy, agreed project terms, support needs,
+                  security needs, and legal obligations.
+                </p>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                13. Privacy
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                Our <a href="/privacy" className="font-semibold text-[#3b82f6] underline">Privacy Policy</a>{" "}
-                                explains how we collect, use, protect, retain, and delete
-                                personal information, including Google user data and Gmail data.
-                                By using the Services, you acknowledge our Privacy Policy.
-                            </p>
+              <Section id="vibe-raising" title="9. Schedule B - Vibe Raising Terms">
+                <p>
+                  Vibe Raising helps founders prepare monthly startup and investor
+                  updates, structure highlights, metrics, risks, asks, milestones,
+                  follow-ups, and relationship context, and may support optional
+                  publishing or investor-readiness workflows.
+                </p>
+                <List>
+                  <li>Vibe Raising may process information you enter, upload, generate, approve, or connect, including startup profiles, monthly updates, investor asks, customer context, company metrics, source URLs, uploaded materials, Gmail, Google Drive, Slack, Xero, Linear, Notion, and other enabled sources.</li>
+                  <li>Connected accounts are optional. You must own, administer, or have authority to connect the relevant account, workspace, files, channels, or data.</li>
+                  <li>You must review every generated founder update, metric, claim, summary, ask, and follow-up before sending, publishing, or relying on it.</li>
+                  <li>You must not include confidential third-party information, investor information, customer information, employee information, or regulated information unless you have the rights and lawful basis to use it.</li>
+                  <li>You must not use Vibe Raising to mislead investors, customers, grant providers, partners, sponsors, or other recipients.</li>
+                </List>
+                <Subsection title="Investor Introduction Disclaimer">
+                  <p>
+                    MLAI may, at its discretion, introduce founders to investors,
+                    mentors, sponsors, ecosystem partners, community members, or
+                    other contacts. MLAI does not guarantee introductions, investment,
+                    investor interest, due diligence outcomes, funding, valuations,
+                    revenue, business success, or any other commercial result.
+                  </p>
+                </Subsection>
+                <Subsection title="No Fundraising or Investment Advice">
+                  <p>
+                    Vibe Raising is not legal, financial, tax, investment,
+                    fundraising, securities, or accounting advice. You are responsible
+                    for obtaining professional advice where appropriate.
+                  </p>
+                </Subsection>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                14. Changes to These Terms
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                We may update these Terms from time to time. We will post the
-                                updated Terms on this page and update the "Last updated" date.
-                                Your continued use of the Services after changes become
-                                effective constitutes acceptance of the updated Terms.
-                            </p>
+              <Section id="vibe-marketing" title="10. Schedule C - Vibe Marketing Terms">
+                <p>
+                  Vibe Marketing may help founders and teams with AI-assisted
+                  marketing strategy, SEO, AEO, GEO, topic discovery, keyword
+                  clustering, content templates, startup profiles, article and page
+                  generation, metadata, schema suggestions, internal linking,
+                  sitemap workflows, analytics-driven recommendations, and optional
+                  publishing workflows.
+                </p>
+                <List>
+                  <li>Vibe Marketing may use user-provided startup profiles, website URLs, public website content, approved founder updates, approved Vibe Raising outputs, Google Analytics, Search Console, keyword tools, public search data, uploaded assets, product screenshots, customer personas, and other authorised materials.</li>
+                  <li>Generated content is draft content unless you or an authorised user approves or publishes it.</li>
+                  <li>You are responsible for reviewing accuracy, legality, brand fit, claims, pricing, testimonials, case studies, regulated-industry statements, competitor references, third-party rights, and confidentiality before publishing.</li>
+                  <li>You must not use Vibe Marketing for doorway pages, spam, deceptive content, impersonation, fake reviews, fabricated case studies, unlawful scraping, undisclosed paid endorsements, or infringing content.</li>
+                  <li>MLAI does not guarantee search rankings, traffic, conversions, revenue, backlinks, citations by AI systems, investor interest, customer acquisition, brand outcomes, or marketing performance.</li>
+                </List>
+                <Subsection title="Cross-Product Use With Vibe Raising">
+                  <p>
+                    Some MLAI products work together. For example, Vibe Raising may
+                    help you prepare founder updates, and Vibe Marketing may help you
+                    turn approved company information, website content, approved
+                    updates, metrics, or themes into marketing content. We will only
+                    use connected-source data across products where that use is
+                    disclosed, user-facing, authorised by you, and permitted by
+                    applicable third-party platform policies.
+                  </p>
+                  <p>
+                    Vibe Marketing should use approved outputs from Vibe Raising,
+                    such as final founder updates, approved company profiles,
+                    approved metrics summaries, and approved customer themes, rather
+                    than raw Gmail messages or broad Google Drive file content unless
+                    that raw-source use is specifically disclosed and enabled by you.
+                  </p>
+                </Subsection>
+              </Section>
 
-                            <h2 className="mt-8 text-xl font-semibold leading-7 text-gray-900">
-                                15. Contact Us
-                            </h2>
-                            <p className="mt-4 text-base leading-7 text-zinc-600">
-                                If you have questions about these Terms, contact us at:
-                            </p>
+              <Section id="grants-projects" title="11. Schedule D - MLAI Grants and Project Delivery Terms">
+                <p>
+                  MLAI may receive grants, sponsorships, purchase orders, invoices,
+                  statements of work, or project funding to deliver educational,
+                  software, community, research, innovation, or project services.
+                  The applicable proposal, invoice, grant agreement, purchase order,
+                  statement of work, or written project terms define the specific
+                  deliverables. These Terms fill gaps unless a signed written
+                  agreement says otherwise. If there is a conflict, signed
+                  project-specific terms prevail to the extent of the conflict.
+                </p>
+                <Subsection title="Deliverables and Project Structure">
+                  <List>
+                    <li>Deliverables may include software builds, hosted access, simulations, games, learning materials, workshops, reports, training, documentation, support, maintenance, configuration, data work, and facilitation.</li>
+                    <li>Milestones, acceptance criteria, timelines, fees, licence scope, support levels, and included features are set out in the relevant proposal, invoice, purchase order, grant agreement, or SOW.</li>
+                    <li>Clients and co-funders must provide timely feedback, assets, approvals, access, subject-matter input, data, branding, curriculum direction, and other dependencies reasonably needed for delivery.</li>
+                    <li>MLAI is not responsible for delays caused by missing feedback, delayed approvals, unavailable third-party services, missing access, changed requirements, or client-side dependencies.</li>
+                    <li>Change requests, expanded deployment, new integrations, major curriculum changes, additional modules, substantial UI redesign, and new feature work are separate work unless expressly included in the SOW.</li>
+                  </List>
+                </Subsection>
 
-                            <div className="mt-4 bg-gray-50 p-6 rounded-lg">
-                                <p className="mb-2 text-base leading-7 text-zinc-600">
-                                    <strong>MLAI Aus Inc</strong>
-                                </p>
-                                <p className="mb-2 text-base leading-7 text-zinc-600">Email: hi@mlai.au</p>
-                                <p className="text-base leading-7 text-zinc-600">Website: https://mlai.au</p>
-                            </div>
-                        </div>
-                    </div>
+                <Subsection title="Acceptance">
+                  <p>
+                    Unless the relevant SOW says otherwise, deliverables are accepted
+                    when MLAI makes them available for use, delivery, testing, or
+                    review and the client does not reject them in writing with
+                    specific material defects within 10 business days. Minor defects,
+                    ordinary support issues, and enhancement requests do not prevent
+                    acceptance and may be handled through support, maintenance, or
+                    change-request processes.
+                  </p>
+                </Subsection>
+              </Section>
+
+              <Section id="studio" title="12. Schedule E - MLAI Studio Terms">
+                <p>
+                  MLAI Studio may provide AI-assisted product building, design,
+                  prototyping, automation, development, content, integration,
+                  analysis, research, product support, builder hours, subscriptions,
+                  retainers, or fixed-scope work.
+                </p>
+                <List>
+                  <li>Builder hours are time spent by MLAI personnel, contributors, or approved contractors on agreed work, including planning, scoping, development, design, prompting, debugging, testing, documentation, review, meetings, deployment, and project coordination.</li>
+                  <li>Meetings, project management, review, documentation, QA, deployment, and coordination may count as builder hours unless the applicable SOW says otherwise.</li>
+                  <li>Unused hours expire at the end of the billing period unless the applicable plan or SOW expressly allows rollover.</li>
+                  <li>Urgent work, out-of-scope work, substantial revisions, new integrations, production hardening, security reviews, legal reviews, and support outside the agreed scope may require additional fees.</li>
+                  <li>Unless otherwise agreed, the client is responsible for maintaining third-party accounts, API keys, billing, licences, domain names, hosting, analytics accounts, backups, and platform permissions.</li>
+                  <li>MLAI Studio provides builder capacity and project support. MLAI does not guarantee funding, customers, revenue, production readiness, regulatory approval, search rankings, investment, or business success.</li>
+                </List>
+                <Subsection title="Studio Deliverables and IP">
+                  <p>
+                    Unless the applicable SOW says otherwise, the client owns bespoke
+                    deliverables created specifically for the client after full
+                    payment, except MLAI retains ownership of MLAI background IP,
+                    templates, reusable components, libraries, tools, automations,
+                    prompts, platform code, systems, workflows, know-how, and
+                    pre-existing materials.
+                  </p>
+                </Subsection>
+              </Section>
+
+              <Section id="software-licence" title="13. Schedule F - Software Licence Terms">
+                <Subsection title="Software Ownership">
+                  <p>
+                    Unless expressly agreed otherwise in writing, MLAI retains all
+                    intellectual property rights in MLAI software, source code, game
+                    systems, simulations, templates, reusable components, designs,
+                    educational materials, assets, workflows, know-how, and
+                    improvements.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Client Licence">
+                  <p>
+                    A client receives a non-exclusive, non-transferable licence to
+                    access and use MLAI software for the agreed program, term, users,
+                    sites, and purposes stated in the applicable proposal, invoice,
+                    licence document, purchase order, or SOW. No ownership transfer
+                    occurs unless MLAI expressly agrees in a signed written
+                    assignment.
+                  </p>
+                </Subsection>
+
+                <Subsection title="Maintenance and Enhancements">
+                  <List>
+                    <li>Basic maintenance means bug fixes, reasonable technical support, compatibility or security updates, and minor corrections required to keep the software usable for the agreed program, only where included in the proposal, invoice, licence, or SOW.</li>
+                    <li>Basic maintenance does not include new features, new modules, new integrations, expanded deployment, major curriculum changes, substantial UI redesign, new asset packs, or production-scale support unless expressly included.</li>
+                    <li>New features, material UI changes, additional modules, integrations, expanded deployment, curriculum redevelopment, and new asset packs are separate enhancement work unless expressly included in the SOW.</li>
+                    <li>Payment for configuration, enhancements, feature work, or support does not transfer ownership of the underlying software or MLAI platform.</li>
+                  </List>
+                </Subsection>
+
+                <Subsection title="Carbon, Cost & Convenience">
+                  <p>
+                    Carbon, Cost &amp; Convenience is MLAI-owned educational software.
+                    Monash Tech School receives a non-exclusive, non-transferable
+                    licence to use the software for the Monash Tech School /
+                    Supersystems educational program for the period stated in the
+                    applicable invoice, proposal, or SOW. Unless a later written
+                    agreement says otherwise, the licence period is 1 November 2025
+                    to 1 November 2027.
+                  </p>
+                  <p>
+                    Additional feature work, including the additional $24,300
+                    enhancement package, is a fixed-fee enhancement package to the
+                    existing licensed software. It does not transfer ownership, does
+                    not create a subscription, and does not extend the licence term
+                    unless agreed in writing.
+                  </p>
+                  <p>
+                    Carbon, Cost &amp; Convenience is an educational simulation. It is
+                    not engineering, energy-market, financial, environmental, legal,
+                    or public policy advice.
+                  </p>
+                </Subsection>
+              </Section>
+
+              <Section id="workshops" title="14. Schedule G - Paid Workshops and Organiser Terms">
+                <List>
+                  <li>Paid workshops may be governed by separate invoices, event pages, proposals, ticketing terms, sponsorship terms, or organiser agreements.</li>
+                  <li>Workshop materials, examples, recordings, templates, code, and slides remain MLAI IP or speaker IP unless expressly transferred in writing.</li>
+                  <li>Attendee lists, sponsor leads, event recordings, and workshop outputs may only be used as agreed with MLAI and in accordance with applicable privacy requirements.</li>
+                  <li>Organiser payments, speaker fees, sponsor payments, revenue shares, reimbursement arrangements, and ticketing splits must be agreed in writing.</li>
+                </List>
+              </Section>
+
+              <Section id="fees-payment" title="15. Fees, Taxes, Subscriptions, and Credits">
+                <List>
+                  <li>Fees, GST, payment timing, renewal terms, subscription terms, credit packs, builder-hour packs, workshop fees, sponsorship fees, and licence fees are set out in the applicable checkout, invoice, proposal, SOW, or written agreement.</li>
+                  <li>Unless stated otherwise, fees are payable in Australian dollars and are exclusive of GST and third-party fees.</li>
+                  <li>MLAI may suspend or limit paid Services for unpaid amounts, failed payments, expired subscriptions, or payment disputes, subject to applicable law.</li>
+                  <li>Subscriptions renew for the stated billing period unless cancelled in accordance with the applicable plan or SOW.</li>
+                  <li>Credits, builder-hour packs, and prepaid services expire according to the applicable plan, invoice, or SOW.</li>
+                </List>
+              </Section>
+
+              <Section id="acceptable-use" title="16. Acceptable Use">
+                <p>You must not, and must not attempt to:</p>
+                <List>
+                  <li>Use the Services unlawfully, deceptively, abusively, or in a way that infringes third-party rights.</li>
+                  <li>Connect accounts, files, datasets, workspaces, channels, messages, records, or systems that you are not authorised to use.</li>
+                  <li>Upload, generate, publish, or send unlawful, misleading, defamatory, infringing, harassing, discriminatory, harmful, unsafe, confidential, or malicious content.</li>
+                  <li>Use the Services to send spam, mass unsolicited messages, fake reviews, deceptive advertising, or misleading investor or customer communications.</li>
+                  <li>Reverse engineer, scrape, bypass, overload, compromise, probe, or interfere with the Services or related systems except as permitted by law.</li>
+                  <li>Upload malware, exploit code, secrets, tokens, API keys, credentials, or data you do not have authority to process.</li>
+                  <li>Use the Services to make high-risk decisions without appropriate human review, professional advice, testing, and safeguards.</li>
+                </List>
+              </Section>
+
+              <Section id="third-party-services" title="17. Third-Party Services">
+                <p>
+                  The Services may integrate with third-party services, including
+                  Google, Gmail, Google Drive, Google Analytics, Search Console,
+                  Slack, Xero, Linear, Notion, payment processors, hosting providers,
+                  AI infrastructure providers, email tools, analytics services,
+                  ticketing platforms, and other software or infrastructure
+                  providers. Third-party services are governed by their own terms and
+                  policies. MLAI is not responsible for third-party service outages,
+                  API changes, rate limits, account restrictions, scope changes,
+                  billing issues, security incidents, or policy changes.
+                </p>
+              </Section>
+
+              <Section id="disclaimers" title="18. Disclaimers">
+                <p>
+                  To the maximum extent permitted by law, the Services are provided
+                  on an "as is" and "as available" basis. MLAI does not warrant that
+                  the Services will be uninterrupted, secure, error-free, compliant
+                  with every use case, or suitable for your particular needs.
+                </p>
+                <p>
+                  MLAI does not guarantee fundraising outcomes, investment, investor
+                  interest, search rankings, traffic, conversions, customers,
+                  revenue, prizes, jobs, grants, educational outcomes, software
+                  availability, regulatory compliance, production readiness, or
+                  business success.
+                </p>
+              </Section>
+
+              <Section id="australian-consumer-law" title="19. Australian Consumer Law">
+                <p>
+                  Nothing in these Terms excludes, restricts, or modifies any rights,
+                  guarantees, warranties, or remedies that cannot be excluded,
+                  restricted, or modified under the Australian Consumer Law or other
+                  applicable law.
+                </p>
+                <p>
+                  Where MLAI is permitted by law to limit its liability for breach of
+                  a non-excludable guarantee, MLAI may limit its liability to the
+                  resupply of the relevant services, payment of the cost of resupply,
+                  repair or replacement of the relevant goods or software, or payment
+                  of the cost of repair or replacement, as applicable.
+                </p>
+              </Section>
+
+              <Section id="liability" title="20. Limitation of Liability and Indemnity">
+                <p>
+                  To the maximum extent permitted by law, MLAI is not liable for
+                  indirect, incidental, special, consequential, punitive, exemplary,
+                  or economic loss, or any loss of profits, revenue, goodwill,
+                  opportunity, business interruption, data, content, contracts,
+                  funding, investment, search rankings, customers, or reputation
+                  arising from or related to the Services.
+                </p>
+                <p>
+                  You agree to indemnify MLAI against claims, liabilities, damages,
+                  losses, and expenses arising out of or related to your use of the
+                  Services, your User Content, your connected accounts or data, your
+                  breach of these Terms, your breach of law, or your infringement of
+                  third-party rights.
+                </p>
+              </Section>
+
+              <Section id="suspension-termination" title="21. Suspension and Termination">
+                <p>
+                  MLAI may suspend, restrict, or terminate access to the Services if
+                  we reasonably believe you have breached these Terms, pose a risk to
+                  MLAI, other users, third parties, or systems, have unpaid fees, or
+                  if suspension is required by law, a platform provider, security
+                  need, or operational requirement. You may stop using the Services
+                  at any time and may revoke connected account access as described in
+                  our Privacy Policy.
+                </p>
+              </Section>
+
+              <Section id="changes-governing-law" title="22. Changes, Governing Law, and Contact">
+                <p>
+                  We may update these Terms from time to time. We will post the
+                  updated Terms on this page and update the "Last updated" date. If a
+                  change materially affects a paid Service, Google user data use, or
+                  a connected-account feature, we will provide notice or seek consent
+                  where required.
+                </p>
+                <p>
+                  These Terms are governed by the laws of Victoria, Australia. The
+                  parties submit to the non-exclusive jurisdiction of the courts of
+                  Victoria and the Commonwealth courts of Australia.
+                </p>
+                <p>
+                  Our <PolicyLink href="/privacy">Privacy Policy</PolicyLink>{" "}
+                  explains how we collect, use, protect, retain, and delete personal
+                  information, including Google user data and connected-source data.
+                </p>
+
+                <div className="mt-6 rounded-[1.5rem] bg-[var(--brutalist-black)] p-6 text-white">
+                  <p className="mb-2 text-base leading-7 text-white">
+                    <strong>MLAI Aus Inc</strong>
+                  </p>
+                  <p className="mb-2 text-base leading-7 text-white/80">Email: hi@mlai.au</p>
+                  <p className="text-base leading-7 text-white/80">Website: https://mlai.au</p>
                 </div>
-            </Container>
-        </>
-    );
+              </Section>
+            </div>
+          </article>
+        </section>
+      </main>
+  );
 }


### PR DESCRIPTION
## Summary

- Replaces the narrow Vibe Raising-only terms and privacy pages with MLAI-wide legal policy content.
- Adds product-specific coverage for Vibe Raising, Vibe Marketing, MLAI Studio, grants/project delivery, software licensing, CC&C, and paid workshops.
- Restyles `/terms` and `/privacy` to match the main MLAI brutalist page shell: beige background, rounded bordered panels, oversized display headings, section dividers, and black schedule navigation blocks.

## Validation

- `bun run typecheck`
- `bun run build` (completed successfully; postbuild IndexNow submission returned the existing 403 Forbidden response)
- Local browser verification against the clean PR worktree for `/terms` and `/privacy`: correct titles/H1s, beige background, 40px rounded panels, expected nav links, no horizontal overflow, no console errors.