### PR TITLE
Stop polling failed article setup runs

### DIFF
--- a/app/lib/vibe-marketing-run-polling.ts
+++ b/app/lib/vibe-marketing-run-polling.ts
@@ -1,0 +1,55 @@
+type LivePreviewLike = {
+  status?: string | null;
+  platformStatus?: string | null;
+  error?: string | null;
+};
+
+type RunLike = {
+  runId?: string | null;
+  workflow?: string | null;
+  status?: string | null;
+  currentStep?: string | null;
+  updatedAt?: string | null;
+  error?: string | null;
+  livePreview?: LivePreviewLike | null;
+};
+
+const ACTIVE_PREVIEW_STATUSES = new Set(["queued", "pending", "preparing", "starting", "building", "running"]);
+const FAILED_PREVIEW_STATUSES = new Set(["failed", "blocked", "expired", "cancelled", "canceled", "timeout", "timed_out"]);
+const TERMINAL_ARTICLE_SETUP_STATUSES = new Set(["blocked", "blocked_verification", "failed", "denied", "cancelled", "canceled"]);
+
+function normalized(value: string | null | undefined) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+export function isArticleSystemSetupTerminalStatus(status: string | null | undefined) {
+  return TERMINAL_ARTICLE_SETUP_STATUSES.has(normalized(status));
+}
+
+export function isLivePreviewFailedForPolling(preview: LivePreviewLike | null | undefined) {
+  const previewStatus = normalized(preview?.status);
+  const platformStatus = normalized(preview?.platformStatus);
+  if (ACTIVE_PREVIEW_STATUSES.has(previewStatus) || ACTIVE_PREVIEW_STATUSES.has(platformStatus)) return false;
+  return Boolean(preview?.error || FAILED_PREVIEW_STATUSES.has(previewStatus) || FAILED_PREVIEW_STATUSES.has(platformStatus));
+}
+
+export function shouldPollArticleSystemSetupRun(run: RunLike) {
+  if (run.workflow !== "article_system_setup") return true;
+  if (isArticleSystemSetupTerminalStatus(run.status)) return false;
+  if (isLivePreviewFailedForPolling(run.livePreview)) return false;
+  return true;
+}
+
+export function statusPollRefreshKey(run: RunLike) {
+  if (run.workflow === "article_system_setup" && !shouldPollArticleSystemSetupRun(run)) {
+    return [
+      run.runId,
+      normalized(run.status),
+      run.currentStep ?? "",
+      normalized(run.livePreview?.status),
+      normalized(run.livePreview?.platformStatus),
+      run.error ?? run.livePreview?.error ?? "",
+    ].join(":");
+  }
+  return [run.runId, run.status, run.updatedAt ?? "", run.currentStep ?? ""].join(":");
+}

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -42,6 +42,11 @@ import {
   startVibeMarketingArticle,
   updateVibeMarketingComponentComment,
 } from "~/lib/vibe-marketing";
+import {
+  isArticleSystemSetupTerminalStatus,
+  shouldPollArticleSystemSetupRun,
+  statusPollRefreshKey,
+} from "~/lib/vibe-marketing-run-polling";
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
 import type {
   VibeMarketingComponentManifestItem,
@@ -211,6 +216,10 @@ function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
     return true;
   }
   return false;
