### PR TITLE
[codex] Update MLAI legal policy copy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
+- [x] Replace `/terms` and `/privacy` legal copy with the May 20 updated text
 - [x] Restyle `/terms` and `/privacy` to match the main MLAI brutalist page shell
 - [x] Verify styled legal pages in the local browser
 - [x] Rewrite `/terms` as MLAI-wide Terms of Service with product schedules

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -4,13 +4,24 @@ import SectionDivider from "~/components/SectionDivider";
 
 const LAST_UPDATED = "20 May 2026";
 
+type LegalBlock =
+  | { type: "p"; text: string }
+  | { type: "h3"; text: string }
+  | { type: "list"; items: string[] };
+
+type LegalSection = {
+  id: string;
+  title: string;
+  blocks: LegalBlock[];
+};
+
 export const meta: MetaFunction = () => {
   return [
     { title: "MLAI Privacy Policy" },
     {
       name: "description",
       content:
-        "MLAI Privacy Policy covering MLAI websites, events, community programs, Vibe Raising, Vibe Marketing, MLAI Studio, grants, project services, software, Google OAuth, Gmail, Drive, Analytics, Search Console, connected services, AI processing, retention, deletion, and Limited Use commitments.",
+        "MLAI Privacy Policy covering MLAI websites, events, community programs, founder tools, connected-account products, project services, software, Google OAuth, Gmail, Drive, Analytics, Search Console, AI processing, retention, deletion, and Limited Use commitments.",
     },
     {
       name: "keywords",
@@ -19,6 +30,449 @@ export const meta: MetaFunction = () => {
     },
   ];
 };
+
+const introParagraphs = [
+  "This Privacy Policy explains how MLAI Aus Inc ABN 94 807 394 137 collects, uses, stores, shares, protects, retains and deletes information when you use MLAI websites, events, community programs, founder tools, connected-account products, project services, software, workshops and related services.",
+  "In this Privacy Policy, “MLAI”, “we”, “our” and “us” means MLAI Aus Inc.",
+  "This policy covers MLAI generally, Vibe Raising, Vibe Marketing, MLAI Studio, MLAI Grants and project work, educational software, paid workshops, community activities, volunteers, sponsors, and connected services such as Google, Gmail, Google Drive, Google Analytics, Search Console, Slack, Xero, Linear, Notion and similar services where enabled.",
+];
+
+const sections: LegalSection[] = [
+  {
+    id: "who-we-are",
+    title: "1. Who we are and how to contact us",
+    blocks: [
+      { type: "p", text: "MLAI Aus Inc operates MLAI websites, community programs, events, founder tools, software, project services, educational programs and related services." },
+      { type: "p", text: "Depending on the service you use, MLAI may act as a community operator, service provider, software provider, project delivery partner, event organiser, sponsor or partner contact point, and platform operator." },
+      { type: "p", text: "Contact us at hi@mlai.au for privacy questions, access requests, correction requests, deletion requests, complaints or questions about connected accounts." },
+    ],
+  },
+  {
+    id: "scope",
+    title: "2. Scope of this policy",
+    blocks: [
+      { type: "p", text: "This Privacy Policy applies to information MLAI handles through:" },
+      {
+        type: "list",
+        items: [
+          "MLAI websites, landing pages, articles, forms, analytics and newsletters;",
+          "events, hackathons, workshops, meetups, community spaces, Slack or Discord groups, member directories and volunteer programs;",
+          "founder tools, including Vibe Raising and Vibe Marketing;",
+          "MLAI Studio, builder-hour services, subscriptions, retainers, scoped project delivery and product support;",
+          "MLAI Grants, sponsored projects, educational software, client projects, research, innovation programs and software licences;",
+          "optional connected services, including Google services and other third-party platforms that you choose to connect.",
+        ],
+      },
+      {
+        type: "p",
+        text: "Third-party websites, platforms, venues, payment processors, ticketing providers and connected services have their own privacy policies. You should review those policies before using them.",
+      },
+    ],
+  },
+  {
+    id: "information-we-collect",
+    title: "3. Information we collect",
+    blocks: [
+      { type: "h3", text: "Account, contact and support information" },
+      {
+        type: "p",
+        text: "We may collect your name, email address, phone number, company name, role, organisation, profile information, login details, account settings, preferences, support messages, contact forms, communications and authentication information.",
+      },
+      { type: "h3", text: "Website, analytics and usage information" },
+      {
+        type: "p",
+        text: "We may collect IP address, browser type, device information, referral source, pages viewed, timestamps, product events, approximate location, cookies or similar identifiers, error diagnostics, logs and performance information.",
+      },
+      { type: "p", text: "We may use analytics tools to understand website and product usage." },
+      { type: "h3", text: "Community, event, workshop and volunteer information" },
+      {
+        type: "p",
+        text: "We may collect event registrations, ticketing details, attendance records, dietary or accessibility information you provide, speaker and organiser details, hackathon submissions, team details, judging records, prize eligibility information, workshop participation, community profile information, Slack or Discord profile information, volunteer applications, volunteer role information, sponsor and partner contact details, newsletter subscriptions, photos, video, recordings and feedback.",
+      },
+      { type: "h3", text: "Startup, founder, client and project information" },
+      {
+        type: "p",
+        text: "We may collect startup profiles, company descriptions, website URLs, stage, sector, goals, metrics, milestones, investor asks, customer themes, team details, traction, funding context, uploaded files, product screenshots, brand assets, project briefs, grant information, curriculum materials, client requirements, statement-of-work details, support tickets, deliverables, invoices, purchase orders and project communications.",
+      },
+      { type: "h3", text: "Connected-account and source data" },
+      {
+        type: "p",
+        text: "If you choose to connect a third-party service or data source, we may collect account identifiers, workspace identifiers, OAuth tokens, permission details, selected files, selected messages, metadata, extracted text, analytics reports, project records, finance records, source URLs, uploaded materials, generated outputs and other data permitted by the access you grant and the feature you enable.",
+      },
+    ],
+  },
+  {
+    id: "product-specific-data",
+    title: "4. Product-specific data",
+    blocks: [
+      { type: "h3", text: "Vibe Raising" },
+      { type: "p", text: "Vibe Raising helps founders prepare monthly founder and investor updates." },
+      {
+        type: "p",
+        text: "We may process startup profile data, monthly update drafts, final updates, metrics, milestones, highlights, risks, blockers, asks, investor relationship notes, customer or partner conversations, uploaded materials, source URLs, and optional connected-source data from services such as Gmail, Google Drive, Slack, Xero, Linear, Notion, Google Analytics and Search Console where enabled.",
+      },
+      {
+        type: "p",
+        text: "We may create derived outputs such as relevance scores, summaries, extracted events, extracted metrics, source context, suggested asks, draft updates, review notes and final updates.",
+      },
+      { type: "h3", text: "Vibe Marketing" },
+      {
+        type: "p",
+        text: "Vibe Marketing may help founders and teams with AI-assisted marketing strategy, SEO, AEO, GEO, topic discovery, keyword clustering, content templates, startup profiles, article and page generation, metadata, schema suggestions, internal linking, sitemap workflows, analytics-driven recommendations and optional publishing workflows.",
+      },
+      {
+        type: "p",
+        text: "We may process startup profiles, public website content, website URLs, product descriptions, approved founder updates, approved Vibe Raising outputs, brand assets, customer personas, topic ideas, keyword research, content templates, generated drafts, metadata, schema suggestions, internal-linking suggestions, sitemap information, Google Analytics reports, Search Console reports and performance data where connected.",
+      },
+      {
+        type: "p",
+        text: "Vibe Marketing is designed to use approved outputs and user-provided marketing inputs by default, not raw Gmail messages or broad Google Drive content, unless that raw-source use is clearly disclosed in-product, you choose to enable it, and the use is permitted by applicable platform policies and law.",
+      },
+      { type: "h3", text: "MLAI Studio and project services" },
+      {
+        type: "p",
+        text: "MLAI Studio and project services may process project briefs, business requirements, design files, code repositories, API keys or credentials you provide, tickets, product analytics, support logs, documents, meeting notes, client content, third-party account details, deliverables, invoices and communications needed to deliver scoped work, subscriptions, retainers, builder hours, support and maintenance.",
+      },
+      { type: "h3", text: "MLAI Grants, educational software and client programs" },
+      {
+        type: "p",
+        text: "Grant-funded and educational programs may involve participant registrations, teacher or facilitator information, student or team submissions, school or partner details, project reports, curriculum inputs, assessment or judging records, usage logs, support records, simulated data, de-identified datasets and software licence information.",
+      },
+      {
+        type: "p",
+        text: "Where a program involves children or students, MLAI aims to collect only what is reasonably needed for the educational purpose, use simulated or de-identified data where appropriate, and follow applicable school, partner, consent and legal requirements.",
+      },
+    ],
+  },
+  {
+    id: "google-user-data",
+    title: "5. Google user data",
+    blocks: [
+      { type: "p", text: "If you connect a Google account, Google will show the exact permissions requested before you grant access." },
+      { type: "p", text: "The Google data MLAI accesses depends on the product, feature, scopes, consent screen and in-product choices you use." },
+      { type: "p", text: "MLAI requests Google data only for disclosed user-facing features that you choose to enable." },
+      { type: "h3", text: "Google Account and OAuth data" },
+      { type: "p", text: "We may process:" },
+      {
+        type: "list",
+        items: [
+          "Google account identifiers such as email address, profile information and account ID;",
+          "OAuth access tokens, refresh tokens, scope grants, token expiry details and connection status;",
+          "account, property, file, message, thread, label or service identifiers needed to operate the connected feature.",
+        ],
+      },
+      { type: "h3", text: "Gmail data" },
+      {
+        type: "p",
+        text: "If you enable a Gmail-powered feature, MLAI may access or process Gmail data permitted by the scopes you approve, which may include:",
+      },
+      {
+        type: "list",
+        items: [
+          "message and thread identifiers;",
+          "history identifiers;",
+          "labels;",
+          "headers;",
+          "dates;",
+          "subjects;",
+          "sender and recipient fields;",
+          "snippets;",
+          "body text;",
+          "cleaned or extracted text;",
+          "previews;",
+          "attachment metadata;",
+          "attachment content where required for the feature;",
+          "derived artifacts such as relevance scores, summaries, extracted events, metrics, asks, risks and generated drafts.",
+        ],
+      },
+      {
+        type: "p",
+        text: "Gmail access is used for disclosed user-facing workflows, such as finding relevant context for a founder update that you request.",
+      },
+      {
+        type: "p",
+        text: "We do not use Gmail data for advertising, retargeting, personalised advertising, data broker services, credit-worthiness, lending or generalized AI model training.",
+      },
+      { type: "h3", text: "Google Drive data" },
+      {
+        type: "p",
+        text: "If you enable Google Drive features, MLAI may access or process selected files, file identifiers, folder or permission metadata, document names, MIME types, modified dates, extracted text, comments or content where authorised, and derived outputs needed for the user-facing feature.",
+      },
+      {
+        type: "p",
+        text: "Where practicable, MLAI prefers selected file access, file-picker flows, app-created files or per-file access rather than broad Drive-wide access.",
+      },
+      {
+        type: "p",
+        text: "We do not use Google Drive file content for advertising, retargeting, personalised advertising, data broker services, credit-worthiness, lending or generalized AI model training.",
+      },
+      { type: "h3", text: "Google Analytics and Search Console data" },
+      {
+        type: "p",
+        text: "If you connect Google Analytics or Search Console, MLAI may process account, property, site, query, page, landing page, impressions, clicks, click-through rate, rankings, traffic, source, medium, conversion, engagement, device, geography and reporting data permitted by the scopes you approve.",
+      },
+      {
+        type: "p",
+        text: "We use this data for user-facing reporting, marketing insights, content measurement and optimisation workflows you enable.",
+      },
+    ],
+  },
+  {
+    id: "other-connected-services",
+    title: "6. Other connected services",
+    blocks: [
+      { type: "p", text: "Depending on the features you enable, MLAI may process data from other connected services." },
+      { type: "p", text: "This may include:" },
+      {
+        type: "list",
+        items: [
+          "Slack workspace identifiers, channel identifiers, selected channel names, public or private channel indicators, messages, threads, timestamps and metadata;",
+          "Xero organisation, tenant, invoice, payment, contact, account, report, profit and loss, balance sheet and metric information permitted by granted scopes;",
+          "Linear workspace, project, issue, comment, status, assignee, cycle, label and delivery context;",
+          "Notion selected pages, databases, blocks, titles, metadata, extracted text and related content;",
+          "manual materials such as uploaded files, source URLs, notes, pasted text, recorded walkthroughs, pitch decks, screenshots, summaries and supporting documents.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "ai-processing",
+    title: "7. AI processing",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI may use AI systems and AI infrastructure providers to assist with drafting, summarisation, extraction, classification, coding, testing, search, marketing, analytics, education, simulation, research, review, automation and support.",
+      },
+      {
+        type: "p",
+        text: "We may send relevant inputs and context to those providers only as needed to provide the user-facing feature, service, project or support you request.",
+      },
+      {
+        type: "p",
+        text: "Where information received from Google Workspace APIs is processed by AI infrastructure providers, we use that information only to provide or improve the visible user-facing feature you enabled, and not to train or improve generalized or non-personalized AI or machine learning models.",
+      },
+      {
+        type: "p",
+        text: "We do not use Google Workspace API data, including Gmail data or Google Drive file content, to create, train or improve generalized or non-personalized AI or machine learning models.",
+      },
+      {
+        type: "p",
+        text: "AI-assisted outputs may be retained as part of your account, project, support or product history as described in this policy.",
+      },
+    ],
+  },
+  {
+    id: "how-we-use",
+    title: "8. How we use information",
+    blocks: [
+      { type: "p", text: "We use information to:" },
+      {
+        type: "list",
+        items: [
+          "provide, operate, personalise, maintain, secure, troubleshoot and improve MLAI services;",
+          "run events, workshops, hackathons, community programs, volunteer programs, sponsorships and partnerships;",
+          "create founder updates, marketing drafts, summaries, analytics reports, product recommendations, educational materials, software deliverables and project outputs you request;",
+          "maintain account access, connected account status, OAuth tokens, product settings and service records;",
+          "process payments, invoices, refunds, subscriptions, sponsorships, grants, licences and workshop fees;",
+          "communicate with you about services, support, security, products, events, newsletters and community activity;",
+          "prevent abuse, protect security, debug issues, enforce terms, comply with law, and protect MLAI, users, partners and the public;",
+          "prepare de-identified, aggregated or statistical insights for operations, reporting, community impact, sponsor reporting, grant reporting and service improvement.",
+        ],
+      },
+      {
+        type: "p",
+        text: "For Google user data, the general purposes above are limited by the Google-specific commitments in this policy. MLAI uses Google user data only for disclosed user-facing features you enable and as otherwise permitted by the Google API Services User Data Policy and applicable law.",
+      },
+    ],
+  },
+  {
+    id: "cross-product",
+    title: "9. Cross-product data use",
+    blocks: [
+      {
+        type: "p",
+        text: "Where you use multiple MLAI products, we may use your account information, startup profile, approved outputs and product settings across those products to provide a connected experience.",
+      },
+      {
+        type: "p",
+        text: "We do not use raw Google Workspace API data, including Gmail messages or Google Drive file content, for a different MLAI product unless that use is clearly disclosed in the product, is part of a user-facing feature you choose to enable, and is permitted by Google policy and applicable law.",
+      },
+      { type: "p", text: "Account data such as name, email, company and role may be used across MLAI services." },
+      { type: "p", text: "Startup profile data such as company description, website, stage, sector and goals may be used across Vibe Raising and Vibe Marketing with notice." },
+      { type: "p", text: "Approved outputs such as final founder updates, approved summaries, approved metrics and approved themes may be used by Vibe Marketing if you opt in or approve that use." },
+      { type: "p", text: "Restricted source data such as raw Gmail, Google Drive file content, private Slack, Xero, Linear, OAuth tokens and other connected-source data is not used across products by default." },
+    ],
+  },
+  {
+    id: "sharing",
+    title: "10. Sharing and disclosure",
+    blocks: [
+      { type: "p", text: "We do not sell personal information, Google user data, Gmail data, Google Drive content or connected-source data." },
+      { type: "p", text: "We may disclose information only in limited circumstances, including:" },
+      {
+        type: "list",
+        items: [
+          "to service providers that help us host, operate, secure, analyse, support, communicate, process payments, deliver events, manage email, provide AI infrastructure or provide the Services;",
+          "to AI infrastructure providers only as needed to provide the user-facing feature, service, support or project you request;",
+          "when you direct us to share an output, send an update, invite a collaborator, publish content, submit a project, join an event or connect a third-party service;",
+          "with venues, event partners, sponsors, mentors, judges, facilitators, co-organisers, schools, clients, grant providers or project partners where needed for the relevant program and disclosed or reasonably expected;",
+          "when required by law, regulation, legal process, grant reporting requirement, safety need, security incident response, or to protect rights and prevent abuse;",
+          "in connection with a merger, acquisition, financing, reorganisation or sale of assets, subject to applicable law and any user consent required by Google policy.",
+        ],
+      },
+      {
+        type: "p",
+        text: "For Google user data, transfers are limited to those permitted by the Google API Services User Data Policy, including the Limited Use requirements.",
+      },
+    ],
+  },
+  {
+    id: "limited-use",
+    title: "11. Google Limited Use commitments",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI’s use and transfer of information received from Google APIs will adhere to the Google API Services User Data Policy, including the Limited Use requirements.",
+      },
+      { type: "p", text: "In particular:" },
+      {
+        type: "list",
+        items: [
+          "we use Google user data only to provide or improve user-facing features that are visible in the requesting MLAI product;",
+          "we request Google permissions only where needed for implemented features and aim to use the narrowest practical scopes;",
+          "we do not sell Google user data;",
+          "we do not use Google user data for advertising, retargeting, personalised advertising, interest-based advertising, data broker services, credit-worthiness or lending purposes;",
+          "we do not use Google Workspace API data to create, train or improve generalized or non-personalized AI or machine learning models;",
+          "we do not transfer Google user data except as needed to provide or improve a visible user-facing feature with your consent, comply with law, protect security, or as otherwise permitted by Google policy;",
+          "we do not allow humans to read Google user data unless you have given affirmative permission for specific data, it is necessary for security or legal compliance, or the data has been aggregated and anonymised for permitted internal operations.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "human-access",
+    title: "12. Human access to Google user data",
+    blocks: [
+      { type: "p", text: "MLAI restricts human access to Google user data." },
+      { type: "p", text: "MLAI personnel, contractors or service providers may access Google user data only where:" },
+      {
+        type: "list",
+        items: [
+          "you have given affirmative permission for specific data;",
+          "access is needed to provide support you request;",
+          "access is needed to investigate security, abuse, reliability or technical issues;",
+          "access is required by law;",
+          "access is to aggregated and anonymised data for permitted internal operations; or",
+          "access is otherwise permitted by Google policy and applicable law.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "security",
+    title: "13. Security",
+    blocks: [
+      { type: "p", text: "We use technical and organisational safeguards designed to protect information from unauthorised access, alteration, disclosure or destruction." },
+      { type: "p", text: "Safeguards may include HTTPS, encryption for sensitive stored data where applicable, access controls, token protection, logging, internal access restrictions, least-privilege practices, provider review, backups and security review of systems that handle connected-source data." },
+      { type: "p", text: "No system is perfectly secure. You should use care when choosing what to upload, connect or share." },
+      { type: "p", text: "Where Google restricted-scope data is stored or transmitted through MLAI systems, MLAI will follow applicable Google verification, security assessment and data protection requirements." },
+    ],
+  },
+  {
+    id: "international",
+    title: "14. International providers and transfers",
+    blocks: [
+      { type: "p", text: "MLAI is based in Australia, but some service providers, hosting providers, analytics providers, AI infrastructure providers, payment processors, email tools and support tools may process information in other countries." },
+      { type: "p", text: "Where we disclose personal information to overseas providers, we take reasonable steps to use providers with appropriate privacy, security, confidentiality and contractual protections." },
+    ],
+  },
+  {
+    id: "retention-deletion",
+    title: "15. Retention, deletion and disconnecting accounts",
+    blocks: [
+      {
+        type: "p",
+        text: "We retain information only for as long as needed to provide the Services, operate MLAI, comply with legal obligations, resolve disputes, enforce agreements, maintain security, complete grant or project reporting, and support legitimate operational purposes.",
+      },
+      { type: "p", text: "OAuth tokens are retained while the relevant connection is active." },
+      { type: "p", text: "If you disconnect or revoke access, we delete or invalidate stored OAuth tokens within a reasonable time." },
+      { type: "p", text: "Gmail artifacts and Google source context are retained only while needed for the user-facing workflow, support, security, troubleshooting, legal compliance or your account history, unless you request deletion or law permits or requires longer retention." },
+      { type: "p", text: "Generated outputs such as drafts, summaries, reports, marketing content and final updates may be retained while your account, project or product history remains active or until deleted or requested for deletion." },
+      { type: "p", text: "Event, workshop, volunteer, sponsor, grant, project, licence and payment records may be retained for operational, accounting, legal, tax, grant reporting, insurance and governance purposes." },
+      { type: "p", text: "Backups and logs may retain limited data for a reasonable period before deletion cycles complete." },
+      { type: "p", text: "You may disconnect connected accounts in product settings where available, revoke access directly with the third-party provider, or email hi@mlai.au." },
+      { type: "p", text: "After disconnecting, connector-powered features may stop working. Historical generated outputs or cached artifacts may remain until deleted through product controls or by request, unless retention is required or permitted by law, security or legitimate operational needs." },
+    ],
+  },
+  {
+    id: "rights",
+    title: "16. Your rights and choices",
+    blocks: [
+      { type: "p", text: "You may request access, correction, deletion, export, restriction or information about how MLAI handles your personal information, subject to verification, applicable law, technical feasibility, safety, security, legal and operational requirements." },
+      { type: "p", text: "You can choose not to connect optional services such as Gmail, Google Drive, Google Analytics, Search Console, Slack, Xero, Linear or Notion." },
+      { type: "p", text: "You can revoke Google access from your Google Account permissions and disconnect in MLAI settings where available." },
+      { type: "p", text: "You can unsubscribe from marketing emails using the unsubscribe link or by contacting MLAI." },
+      { type: "p", text: "You can request deletion of account data, connected-source data, generated outputs or support records by emailing hi@mlai.au with enough detail to verify and action the request." },
+    ],
+  },
+  {
+    id: "marketing",
+    title: "17. Marketing communications",
+    blocks: [
+      { type: "p", text: "If you subscribe to MLAI emails, register for an event, join a community program, use a product, or otherwise engage with MLAI, we may send service, transactional, product, event, community, sponsor or newsletter communications." },
+      { type: "p", text: "You can unsubscribe from marketing emails, but we may still send transactional, security, account, legal or service-related messages." },
+    ],
+  },
+  {
+    id: "children-students",
+    title: "18. Children and students",
+    blocks: [
+      { type: "p", text: "MLAI’s general websites and founder tools are not directed to children under 13." },
+      { type: "p", text: "Some MLAI educational programs, hackathons or school software may involve students or young people through a school, parent, guardian, client, partner or facilitator." },
+      { type: "p", text: "In those settings, MLAI aims to collect only what is reasonably needed for the educational program, use simulated or de-identified data where appropriate, and follow applicable consent, school, partner and legal requirements." },
+      { type: "p", text: "MLAI does not intend for children under 13 to connect personal Google accounts to MLAI connected-account products." },
+      { type: "p", text: "Where a school or educational partner uses MLAI software with students, the school or partner is responsible for obtaining any required notices, consents and approvals unless otherwise agreed in writing." },
+    ],
+  },
+  {
+    id: "sensitive-information",
+    title: "19. Sensitive information",
+    blocks: [
+      { type: "p", text: "You should not provide sensitive information, health information, financial account information, government identifiers, student records, confidential third-party data, regulated data or highly sensitive information unless it is necessary for the relevant Service and you are authorised to provide it." },
+      { type: "p", text: "If sensitive information is required for a specific project, school program or client engagement, MLAI may require additional written arrangements." },
+    ],
+  },
+  {
+    id: "changes",
+    title: "20. Changes to this policy",
+    blocks: [
+      { type: "p", text: "We may update this Privacy Policy from time to time." },
+      { type: "p", text: "We will post the updated policy on the MLAI website and update the “Last updated” date." },
+      { type: "p", text: "If we change how MLAI uses Google user data in a material way, we will update this Privacy Policy and provide notice or seek consent where required before using Google user data for the new purpose." },
+    ],
+  },
+  {
+    id: "contact",
+    title: "21. Complaints and contact",
+    blocks: [
+      { type: "p", text: "If you have questions, requests or complaints about this Privacy Policy or MLAI’s privacy practices, contact us at:" },
+      { type: "p", text: "We will assess privacy complaints and respond within a reasonable period." },
+      { type: "p", text: "If you are not satisfied with our response, you may be able to contact the Office of the Australian Information Commissioner or another applicable regulator." },
+      { type: "p", text: "Our Terms of Service explain the terms that apply to MLAI websites, events, community programs, founder tools, connected-account products, project services, software, workshops and related services." },
+    ],
+  },
+];
+
+const navLinks = [
+  { href: "#information-we-collect", label: "Information we collect" },
+  { href: "#product-specific-data", label: "Product-specific data" },
+  { href: "#google-user-data", label: "Google user data" },
+  { href: "#limited-use", label: "Limited Use commitments" },
+  { href: "#human-access", label: "Human access" },
+  { href: "#retention-deletion", label: "Retention and deletion" },
+  { href: "#rights", label: "Your rights" },
+  { href: "#contact", label: "Contact" },
+];
 
 function Section({ id, title, children }: { id: string; title: string; children: ReactNode }) {
   return (
@@ -32,13 +486,8 @@ function Section({ id, title, children }: { id: string; title: string; children:
   );
 }
 
-function Subsection({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <div className="space-y-4">
-      <h3 className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-orange)]">{title}</h3>
-      {children}
-    </div>
-  );
+function Subsection({ title }: { title: string }) {
+  return <h3 className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-orange)]">{title}</h3>;
 }
 
 function List({ children }: { children: ReactNode }) {
@@ -58,6 +507,48 @@ function PolicyLink({
     <a href={href} className={`font-black underline underline-offset-4 ${className}`}>
       {children}
     </a>
+  );
+}
+
+function RenderBlock({ block }: { block: LegalBlock }) {
+  if (block.type === "h3") {
+    return <Subsection title={block.text} />;
+  }
+
+  if (block.type === "list") {
+    return (
+      <List>
+        {block.items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </List>
+    );
+  }
+
+  if (block.text.startsWith("Our Terms of Service")) {
+    return (
+      <p>
+        Our <PolicyLink href="/terms">Terms of Service</PolicyLink> explain the terms that apply to MLAI
+        websites, events, community programs, founder tools, connected-account products, project services,
+        software, workshops and related services.
+      </p>
+    );
+  }
+
+  return <p>{block.text}</p>;
+}
+
+function ContactCard() {
+  return (
+    <div className="mt-6 rounded-[1.5rem] bg-[var(--brutalist-black)] p-6 text-white">
+      <p className="mb-2 text-base leading-7 text-white">
+        <strong>MLAI Aus Inc</strong>
+      </p>
+      <p className="mb-2 text-base leading-7 text-white/80">ABN 94 807 394 137</p>
+      <p className="mb-2 text-base leading-7 text-white/80">585 Little Collins Street, Melbourne VIC 3000</p>
+      <p className="mb-2 text-base leading-7 text-white/80">Email: hi@mlai.au</p>
+      <p className="text-base leading-7 text-white/80">Website: mlai.au</p>
+    </div>
   );
 }
 
@@ -91,23 +582,9 @@ export default function Privacy() {
             </p>
 
             <div className="mt-8 grid gap-5 text-lg leading-8 text-[var(--brutalist-black)]/78 lg:grid-cols-2">
-              <p>
-                MLAI Aus Inc ("MLAI", "we", "our", or "us") is a
-                not-for-profit community based in Australia. This Privacy Policy
-                explains how we collect, use, store, share, protect, retain, and
-                delete information when you use MLAI websites, events, community
-                programs, founder tools, connected-account products, project
-                services, software, workshops, and related services.
-              </p>
-
-              <p>
-                This policy covers MLAI generally, Vibe Raising, Vibe Marketing,
-                MLAI Studio, MLAI Grants and project work, educational software,
-                paid workshops, community activities, volunteers, sponsors, and
-                connected services such as Google, Gmail, Google Drive, Google
-                Analytics, Search Console, Slack, Xero, Linear, and Notion where
-                enabled.
-              </p>
+              {introParagraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
             </div>
 
             <div className="mt-8 rounded-[1.5rem] bg-[var(--brutalist-black)] p-5 text-white sm:p-6">
@@ -115,456 +592,40 @@ export default function Privacy() {
                 Policy sections
               </p>
               <nav className="mt-4 grid gap-2 text-sm font-semibold leading-6 sm:grid-cols-2 lg:grid-cols-4">
-                  <PolicyLink href="#information-we-collect" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Information We Collect</PolicyLink>
-                  <PolicyLink href="#product-data" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Product-Specific Data</PolicyLink>
-                  <PolicyLink href="#google-data" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Google User Data</PolicyLink>
-                  <PolicyLink href="#ai-processing" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">AI Processing</PolicyLink>
-                  <PolicyLink href="#cross-product" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Cross-Product Data Use</PolicyLink>
-                  <PolicyLink href="#limited-use" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Google Limited Use Commitments</PolicyLink>
-                  <PolicyLink href="#retention-deletion" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Retention, Deletion, and Disconnecting</PolicyLink>
-                  <PolicyLink href="#rights" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Your Rights and Choices</PolicyLink>
-                </nav>
-              </div>
-
-            </header>
-
-            <div className="mt-10 space-y-10">
-
-              <Section id="who-we-are" title="1. Who We Are and How to Contact Us">
-                <p>
-                  MLAI Aus Inc operates MLAI websites, community programs, events,
-                  founder tools, software, project services, educational programs,
-                  and related services. We may act as a community operator, service
-                  provider, software provider, project delivery partner, event
-                  organiser, sponsor or partner contact point, and platform operator,
-                  depending on the service you use.
-                </p>
-                <p>
-                  Contact us at hi@mlai.au for privacy questions, access requests,
-                  correction requests, deletion requests, complaints, or questions
-                  about connected accounts.
-                </p>
-              </Section>
-
-              <Section id="scope" title="2. Scope of This Policy">
-                <p>This Privacy Policy applies to information MLAI handles through:</p>
-                <List>
-                  <li>MLAI websites, landing pages, articles, forms, analytics, and newsletters.</li>
-                  <li>Events, hackathons, workshops, meetups, community spaces, Slack or Discord groups, member directories, and volunteer programs.</li>
-                  <li>Founder tools, including Vibe Raising and Vibe Marketing.</li>
-                  <li>MLAI Studio, builder-hour services, subscriptions, retainers, scoped project delivery, and product support.</li>
-                  <li>MLAI Grants, sponsored projects, educational software, client projects, research, innovation programs, and software licences.</li>
-                  <li>Optional connected services, including Google services and other third-party platforms that you choose to connect.</li>
-                </List>
-                <p>
-                  Third-party websites, platforms, venues, payment processors,
-                  ticketing providers, and connected services have their own privacy
-                  policies. You should review those policies before using them.
-                </p>
-              </Section>
-
-              <Section id="information-we-collect" title="3. Information We Collect">
-                <Subsection title="Account, Contact, and Support Information">
-                  <p>
-                    We may collect your name, email address, phone number, company
-                    name, role, organisation, profile information, login details,
-                    account settings, preferences, support messages, contact forms,
-                    communications, and authentication information.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Website, Analytics, and Usage Information">
-                  <p>
-                    We may collect IP address, browser type, device information,
-                    referral source, pages viewed, timestamps, product events,
-                    approximate location, cookies or similar identifiers, error
-                    diagnostics, logs, and performance information. We may use
-                    analytics tools to understand website and product usage.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Community, Event, Workshop, and Volunteer Information">
-                  <p>
-                    We may collect event registrations, ticketing details, attendance
-                    records, dietary or accessibility information you provide,
-                    speaker and organiser details, hackathon submissions, team
-                    details, judging records, prize eligibility information, workshop
-                    participation, community profile information, Slack or Discord
-                    profile information, volunteer applications, volunteer role
-                    information, sponsor and partner contact details, newsletter
-                    subscriptions, photos, video, recordings, and feedback.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Startup, Founder, Client, and Project Information">
-                  <p>
-                    We may collect startup profiles, company descriptions, website
-                    URLs, stage, sector, goals, metrics, milestones, investor asks,
-                    customer themes, team details, traction, funding context,
-                    uploaded files, product screenshots, brand assets, project
-                    briefs, grants information, curriculum materials, client
-                    requirements, SOW details, support tickets, deliverables,
-                    invoices, purchase orders, and project communications.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Connected-Account and Source Data">
-                  <p>
-                    If you choose to connect a third-party service or data source, we
-                    may collect account identifiers, workspace identifiers, OAuth
-                    tokens, permission details, selected files, selected messages,
-                    metadata, extracted text, analytics reports, project records,
-                    finance records, source URLs, uploaded materials, generated
-                    outputs, and other data permitted by the access you grant and the
-                    feature you enable.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="product-data" title="4. Product-Specific Data">
-                <Subsection title="Vibe Raising">
-                  <p>
-                    Vibe Raising helps founders prepare monthly founder and investor
-                    updates. We may process startup profile data, monthly update
-                    drafts, final updates, metrics, milestones, highlights, risks,
-                    blockers, asks, investor relationship notes, customer or partner
-                    conversations, uploaded materials, source URLs, and optional
-                    connected-source data from services such as Gmail, Google Drive,
-                    Slack, Xero, Linear, Notion, Google Analytics, and Search Console
-                    where enabled.
-                  </p>
-                  <p>
-                    We may also create derived outputs such as relevance scores,
-                    summaries, extracted events, extracted metrics, source context,
-                    suggested asks, draft updates, review notes, and final updates.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Vibe Marketing">
-                  <p>
-                    Vibe Marketing may process startup profiles, public website
-                    content, website URLs, product descriptions, approved founder
-                    updates, approved Vibe Raising outputs, brand assets, customer
-                    personas, topic ideas, keyword research, content templates,
-                    generated drafts, metadata, schema suggestions, internal-linking
-                    suggestions, sitemap information, Google Analytics reports,
-                    Search Console reports, and performance data where connected.
-                  </p>
-                  <p>
-                    Vibe Marketing is designed to use approved outputs and
-                    user-provided marketing inputs by default, not raw Gmail messages
-                    or broad Google Drive content, unless that raw-source use is
-                    clearly disclosed in-product, you choose to enable it, and the
-                    use is permitted by applicable platform policies and law.
-                  </p>
-                </Subsection>
-
-                <Subsection title="MLAI Studio and Project Services">
-                  <p>
-                    MLAI Studio and project services may process project briefs,
-                    business requirements, design files, code repositories, API keys
-                    or credentials you provide, tickets, product analytics, support
-                    logs, documents, meeting notes, client content, third-party
-                    account details, deliverables, invoices, and communications
-                    needed to deliver scoped work, subscriptions, retainers, builder
-                    hours, support, and maintenance.
-                  </p>
-                </Subsection>
-
-                <Subsection title="MLAI Grants, Educational Software, and Client Programs">
-                  <p>
-                    Grant-funded and educational programs may involve participant
-                    registrations, teacher or facilitator information, student or
-                    team submissions, school or partner details, project reports,
-                    curriculum inputs, assessment or judging records, usage logs,
-                    support records, simulated data, de-identified datasets, and
-                    software licence information. Where a program involves children
-                    or students, MLAI aims to collect the minimum information needed
-                    for the educational purpose and to follow applicable school,
-                    partner, consent, and legal requirements.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="google-data" title="5. Google User Data">
-                <p>
-                  If you connect a Google account, Google will show the exact
-                  permissions requested before you grant access. The Google data MLAI
-                  accesses depends on the product, feature, scopes, consent screen,
-                  and in-product choices you use.
-                </p>
-
-                <Subsection title="Google Account and OAuth Data">
-                  <List>
-                    <li>Google account identifiers such as email address, profile information, and account ID.</li>
-                    <li>OAuth access tokens, refresh tokens, scope grants, token expiry details, and connection status.</li>
-                    <li>Account, property, file, message, thread, label, or service identifiers needed to operate the connected feature.</li>
-                  </List>
-                </Subsection>
-
-                <Subsection title="Gmail Data">
-                  <p>
-                    If you enable a Gmail-powered feature, MLAI may access or process
-                    Gmail data permitted by the scopes you approve, which may include
-                    message and thread identifiers, history identifiers, labels,
-                    headers, dates, subjects, sender and recipient fields, snippets,
-                    body text, cleaned or extracted text, previews, attachment
-                    metadata, attachment content where required for the feature, and
-                    derived artifacts such as relevance scores, summaries, extracted
-                    events, metrics, asks, risks, and generated drafts.
-                  </p>
-                  <p>
-                    Gmail access is used for disclosed user-facing workflows such as
-                    finding relevant context for a founder update that you request.
-                    We do not use Gmail data for advertising, retargeting, data
-                    broker services, credit-worthiness, lending, or generalized AI
-                    model training.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Google Drive Data">
-                  <p>
-                    If you enable Google Drive features, MLAI may access selected
-                    files, file identifiers, folder or permission metadata, document
-                    names, MIME types, modified dates, extracted text, comments or
-                    content where authorised, and derived outputs needed for the
-                    user-facing feature. Where practicable, MLAI prefers selected
-                    file access, file-picker flows, app-created files, or per-file
-                    access rather than broad Drive-wide access.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Google Analytics and Search Console Data">
-                  <p>
-                    If you connect Google Analytics or Search Console, MLAI may
-                    process account, property, site, query, page, landing page,
-                    impressions, clicks, click-through rate, rankings, traffic,
-                    source, medium, conversion, engagement, device, geography, and
-                    reporting data permitted by the scopes you approve. We use this
-                    data for user-facing reporting, marketing insights, content
-                    measurement, and optimisation workflows you enable.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="other-connected-services" title="6. Other Connected Services">
-                <p>Depending on the features you enable, MLAI may process:</p>
-                <List>
-                  <li><strong>Slack:</strong> workspace identifiers, channel identifiers, selected channel names, public or private channel indicators, messages, threads, timestamps, and metadata.</li>
-                  <li><strong>Xero:</strong> organisation, tenant, invoice, payment, contact, account, report, profit and loss, balance sheet, and metric information permitted by granted scopes.</li>
-                  <li><strong>Linear:</strong> workspace, project, issue, comment, status, assignee, cycle, label, and delivery context.</li>
-                  <li><strong>Notion:</strong> selected pages, databases, blocks, titles, metadata, extracted text, and related content.</li>
-                  <li><strong>Manual materials:</strong> uploaded files, source URLs, notes, pasted text, recorded walkthroughs, pitch decks, screenshots, summaries, and supporting documents.</li>
-                </List>
-              </Section>
-
-              <Section id="ai-processing" title="7. AI Processing">
-                <p>
-                  MLAI may use AI systems and AI infrastructure providers to assist
-                  with drafting, summarisation, extraction, classification, coding,
-                  testing, search, marketing, analytics, education, simulation,
-                  research, review, automation, and support. We may send relevant
-                  inputs and context to those providers only as needed to provide the
-                  user-facing feature, service, project, or support you request.
-                </p>
-                <p>
-                  We do not use Google Workspace API data, including Gmail data or
-                  Google Drive file content, to create, train, or improve generalized
-                  AI or machine learning models. AI-assisted outputs may be retained
-                  as part of your account, project, support, or product history as
-                  described in this policy.
-                </p>
-              </Section>
-
-              <Section id="how-we-use" title="8. How We Use Information">
-                <p>We use information to:</p>
-                <List>
-                  <li>Provide, operate, personalise, maintain, secure, troubleshoot, and improve MLAI Services.</li>
-                  <li>Run events, workshops, hackathons, community programs, volunteer programs, sponsorships, and partnerships.</li>
-                  <li>Create founder updates, marketing drafts, summaries, analytics reports, product recommendations, educational materials, software deliverables, and project outputs you request.</li>
-                  <li>Maintain account access, connected account status, OAuth tokens, product settings, and service records.</li>
-                  <li>Process payments, invoices, refunds, subscriptions, sponsorships, grants, licences, and workshop fees.</li>
-                  <li>Communicate with you about services, support, security, products, events, newsletters, and community activity.</li>
-                  <li>Prevent abuse, protect security, debug issues, enforce terms, comply with law, and protect MLAI, users, partners, and the public.</li>
-                  <li>Prepare de-identified, aggregated, or statistical insights for operations, reporting, community impact, sponsor reporting, grant reporting, and service improvement.</li>
-                </List>
-              </Section>
-
-              <Section id="cross-product" title="9. Cross-Product Data Use">
-                <p>
-                  Where you use multiple MLAI products, we may use your account
-                  information, startup profile, approved outputs, and product
-                  settings across those products to provide a connected experience.
-                  We do not use raw Google Workspace API data, including Gmail
-                  messages or Google Drive file content, for a different MLAI product
-                  unless that use is clearly disclosed in the product, is part of a
-                  user-facing feature you choose to enable, and is permitted by
-                  Google policy and applicable law.
-                </p>
-                <List>
-                  <li><strong>Account data</strong> such as name, email, company, and role may be used across MLAI services.</li>
-                  <li><strong>Startup profile data</strong> such as company description, website, stage, sector, and goals may be used across Vibe Raising and Vibe Marketing with notice.</li>
-                  <li><strong>Approved outputs</strong> such as final founder updates, approved summaries, approved metrics, and approved themes may be used by Vibe Marketing if you opt in or approve that use.</li>
-                  <li><strong>Restricted source data</strong> such as raw Gmail, Google Drive file content, private Slack, Xero, Linear, OAuth tokens, and other connected-source data is not used across products by default.</li>
-                </List>
-              </Section>
-
-              <Section id="sharing" title="10. Sharing and Disclosure">
-                <p>
-                  We do not sell personal information, Google user data, Gmail data,
-                  Google Drive content, or connected-source data. We may disclose
-                  information only in limited circumstances:
-                </p>
-                <List>
-                  <li>To service providers that help us host, operate, secure, analyse, support, communicate, process payments, deliver events, manage email, provide AI infrastructure, or provide the Services.</li>
-                  <li>To AI infrastructure providers only as needed to provide the user-facing feature, service, support, or project you request.</li>
-                  <li>When you direct us to share an output, send an update, invite a collaborator, publish content, submit a project, join an event, or connect a third-party service.</li>
-                  <li>With venues, event partners, sponsors, mentors, judges, facilitators, co-organisers, schools, clients, grant providers, or project partners where needed for the relevant program and disclosed or reasonably expected.</li>
-                  <li>When required by law, regulation, legal process, grant reporting requirement, safety need, security incident response, or to protect rights and prevent abuse.</li>
-                  <li>In connection with a merger, acquisition, financing, reorganisation, or sale of assets, subject to applicable law and any user consent required by Google policy.</li>
-                </List>
-              </Section>
-
-              <Section id="limited-use" title="11. Google Limited Use Commitments">
-                <p>
-                  MLAI's use and transfer of information received from Google APIs
-                  will adhere to the Google API Services User Data Policy, including
-                  the Limited Use requirements. In particular:
-                </p>
-                <List>
-                  <li>We use Google user data only to provide or improve user-facing features that are visible in the requesting MLAI product.</li>
-                  <li>We request Google permissions only where needed for implemented features and aim to use the narrowest practical scopes.</li>
-                  <li>We do not sell Google user data.</li>
-                  <li>We do not use Google user data for advertising, retargeting, personalised advertising, data broker services, credit-worthiness, or lending purposes.</li>
-                  <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
-                  <li>We do not transfer Google user data except as needed to provide or improve a visible user-facing feature with your consent, comply with law, protect security, or as otherwise permitted by Google policy.</li>
-                  <li>We do not allow humans to read Google user data unless you have given affirmative permission for specific data, it is necessary for security or legal compliance, or the data has been aggregated and anonymised for permitted internal operations.</li>
-                </List>
-              </Section>
-
-              <Section id="international" title="12. International Providers and Transfers">
-                <p>
-                  MLAI is based in Australia, but some service providers, hosting
-                  providers, analytics providers, AI infrastructure providers,
-                  payment processors, email tools, and support tools may process
-                  information in other countries. Where we disclose personal
-                  information to overseas providers, we take reasonable steps to use
-                  providers with appropriate privacy, security, confidentiality, and
-                  contractual protections.
-                </p>
-              </Section>
-
-              <Section id="security" title="13. Data Security">
-                <p>
-                  We use technical and organisational safeguards designed to protect
-                  information from unauthorised access, alteration, disclosure, or
-                  destruction. Safeguards may include HTTPS, encryption for sensitive
-                  stored data where applicable, access controls, token protection,
-                  logging, internal access restrictions, least-privilege practices,
-                  and security review of systems that handle connected-source data.
-                  No system is perfectly secure, and you should use care when
-                  choosing what to upload, connect, or share.
-                </p>
-              </Section>
-
-              <Section id="retention-deletion" title="14. Retention, Deletion, and Disconnecting Accounts">
-                <p>
-                  We retain information only for as long as needed to provide the
-                  Services, operate MLAI, comply with legal obligations, resolve
-                  disputes, enforce agreements, maintain security, complete grant or
-                  project reporting, and support legitimate operational purposes.
-                </p>
-                <List>
-                  <li><strong>OAuth tokens</strong> are retained while the relevant connection is active. If you disconnect or revoke access, we delete or invalidate stored tokens within a reasonable time.</li>
-                  <li><strong>Gmail artifacts and Google source context</strong> are retained only while needed for the user-facing workflow, support, security, troubleshooting, legal compliance, or your account history, unless you request deletion or law permits or requires longer retention.</li>
-                  <li><strong>Generated outputs</strong> such as drafts, summaries, reports, marketing content, and final updates may be retained while your account, project, or product history remains active or until deleted or requested for deletion.</li>
-                  <li><strong>Event, workshop, volunteer, sponsor, grant, project, licence, and payment records</strong> may be retained for operational, accounting, legal, tax, grant reporting, insurance, and governance purposes.</li>
-                  <li><strong>Backups and logs</strong> may retain limited data for a reasonable period before deletion cycles complete.</li>
-                </List>
-                <p>
-                  You may disconnect connected accounts in product settings where
-                  available, revoke access directly with the third-party provider, or
-                  email hi@mlai.au. After disconnecting, connector-powered features
-                  may stop working. Historical generated outputs or cached artifacts
-                  may remain until deleted through product controls or by request,
-                  unless retention is required or permitted by law, security, or
-                  legitimate operational needs.
-                </p>
-              </Section>
-
-              <Section id="rights" title="15. Your Rights and Choices">
-                <p>
-                  You may request access, correction, deletion, export, restriction,
-                  or information about how MLAI handles your personal information,
-                  subject to verification, applicable law, technical feasibility,
-                  safety, security, legal, and operational requirements.
-                </p>
-                <List>
-                  <li>You can choose not to connect optional services such as Gmail, Google Drive, Google Analytics, Search Console, Slack, Xero, Linear, or Notion.</li>
-                  <li>You can revoke Google access from your Google Account permissions and disconnect in MLAI settings where available.</li>
-                  <li>You can unsubscribe from marketing emails using the unsubscribe link or by contacting hi@mlai.au.</li>
-                  <li>You can request deletion of account data, connected-source data, generated outputs, or support records by emailing hi@mlai.au with enough detail to verify and action the request.</li>
-                </List>
-              </Section>
-
-              <Section id="marketing" title="16. Marketing Communications">
-                <p>
-                  If you subscribe to MLAI emails, register for an event, join a
-                  community program, use a product, or otherwise engage with MLAI, we
-                  may send service, transactional, product, event, community,
-                  sponsor, or newsletter communications. You can unsubscribe from
-                  marketing emails, but we may still send transactional, security,
-                  account, legal, or service-related messages.
-                </p>
-              </Section>
-
-              <Section id="children-students" title="17. Children and Students">
-                <p>
-                  MLAI's general websites and founder tools are not directed to
-                  children under 13. Some MLAI educational programs, hackathons, or
-                  school software may involve students or young people through a
-                  school, parent, guardian, client, partner, or facilitator. In those
-                  settings, MLAI aims to collect only what is reasonably needed for
-                  the educational program, use simulated or de-identified data where
-                  appropriate, and follow applicable consent, school, partner, and
-                  legal requirements.
-                </p>
-              </Section>
-
-              <Section id="changes-contact" title="18. Changes, Contact, and Complaints">
-                <p>
-                  We may update this Privacy Policy from time to time. We will post
-                  the updated policy on this page and update the "Last updated" date.
-                  If we change how MLAI uses Google user data in a material way, we
-                  will update this Privacy Policy and provide notice or seek consent
-                  where required before using Google user data for the new purpose.
-                </p>
-                <p>
-                  If you have questions, requests, or complaints about this Privacy
-                  Policy or MLAI's privacy practices, contact us at hi@mlai.au. We
-                  will assess privacy complaints and respond within a reasonable
-                  period. If you are not satisfied with our response, you may be able
-                  to contact the Office of the Australian Information Commissioner or
-                  another applicable regulator.
-                </p>
-                <p>
-                  Our <PolicyLink href="/terms">Terms of Service</PolicyLink>{" "}
-                  explain the terms that apply to MLAI websites, events, community
-                  programs, founder tools, connected-account products, project
-                  services, software, workshops, and related services.
-                </p>
-
-                <div className="mt-6 rounded-[1.5rem] bg-[var(--brutalist-black)] p-6 text-white">
-                  <p className="mb-2 text-base leading-7 text-white">
-                    <strong>MLAI Aus Inc</strong>
-                  </p>
-                  <p className="mb-2 text-base leading-7 text-white/80">Email: hi@mlai.au</p>
-                  <p className="text-base leading-7 text-white/80">Website: https://mlai.au</p>
-                </div>
-              </Section>
+                {navLinks.map((link) => (
+                  <PolicyLink
+                    key={link.href}
+                    href={link.href}
+                    className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10"
+                  >
+                    {link.label}
+                  </PolicyLink>
+                ))}
+              </nav>
             </div>
-          </article>
-        </section>
-      </main>
+          </header>
+
+          <div className="mt-10 space-y-10">
+            {sections.map((section) => (
+              <Section key={section.id} id={section.id} title={section.title}>
+                {section.blocks.map((block, index) => {
+                  const shouldShowContact =
+                    section.id === "contact" &&
+                    block.type === "p" &&
+                    block.text.startsWith("If you have questions");
+
+                  return (
+                    <div key={`${section.id}-${index}`}>
+                      <RenderBlock block={block} />
+                      {shouldShowContact ? <ContactCard /> : null}
+                    </div>
+                  );
+                })}
+              </Section>
+            ))}
+          </div>
+        </article>
+      </section>
+    </main>
   );
 }

--- a/app/routes/terms.tsx
+++ b/app/routes/terms.tsx
@@ -4,13 +4,23 @@ import SectionDivider from "~/components/SectionDivider";
 
 const LAST_UPDATED = "20 May 2026";
 
+type LegalBlock =
+  | { type: "p"; text: string }
+  | { type: "list"; items: string[] };
+
+type LegalSection = {
+  id: string;
+  title: string;
+  blocks: LegalBlock[];
+};
+
 export const meta: MetaFunction = () => {
   return [
     { title: "MLAI Terms of Service" },
     {
       name: "description",
       content:
-        "MLAI Terms of Service for MLAI websites, events, community programs, founder tools, Vibe Raising, Vibe Marketing, MLAI Studio, project services, grants, software licences, workshops, connected accounts, AI outputs, payments, acceptable use, and Google API data commitments.",
+        "MLAI Terms of Service for MLAI websites, events, community programs, founder tools, software, project services, workshops, grants, connected accounts, AI outputs, payments, acceptable use, and Google API data commitments.",
     },
     {
       name: "keywords",
@@ -19,6 +29,718 @@ export const meta: MetaFunction = () => {
     },
   ];
 };
+
+const introParagraphs = [
+  "These Terms of Service govern access to and use of the websites, applications, events, community programs, founder tools, software, project services, workshops, grant-funded programs, and related services provided by MLAI Aus Inc ABN 94 807 394 137.",
+  "In these Terms, “MLAI”, “we”, “our” and “us” means MLAI Aus Inc. “You” means the person, organisation, client, participant, member, founder, student, teacher, sponsor, partner, customer or other user accessing or using the Services.",
+  "These Terms are intended to operate as MLAI’s standard public terms for MLAI services, including community programs, software tools, software licences, connected-account products, grants, project delivery, workshops, studio services, subscriptions and related deliverables.",
+  "If you do not agree to these Terms, do not use the Services.",
+];
+
+const sections: LegalSection[] = [
+  {
+    id: "services-covered",
+    title: "1. Services covered",
+    blocks: [
+      { type: "p", text: "These Terms apply to MLAI services, including:" },
+      {
+        type: "list",
+        items: [
+          "MLAI websites, articles, resources, newsletters and public content;",
+          "community programs, meetups, events, hackathons, workshops and member spaces;",
+          "founder tools, including Vibe Raising and Vibe Marketing;",
+          "MLAI Studio services, builder hours, subscriptions, retainers and scoped project work;",
+          "grant-funded, sponsored, educational, research, innovation and project delivery work;",
+          "software licences, hosted tools, educational simulations, maintenance, support, configuration and feature enhancements;",
+          "paid workshops, organiser services, sponsorship arrangements and related deliverables;",
+          "connected-account products involving services such as Google, Gmail, Google Drive, Google Analytics, Search Console, Slack, Xero, Linear, Notion and similar services where enabled.",
+        ],
+      },
+      {
+        type: "p",
+        text: "Some services may also be governed by a proposal, quote, invoice, event page, grant agreement, purchase order, statement of work, signed agreement, checkout page, product plan or written project terms.",
+      },
+    ],
+  },
+  {
+    id: "accepting-terms",
+    title: "2. Accepting these Terms",
+    blocks: [
+      { type: "p", text: "You accept these Terms when you:" },
+      {
+        type: "list",
+        items: [
+          "access or use any MLAI website, product, software, event, community space or service;",
+          "create an account or connect a third-party account;",
+          "register for or attend an event, hackathon, workshop or program;",
+          "approve a proposal, quote, invoice, checkout, purchase order, statement of work or written project scope that refers to MLAI services;",
+          "pay or arrange payment for MLAI services;",
+          "receive, access, test or use a deliverable, software build, hosted product, grant-funded output or project service from MLAI;",
+          "continue an engagement after being given or directed to these Terms; or",
+          "use MLAI services on behalf of an organisation.",
+        ],
+      },
+      {
+        type: "p",
+        text: "If you use the Services on behalf of an organisation, you represent that you have authority to bind that organisation to these Terms.",
+      },
+    ],
+  },
+  {
+    id: "order-of-documents",
+    title: "3. Order of documents",
+    blocks: [
+      {
+        type: "p",
+        text: "If there is any inconsistency between documents, the following order applies unless expressly stated otherwise:",
+      },
+      {
+        type: "list",
+        items: [
+          "a signed written agreement between MLAI and the relevant counterparty;",
+          "a signed statement of work or signed special conditions;",
+          "a grant agreement or formal funding agreement accepted by MLAI;",
+          "an MLAI proposal, quote, invoice, checkout page or product plan;",
+          "these Terms;",
+          "other operational communications such as emails, tickets, messages or project notes.",
+        ],
+      },
+      {
+        type: "p",
+        text: "Purchase order terms, procurement terms or customer standard terms do not override these Terms unless MLAI expressly agrees to them in writing.",
+      },
+    ],
+  },
+  {
+    id: "eligibility-accounts-authority",
+    title: "4. Eligibility, accounts and authority",
+    blocks: [
+      { type: "p", text: "You must be able to form a legally binding contract to use the Services." },
+      { type: "p", text: "You must provide accurate, current and complete information and keep it updated." },
+      {
+        type: "p",
+        text: "You are responsible for maintaining the confidentiality of your account credentials and for activity under your account.",
+      },
+      {
+        type: "p",
+        text: "You must only use accounts, workspaces, files, datasets, API keys, systems, content, platforms or third-party services that you own, administer or are authorised to use.",
+      },
+      {
+        type: "p",
+        text: "You must not connect, upload, process or disclose information unless you have the necessary rights, permissions and lawful basis to do so.",
+      },
+    ],
+  },
+  {
+    id: "community-terms",
+    title: "5. General MLAI community terms",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI may run public, private, free, paid, sponsored, grant-funded, in-person, online or hybrid events, workshops, hackathons, programs and community activities.",
+      },
+      {
+        type: "p",
+        text: "Registration, ticketing, refunds, cancellations, rescheduling, venue rules, eligibility, judging, prizes, workshop materials and sponsorship arrangements may be governed by event-specific terms in addition to these Terms.",
+      },
+      {
+        type: "p",
+        text: "MLAI may cancel, postpone, reschedule, change venues, change speakers, modify formats, refuse entry, remove participants or restrict access where reasonably necessary.",
+      },
+      {
+        type: "p",
+        text: "Unless required by law or stated in event-specific terms, ticket refunds and transfers are handled at MLAI’s discretion.",
+      },
+      {
+        type: "p",
+        text: "You are responsible for your own travel, accommodation, equipment, dietary requirements, allergy management, accessibility requirements, health needs and participation decisions.",
+      },
+      {
+        type: "p",
+        text: "MLAI does not guarantee jobs, funding, investment, introductions, prizes, rankings, commercial outcomes, technical outcomes, educational outcomes or business success from any event, program or community activity.",
+      },
+    ],
+  },
+  {
+    id: "community-spaces-conduct",
+    title: "6. Community spaces and conduct",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI may provide community spaces such as Slack, Discord, mailing lists, member directories, forums, event groups and other collaboration channels.",
+      },
+      {
+        type: "p",
+        text: "You must participate respectfully, lawfully and consistently with any code of conduct or moderation rules published by MLAI.",
+      },
+      {
+        type: "p",
+        text: "MLAI may moderate, remove, suspend, restrict or terminate access to community spaces, events or programs if conduct creates risk, disrupts the community, breaches these Terms, or is otherwise inappropriate.",
+      },
+      {
+        type: "p",
+        text: "Community posts, jobs, opportunities, sponsor content, member profiles and third-party offers are not endorsed by MLAI unless expressly stated.",
+      },
+    ],
+  },
+  {
+    id: "event-media",
+    title: "7. Photos, recordings and event media",
+    blocks: [
+      { type: "p", text: "MLAI events may be photographed, filmed, livestreamed or recorded." },
+      {
+        type: "p",
+        text: "By attending an MLAI event or program, you consent to MLAI capturing and using event media that may include your image, likeness or voice for event operations, community updates, education, archives, reporting and promotion.",
+      },
+      {
+        type: "p",
+        text: "If you do not want to be featured in event media, you should notify MLAI in advance or at the event where reasonably practicable.",
+      },
+    ],
+  },
+  {
+    id: "volunteers-sponsors-partners",
+    title: "8. Volunteers, sponsors and partners",
+    blocks: [
+      { type: "p", text: "Volunteer participation does not create an employment relationship unless separately agreed in writing." },
+      { type: "p", text: "Volunteer reimbursements are payable only if MLAI approves them in advance." },
+      {
+        type: "p",
+        text: "Volunteers must protect confidential information, use MLAI systems responsibly, follow access rules and disclose conflicts of interest.",
+      },
+      {
+        type: "p",
+        text: "Sponsor recognition, event involvement, brand use, speaker slots, attendee-list access, content rights and sponsorship deliverables must be agreed with MLAI.",
+      },
+      {
+        type: "p",
+        text: "Sponsorship or partnership does not mean MLAI endorses a sponsor, product, service, investment opportunity, job listing or other third-party offer unless expressly stated.",
+      },
+    ],
+  },
+  {
+    id: "educational-public-content",
+    title: "9. Educational and public content",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI articles, guides, talks, workshops, templates, resources, hackathon materials, simulations and educational programs are provided for general educational, community and informational purposes.",
+      },
+      {
+        type: "p",
+        text: "They are not legal, financial, tax, investment, fundraising, medical, engineering, energy-market, environmental, public policy, cybersecurity, accounting or other professional advice unless MLAI expressly agrees otherwise in a separate written engagement with a qualified professional.",
+      },
+      { type: "p", text: "You are responsible for seeking professional advice where appropriate." },
+    ],
+  },
+  {
+    id: "connected-accounts-oauth",
+    title: "10. Connected accounts and OAuth",
+    blocks: [
+      {
+        type: "p",
+        text: "Some Services allow you to connect third-party accounts, workspaces, analytics properties, file stores, communication systems, project systems, finance systems or other data sources. Connector use is optional unless a specific project, statement of work or product feature requires it.",
+      },
+      {
+        type: "p",
+        text: "When you connect a third-party service, you authorise MLAI to access and process the data you grant through the relevant consent screen, API authorisation, in-product disclosure, file picker, account setting or connector interface.",
+      },
+      {
+        type: "p",
+        text: "The exact permissions requested should be shown before you grant access. You should not connect a service unless you understand and accept the requested access.",
+      },
+      {
+        type: "p",
+        text: "You may disconnect connected accounts where product controls are available, revoke access directly with the third-party provider, or contact MLAI.",
+      },
+      {
+        type: "p",
+        text: "Connector features may stop working if you revoke access, scopes change, a provider changes its API or policy, tokens expire, the third-party service is unavailable, your account is restricted, or you no longer have permissions.",
+      },
+      { type: "p", text: "Third-party services are governed by their own terms and policies." },
+    ],
+  },
+  {
+    id: "google-api-data",
+    title: "11. Google API data commitments",
+    blocks: [
+      {
+        type: "p",
+        text: "Where MLAI uses information received from Google APIs, MLAI’s use and transfer of that information will adhere to the Google API Services User Data Policy, including the Limited Use requirements.",
+      },
+      { type: "p", text: "In particular:" },
+      {
+        type: "list",
+        items: [
+          "MLAI uses Google user data only to provide or improve user-facing features that are visible in the requesting MLAI product and that you choose to enable;",
+          "MLAI requests Google permissions only where needed for implemented features and aims to use the narrowest practical permissions;",
+          "MLAI does not sell Google user data or Gmail data;",
+          "MLAI does not use Google user data for advertising, retargeting, personalised advertising, interest-based advertising, data broker services, credit-worthiness or lending purposes;",
+          "MLAI does not use Google Workspace API data, including Gmail data or Google Drive file content, to create, train or improve generalized or non-personalized AI or machine learning models;",
+          "MLAI does not transfer Google user data except as needed to provide or improve a visible user-facing feature with your consent, comply with law, protect security, or as otherwise permitted by Google policy;",
+          "MLAI limits human access to Google user data to cases where you have given affirmative permission for specific data, where access is necessary for support, security or legal compliance, or where data is aggregated and anonymised for permitted internal operations.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "ai-outputs-user-review",
+    title: "12. AI outputs and user review",
+    blocks: [
+      {
+        type: "p",
+        text: "The Services may use automated systems and AI models to assist with drafting, summarisation, coding, analysis, marketing, education, research, extraction, recommendations, simulation, automation, testing and support.",
+      },
+      {
+        type: "p",
+        text: "AI-generated or AI-assisted outputs may be inaccurate, incomplete, outdated, biased, unsafe, unsuitable, infringing or misleading.",
+      },
+      {
+        type: "p",
+        text: "You must review outputs before relying on them, publishing them, sending them, deploying them, presenting them, submitting them, or using them in decisions.",
+      },
+      {
+        type: "p",
+        text: "You are responsible for the accuracy, legality, suitability, approvals, permissions, confidentiality and third-party rights associated with your content and your use of outputs.",
+      },
+      {
+        type: "p",
+        text: "MLAI does not guarantee that AI outputs will be error-free, original, secure, compliant, production-ready, commercially effective or suitable for any particular purpose.",
+      },
+      { type: "p", text: "Outputs are not professional advice unless MLAI expressly agrees otherwise in a separate written engagement." },
+    ],
+  },
+  {
+    id: "user-content",
+    title: "13. User content",
+    blocks: [
+      {
+        type: "p",
+        text: "You retain ownership of content, data, materials, files, prompts, instructions, brand assets, business information, project information and other inputs that you provide to MLAI.",
+      },
+      {
+        type: "p",
+        text: "You grant MLAI a limited licence to host, copy, process, transmit, analyse, display, transform and use your content as needed to provide, operate, secure, support, troubleshoot, improve and document the Services, subject to these Terms and our Privacy Policy.",
+      },
+      {
+        type: "p",
+        text: "You must ensure that your content does not infringe third-party rights, breach confidentiality obligations, breach privacy laws, contain unlawful material, or include information you are not authorised to provide.",
+      },
+    ],
+  },
+  {
+    id: "mlai-ip",
+    title: "14. MLAI intellectual property",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI and its licensors retain ownership of MLAI websites, software, source code, platform code, game systems, simulations, templates, reusable components, educational materials, tools, libraries, automations, prompts, workflows, designs, models, processes, documentation, know-how, improvements and other pre-existing or reusable materials.",
+      },
+      { type: "p", text: "No ownership transfer occurs unless MLAI expressly agrees in a signed written assignment." },
+      {
+        type: "p",
+        text: "Feedback, suggestions, ideas, examples, code snippets, prompts, designs, workshop contributions, hackathon submissions or other contributions you provide to MLAI may be used by MLAI for community, educational, product, operational and promotional purposes, unless MLAI has agreed different written terms.",
+      },
+    ],
+  },
+  {
+    id: "confidentiality",
+    title: "15. Confidentiality",
+    blocks: [
+      {
+        type: "p",
+        text: "If a project, workshop, founder workflow, grant, studio engagement, software licence or community role gives you access to non-public information, you must keep that information confidential and use it only for the purpose for which it was provided.",
+      },
+      {
+        type: "p",
+        text: "MLAI will use reasonable care to protect confidential information you provide, subject to these Terms, our Privacy Policy, agreed project terms, support needs, security needs and legal obligations.",
+      },
+      {
+        type: "p",
+        text: "Confidentiality obligations do not apply to information that is public through no breach, already known without restriction, independently developed, or required to be disclosed by law.",
+      },
+    ],
+  },
+  {
+    id: "vibe-raising",
+    title: "16. Vibe Raising terms",
+    blocks: [
+      {
+        type: "p",
+        text: "Vibe Raising helps founders and teams prepare founder updates, investor updates, monthly updates, relationship context, milestones, metrics, risks, asks, follow-ups and related investor-readiness materials.",
+      },
+      {
+        type: "p",
+        text: "Vibe Raising may process information you enter, upload, generate, approve or connect, including startup profiles, monthly updates, investor asks, customer context, company metrics, source URLs, uploaded materials and enabled sources such as Gmail, Google Drive, Slack, Xero, Linear, Notion, Google Analytics and Search Console.",
+      },
+      {
+        type: "p",
+        text: "Connected accounts are optional. You must own, administer or have authority to connect the relevant account, workspace, files, channels or data.",
+      },
+      {
+        type: "p",
+        text: "You must review every generated founder update, metric, claim, summary, ask and follow-up before sending, publishing or relying on it.",
+      },
+      {
+        type: "p",
+        text: "You must not include confidential third-party information, investor information, customer information, employee information or regulated information unless you have the rights and lawful basis to use it.",
+      },
+      {
+        type: "p",
+        text: "You must not use Vibe Raising to mislead investors, customers, grant providers, partners, sponsors or other recipients.",
+      },
+      {
+        type: "p",
+        text: "MLAI may, at its discretion, introduce founders to investors, mentors, sponsors, ecosystem partners, community members or other contacts. MLAI does not guarantee introductions, investment, investor interest, due diligence outcomes, funding, valuations, revenue, business success or any other commercial result.",
+      },
+      { type: "p", text: "Vibe Raising is not legal, financial, tax, investment, fundraising, securities or accounting advice." },
+    ],
+  },
+  {
+    id: "vibe-marketing",
+    title: "17. Vibe Marketing terms",
+    blocks: [
+      {
+        type: "p",
+        text: "Vibe Marketing may help founders and teams with AI-assisted marketing strategy, SEO, AEO, GEO, content planning, topic discovery, keyword clustering, content templates, startup profiles, article generation, page generation, metadata, schema suggestions, internal linking, sitemap workflows, analytics-driven recommendations and optional publishing workflows.",
+      },
+      {
+        type: "p",
+        text: "Vibe Marketing may use user-provided startup profiles, website URLs, public website content, approved founder updates, approved Vibe Raising outputs, Google Analytics, Search Console, keyword tools, public search data, uploaded assets, product screenshots, customer personas and other authorised materials.",
+      },
+      { type: "p", text: "Generated content is draft content unless you or an authorised user approves or publishes it." },
+      {
+        type: "p",
+        text: "You are responsible for reviewing accuracy, legality, brand fit, claims, pricing, testimonials, case studies, regulated-industry statements, competitor references, third-party rights and confidentiality before publishing.",
+      },
+      {
+        type: "p",
+        text: "You must not use Vibe Marketing for doorway pages, spam, deceptive content, impersonation, fake reviews, fabricated case studies, unlawful scraping, undisclosed paid endorsements, infringing content or misleading marketing.",
+      },
+      {
+        type: "p",
+        text: "MLAI does not guarantee search rankings, traffic, conversions, revenue, backlinks, citations by AI systems, investor interest, customer acquisition, brand outcomes or marketing performance.",
+      },
+    ],
+  },
+  {
+    id: "cross-product-use",
+    title: "18. Cross-product use between Vibe Raising and Vibe Marketing",
+    blocks: [
+      {
+        type: "p",
+        text: "Some MLAI products work together. For example, Vibe Raising may help you prepare founder updates, and Vibe Marketing may help you turn approved company information, website content, approved updates, metrics or themes into marketing content.",
+      },
+      {
+        type: "p",
+        text: "MLAI may use your account information, startup profile, product settings, approved outputs and user-approved summaries across MLAI products to provide a connected experience.",
+      },
+      {
+        type: "p",
+        text: "MLAI will only use connected-source data across products where that use is disclosed, user-facing, authorised by you and permitted by applicable third-party platform policies.",
+      },
+      {
+        type: "p",
+        text: "Vibe Marketing is designed to use approved outputs from Vibe Raising, such as final founder updates, approved company profiles, approved metrics summaries and approved customer themes, rather than raw Gmail messages or broad Google Drive file content.",
+      },
+      {
+        type: "p",
+        text: "Raw Gmail messages, Google Drive file content, OAuth tokens and other restricted connected-source data are not used across products by default.",
+      },
+    ],
+  },
+  {
+    id: "grants-project-delivery",
+    title: "19. MLAI Grants and project delivery terms",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI may receive grants, sponsorships, purchase orders, invoices, statements of work or project funding to deliver educational, software, community, research, innovation, product, data, workshop or project services.",
+      },
+      { type: "p", text: "The applicable proposal, invoice, grant agreement, purchase order, statement of work or written project terms define the specific deliverables." },
+      { type: "p", text: "These Terms fill gaps unless a signed written agreement says otherwise." },
+      {
+        type: "p",
+        text: "Deliverables may include software builds, hosted access, simulations, games, learning materials, workshops, reports, training, documentation, support, maintenance, configuration, data work and facilitation.",
+      },
+      {
+        type: "p",
+        text: "Milestones, acceptance criteria, timelines, fees, licence scope, support levels and included features are set out in the relevant proposal, invoice, purchase order, grant agreement or statement of work.",
+      },
+      {
+        type: "p",
+        text: "Clients and co-funders must provide timely feedback, assets, approvals, access, subject-matter input, data, branding, curriculum direction and other dependencies reasonably needed for delivery.",
+      },
+      {
+        type: "p",
+        text: "MLAI is not responsible for delays caused by missing feedback, delayed approvals, unavailable third-party services, missing access, changed requirements or client-side dependencies.",
+      },
+      {
+        type: "p",
+        text: "Change requests, expanded deployment, new integrations, major curriculum changes, additional modules, substantial UI redesign and new feature work are separate work unless expressly included in the applicable scope.",
+      },
+      {
+        type: "p",
+        text: "Unless the relevant statement of work says otherwise, deliverables are accepted when MLAI makes them available for use, delivery, testing or review and the client does not reject them in writing with specific material defects within 10 business days.",
+      },
+      {
+        type: "p",
+        text: "Minor defects, ordinary support issues and enhancement requests do not prevent acceptance and may be handled through support, maintenance or change-request processes.",
+      },
+    ],
+  },
+  {
+    id: "default-software-licence",
+    title: "20. Default software licence for grants, projects and MLAI products",
+    blocks: [
+      {
+        type: "p",
+        text: "This clause applies where MLAI provides access to MLAI software, hosted tools, educational simulations, games, platforms, prototypes, internal tools, automations or other software as part of a grant, project, client engagement, invoice, proposal or statement of work.",
+      },
+      {
+        type: "p",
+        text: "Unless the applicable proposal, invoice, licence, checkout, product plan, statement of work or signed agreement says otherwise, the client receives a non-exclusive, non-transferable, non-sublicensable licence to access and use the MLAI software for the agreed program, users, sites and purposes for two years.",
+      },
+      { type: "p", text: "The default two-year licence begins on the earliest of:" },
+      {
+        type: "list",
+        items: [
+          "the start date stated in the proposal, invoice, statement of work or product plan;",
+          "the date MLAI first makes the software available to the client;",
+          "the project commencement date; or",
+          "the invoice or billing period start date.",
+        ],
+      },
+      {
+        type: "p",
+        text: "If a proposal, invoice, licence, product plan, statement of work or signed agreement specifies a different term, that specified term applies.",
+      },
+      {
+        type: "p",
+        text: "Unless expressly stated otherwise, the default two-year licence does not apply to ordinary website access, event registration, community membership, trial access, temporary demos or subscription products that state their own billing period.",
+      },
+      {
+        type: "p",
+        text: "A software licence does not transfer ownership of MLAI software, source code, platform code, game systems, simulations, templates, reusable components, designs, educational materials, assets, workflows, know-how or improvements.",
+      },
+    ],
+  },
+  {
+    id: "maintenance-enhancements",
+    title: "21. Maintenance and enhancements",
+    blocks: [
+      {
+        type: "p",
+        text: "For software made available as part of a client project, grant project or educational software licence, basic maintenance is included only where stated in the proposal, invoice, licence, statement of work or product plan.",
+      },
+      {
+        type: "p",
+        text: "If software is licensed as part of a grant, education or project deliverable and no maintenance level is specified, basic maintenance means reasonable bug fixes, reasonable technical support, compatibility or security updates, and minor corrections required to keep the software usable for the agreed program during the licence term.",
+      },
+      {
+        type: "p",
+        text: "Basic maintenance does not include new features, new modules, new integrations, expanded deployment, major curriculum changes, substantial UI redesign, new asset packs, in-person facilitation, production-scale support, data migration, custom reporting or new product development unless expressly included.",
+      },
+      {
+        type: "p",
+        text: "New features, material UI changes, additional modules, integrations, expanded deployment, curriculum redevelopment and new asset packs are separate enhancement work unless expressly included in the applicable scope.",
+      },
+      {
+        type: "p",
+        text: "Payment for configuration, enhancements, feature work or support does not transfer ownership of the underlying software or MLAI platform.",
+      },
+      {
+        type: "p",
+        text: "Unless expressly stated otherwise, a feature enhancement package does not create a subscription, does not extend the licence term and does not transfer ownership.",
+      },
+    ],
+  },
+  {
+    id: "studio-builder-hours",
+    title: "22. MLAI Studio and builder hours",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI Studio may provide AI-assisted product building, design, prototyping, automation, development, content, integration, analysis, research, product support, builder hours, subscriptions, retainers or fixed-scope work.",
+      },
+      {
+        type: "p",
+        text: "Builder hours are time spent by MLAI personnel, contributors or approved contractors on agreed work, including planning, scoping, development, design, prompting, debugging, testing, documentation, review, meetings, deployment and project coordination.",
+      },
+      {
+        type: "p",
+        text: "Meetings, project management, review, documentation, QA, deployment and coordination may count as builder hours unless the applicable plan or statement of work says otherwise.",
+      },
+      { type: "p", text: "Unused hours expire at the end of the billing period unless the applicable plan or statement of work expressly allows rollover." },
+      {
+        type: "p",
+        text: "Urgent work, out-of-scope work, substantial revisions, new integrations, production hardening, security reviews, legal reviews and support outside the agreed scope may require additional fees.",
+      },
+      {
+        type: "p",
+        text: "Unless otherwise agreed, the client is responsible for maintaining third-party accounts, API keys, billing, licences, domain names, hosting, analytics accounts, backups and platform permissions.",
+      },
+      {
+        type: "p",
+        text: "MLAI Studio provides builder capacity and project support. MLAI does not guarantee funding, customers, revenue, production readiness, regulatory approval, search rankings, investment or business success.",
+      },
+      {
+        type: "p",
+        text: "Unless the applicable statement of work says otherwise, the client owns bespoke deliverables created specifically for the client after full payment, except that MLAI retains ownership of MLAI background IP, templates, reusable components, libraries, tools, automations, prompts, platform code, systems, workflows, know-how and pre-existing materials.",
+      },
+    ],
+  },
+  {
+    id: "workshops-organisers",
+    title: "23. Paid workshops and organiser terms",
+    blocks: [
+      { type: "p", text: "Paid workshops may be governed by separate invoices, event pages, proposals, ticketing terms, sponsorship terms or organiser agreements." },
+      { type: "p", text: "Workshop materials, examples, recordings, templates, code, prompts and slides remain MLAI IP or speaker IP unless expressly transferred in writing." },
+      { type: "p", text: "Attendee lists, sponsor leads, event recordings and workshop outputs may only be used as agreed with MLAI and in accordance with applicable privacy requirements." },
+      { type: "p", text: "Organiser payments, speaker fees, sponsor payments, revenue shares, reimbursement arrangements and ticketing splits must be agreed in writing." },
+    ],
+  },
+  {
+    id: "fees-taxes-subscriptions",
+    title: "24. Fees, taxes, subscriptions and credits",
+    blocks: [
+      {
+        type: "p",
+        text: "Fees, GST, payment timing, renewal terms, subscription terms, credit packs, builder-hour packs, workshop fees, sponsorship fees and licence fees are set out in the applicable checkout, invoice, proposal, product plan, statement of work or written agreement.",
+      },
+      { type: "p", text: "Unless stated otherwise, fees are payable in Australian dollars and are exclusive of GST and third-party fees." },
+      { type: "p", text: "MLAI may suspend or limit paid Services for unpaid amounts, failed payments, expired subscriptions or payment disputes, subject to applicable law." },
+      { type: "p", text: "Subscriptions renew for the stated billing period unless cancelled in accordance with the applicable plan or statement of work." },
+      { type: "p", text: "Credits, builder-hour packs and prepaid services expire according to the applicable plan, invoice or statement of work." },
+      { type: "p", text: "Third-party software, API, hosting, cloud, domain, payment, SMS, email, analytics or infrastructure fees are the client’s responsibility unless expressly included." },
+    ],
+  },
+  {
+    id: "acceptable-use",
+    title: "25. Acceptable use",
+    blocks: [
+      { type: "p", text: "You must not, and must not attempt to:" },
+      {
+        type: "list",
+        items: [
+          "use the Services unlawfully, deceptively, abusively or in a way that infringes third-party rights;",
+          "connect accounts, files, datasets, workspaces, channels, messages, records or systems that you are not authorised to use;",
+          "upload malware, exploit code, secrets, tokens, credentials, API keys or data you do not have authority to process;",
+          "misuse Google, Gmail, Google Drive, Google Analytics, Search Console or other connected services;",
+          "send spam, mass unsolicited messages, fake reviews, deceptive advertising or misleading investor, grant, sponsor or customer communications;",
+          "reverse engineer, scrape, bypass, overload, compromise, probe or interfere with the Services or related systems except as permitted by law;",
+          "use the Services for surveillance, discriminatory profiling, unlawful monitoring, credit-worthiness, lending, insurance, employment, medical, legal or other high-risk decisions without appropriate professional advice, safeguards and lawful basis;",
+          "publish or generate content that is unlawful, defamatory, misleading, infringing, confidential, harmful or deceptive;",
+          "use MLAI services to impersonate any person or organisation;",
+          "remove attribution, copyright notices or technical controls unless authorised.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "third-party-services",
+    title: "26. Third-party services",
+    blocks: [
+      {
+        type: "p",
+        text: "The Services may integrate with third-party services, including Google, Gmail, Google Drive, Google Analytics, Search Console, Slack, Xero, Linear, Notion, payment processors, hosting providers, AI infrastructure providers, email tools, analytics services, ticketing platforms and other software or infrastructure providers.",
+      },
+      { type: "p", text: "Third-party services are governed by their own terms and policies." },
+      { type: "p", text: "MLAI is not responsible for third-party service outages, API changes, rate limits, account restrictions, scope changes, billing issues, security incidents or policy changes." },
+    ],
+  },
+  {
+    id: "subcontractors",
+    title: "27. Subcontractors and service providers",
+    blocks: [
+      {
+        type: "p",
+        text: "MLAI may use employees, volunteers, contractors, subcontractors, developers, designers, builders, facilitators, hosting providers, AI infrastructure providers, payment processors, analytics providers and other service providers to deliver the Services.",
+      },
+      { type: "p", text: "MLAI remains responsible for its delivery obligations under agreed project terms, subject to these Terms." },
+    ],
+  },
+  {
+    id: "disclaimers",
+    title: "28. Disclaimers",
+    blocks: [
+      { type: "p", text: "To the maximum extent permitted by law, the Services are provided on an “as is” and “as available” basis." },
+      { type: "p", text: "MLAI does not warrant that the Services will be uninterrupted, secure, error-free, compliant with every use case, compatible with every system, or suitable for your particular needs." },
+      { type: "p", text: "MLAI does not guarantee fundraising outcomes, investment, investor interest, search rankings, traffic, conversions, customers, revenue, prizes, jobs, grants, educational outcomes, software availability, regulatory compliance, production readiness or business success." },
+    ],
+  },
+  {
+    id: "australian-consumer-law",
+    title: "29. Australian Consumer Law",
+    blocks: [
+      { type: "p", text: "Nothing in these Terms excludes, restricts or modifies any rights, guarantees, warranties or remedies that cannot be excluded, restricted or modified under the Australian Consumer Law or other applicable law." },
+      { type: "p", text: "Where MLAI is permitted by law to limit its liability for breach of a non-excludable guarantee, MLAI may limit its liability to the resupply of the relevant services, payment of the cost of resupply, repair or replacement of the relevant goods or software, or payment of the cost of repair or replacement, as applicable." },
+    ],
+  },
+  {
+    id: "liability",
+    title: "30. Limitation of liability",
+    blocks: [
+      { type: "p", text: "To the maximum extent permitted by law, MLAI is not liable for indirect, incidental, special, consequential, punitive, exemplary or economic loss, or any loss of profits, revenue, goodwill, opportunity, business interruption, data, content, contracts, funding, investment, search rankings, customers or reputation arising from or related to the Services." },
+      { type: "p", text: "For paid Services, to the maximum extent permitted by law and unless a signed agreement says otherwise, MLAI’s total liability is limited to the fees paid by you for the relevant Service in the six months before the event giving rise to the claim." },
+      { type: "p", text: "For free Services, to the maximum extent permitted by law, MLAI’s total liability is limited to AUD $100." },
+      { type: "p", text: "These limitations do not limit liability that cannot be limited by law." },
+    ],
+  },
+  {
+    id: "indemnity",
+    title: "31. Indemnity",
+    blocks: [
+      { type: "p", text: "You agree to indemnify MLAI against claims, liabilities, damages, losses and expenses arising out of or related to your use of the Services, your content, your connected accounts or data, your breach of these Terms, your breach of law, or your infringement of third-party rights." },
+    ],
+  },
+  {
+    id: "suspension-termination",
+    title: "32. Suspension and termination",
+    blocks: [
+      { type: "p", text: "MLAI may suspend, restrict or terminate access to the Services if we reasonably believe you have breached these Terms, pose a risk to MLAI, other users, third parties or systems, have unpaid fees, or if suspension is required by law, a platform provider, security need or operational requirement." },
+      { type: "p", text: "You may stop using the Services at any time and may revoke connected account access as described in our Privacy Policy." },
+      { type: "p", text: "Termination does not affect rights, obligations or liabilities that accrued before termination." },
+      { type: "p", text: "Clauses intended to survive termination continue, including clauses relating to IP, confidentiality, fees, privacy, liability, indemnity, governing law and dispute resolution." },
+    ],
+  },
+  {
+    id: "changes",
+    title: "33. Changes to these Terms",
+    blocks: [
+      { type: "p", text: "We may update these Terms from time to time." },
+      { type: "p", text: "We will post the updated Terms on the MLAI website and update the “Last updated” date." },
+      { type: "p", text: "If a change materially affects a paid Service, Google user data use or connected-account feature, we will provide notice or seek consent where required." },
+    ],
+  },
+  {
+    id: "governing-law",
+    title: "34. Governing law",
+    blocks: [
+      { type: "p", text: "These Terms are governed by the laws of Victoria, Australia." },
+      { type: "p", text: "The parties submit to the non-exclusive jurisdiction of the courts of Victoria and the Commonwealth courts of Australia." },
+    ],
+  },
+  {
+    id: "contact",
+    title: "35. Contact",
+    blocks: [
+      { type: "p", text: "Our Privacy Policy explains how we collect, use, protect, retain and delete personal information, including Google user data and connected-source data." },
+    ],
+  },
+];
+
+const navLinks = [
+  { href: "#services-covered", label: "Services covered" },
+  { href: "#connected-accounts-oauth", label: "Connected accounts" },
+  { href: "#google-api-data", label: "Google API data" },
+  { href: "#vibe-raising", label: "Vibe Raising" },
+  { href: "#vibe-marketing", label: "Vibe Marketing" },
+  { href: "#grants-project-delivery", label: "Grants and projects" },
+  { href: "#default-software-licence", label: "Software licence" },
+  { href: "#studio-builder-hours", label: "MLAI Studio" },
+  { href: "#contact", label: "Contact" },
+];
 
 function Section({ id, title, children }: { id: string; title: string; children: ReactNode }) {
   return (
@@ -29,15 +751,6 @@ function Section({ id, title, children }: { id: string; title: string; children:
       </h2>
       <div className="mt-5 space-y-4 text-base leading-7 text-[var(--brutalist-black)]/75">{children}</div>
     </section>
-  );
-}
-
-function Subsection({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <div className="space-y-4">
-      <h3 className="mt-6 text-lg font-black leading-7 text-[var(--brutalist-blue)]">{title}</h3>
-      {children}
-    </div>
   );
 }
 
@@ -58,6 +771,43 @@ function PolicyLink({
     <a href={href} className={`font-black underline underline-offset-4 ${className}`}>
       {children}
     </a>
+  );
+}
+
+function RenderBlock({ block }: { block: LegalBlock }) {
+  if (block.type === "list") {
+    return (
+      <List>
+        {block.items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </List>
+    );
+  }
+
+  if (block.text.startsWith("Our Privacy Policy")) {
+    return (
+      <p>
+        Our <PolicyLink href="/privacy">Privacy Policy</PolicyLink> explains how we collect, use, protect,
+        retain and delete personal information, including Google user data and connected-source data.
+      </p>
+    );
+  }
+
+  return <p>{block.text}</p>;
+}
+
+function ContactCard() {
+  return (
+    <div className="mt-6 rounded-[1.5rem] bg-[var(--brutalist-black)] p-6 text-white">
+      <p className="mb-2 text-base leading-7 text-white">
+        <strong>MLAI Aus Inc</strong>
+      </p>
+      <p className="mb-2 text-base leading-7 text-white/80">ABN 94 807 394 137</p>
+      <p className="mb-2 text-base leading-7 text-white/80">585 Little Collins Street, Melbourne VIC 3000</p>
+      <p className="mb-2 text-base leading-7 text-white/80">Email: hi@mlai.au</p>
+      <p className="text-base leading-7 text-white/80">Website: mlai.au</p>
+    </div>
   );
 }
 
@@ -91,559 +841,41 @@ export default function TermsOfService() {
             </p>
 
             <div className="mt-8 grid gap-5 text-lg leading-8 text-[var(--brutalist-black)]/78 lg:grid-cols-2">
-              <p>
-                These Terms of Service ("Terms") govern your access to and use of
-                the websites, applications, events, community programs, founder
-                tools, project services, software, workshops, and other services
-                provided by MLAI Aus Inc ("MLAI", "we", "our", or "us").
-              </p>
-
-              <p>
-                These Terms apply to MLAI websites, events, community programs,
-                Vibe Raising, Vibe Marketing, MLAI Studio, MLAI Grants and project
-                work, software licensing, paid workshops, subscriptions, builder
-                hours, connected-account products, and related services
-                (collectively, the "Services"). By accessing or using the Services,
-                you agree to be bound by these Terms. If you do not agree, do not
-                use the Services.
-              </p>
+              {introParagraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
             </div>
 
             <div className="mt-8 rounded-[1.5rem] bg-[var(--brutalist-black)] p-5 text-white sm:p-6">
               <p className="text-xs font-black uppercase tracking-[0.24em] text-[var(--brutalist-mint)]">
-                Product schedules
+                Terms sections
               </p>
               <nav className="mt-4 grid gap-2 text-sm font-semibold leading-6 sm:grid-cols-2 lg:grid-cols-3">
-                  <PolicyLink href="#community" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule A - General MLAI Community Terms</PolicyLink>
-                  <PolicyLink href="#vibe-raising" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule B - Vibe Raising Terms</PolicyLink>
-                  <PolicyLink href="#vibe-marketing" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule C - Vibe Marketing Terms</PolicyLink>
-                  <PolicyLink href="#grants-projects" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule D - MLAI Grants and Project Delivery Terms</PolicyLink>
-                  <PolicyLink href="#studio" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule E - MLAI Studio Terms</PolicyLink>
-                  <PolicyLink href="#software-licence" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule F - Software Licence Terms</PolicyLink>
-                  <PolicyLink href="#workshops" className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10">Schedule G - Paid Workshops and Organiser Terms</PolicyLink>
-                </nav>
-              </div>
-
-            </header>
-
-            <div className="mt-10 space-y-10">
-
-              <Section id="who-we-are" title="1. Who We Are">
-                <p>
-                  MLAI Aus Inc is a not-for-profit community based in Australia
-                  that aims to empower the Australian AI community through events,
-                  education, learning-by-doing programs, founder tools, software,
-                  project delivery, sponsorships, partnerships, and community
-                  programs.
-                </p>
-                <p>
-                  These Terms are intended to operate as MLAI's standard terms for
-                  general community participation, software tools, licences, project
-                  services, grants, events, workshops, and related deliverables
-                  unless MLAI and a counterparty have signed a separate written
-                  agreement that says otherwise.
-                </p>
-              </Section>
-
-              <Section id="services-covered" title="2. Services Covered">
-                <p>The Services may include:</p>
-                <List>
-                  <li>MLAI websites, articles, resources, guides, newsletters, and public content.</li>
-                  <li>Events, hackathons, workshops, meetups, community programs, and member spaces.</li>
-                  <li>Founder tools, including Vibe Raising and Vibe Marketing.</li>
-                  <li>MLAI Studio services, builder hours, subscriptions, retainers, and scoped delivery work.</li>
-                  <li>Grant-funded, sponsored, educational, software, research, innovation, and project delivery work.</li>
-                  <li>Software licences, hosted tools, educational simulations, maintenance, support, configuration, and feature enhancements.</li>
-                  <li>Paid workshops, organiser services, sponsorship packages, and related attendee or sponsor deliverables.</li>
-                </List>
-              </Section>
-
-              <Section id="eligibility-accounts" title="3. Eligibility and Accounts">
-                <List>
-                  <li>You must be able to form a legally binding contract to use the Services.</li>
-                  <li>You must provide accurate, current, and complete information and keep it updated.</li>
-                  <li>You are responsible for maintaining the confidentiality of your account credentials and for activity under your account.</li>
-                  <li>You must only use accounts, workspaces, API keys, files, datasets, platforms, content, or third-party services that you own, administer, or are authorised to use.</li>
-                  <li>If you use the Services on behalf of an organisation, you represent that you have authority to bind that organisation to these Terms.</li>
-                </List>
-              </Section>
-
-              <Section id="community" title="4. Schedule A - General MLAI Community Terms">
-                <Subsection title="Events, Hackathons, and Workshops">
-                  <List>
-                    <li>MLAI may run in-person, online, hybrid, public, private, free, paid, sponsored, or grant-funded events, workshops, hackathons, and education programs.</li>
-                    <li>Registration, ticketing, refunds, cancellations, rescheduling, venue rules, eligibility, judging, prizes, and workshop materials may be governed by event-specific terms in addition to these Terms.</li>
-                    <li>MLAI may cancel, postpone, reschedule, change venues, change speakers, modify formats, or refuse entry where reasonably necessary.</li>
-                    <li>Unless required by law or stated in event-specific terms, ticket refunds and transfers are handled at MLAI's discretion.</li>
-                    <li>You are responsible for your own travel, accommodation, equipment, dietary requirements, allergy management, health needs, and participation decisions.</li>
-                    <li>MLAI does not guarantee jobs, funding, investment, introductions, prizes, rankings, commercial outcomes, technical outcomes, or business success from any event or program.</li>
-                  </List>
-                </Subsection>
-
-                <Subsection title="Community Spaces and Conduct">
-                  <List>
-                    <li>MLAI may provide community spaces such as Slack, Discord, mailing lists, member directories, event groups, forums, and other collaboration channels.</li>
-                    <li>You must participate respectfully, lawfully, and consistently with any code of conduct or moderation rules published by MLAI.</li>
-                    <li>MLAI may moderate, remove, suspend, restrict, or terminate access to community spaces or events if conduct creates risk, disrupts the community, breaches these Terms, or is otherwise inappropriate.</li>
-                    <li>Community posts, jobs, opportunities, sponsor content, member profiles, and third-party offers are not endorsed by MLAI unless expressly stated.</li>
-                  </List>
-                </Subsection>
-
-                <Subsection title="Photos, Video, and Recordings">
-                  <p>
-                    MLAI events may be photographed, filmed, livestreamed, or
-                    recorded. By attending an event, you consent to MLAI capturing
-                    and using event media that may include your image, likeness, or
-                    voice for event operations, community updates, education,
-                    archives, reporting, and promotion, unless you notify MLAI in
-                    advance or at the event that you do not want to be featured
-                    where reasonably practicable.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Volunteers, Sponsors, and Partners">
-                  <List>
-                    <li>Volunteer participation does not create an employment relationship unless separately agreed in writing.</li>
-                    <li>Volunteer reimbursements are payable only if MLAI approves them in advance.</li>
-                    <li>Volunteers must protect confidential information, use MLAI systems responsibly, follow access rules, and disclose conflicts of interest.</li>
-                    <li>Sponsor recognition, event involvement, brand use, speaker slots, attendee-list access, content rights, and sponsorship deliverables must be agreed with MLAI.</li>
-                    <li>Sponsorship or partnership does not mean MLAI endorses a sponsor, product, service, investment opportunity, or job listing unless expressly stated.</li>
-                  </List>
-                </Subsection>
-
-                <Subsection title="Educational Content">
-                  <p>
-                    MLAI articles, guides, talks, workshops, templates, resources,
-                    hackathon materials, and educational programs are provided for
-                    general educational and community purposes. They are not legal,
-                    financial, tax, investment, medical, engineering, energy-market,
-                    environmental, public policy, cyber security, or other
-                    professional advice unless MLAI expressly agrees otherwise in a
-                    separate written engagement with a qualified professional.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="connected-accounts" title="5. Connected Accounts and OAuth">
-                <p>
-                  Some Services allow you to connect third-party accounts,
-                  workspaces, analytics properties, file stores, communication
-                  systems, project systems, finance systems, or other data sources.
-                  Connector use is optional unless a specific project or SOW requires
-                  it.
-                </p>
-                <List>
-                  <li>You authorise MLAI to access and process the data you grant through the relevant consent screen, API authorisation, in-product disclosure, file picker, account setting, or connector UI.</li>
-                  <li>The exact permissions requested should be shown before you grant access. You should not connect a service unless you understand and accept the requested access.</li>
-                  <li>You may disconnect connected accounts where product controls are available, revoke access directly with the third-party provider, or contact MLAI at hi@mlai.au.</li>
-                  <li>Connector features may stop working if you revoke access, scopes change, a provider changes its API or policy, tokens expire, the third-party service is unavailable, or you no longer have permissions.</li>
-                </List>
-                <Subsection title="Google API Data Commitments">
-                  <p>
-                    MLAI's use and transfer of information received from Google APIs
-                    will adhere to the Google API Services User Data Policy,
-                    including the Limited Use requirements. In particular:
-                  </p>
-                  <List>
-                    <li>We do not sell Google user data or Gmail data.</li>
-                    <li>We do not use Google user data for advertising, retargeting, personalised advertising, data broker services, credit-worthiness, or lending purposes.</li>
-                    <li>We do not use Google Workspace API data to create, train, or improve generalized AI or machine learning models.</li>
-                    <li>We use Google user data only for disclosed user-facing features that you choose to enable and as otherwise permitted by Google policy and applicable law.</li>
-                    <li>We limit human access to Google user data to cases permitted by Google policy, such as your affirmative agreement, support, security, legal compliance, or aggregated internal operations.</li>
-                  </List>
-                </Subsection>
-              </Section>
-
-              <Section id="ai-outputs" title="6. AI Outputs and User Review">
-                <p>
-                  The Services may use automated systems and AI models to assist with
-                  drafting, summarisation, coding, analysis, marketing, education,
-                  research, extraction, recommendations, simulation, and support.
-                  AI-generated or AI-assisted outputs may be inaccurate, incomplete,
-                  outdated, biased, unsafe, unsuitable, or misleading.
-                </p>
-                <List>
-                  <li>You must review outputs before relying on them, publishing them, sending them, deploying them, presenting them, or using them in decisions.</li>
-                  <li>You are responsible for the accuracy, legality, suitability, approvals, permissions, and third-party rights associated with your content and your use of outputs.</li>
-                  <li>MLAI does not guarantee that AI outputs will be error-free, original, secure, compliant, production-ready, commercially effective, or suitable for any particular purpose.</li>
-                  <li>Outputs are not professional advice unless MLAI expressly agrees otherwise in a separate written engagement.</li>
-                </List>
-              </Section>
-
-              <Section id="user-content-ip" title="7. User Content, MLAI IP, and Licences">
-                <Subsection title="Your Content">
-                  <p>
-                    You retain ownership of content, data, materials, files,
-                    prompts, instructions, brand assets, business information, and
-                    other inputs that you provide to MLAI ("User Content"). You grant
-                    MLAI a limited licence to host, copy, process, transmit, analyse,
-                    display, transform, and use User Content as needed to provide,
-                    operate, secure, support, troubleshoot, improve, and document the
-                    Services, subject to these Terms and our{" "}
-                    <PolicyLink href="/privacy">Privacy Policy</PolicyLink>.
-                  </p>
-                </Subsection>
-
-                <Subsection title="MLAI Intellectual Property">
-                  <p>
-                    MLAI and its licensors retain ownership of MLAI websites,
-                    software, source code, platform code, game systems, simulations,
-                    templates, reusable components, educational materials, tools,
-                    libraries, automations, prompts, workflows, designs, models,
-                    processes, documentation, know-how, improvements, and other
-                    pre-existing or reusable materials unless a signed written
-                    agreement expressly transfers ownership.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Community and Workshop Contributions">
-                  <p>
-                    If you contribute ideas, feedback, code, content, designs,
-                    prompts, examples, workshop materials, hackathon submissions, or
-                    suggestions to MLAI, you grant MLAI a non-exclusive, worldwide,
-                    royalty-free licence to use, reproduce, adapt, publish, display,
-                    distribute, and improve those contributions for community,
-                    educational, product, operational, and promotional purposes,
-                    unless MLAI has agreed different written terms.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="confidentiality" title="8. Confidentiality">
-                <p>
-                  If a project, workshop, founder workflow, grant, studio engagement,
-                  or community role gives you access to non-public information, you
-                  must keep that information confidential and use it only for the
-                  purpose for which it was provided. MLAI will use reasonable care to
-                  protect confidential information you provide, subject to these
-                  Terms, our Privacy Policy, agreed project terms, support needs,
-                  security needs, and legal obligations.
-                </p>
-              </Section>
-
-              <Section id="vibe-raising" title="9. Schedule B - Vibe Raising Terms">
-                <p>
-                  Vibe Raising helps founders prepare monthly startup and investor
-                  updates, structure highlights, metrics, risks, asks, milestones,
-                  follow-ups, and relationship context, and may support optional
-                  publishing or investor-readiness workflows.
-                </p>
-                <List>
-                  <li>Vibe Raising may process information you enter, upload, generate, approve, or connect, including startup profiles, monthly updates, investor asks, customer context, company metrics, source URLs, uploaded materials, Gmail, Google Drive, Slack, Xero, Linear, Notion, and other enabled sources.</li>
-                  <li>Connected accounts are optional. You must own, administer, or have authority to connect the relevant account, workspace, files, channels, or data.</li>
-                  <li>You must review every generated founder update, metric, claim, summary, ask, and follow-up before sending, publishing, or relying on it.</li>
-                  <li>You must not include confidential third-party information, investor information, customer information, employee information, or regulated information unless you have the rights and lawful basis to use it.</li>
-                  <li>You must not use Vibe Raising to mislead investors, customers, grant providers, partners, sponsors, or other recipients.</li>
-                </List>
-                <Subsection title="Investor Introduction Disclaimer">
-                  <p>
-                    MLAI may, at its discretion, introduce founders to investors,
-                    mentors, sponsors, ecosystem partners, community members, or
-                    other contacts. MLAI does not guarantee introductions, investment,
-                    investor interest, due diligence outcomes, funding, valuations,
-                    revenue, business success, or any other commercial result.
-                  </p>
-                </Subsection>
-                <Subsection title="No Fundraising or Investment Advice">
-                  <p>
-                    Vibe Raising is not legal, financial, tax, investment,
-                    fundraising, securities, or accounting advice. You are responsible
-                    for obtaining professional advice where appropriate.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="vibe-marketing" title="10. Schedule C - Vibe Marketing Terms">
-                <p>
-                  Vibe Marketing may help founders and teams with AI-assisted
-                  marketing strategy, SEO, AEO, GEO, topic discovery, keyword
-                  clustering, content templates, startup profiles, article and page
-                  generation, metadata, schema suggestions, internal linking,
-                  sitemap workflows, analytics-driven recommendations, and optional
-                  publishing workflows.
-                </p>
-                <List>
-                  <li>Vibe Marketing may use user-provided startup profiles, website URLs, public website content, approved founder updates, approved Vibe Raising outputs, Google Analytics, Search Console, keyword tools, public search data, uploaded assets, product screenshots, customer personas, and other authorised materials.</li>
-                  <li>Generated content is draft content unless you or an authorised user approves or publishes it.</li>
-                  <li>You are responsible for reviewing accuracy, legality, brand fit, claims, pricing, testimonials, case studies, regulated-industry statements, competitor references, third-party rights, and confidentiality before publishing.</li>
-                  <li>You must not use Vibe Marketing for doorway pages, spam, deceptive content, impersonation, fake reviews, fabricated case studies, unlawful scraping, undisclosed paid endorsements, or infringing content.</li>
-                  <li>MLAI does not guarantee search rankings, traffic, conversions, revenue, backlinks, citations by AI systems, investor interest, customer acquisition, brand outcomes, or marketing performance.</li>
-                </List>
-                <Subsection title="Cross-Product Use With Vibe Raising">
-                  <p>
-                    Some MLAI products work together. For example, Vibe Raising may
-                    help you prepare founder updates, and Vibe Marketing may help you
-                    turn approved company information, website content, approved
-                    updates, metrics, or themes into marketing content. We will only
-                    use connected-source data across products where that use is
-                    disclosed, user-facing, authorised by you, and permitted by
-                    applicable third-party platform policies.
-                  </p>
-                  <p>
-                    Vibe Marketing should use approved outputs from Vibe Raising,
-                    such as final founder updates, approved company profiles,
-                    approved metrics summaries, and approved customer themes, rather
-                    than raw Gmail messages or broad Google Drive file content unless
-                    that raw-source use is specifically disclosed and enabled by you.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="grants-projects" title="11. Schedule D - MLAI Grants and Project Delivery Terms">
-                <p>
-                  MLAI may receive grants, sponsorships, purchase orders, invoices,
-                  statements of work, or project funding to deliver educational,
-                  software, community, research, innovation, or project services.
-                  The applicable proposal, invoice, grant agreement, purchase order,
-                  statement of work, or written project terms define the specific
-                  deliverables. These Terms fill gaps unless a signed written
-                  agreement says otherwise. If there is a conflict, signed
-                  project-specific terms prevail to the extent of the conflict.
-                </p>
-                <Subsection title="Deliverables and Project Structure">
-                  <List>
-                    <li>Deliverables may include software builds, hosted access, simulations, games, learning materials, workshops, reports, training, documentation, support, maintenance, configuration, data work, and facilitation.</li>
-                    <li>Milestones, acceptance criteria, timelines, fees, licence scope, support levels, and included features are set out in the relevant proposal, invoice, purchase order, grant agreement, or SOW.</li>
-                    <li>Clients and co-funders must provide timely feedback, assets, approvals, access, subject-matter input, data, branding, curriculum direction, and other dependencies reasonably needed for delivery.</li>
-                    <li>MLAI is not responsible for delays caused by missing feedback, delayed approvals, unavailable third-party services, missing access, changed requirements, or client-side dependencies.</li>
-                    <li>Change requests, expanded deployment, new integrations, major curriculum changes, additional modules, substantial UI redesign, and new feature work are separate work unless expressly included in the SOW.</li>
-                  </List>
-                </Subsection>
-
-                <Subsection title="Acceptance">
-                  <p>
-                    Unless the relevant SOW says otherwise, deliverables are accepted
-                    when MLAI makes them available for use, delivery, testing, or
-                    review and the client does not reject them in writing with
-                    specific material defects within 10 business days. Minor defects,
-                    ordinary support issues, and enhancement requests do not prevent
-                    acceptance and may be handled through support, maintenance, or
-                    change-request processes.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="studio" title="12. Schedule E - MLAI Studio Terms">
-                <p>
-                  MLAI Studio may provide AI-assisted product building, design,
-                  prototyping, automation, development, content, integration,
-                  analysis, research, product support, builder hours, subscriptions,
-                  retainers, or fixed-scope work.
-                </p>
-                <List>
-                  <li>Builder hours are time spent by MLAI personnel, contributors, or approved contractors on agreed work, including planning, scoping, development, design, prompting, debugging, testing, documentation, review, meetings, deployment, and project coordination.</li>
-                  <li>Meetings, project management, review, documentation, QA, deployment, and coordination may count as builder hours unless the applicable SOW says otherwise.</li>
-                  <li>Unused hours expire at the end of the billing period unless the applicable plan or SOW expressly allows rollover.</li>
-                  <li>Urgent work, out-of-scope work, substantial revisions, new integrations, production hardening, security reviews, legal reviews, and support outside the agreed scope may require additional fees.</li>
-                  <li>Unless otherwise agreed, the client is responsible for maintaining third-party accounts, API keys, billing, licences, domain names, hosting, analytics accounts, backups, and platform permissions.</li>
-                  <li>MLAI Studio provides builder capacity and project support. MLAI does not guarantee funding, customers, revenue, production readiness, regulatory approval, search rankings, investment, or business success.</li>
-                </List>
-                <Subsection title="Studio Deliverables and IP">
-                  <p>
-                    Unless the applicable SOW says otherwise, the client owns bespoke
-                    deliverables created specifically for the client after full
-                    payment, except MLAI retains ownership of MLAI background IP,
-                    templates, reusable components, libraries, tools, automations,
-                    prompts, platform code, systems, workflows, know-how, and
-                    pre-existing materials.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="software-licence" title="13. Schedule F - Software Licence Terms">
-                <Subsection title="Software Ownership">
-                  <p>
-                    Unless expressly agreed otherwise in writing, MLAI retains all
-                    intellectual property rights in MLAI software, source code, game
-                    systems, simulations, templates, reusable components, designs,
-                    educational materials, assets, workflows, know-how, and
-                    improvements.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Client Licence">
-                  <p>
-                    A client receives a non-exclusive, non-transferable licence to
-                    access and use MLAI software for the agreed program, term, users,
-                    sites, and purposes stated in the applicable proposal, invoice,
-                    licence document, purchase order, or SOW. No ownership transfer
-                    occurs unless MLAI expressly agrees in a signed written
-                    assignment.
-                  </p>
-                </Subsection>
-
-                <Subsection title="Maintenance and Enhancements">
-                  <List>
-                    <li>Basic maintenance means bug fixes, reasonable technical support, compatibility or security updates, and minor corrections required to keep the software usable for the agreed program, only where included in the proposal, invoice, licence, or SOW.</li>
-                    <li>Basic maintenance does not include new features, new modules, new integrations, expanded deployment, major curriculum changes, substantial UI redesign, new asset packs, or production-scale support unless expressly included.</li>
-                    <li>New features, material UI changes, additional modules, integrations, expanded deployment, curriculum redevelopment, and new asset packs are separate enhancement work unless expressly included in the SOW.</li>
-                    <li>Payment for configuration, enhancements, feature work, or support does not transfer ownership of the underlying software or MLAI platform.</li>
-                  </List>
-                </Subsection>
-
-                <Subsection title="Carbon, Cost & Convenience">
-                  <p>
-                    Carbon, Cost &amp; Convenience is MLAI-owned educational software.
-                    Monash Tech School receives a non-exclusive, non-transferable
-                    licence to use the software for the Monash Tech School /
-                    Supersystems educational program for the period stated in the
-                    applicable invoice, proposal, or SOW. Unless a later written
-                    agreement says otherwise, the licence period is 1 November 2025
-                    to 1 November 2027.
-                  </p>
-                  <p>
-                    Additional feature work, including the additional $24,300
-                    enhancement package, is a fixed-fee enhancement package to the
-                    existing licensed software. It does not transfer ownership, does
-                    not create a subscription, and does not extend the licence term
-                    unless agreed in writing.
-                  </p>
-                  <p>
-                    Carbon, Cost &amp; Convenience is an educational simulation. It is
-                    not engineering, energy-market, financial, environmental, legal,
-                    or public policy advice.
-                  </p>
-                </Subsection>
-              </Section>
-
-              <Section id="workshops" title="14. Schedule G - Paid Workshops and Organiser Terms">
-                <List>
-                  <li>Paid workshops may be governed by separate invoices, event pages, proposals, ticketing terms, sponsorship terms, or organiser agreements.</li>
-                  <li>Workshop materials, examples, recordings, templates, code, and slides remain MLAI IP or speaker IP unless expressly transferred in writing.</li>
-                  <li>Attendee lists, sponsor leads, event recordings, and workshop outputs may only be used as agreed with MLAI and in accordance with applicable privacy requirements.</li>
-                  <li>Organiser payments, speaker fees, sponsor payments, revenue shares, reimbursement arrangements, and ticketing splits must be agreed in writing.</li>
-                </List>
-              </Section>
-
-              <Section id="fees-payment" title="15. Fees, Taxes, Subscriptions, and Credits">
-                <List>
-                  <li>Fees, GST, payment timing, renewal terms, subscription terms, credit packs, builder-hour packs, workshop fees, sponsorship fees, and licence fees are set out in the applicable checkout, invoice, proposal, SOW, or written agreement.</li>
-                  <li>Unless stated otherwise, fees are payable in Australian dollars and are exclusive of GST and third-party fees.</li>
-                  <li>MLAI may suspend or limit paid Services for unpaid amounts, failed payments, expired subscriptions, or payment disputes, subject to applicable law.</li>
-                  <li>Subscriptions renew for the stated billing period unless cancelled in accordance with the applicable plan or SOW.</li>
-                  <li>Credits, builder-hour packs, and prepaid services expire according to the applicable plan, invoice, or SOW.</li>
-                </List>
-              </Section>
-
-              <Section id="acceptable-use" title="16. Acceptable Use">
-                <p>You must not, and must not attempt to:</p>
-                <List>
-                  <li>Use the Services unlawfully, deceptively, abusively, or in a way that infringes third-party rights.</li>
-                  <li>Connect accounts, files, datasets, workspaces, channels, messages, records, or systems that you are not authorised to use.</li>
-                  <li>Upload, generate, publish, or send unlawful, misleading, defamatory, infringing, harassing, discriminatory, harmful, unsafe, confidential, or malicious content.</li>
-                  <li>Use the Services to send spam, mass unsolicited messages, fake reviews, deceptive advertising, or misleading investor or customer communications.</li>
-                  <li>Reverse engineer, scrape, bypass, overload, compromise, probe, or interfere with the Services or related systems except as permitted by law.</li>
-                  <li>Upload malware, exploit code, secrets, tokens, API keys, credentials, or data you do not have authority to process.</li>
-                  <li>Use the Services to make high-risk decisions without appropriate human review, professional advice, testing, and safeguards.</li>
-                </List>
-              </Section>
-
-              <Section id="third-party-services" title="17. Third-Party Services">
-                <p>
-                  The Services may integrate with third-party services, including
-                  Google, Gmail, Google Drive, Google Analytics, Search Console,
-                  Slack, Xero, Linear, Notion, payment processors, hosting providers,
-                  AI infrastructure providers, email tools, analytics services,
-                  ticketing platforms, and other software or infrastructure
-                  providers. Third-party services are governed by their own terms and
-                  policies. MLAI is not responsible for third-party service outages,
-                  API changes, rate limits, account restrictions, scope changes,
-                  billing issues, security incidents, or policy changes.
-                </p>
-              </Section>
-
-              <Section id="disclaimers" title="18. Disclaimers">
-                <p>
-                  To the maximum extent permitted by law, the Services are provided
-                  on an "as is" and "as available" basis. MLAI does not warrant that
-                  the Services will be uninterrupted, secure, error-free, compliant
-                  with every use case, or suitable for your particular needs.
-                </p>
-                <p>
-                  MLAI does not guarantee fundraising outcomes, investment, investor
-                  interest, search rankings, traffic, conversions, customers,
-                  revenue, prizes, jobs, grants, educational outcomes, software
-                  availability, regulatory compliance, production readiness, or
-                  business success.
-                </p>
-              </Section>
-
-              <Section id="australian-consumer-law" title="19. Australian Consumer Law">
-                <p>
-                  Nothing in these Terms excludes, restricts, or modifies any rights,
-                  guarantees, warranties, or remedies that cannot be excluded,
-                  restricted, or modified under the Australian Consumer Law or other
-                  applicable law.
-                </p>
-                <p>
-                  Where MLAI is permitted by law to limit its liability for breach of
-                  a non-excludable guarantee, MLAI may limit its liability to the
-                  resupply of the relevant services, payment of the cost of resupply,
-                  repair or replacement of the relevant goods or software, or payment
-                  of the cost of repair or replacement, as applicable.
-                </p>
-              </Section>
-
-              <Section id="liability" title="20. Limitation of Liability and Indemnity">
-                <p>
-                  To the maximum extent permitted by law, MLAI is not liable for
-                  indirect, incidental, special, consequential, punitive, exemplary,
-                  or economic loss, or any loss of profits, revenue, goodwill,
-                  opportunity, business interruption, data, content, contracts,
-                  funding, investment, search rankings, customers, or reputation
-                  arising from or related to the Services.
-                </p>
-                <p>
-                  You agree to indemnify MLAI against claims, liabilities, damages,
-                  losses, and expenses arising out of or related to your use of the
-                  Services, your User Content, your connected accounts or data, your
-                  breach of these Terms, your breach of law, or your infringement of
-                  third-party rights.
-                </p>
-              </Section>
-
-              <Section id="suspension-termination" title="21. Suspension and Termination">
-                <p>
-                  MLAI may suspend, restrict, or terminate access to the Services if
-                  we reasonably believe you have breached these Terms, pose a risk to
-                  MLAI, other users, third parties, or systems, have unpaid fees, or
-                  if suspension is required by law, a platform provider, security
-                  need, or operational requirement. You may stop using the Services
-                  at any time and may revoke connected account access as described in
-                  our Privacy Policy.
-                </p>
-              </Section>
-
-              <Section id="changes-governing-law" title="22. Changes, Governing Law, and Contact">
-                <p>
-                  We may update these Terms from time to time. We will post the
-                  updated Terms on this page and update the "Last updated" date. If a
-                  change materially affects a paid Service, Google user data use, or
-                  a connected-account feature, we will provide notice or seek consent
-                  where required.
-                </p>
-                <p>
-                  These Terms are governed by the laws of Victoria, Australia. The
-                  parties submit to the non-exclusive jurisdiction of the courts of
-                  Victoria and the Commonwealth courts of Australia.
-                </p>
-                <p>
-                  Our <PolicyLink href="/privacy">Privacy Policy</PolicyLink>{" "}
-                  explains how we collect, use, protect, retain, and delete personal
-                  information, including Google user data and connected-source data.
-                </p>
-
-                <div className="mt-6 rounded-[1.5rem] bg-[var(--brutalist-black)] p-6 text-white">
-                  <p className="mb-2 text-base leading-7 text-white">
-                    <strong>MLAI Aus Inc</strong>
-                  </p>
-                  <p className="mb-2 text-base leading-7 text-white/80">Email: hi@mlai.au</p>
-                  <p className="text-base leading-7 text-white/80">Website: https://mlai.au</p>
-                </div>
-              </Section>
+                {navLinks.map((link) => (
+                  <PolicyLink
+                    key={link.href}
+                    href={link.href}
+                    className="rounded-full border border-white/15 px-3 py-2 text-white no-underline transition hover:bg-white/10"
+                  >
+                    {link.label}
+                  </PolicyLink>
+                ))}
+              </nav>
             </div>
-          </article>
-        </section>
-      </main>
+          </header>
+
+          <div className="mt-10 space-y-10">
+            {sections.map((section) => (
+              <Section key={section.id} id={section.id} title={section.title}>
+                {section.blocks.map((block, index) => (
+                  <RenderBlock key={`${section.id}-${index}`} block={block} />
+                ))}
+                {section.id === "contact" ? <ContactCard /> : null}
+              </Section>
+            ))}
+          </div>
+        </article>
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the `/terms` body copy with the requested updated MLAI Terms of Service text, including ABN, document-order rules, default software licence terms, builder-hour terms, ACL language, liability, and contact details.
- Replaces the `/privacy` body copy with the requested updated MLAI Privacy Policy text, including product-specific data, Google user data, Limited Use commitments, human access, security, retention, children/students, sensitive information, and contact details.
- Keeps the recently merged MLAI brutalist styling shell for both legal pages.

## Validation

- `bun run typecheck`
- `bun run build` (completed successfully; postbuild IndexNow submission returned the existing 403 Forbidden response)
- Local browser verification for `/terms` and `/privacy`: ABN/address copy present, replacement clauses present, beige background and 40px panels retained, no horizontal overflow, no console errors.