### PR TITLE
[codex] Improve startup profile AI helper flow

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -972,6 +972,29 @@ function isStartupProfileComplete(values: StartupSetupValues) {
   return isBasicsComplete(values) && isCompanyDetailsComplete(values);
 }
 
+function applyAutofillToEmptyStartupFields(values: StartupSetupValues, autofill: VibeMarketingAutofillResult): StartupSetupValues {
+  const profileFields = autofill.profileFields;
+  const updates: Partial<StartupSetupValues> = {
+    companyLinkedInUrl: autofill.companyLinkedInUrl ?? undefined,
+    location: profileFields?.location ?? undefined,
+    abn: profileFields?.abn ?? undefined,
+    shortDescription: profileFields?.shortDescription ?? undefined,
+    problemSolved: profileFields?.problemSolved ?? undefined,
+    targetAudience: profileFields?.targetAudience ?? undefined,
+    founderNames: profileFields?.founderNames ?? undefined,
+    stage: profileFields?.stage ?? undefined,
+    organizationKind: profileFields?.organizationKind ?? undefined,
+    competitors: autofill.competitors?.join("\n"),
+    seedKeywords: autofill.seedKeywords?.join(", "),
+  };
+
+  return Object.entries(updates).reduce<StartupSetupValues>((nextValues, [field, value]) => {
+    const nextValue = String(value ?? "").trim();
+    if (!nextValue || nextValues[field as StartupSetupField].trim()) return nextValues;
+    return { ...nextValues, [field]: nextValue };
+  }, values);
+}
+
 function defaultSectionExpanded(values: StartupSetupValues, complete: (values: StartupSetupValues) => boolean, collapseCompletedSectionsByDefault: boolean) {
   return !collapseCompletedSectionsByDefault || !complete(values);
 }
@@ -1175,6 +1198,31 @@ function SetupDocumentMockups() {
         </div>
       </div>
     </div>
+  );
+}
+
+function StartupProfileAiHelperBanner() {
+  return (
+    <section className="overflow-hidden rounded-xl border border-violet-200 bg-gradient-to-r from-violet-50 via-white to-violet-50/70 p-5">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex gap-4">
+          <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-violet-700 text-white shadow-lg shadow-violet-200">
+            <Sparkles className="h-7 w-7" />
+          </span>
+          <div>
+            <h3 className="text-xl font-black tracking-normal text-violet-800">Let AI do the heavy lifting</h3>
+            <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-700">
+              <span className="sm:hidden">Fill the basics, then let AI prep company context from public sources.</span>
+              <span className="hidden sm:inline">Add or review your details below, then AI can scan public sources and prepare article-generation context from your answers.</span>
+              <span className="ml-2 inline-flex items-center gap-1 font-black text-violet-700">
+                Learn how it works <ArrowRight className="h-4 w-4" />
+              </span>
+            </p>
+          </div>
+        </div>
+        <SetupDocumentMockups />
+      </div>
+    </section>
   );
 }
 
@@ -2079,6 +2127,7 @@ export default function VibeMarketingStartupBaselineSetup({
     if (!autofill || (autofillRun?.status !== "completed" && !autofill.partial)) return;
     const profileFields = autofill.profileFields;
     setGeneratedCompanyContext(String(profileFields?.companyContext || autofill.companyContext || "").trim());
+    setStartupValues((current) => applyAutofillToEmptyStartupFields(current, autofill));
     setAppliedAutofillRunId(autofillRunId);
   }, [appliedAutofillRunId, autofillRun, autofillRunId]);
 
@@ -2123,6 +2172,8 @@ export default function VibeMarketingStartupBaselineSetup({
           ) : null}
         </div>
 