+}
+
+function shouldUseStatusPollResult(run: VibeMarketingRunSummary) {
+  return !statusPollNeedsFullRefresh(run);
 }
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
@@ -2949,6 +2958,7 @@ function prNumberFromPullUrl(url: string) {
 }
 
 function hasPublishHandoffEvidence(run: VibeMarketingRunSummary) {
+  if (run.workflow === "article_system_setup") return false;
   return Boolean(
     publishPrUrlForRun(run) ||
       publishPreviewUrlForRun(run) ||
@@ -3118,14 +3128,15 @@ export default function FounderToolsMarketingRun() {
   const isRunActionNeeded = ["awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const isArticleSystemSetupRun = workflow === "article_system_setup";
-  const setupTerminal = ["blocked", "failed", "cancelled", "canceled"].includes(run.status);
+  const setupTerminal = isArticleSystemSetupRun && isArticleSystemSetupTerminalStatus(run.status);
   const setupPreviewActive = isArticleSystemSetupRun && !setupTerminal && hasActiveLivePreview(run.livePreview);
   const setupPreviewFailed = isArticleSystemSetupRun && (setupTerminal || isFailedArticlePreview(run.livePreview));
   const shouldPoll =
-    (POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
-    setupPreviewActive ||
-    hasPendingArticlePreview(run) ||
-    hasPublishHandoffEvidence(run);
+    shouldPollArticleSystemSetupRun(run) &&
+    ((POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
+      setupPreviewActive ||
+      hasPendingArticlePreview(run) ||
+      hasPublishHandoffEvidence(run));
   const setupRun = isArticleSystemSetupRun ? run : loaderSetupRun;
   const isArticleWorkflowRun = isArticleWorkflow(workflow);
   const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
@@ -3215,8 +3226,8 @@ export default function FounderToolsMarketingRun() {
     ) {
       return;
     }
-    if (statusPollNeedsFullRefresh(runStatusFetcher.data)) {
-      const refreshKey = `${runStatusFetcher.data.runId}:${runStatusFetcher.data.status}:${runStatusFetcher.data.updatedAt ?? ""}:${runStatusFetcher.data.currentStep ?? ""}`;
+    if (!shouldUseStatusPollResult(runStatusFetcher.data)) {
+      const refreshKey = statusPollRefreshKey(runStatusFetcher.data);
       if (statusRefreshRef.current !== refreshKey) {
         statusRefreshRef.current = refreshKey;
         setPolledRun(null);

--- a/tests/vibe-marketing-run-polling.test.ts
+++ b/tests/vibe-marketing-run-polling.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isArticleSystemSetupTerminalStatus,
+  shouldPollArticleSystemSetupRun,
+  statusPollRefreshKey,
+} from "../app/lib/vibe-marketing-run-polling";
+
+describe("vibe marketing run polling", () => {
+  test("does not poll failed article setup runs", () => {
+    expect(
+      shouldPollArticleSystemSetupRun({
+        workflow: "article_system_setup",
+        status: "failed",
+        livePreview: { status: "failed", error: "Directory scaffold dependency validation failed" },
+      }),
+    ).toBe(false);
+    expect(isArticleSystemSetupTerminalStatus("blocked_verification")).toBe(true);
+    expect(isArticleSystemSetupTerminalStatus("running")).toBe(false);
+  });
+
+  test("does not poll failed article setup previews", () => {
+    expect(
+      shouldPollArticleSystemSetupRun({
+        workflow: "article_system_setup",
+        status: "running",
+        livePreview: { status: "failed", platformStatus: "failed" },
+      }),
+    ).toBe(false);
+  });
+
+  test("keeps terminal refresh keys stable when updatedAt changes", () => {
+    const first = statusPollRefreshKey({
+      runId: "setup-1",
+      workflow: "article_system_setup",
+      status: "failed",
+      currentStep: "build_setup_page",
+      updatedAt: "2026-05-23T10:10:00Z",
+      error: "Missing required directory component slots: article_list",
+    });
+    const second = statusPollRefreshKey({
+      runId: "setup-1",
+      workflow: "article_system_setup",
+      status: "failed",
+      currentStep: "build_setup_page",
+      updatedAt: "2026-05-23T10:11:00Z",
+      error: "Missing required directory component slots: article_list",
+    });
+
+    expect(second).toBe(first);
+  });
+
+  test("still polls active article setup runs", () => {
+    expect(
+      shouldPollArticleSystemSetupRun({
+        workflow: "article_system_setup",
+        status: "running",
+        livePreview: { status: "building" },
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add terminal-aware article setup polling helpers
- stop failed setup runs/previews from continuing run status polling
- keep terminal refresh keys stable when backend updatedAt changes

## Tests
- bun test tests/vibe-marketing-run-polling.test.ts
- bun run typecheck