### PR TITLE
[codex] Add Vibe Marketing company avatars

### DIFF
--- a/app/components/AvatarModal.tsx
+++ b/app/components/AvatarModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, Fragment } from 'react';
+import React, { useCallback, useEffect, useState, Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import Cropper from 'react-easy-crop';
 import { useDropzone } from 'react-dropzone';
@@ -10,14 +10,23 @@ interface AvatarModalProps {
     onClose: () => void;
     onSave: (file: File) => void;
     initialImage?: string;
+    seedInitialImage?: boolean;
     title?: string;
 }
 
-export default function AvatarModal({ isOpen, onClose, onSave, initialImage, title }: AvatarModalProps) {
+export default function AvatarModal({ isOpen, onClose, onSave, initialImage, seedInitialImage = false, title }: AvatarModalProps) {
     const [imageSrc, setImageSrc] = useState<string | null>(null);
     const [crop, setCrop] = useState({ x: 0, y: 0 });
     const [zoom, setZoom] = useState(1);
     const [croppedAreaPixels, setCroppedAreaPixels] = useState<any>(null);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        setCrop({ x: 0, y: 0 });
+        setZoom(1);
+        setCroppedAreaPixels(null);
+        setImageSrc(seedInitialImage && initialImage ? initialImage : null);
+    }, [initialImage, isOpen, seedInitialImage]);
 
     const onCropComplete = useCallback((_: any, croppedAreaPixels: any) => {
         setCroppedAreaPixels(croppedAreaPixels);
@@ -161,7 +170,7 @@ export default function AvatarModal({ isOpen, onClose, onSave, initialImage, tit
                                     </button>
                                     <button
                                         onClick={handleSave}
-                                        disabled={!imageSrc}
+                                        disabled={!imageSrc || !croppedAreaPixels}
                                         className="inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50"
                                     >
                                         Save

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -272,6 +272,7 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
       companyLinkedInUrl: asNullableString(company.companyLinkedInUrl) ?? asNullableString(company.company_linkedin_url),
       location: asNullableString(company.location),
       abn: asNullableString(company.abn),
+      avatarUrl: asNullableString(company.avatarUrl) ?? asNullableString(company.avatar_url),
       organizationId: Number(company.organizationId ?? company.organization_id ?? 0) || null,
     },
     organization: {
@@ -1241,6 +1242,14 @@ export async function getVibeMarketingBootstrap(
 export async function saveVibeMarketingSettings(env: Env, request: Request, body: Record<string, unknown>) {
   const client = createApiClient(env, request);
   const response = await client.put(`${BASE_PATH}/settings`, body);
+  return normalizeBootstrap(response.data);
+}
+
+export async function uploadVibeMarketingCompanyAvatar(env: Env, request: Request, file: File) {
+  const client = createApiClient(env, request);
+  const formData = new FormData();
+  formData.set("avatar", file);
+  const response = await client.post(`${BASE_PATH}/company/avatar/`, formData);
   return normalizeBootstrap(response.data);
 }
 

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -232,6 +232,9 @@ function normalizeCompany(raw: unknown): VibeRaisingCompany {
   const companyLinkedInUrl =
     asNullableString(payload.companyLinkedInUrl) ??
     asNullableString(payload.company_linkedin_url);
+  const avatarUrl =
+    asNullableString(payload.avatarUrl) ??
+    asNullableString(payload.avatar_url);
   const location =
     asNullableString(payload.location) ??
     asNullableString(payload.companyLocation) ??
@@ -282,6 +285,7 @@ function normalizeCompany(raw: unknown): VibeRaisingCompany {
     companyLinkedInUrl,
     abn,
     location,
+    avatarUrl,
     founderProfiles,
     founderNames,
     stage,

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3,
   BookOpen,
   Brain,
+  Camera,
   CheckCircle2,
   ChevronDown,
   CircleHelp,
@@ -36,6 +37,7 @@ import { clsx } from "clsx";
 
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import type { MarketingRunProgressTheme } from "~/components/MarketingRunProgressCard";
+import AvatarModal from "~/components/AvatarModal";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
@@ -53,6 +55,7 @@ import {
   startVibeMarketingBaseline,
   startVibeMarketingDiscovery,
   startVibeMarketingScan,
+  uploadVibeMarketingCompanyAvatar,
 } from "~/lib/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
@@ -283,6 +286,18 @@ export async function action({ request, context }: Route.ActionArgs) {
   const intent = stringFromForm(formData, "intent");
 
   try {
+    if (intent === "save-company-avatar") {
+      if (!vibeContext.appUser) {
+        return { intent, error: "Create your startup profile before adding an avatar." };
+      }
+      const avatar = formData.get("avatar");
+      if (!(avatar instanceof File) || avatar.size === 0) {
+        return { intent, error: "Choose an avatar image before saving." };
+      }
+      const bootstrap = await uploadVibeMarketingCompanyAvatar(env, request, avatar);
+      return { intent, avatarUrl: bootstrap.company.avatarUrl ?? null };
+    }
+
     if (intent === "save-startup-details") {
       const { founderProfiles, founderNames } = founderNamesFromForm(formData);
       const name = stringFromForm(formData, "companyName");
@@ -2552,6 +2567,12 @@ type ContentIslandDiscoveryActionData = {
   errors?: string[];
 };
 
+type CompanyAvatarActionData = {
+  intent?: string;
+  avatarUrl?: string | null;
+  error?: string | null;
+};
+
 type ContentIslandDiscoveryRunState = {
   runId: string;
   islandSlug: string;
@@ -3003,6 +3024,7 @@ function ReturningTopicPickerPage({
   const restoreFetcher = useFetcher<TopicFeedbackActionData>();
   const contentIslandDiscoveryFetcher = useFetcher<ContentIslandDiscoveryActionData>({ key: "content-island-discovery" });
   const contentIslandRunStatusFetcher = useFetcher<VibeMarketingRunSummary>({ key: "content-island-discovery-status" });
+  const companyAvatarFetcher = useFetcher<CompanyAvatarActionData>({ key: "company-avatar" });
   const topicListRef = useRef<HTMLDivElement | null>(null);
   const pillarHelpRef = useRef<HTMLDivElement | null>(null);
   const baseTopics = useMemo(
@@ -3018,9 +3040,12 @@ function ReturningTopicPickerPage({
   const [pillarHelpOpen, setPillarHelpOpen] = useState(false);
   const [contentIslandDiscoveryRun, setContentIslandDiscoveryRun] = useState<ContentIslandDiscoveryRunState | null>(null);
   const [contentIslandRefreshRunId, setContentIslandRefreshRunId] = useState<string | null>(null);
+  const [companyAvatarModalOpen, setCompanyAvatarModalOpen] = useState(false);
+  const [companyAvatarPreviewUrl, setCompanyAvatarPreviewUrl] = useState<string | null>(null);
   const undoRequestedTopicIds = useRef<Set<string>>(new Set());
   const completedContentIslandDiscoveryRuns = useRef<Set<string>>(new Set());
   const contentIslandRefreshStartCount = useRef(0);
+  const companyAvatarPreviewObjectUrl = useRef<string | null>(null);
   const articleFormRef = useRef<HTMLFormElement>(null);
   const activePillar = useMemo(
     () => bootstrap.topicPillars.find((pillar) => pillar.slug === activePillarSlug) ?? null,
@@ -3078,6 +3103,13 @@ function ReturningTopicPickerPage({
   const companyName = bootstrap.settings.brandName || bootstrap.organization.name || bootstrap.company.name || "YourStartup";
   const domain = bootstrap.company.domain || bootstrap.organization.domain;
   const tags = startupTags(bootstrap);
+  const savedCompanyAvatarUrl = bootstrap.company.avatarUrl ?? null;
+  const companyAvatarUrl = companyAvatarPreviewUrl || savedCompanyAvatarUrl;
+  const companyAvatarSaving = companyAvatarFetcher.state !== "idle";
+  const companyAvatarError =
+    companyAvatarFetcher.data?.intent === "save-company-avatar"
+      ? companyAvatarFetcher.data.error ?? null
+      : null;
   const latestArticleRunId =
     bootstrap.latestRuns.find((run) => ["article_generation", "content_factory_article", "article_revision"].includes(run.workflow))?.runId ?? "";
   const latestDiscoveryRunId =
@@ -3222,6 +3254,56 @@ function ReturningTopicPickerPage({
       pillarHelpRef.current?.focus({ preventScroll: true });
     }, 0);
   }
+
+  const handleCompanyAvatarSave = useCallback(
+    (file: File) => {
+      if (companyAvatarPreviewObjectUrl.current) {
+        window.URL.revokeObjectURL(companyAvatarPreviewObjectUrl.current);
+      }
+      const previewUrl = window.URL.createObjectURL(file);
+      companyAvatarPreviewObjectUrl.current = previewUrl;
+      setCompanyAvatarPreviewUrl(previewUrl);
+      setToast(null);
+
+      const formData = new FormData();
+      formData.set("intent", "save-company-avatar");
+      formData.set("avatar", file);
+      companyAvatarFetcher.submit(formData, {
+        method: "POST",
+        encType: "multipart/form-data",
+      });
+    },
+    [companyAvatarFetcher],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (companyAvatarPreviewObjectUrl.current) {
+        window.URL.revokeObjectURL(companyAvatarPreviewObjectUrl.current);
+        companyAvatarPreviewObjectUrl.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const data = companyAvatarFetcher.data;
+    if (companyAvatarFetcher.state !== "idle" || data?.intent !== "save-company-avatar") return;
+    if (data.error) {
+      if (companyAvatarPreviewObjectUrl.current) {
+        window.URL.revokeObjectURL(companyAvatarPreviewObjectUrl.current);
+        companyAvatarPreviewObjectUrl.current = null;
+      }
+      setCompanyAvatarPreviewUrl(null);
+      setToast({ kind: "error", message: data.error });
+      return;
+    }
+    if (companyAvatarPreviewObjectUrl.current) {
+      window.URL.revokeObjectURL(companyAvatarPreviewObjectUrl.current);
+      companyAvatarPreviewObjectUrl.current = null;
+    }
+    setCompanyAvatarPreviewUrl(data.avatarUrl ?? null);
+    revalidator.revalidate();
+  }, [companyAvatarFetcher.data, companyAvatarFetcher.state, revalidator]);
 
   useEffect(() => {
     try {
@@ -3674,14 +3756,34 @@ function ReturningTopicPickerPage({
               </Link>
             </div>
             <div className="mt-6 flex items-center gap-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-black text-xl font-black text-white">
-                {companyInitials(companyName)}
+              <div className="group relative h-14 w-14 shrink-0">
+                {companyAvatarUrl ? (
+                  <img
+                    src={companyAvatarUrl}
+                    alt={`${companyName} avatar`}
+                    className="h-14 w-14 rounded-full object-cover ring-1 ring-slate-200"
+                  />
+                ) : (
+                  <div className="flex h-14 w-14 items-center justify-center rounded-full bg-black text-xl font-black text-white">
+                    {companyInitials(companyName)}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setCompanyAvatarModalOpen(true)}
+                  disabled={companyAvatarSaving}
+                  aria-label="Edit company avatar"
+                  className="absolute inset-0 flex items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {companyAvatarSaving ? <Loader2 className="h-5 w-5 animate-spin" /> : <Camera className="h-5 w-5" />}
+                </button>
               </div>
               <div className="min-w-0">
                 <p className="truncate text-lg font-black text-slate-950">{companyName}</p>
                 <p className="mt-1 text-sm font-bold text-slate-500">
                   {tags.length ? tags.join(" · ") : "Startup · SEO · Growth"}
                 </p>
+                {companyAvatarError ? <p className="mt-1 text-xs font-bold text-red-600">{companyAvatarError}</p> : null}
               </div>
             </div>
             <div className="mt-6 flex items-center justify-between gap-4 rounded-xl border border-emerald-100 bg-emerald-50 px-5 py-4">
@@ -3761,6 +3863,14 @@ function ReturningTopicPickerPage({
           </section>
         </aside>
       </div>
+      <AvatarModal
+        isOpen={companyAvatarModalOpen}
+        onClose={() => setCompanyAvatarModalOpen(false)}
+        onSave={handleCompanyAvatarSave}
+        initialImage={savedCompanyAvatarUrl ?? undefined}
+        seedInitialImage={Boolean(savedCompanyAvatarUrl)}
+        title="Update company avatar"
+      />
       {draftDeleteRequest ? (
         <DraftDeleteConfirmationModal
           draft={draftDeleteRequest}

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -157,6 +157,7 @@ export interface VibeMarketingCompany {
   companyLinkedInUrl?: string | null;
   location?: string | null;
   abn?: string | null;
+  avatarUrl?: string | null;
   organizationId?: number | null;
 }
 

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -14,6 +14,7 @@ export interface VibeRaisingCompany {
   companyLinkedInUrl?: string | null;
   abn?: string | null;
   location?: string | null;
+  avatarUrl?: string | null;
   founderProfiles?: VibeRaisingFounderProfile[];
   founderNames?: string[];
   stage?: string | null;


### PR DESCRIPTION
## Summary
- render saved company avatars on the Vibe Marketing startup card with initials fallback
- reuse AvatarModal for hover/focus crop upload flow
- add Vibe Marketing avatar upload API helper and type normalization

## Validation
- PATH=/Users/samdonegan/Documents/Code/mlai-au/node_modules/.bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/samdonegan/.codex/tmp/arg0/codex-arg00BgxGT:/Users/samdonegan/.local/bin:/Users/samdonegan/.antigravity/antigravity/bin:/Users/samdonegan/.bun/bin:/Users/samdonegan/Library/Python/3.9/bin:/Applications/Docker.app/Contents/Resources/bin:/Applications/Codex.app/Contents/Resources npm run typecheck -- --pretty false