### PR TITLE
Fix Studynash autofill progress handling

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -36,6 +36,11 @@ import {
   type StartupSetupField,
   type StartupSetupValues,
 } from "~/lib/vibe-marketing-startup-setup";
+import {
+  autofillProgressState,
+  autofillStartErrorsForDisplay,
+  isAutofillStatusPollFailure,
+} from "~/lib/vibe-marketing-autofill-state";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import type {
   VibeMarketingAutofillCompetitor,
@@ -54,8 +59,8 @@ const FLOW_STEPS = [
   { label: "Drive more traffic & grow", icon: BarChart3 },
 ] as const;
 
-const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running"]);
-const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "cancelled", "denied"]);
+const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running", "processing", "in_progress"]);
+const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "precondition_failed", "cancelled", "canceled", "denied", "error"]);
 const RESEARCH_DONE_STATUSES = new Set(["completed", ...RESEARCH_FAILED_STATUSES]);
 const MOBILE_STARTUP_SETUP_TUTORIAL_STORAGE_KEY = "vibe_marketing_startup_setup_mobile_tour_seen_v1";
 
@@ -1518,7 +1523,7 @@ function ProfileResearchProgressCard({
         run?.errors?.[0] ||
         (failed ? "AI research is unavailable. Check the Content Factory backend and try again." : null);
   const notice = unavailable
-    ? "We have not received a fresh status update for more than 2 minutes. You can retry now, or keep this page open while polling continues."
+    ? "We have not received a fresh status update for more than 10 minutes. You can retry now, or keep this page open while polling continues."
     : stalled
       ? "This is taking longer than expected. We will keep checking for progress in the background."
       : null;
@@ -1583,7 +1588,7 @@ function ProfileResearchProgressCard({
                 {pending ? "Contacting the AI research service" : partial ? "AI prepared partial article context without changing your profile." : autofillStepLabel(run?.currentStep)}
               </p>
               <p className="mt-1 text-sm font-medium text-gray-500">
-                {active ? "Usually takes 1-3 minutes. Refreshing the page is safe." : failed ? "The form is unlocked so you can edit your details or retry." : "Article context is ready for future article generation."}
+                {active ? "Deep research can take several minutes. Refreshing the page is safe." : failed ? "The form is unlocked so you can edit your details or retry." : "Article context is ready for future article generation."}
               </p>
             </>
           ) : null}
@@ -1702,10 +1707,17 @@ export default function VibeMarketingStartupBaselineSetup({
     autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
       ? autofillStartData.status
       : null;
-  const autofillStartError =
+  const autofillStartDisplayErrors =
     autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
-      ? autofillStartData.error ?? autofillStartData.errors?.[0] ?? null
-      : null;
+      ? autofillStartErrorsForDisplay({
+          runId: autofillStartData.autofillRunId,
+          status: autofillStartStatus,
+          error: autofillStartData.error,
+          errors: autofillStartData.errors,
+        })
+      : [];
+  const autofillStartError =
+    autofillStartDisplayErrors[0] ?? null;
   const baselineStartData = baselineStartFetcher.data;
   const baselineRun = baselineRunFetcher.data as VibeMarketingRunSummary | undefined;
   const latestBaselineRun = bootstrap.latestRuns.find((run) => run.workflow === "website_baseline");
@@ -1730,8 +1742,11 @@ export default function VibeMarketingStartupBaselineSetup({
   const baselinePolling = Boolean(baselineRunId && (!baselineRun || ["queued", "running"].includes(baselineRun.status)));
   const autofillStatusAgeMs = autofillStartedAt ? autofillClock - (autofillLastPollAt ?? autofillStartedAt) : 0;
   const autofillProgressAgeMs = autofillStartedAt ? autofillClock - (autofillLastProgressAt ?? autofillStartedAt) : 0;
-  const autofillStalled = Boolean(autofillPolling && autofillProgressAgeMs > 60_000);
-  const autofillUnavailable = Boolean(autofillPolling && (autofillStatusAgeMs > 120_000 || autofillProgressAgeMs > 120_000));
+  const { stalled: autofillStalled, unavailable: autofillUnavailable } = autofillProgressState({
+    polling: autofillPolling,
+    statusAgeMs: autofillStatusAgeMs,
+    progressAgeMs: autofillProgressAgeMs,
+  });
   const researchLocked = autofillPending || (autofillPolling && !autofillUnavailable);
   const canStartAutofill =
     Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) &&
@@ -2019,6 +2034,7 @@ export default function VibeMarketingStartupBaselineSetup({
 
   useEffect(() => {
     if (!autofillRunId || !autofillRun) return;
+    if (isAutofillStatusPollFailure(autofillRun)) return;
     const now = Date.now();
     const signature = researchProgressSignature(autofillRun);
     setAutofillLastPollAt(now);

--- a/app/lib/backend-error.ts
+++ b/app/lib/backend-error.ts
@@ -1,0 +1,81 @@
+type BackendErrorOptions = {
+  fallback?: string;
+  fieldLabels?: Record<string, string>;
+};
+
+const DEFAULT_BACKEND_ERROR = "That action could not be completed.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function looksLikeHtml(value: string) {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized.startsWith("<!doctype html") ||
+    normalized.startsWith("<html") ||
+    (normalized.startsWith("<") && normalized.includes("</html>")) ||
+    normalized.includes("<title>") ||
+    normalized.includes("<body")
+  );
+}
+
+function cleanMessage(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const message = value.trim();
+  if (!message || looksLikeHtml(message)) return null;
+  return message;
+}
+
+function messagesFromValue(value: unknown) {
+  const values = Array.isArray(value) ? value : [value];
+  return values.map(cleanMessage).filter((message): message is string => Boolean(message));
+}
+
+function labelField(field: string, labels?: Record<string, string>) {
+  return labels?.[field] ?? field.replace(/_/g, " ");
+}
+
+function responseDataFromError(error: unknown) {
+  const payload = error as { data?: unknown; response?: { data?: unknown } } | null | undefined;
+  return payload?.data ?? payload?.response?.data;
+}
+
+export function readableBackendErrors(error: unknown, options: BackendErrorOptions = {}) {
+  const fallback = options.fallback ?? DEFAULT_BACKEND_ERROR;
+  const data = responseDataFromError(error);
+
+  if (typeof data === "string") {
+    const message = cleanMessage(data);
+    return message ? [message] : [fallback];
+  }
+
+  if (isRecord(data)) {
+    const explicitErrors = messagesFromValue(data.errors);
+    if (explicitErrors.length > 0) return explicitErrors;
+
+    for (const key of ["detail", "error", "message"]) {
+      const messages = messagesFromValue(data[key]);
+      if (messages.length > 0) return messages;
+    }
+
+    const fieldMessages = Object.entries(data)
+      .flatMap(([field, value]) =>
+        messagesFromValue(value).map((message) => `${labelField(field, options.fieldLabels)}: ${message}`),
+      )
+      .filter(Boolean);
+    if (fieldMessages.length > 0) return fieldMessages;
+  }
+
+  const responsePresent = Boolean((error as { response?: unknown } | null | undefined)?.response);
+  if (!responsePresent) {
+    const message = cleanMessage((error as { message?: unknown } | null | undefined)?.message);
+    if (message) return [message];
+  }
+
+  return [fallback];
+}
+
+export function readableBackendError(error: unknown, options: BackendErrorOptions = {}) {
+  return readableBackendErrors(error, options)[0] ?? options.fallback ?? DEFAULT_BACKEND_ERROR;
+}

--- a/app/lib/vibe-marketing-autofill-state.ts
+++ b/app/lib/vibe-marketing-autofill-state.ts
@@ -1,0 +1,62 @@
+export const AUTOFILL_SLOW_AFTER_MS = 3 * 60 * 1000;
+export const AUTOFILL_UNAVAILABLE_AFTER_MS = 10 * 60 * 1000;
+
+const AUTOFILL_FAILED_STATUSES = new Set([
+  "blocked",
+  "blocked_verification",
+  "cancelled",
+  "canceled",
+  "denied",
+  "error",
+  "failed",
+  "precondition_failed",
+]);
+
+function normalizeStatus(status?: string | null) {
+  return String(status ?? "").trim().toLowerCase();
+}
+
+export function isAutofillStartFailureStatus(status?: string | null) {
+  return AUTOFILL_FAILED_STATUSES.has(normalizeStatus(status));
+}
+
+export function hasAcceptedAutofillRun(runId?: string | null, status?: string | null) {
+  return Boolean(String(runId ?? "").trim()) && !isAutofillStartFailureStatus(status);
+}
+
+export function autofillStartErrorsForDisplay({
+  runId,
+  status,
+  error,
+  errors,
+}: {
+  runId?: string | null;
+  status?: string | null;
+  error?: string | null;
+  errors?: string[] | null;
+}) {
+  if (hasAcceptedAutofillRun(runId, status)) return [];
+  const messages = [...(error ? [error] : []), ...(errors ?? [])]
+    .map((message) => String(message ?? "").trim())
+    .filter(Boolean);
+  return Array.from(new Set(messages));
+}
+
+export function autofillProgressState({
+  polling,
+  statusAgeMs,
+  progressAgeMs,
+}: {
+  polling: boolean;
+  statusAgeMs: number;
+  progressAgeMs: number;
+}) {
+  return {
+    stalled: Boolean(polling && progressAgeMs > AUTOFILL_SLOW_AFTER_MS),
+    unavailable: Boolean(polling && statusAgeMs > AUTOFILL_UNAVAILABLE_AFTER_MS),
+  };
+}
+
+export function isAutofillStatusPollFailure(run?: { diagnostics?: Record<string, unknown> | null } | null) {
+  return Boolean(run?.diagnostics?.statusLoaderError);
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1,4 +1,6 @@
 import { createApiClient, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
+import { readableBackendErrors } from "~/lib/backend-error";
+import { hasAcceptedAutofillRun } from "~/lib/vibe-marketing-autofill-state";
 import type {
   VibeMarketingBootstrap,
   VibeMarketingComponentFeedback,
@@ -1383,16 +1385,37 @@ async function startMarketingRun(env: Env, request: Request, path: string, body:
   const response = await client.post(`${BASE_PATH}/${path}`, body);
   const runId = asNullableString(response.data?.runId) ?? asNullableString(response.data?.run_id);
   const setupRunId = asNullableString(response.data?.setupRunId) ?? asNullableString(response.data?.setup_run_id);
-  const error =
-    asNullableString(response.data?.error) ??
-    asNullableString(response.data?.detail) ??
-    asNullableString(response.data?.message);
+  const rawErrorPayload = {
+    errors: response.data?.errors,
+    detail: response.data?.detail,
+    error: response.data?.error,
+    message: response.data?.message,
+  };
+  const hasErrorPayload = Object.values(rawErrorPayload).some((value) =>
+    Array.isArray(value) ? value.length > 0 : Boolean(value),
+  );
+  const status = asNullableString(response.data?.status) ?? "queued";
+  const errors =
+    path === "autofill" && hasAcceptedAutofillRun(runId, status)
+      ? []
+      : hasErrorPayload
+        ? readableBackendErrors(
+            { data: rawErrorPayload },
+            {
+              fallback:
+                path === "autofill"
+                  ? "AI research could not start. Check the backend logs and try again."
+                  : "That action could not be completed.",
+            },
+          )
+        : [];
+  const error = errors[0] ?? null;
   return {
     runId,
     setupRunId,
-    status: asNullableString(response.data?.status) ?? "queued",
+    status,
     error,
-    errors: asStringList(response.data?.errors ?? (error ? [error] : [])),
+    errors,
   };
 }
 

--- a/app/routes/founder-tools.marketing.autofill-run.tsx
+++ b/app/routes/founder-tools.marketing.autofill-run.tsx
@@ -17,34 +17,34 @@ function runLoaderErrorMessage(error: unknown) {
   return "Company profile research status is unavailable. We will keep trying, but you can retry the research if this continues.";
 }
 
-function blockedRunPayload(runId: string, error: unknown): VibeMarketingRunSummary {
+function statusPollFailurePayload(runId: string, error: unknown): VibeMarketingRunSummary {
   const message = runLoaderErrorMessage(error);
   return {
     runId,
     workflow: "startup_autofill",
     domain: "",
     githubRepo: null,
-    status: "blocked",
-    currentStep: "status_check_failed",
+    status: "running",
+    currentStep: null,
     approvalState: null,
     resumeAvailable: false,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     stepOrder: [],
     steps: [],
-    warnings: [],
-    errors: [message],
+    warnings: [message],
+    errors: [],
     artifacts: [],
     previewUrl: null,
     prUrl: null,
     routePath: null,
-    diagnostics: { statusLoaderError: message },
+    diagnostics: { statusLoaderError: message, retryable: true },
     contentPackage: null,
     componentManifest: null,
     livePreview: null,
     componentFeedback: null,
     workflowProgress: null,
-    result: { error: message, errors: [message], diagnostics: { statusLoaderError: message } },
+    result: { warnings: [message], diagnostics: { statusLoaderError: message, retryable: true } },
   };
 }
 
@@ -55,6 +55,6 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   try {
     return await getVibeMarketingRun(env, request, runId, null, "status");
   } catch (error) {
-    return blockedRunPayload(runId, error);
+    return statusPollFailurePayload(runId, error);
   }
 }

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -24,6 +24,7 @@ import {
 } from "~/components/TopicDecisionCard";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { type VibeMarketingStepKey } from "~/components/VibeMarketingStepper";
+import { readableBackendError } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
@@ -756,14 +757,13 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
+    const fallback =
+      intent === "start-autofill"
+        ? "AI research could not start. Check the backend logs and try again."
+        : "That action could not be completed.";
     return {
       intent,
-      error:
-        error?.data?.detail ??
-        error?.data?.error ??
-        error?.response?.data?.detail ??
-        error?.message ??
-        "That action could not be completed.",
+      error: readableBackendError(error, { fallback }),
     };
   }
 

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -37,8 +37,14 @@ import { clsx } from "clsx";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import type { MarketingRunProgressTheme } from "~/components/MarketingRunProgressCard";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
+import { readableBackendError, readableBackendErrors } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
+import {
+  autofillProgressState,
+  autofillStartErrorsForDisplay,
+  isAutofillStatusPollFailure,
+} from "~/lib/vibe-marketing-autofill-state";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   controlVibeMarketingRun,
@@ -599,19 +605,14 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
-    const responseData = error?.data ?? error?.response?.data;
-    const responseErrors = Array.isArray(responseData?.errors)
-      ? responseData.errors.map((item: unknown) => String(item)).filter(Boolean)
-      : [];
+    const fallback =
+      intent === "start-autofill"
+        ? "AI research could not start. Check the backend logs and try again."
+        : "That action could not be completed.";
+    const responseErrors = readableBackendErrors(error, { fallback });
     return {
       intent,
-      error:
-        responseErrors[0] ??
-        responseData?.detail ??
-        responseData?.error ??
-        responseData?.message ??
-        error?.message ??
-        "That action could not be completed.",
+      error: readableBackendError(error, { fallback }),
       errors: responseErrors,
     };
   }
@@ -1065,8 +1066,8 @@ function competitorStringsFromAutofill(autofill: VibeMarketingAutofillResult) {
     });
 }
 
-const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running"]);
-const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "cancelled", "denied"]);
+const RESEARCH_RUNNING_STATUSES = new Set(["queued", "running", "processing", "in_progress"]);
+const RESEARCH_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "precondition_failed", "cancelled", "canceled", "denied", "error"]);
 const RESEARCH_DONE_STATUSES = new Set(["completed", ...RESEARCH_FAILED_STATUSES]);
 
 const PROFILE_RESEARCH_STEPS = [
@@ -1244,7 +1245,7 @@ function ProfileResearchProgressCard({
     run?.errors?.[0] ||
     (failed ? "AI fill is unavailable. Check the Content Factory backend and try again." : null);
   const notice = unavailable
-    ? "We have not received a fresh status update for more than 2 minutes. You can retry now, or keep this page open while polling continues."
+    ? "We have not received a fresh status update for more than 10 minutes. You can retry now, or keep this page open while polling continues."
     : stalled
       ? "This is taking longer than expected. We will keep checking for progress in the background."
       : null;
@@ -1291,7 +1292,7 @@ function ProfileResearchProgressCard({
           </p>
           <p className="mt-1 text-sm font-medium text-slate-500">
             {active
-              ? "Usually takes 1-3 minutes. Refreshing the page is safe."
+              ? "Deep research can take several minutes. Refreshing the page is safe."
               : failed
                 ? "The form is unlocked so you can retry or fill the fields manually."
                 : "Review the populated fields before continuing."}
@@ -1510,10 +1511,17 @@ function FirstArticleSetupPage({
     autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
       ? autofillStartData.status
       : null;
-  const autofillStartError =
+  const autofillStartDisplayErrors =
     autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
-      ? autofillStartData.error ?? autofillStartData.errors?.[0] ?? null
-      : null;
+      ? autofillStartErrorsForDisplay({
+          runId: autofillStartData.autofillRunId,
+          status: autofillStartStatus,
+          error: autofillStartData.error,
+          errors: autofillStartData.errors,
+        })
+      : [];
+  const autofillStartError =
+    autofillStartDisplayErrors[0] ?? null;
   const baselineStartData = baselineStartFetcher.data;
   const baselineRun = baselineRunFetcher.data as VibeMarketingRunSummary | undefined;
   const latestBaselineRun = bootstrap.latestRuns.find((run) => run.workflow === "website_baseline");
@@ -1535,8 +1543,11 @@ function FirstArticleSetupPage({
   const baselinePolling = Boolean(baselineRunId && (!baselineRun || ["queued", "running"].includes(baselineRun.status)));
   const autofillStatusAgeMs = autofillStartedAt ? autofillClock - (autofillLastPollAt ?? autofillStartedAt) : 0;
   const autofillProgressAgeMs = autofillStartedAt ? autofillClock - (autofillLastProgressAt ?? autofillStartedAt) : 0;
-  const autofillStalled = Boolean(autofillPolling && autofillProgressAgeMs > 60_000);
-  const autofillUnavailable = Boolean(autofillPolling && (autofillStatusAgeMs > 120_000 || autofillProgressAgeMs > 120_000));
+  const { stalled: autofillStalled, unavailable: autofillUnavailable } = autofillProgressState({
+    polling: autofillPolling,
+    statusAgeMs: autofillStatusAgeMs,
+    progressAgeMs: autofillProgressAgeMs,
+  });
   const researchLocked = autofillPending || (autofillPolling && !autofillUnavailable);
   const canStartAutofill =
     Boolean(startupValues.companyName.trim() && startupValues.domain.trim()) &&
@@ -1649,6 +1660,7 @@ function FirstArticleSetupPage({
 
   useEffect(() => {
     if (!autofillRunId || !autofillRun) return;
+    if (isAutofillStatusPollFailure(autofillRun)) return;
     const now = Date.now();
     const signature = researchProgressSignature(autofillRun);
     setAutofillLastPollAt(now);

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -1,6 +1,7 @@
 import { redirect, useActionData, useLoaderData } from "react-router";
 import type { Route } from "./+types/vibe-raising-app.company-setup";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
+import { readableBackendError } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import {
@@ -30,56 +31,19 @@ function stringFromForm(formData: FormData, key: string) {
   return String(formData.get(key) ?? "").trim();
 }
 
-function fieldLabel(field: string) {
-  const labels: Record<string, string> = {
-    companyLinkedInUrl: "Company LinkedIn URL",
-    company_linkedin_url: "Company LinkedIn URL",
-    organizationKind: "Organization type",
-    organization_kind: "Organization type",
-    companyId: "Company",
-    company_id: "Company",
-    name: "Company name",
-    domain: "Website domain",
-    abn: "ABN",
-    location: "Startup location",
-    non_field_errors: "Company details",
-  };
-  return labels[field] ?? field.replace(/_/g, " ");
-}
-
-function readableBackendError(error: any) {
-  const data = error?.data ?? error?.response?.data;
-
-  if (typeof data === "string" && data.trim()) {
-    return data.trim();
-  }
-
-  if (data && typeof data === "object") {
-    const payload = data as Record<string, unknown>;
-    for (const key of ["detail", "error", "message"]) {
-      const value = payload[key];
-      if (typeof value === "string" && value.trim()) {
-        return value.trim();
-      }
-    }
-
-    const fieldMessages = Object.entries(payload)
-      .flatMap(([field, value]) => {
-        const messages = Array.isArray(value) ? value : [value];
-        return messages
-          .map((item) => String(item ?? "").trim())
-          .filter(Boolean)
-          .map((message) => `${fieldLabel(field)}: ${message}`);
-      })
-      .filter(Boolean);
-
-    if (fieldMessages.length > 0) {
-      return fieldMessages.join(" ");
-    }
-  }
-
-  return error?.message ?? "Company details could not be saved.";
-}
+const COMPANY_SETUP_FIELD_LABELS: Record<string, string> = {
+  companyLinkedInUrl: "Company LinkedIn URL",
+  company_linkedin_url: "Company LinkedIn URL",
+  organizationKind: "Organization type",
+  organization_kind: "Organization type",
+  companyId: "Company",
+  company_id: "Company",
+  name: "Company name",
+  domain: "Website domain",
+  abn: "ABN",
+  location: "Startup location",
+  non_field_errors: "Company details",
+};
 
 function emptyBootstrap(profile: VibeRaisingProfile | null, company: VibeRaisingCompany | null): VibeMarketingBootstrap {
   const companyName = company?.name ?? profile?.organizationName ?? "";
@@ -336,7 +300,16 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
-    return { intent, error: readableBackendError(error) };
+    return {
+      intent,
+      error: readableBackendError(error, {
+        fallback:
+          intent === "start-autofill"
+            ? "AI research could not start. Check the backend logs and try again."
+            : "Company details could not be saved.",
+        fieldLabels: COMPANY_SETUP_FIELD_LABELS,
+      }),
+    };
   }
 
   throw redirect("/founder-tools");

--- a/tests/vibe-marketing-autofill-state.test.ts
+++ b/tests/vibe-marketing-autofill-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AUTOFILL_SLOW_AFTER_MS,
+  AUTOFILL_UNAVAILABLE_AFTER_MS,
+  autofillProgressState,
+  autofillStartErrorsForDisplay,
+  hasAcceptedAutofillRun,
+  isAutofillStatusPollFailure,
+} from "../app/lib/vibe-marketing-autofill-state";
+
+describe("vibe marketing autofill state", () => {
+  test("accepts active run ids even when the start response includes warnings", () => {
+    expect(hasAcceptedAutofillRun("run-123", "processing")).toBe(true);
+    expect(
+      autofillStartErrorsForDisplay({
+        runId: "run-123",
+        status: "running",
+        error: "Transient warning from backend",
+        errors: ["Another non-fatal warning"],
+      }),
+    ).toEqual([]);
+  });
+
+  test("keeps errors for failed start statuses", () => {
+    expect(hasAcceptedAutofillRun("run-123", "blocked")).toBe(false);
+    expect(
+      autofillStartErrorsForDisplay({
+        runId: "run-123",
+        status: "blocked",
+        error: "Content Factory worker is unavailable",
+        errors: ["Content Factory worker is unavailable"],
+      }),
+    ).toEqual(["Content Factory worker is unavailable"]);
+  });
+
+  test("does not mark a still-polling run unavailable after two minutes", () => {
+    expect(
+      autofillProgressState({
+        polling: true,
+        statusAgeMs: 2 * 60 * 1000 + 1,
+        progressAgeMs: 2 * 60 * 1000 + 1,
+      }),
+    ).toEqual({ stalled: false, unavailable: false });
+  });
+
+  test("separates slow progress from unavailable status polling", () => {
+    expect(
+      autofillProgressState({
+        polling: true,
+        statusAgeMs: 5_000,
+        progressAgeMs: AUTOFILL_SLOW_AFTER_MS + 1,
+      }),
+    ).toEqual({ stalled: true, unavailable: false });
+
+    expect(
+      autofillProgressState({
+        polling: true,
+        statusAgeMs: AUTOFILL_UNAVAILABLE_AFTER_MS + 1,
+        progressAgeMs: AUTOFILL_UNAVAILABLE_AFTER_MS + 1,
+      }),
+    ).toEqual({ stalled: true, unavailable: true });
+  });
+
+  test("identifies transient status poll failures", () => {
+    expect(isAutofillStatusPollFailure({ diagnostics: { statusLoaderError: "Network connection lost." } })).toBe(true);
+    expect(isAutofillStatusPollFailure({ diagnostics: {} })).toBe(false);
+    expect(isAutofillStatusPollFailure(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keeps valid autofill run ids active even when the start response includes non-fatal warning payloads
- raises slow/unavailable thresholds for long-running company research
- normalizes backend errors and rejects raw HTML/debug bodies in UI error messages
- keeps retry disabled while an active run is still polling

## Tests
- bun test tests/vibe-marketing-autofill-state.test.ts
- bun run typecheck