+        {profileContentExpanded ? <StartupProfileAiHelperBanner /> : null}
+
         <div className={clsx("grid gap-5", profileContentExpanded && "xl:grid-cols-[minmax(0,1fr)_390px]")}>
           <section className={clsx("rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:p-7", researchLocked && "bg-gray-50/80")}>
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -2155,28 +2206,7 @@ export default function VibeMarketingStartupBaselineSetup({
             {!profileContentExpanded ? <p className="mt-4 rounded-xl bg-slate-50 px-4 py-3 text-sm font-bold text-slate-600">{startupProfileSummary(startupValues)}</p> : null}
 
             <div className={clsx("mt-7 border-t border-gray-100 pt-7", !profileContentExpanded && "hidden")}>
-              <section className="overflow-hidden rounded-xl border border-violet-200 bg-gradient-to-r from-violet-50 via-white to-violet-50/70 p-5">
-                <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-                  <div className="flex gap-4">
-                    <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-violet-700 text-white shadow-lg shadow-violet-200">
-                      <Sparkles className="h-7 w-7" />
-                    </span>
-                    <div>
-                      <h3 className="text-xl font-black tracking-normal text-violet-800">Let AI do the heavy lifting</h3>
-                      <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-700">
-                        <span className="sm:hidden">Fill the basics, then let AI prep company context from public sources.</span>
-                        <span className="hidden sm:inline">Add or review your details below, then AI can scan public sources and prepare article-generation context from your answers.</span>
-                        <span className="ml-2 inline-flex items-center gap-1 font-black text-violet-700">
-                          Learn how it works <ArrowRight className="h-4 w-4" />
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <SetupDocumentMockups />
-                </div>
-              </section>
-
-              <div className="mt-7 grid gap-5 lg:grid-cols-2">
+              <div className="grid gap-5 lg:grid-cols-2">
                 <FormField label="Company name" badge={<RequiredPill />} className="lg:col-span-2">
                   <div className="relative">
                     <ControlIcon icon={Building2} />
@@ -2227,6 +2257,47 @@ export default function VibeMarketingStartupBaselineSetup({
                     </p>
                   ) : null}
                 </FormField>
+              </div>
+
+              <button
+                type="button"
+                onClick={startAutofill}
+                disabled={!canStartAutofill}
+                ref={mobileResearchButtonRef}
+                className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-[var(--vr-color-primary)] px-6 py-5 text-left text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span className="flex min-w-0 items-center gap-4">
+                  {autofillPending || autofillPolling ? <Loader2 className="h-7 w-7 shrink-0 animate-spin" /> : <Sparkles className="h-7 w-7 shrink-0" />}
+                  <span className="min-w-0">
+                    <span className="block text-lg font-black">Research my company context</span>
+                    <span className="mt-1 block text-sm font-semibold text-white/80">AI will use these answers to prepare article context and SEO inputs</span>
+                  </span>
+                </span>
+                <ArrowRight className="h-6 w-6 shrink-0" />
+              </button>
+
+              {!canStartAutofill && !autofillPending && !autofillPolling ? (
+                <p className="mt-3 text-xs font-bold text-gray-500">Add a company name and website domain before researching with AI.</p>
+              ) : null}
+              <p className="mt-4 flex items-center justify-center gap-2 text-xs font-bold text-gray-500">
+                <ShieldCheck className="h-4 w-4" />
+                AI can fill empty profile fields; details you already entered stay as you entered them.
+              </p>
+              {autofillStartData?.error && !autofillStartData?.autofillRunId ? (
+                <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">{autofillStartData.error}</div>
+              ) : null}
+              <div className="mt-4">
+                <ProfileResearchProgressCard
+                  run={autofillRun}
+                  runId={autofillRunId}
+                  pending={autofillPending}
+                  startStatus={autofillStartStatus}
+                  startError={autofillStartError}
+                  stalled={autofillStalled}
+                  unavailable={autofillUnavailable}
+                  onRetry={startAutofill}
+                  retryDisabled={!canRetryAutofill}
+                />
               </div>
 
               <div className="mt-7 grid gap-5 md:grid-cols-2 xl:grid-cols-4">
@@ -2373,47 +2444,6 @@ export default function VibeMarketingStartupBaselineSetup({
                     </div>
                   </div>
                 </CompanyDetailsPanel>
-              </div>
-
-              <button
-                type="button"
-                onClick={startAutofill}
-                disabled={!canStartAutofill}
-                ref={mobileResearchButtonRef}
-                className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-[var(--vr-color-primary)] px-6 py-5 text-left text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <span className="flex min-w-0 items-center gap-4">
-                  {autofillPending || autofillPolling ? <Loader2 className="h-7 w-7 shrink-0 animate-spin" /> : <Sparkles className="h-7 w-7 shrink-0" />}
-                  <span className="min-w-0">
-                    <span className="block text-lg font-black">Research my company context</span>
-                    <span className="mt-1 block text-sm font-semibold text-white/80">AI will use these answers to prepare article context and SEO inputs</span>
-                  </span>
-                </span>
-                <ArrowRight className="h-6 w-6 shrink-0" />
-              </button>
-
-              {!canStartAutofill && !autofillPending && !autofillPolling ? (
-                <p className="mt-3 text-xs font-bold text-gray-500">Add a company name and website domain before researching with AI.</p>
-              ) : null}
-              <p className="mt-4 flex items-center justify-center gap-2 text-xs font-bold text-gray-500">
-                <ShieldCheck className="h-4 w-4" />
-                Scan results prepare hidden article context; your visible profile fields stay as you entered them.
-              </p>
-              {autofillStartData?.error && !autofillStartData?.autofillRunId ? (
-                <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">{autofillStartData.error}</div>
-              ) : null}
-              <div className="mt-4">
-                <ProfileResearchProgressCard
-                  run={autofillRun}
-                  runId={autofillRunId}
-                  pending={autofillPending}
-                  startStatus={autofillStartStatus}
-                  startError={autofillStartError}
-                  stalled={autofillStalled}
-                  unavailable={autofillUnavailable}
-                  onRetry={startAutofill}
-                  retryDisabled={!canRetryAutofill}
-                />
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- Moves the “Let AI do the heavy lifting” helper banner below the setup description and above Step 1 so it can span the full setup width.
- Hides the helper banner when the startup profile section is collapsed.
- Moves the research action directly below company name, website domain, and optional LinkedIn fields.
- Applies AI research results into empty startup profile fields only, preserving anything the user already typed.

## Validation
- bun run typecheck
- Browser verification on /founder-tools/company-setup?new=true confirmed banner order and research button placement.
