### PR TITLE
[codex] Stop polling failed setup previews

### DIFF
--- a/app/lib/vibe-marketing-run-polling.ts
+++ b/app/lib/vibe-marketing-run-polling.ts
@@ -12,11 +12,21 @@ type RunLike = {
   updatedAt?: string | null;
   error?: string | null;
   livePreview?: LivePreviewLike | null;
+  result?: Record<string, unknown> | null;
 };
 
 const ACTIVE_PREVIEW_STATUSES = new Set(["queued", "pending", "preparing", "starting", "building", "running"]);
 const FAILED_PREVIEW_STATUSES = new Set(["failed", "blocked", "expired", "cancelled", "canceled", "timeout", "timed_out"]);
-const TERMINAL_ARTICLE_SETUP_STATUSES = new Set(["blocked", "blocked_verification", "failed", "denied", "cancelled", "canceled"]);
+const TERMINAL_ARTICLE_SETUP_STATUSES = new Set([
+  "blocked",
+  "blocked_verification",
+  "failed",
+  "denied",
+  "cancelled",
+  "canceled",
+  "preview_failed",
+  "fallback_ready",
+]);
 
 function normalized(value: string | null | undefined) {
   return String(value ?? "").trim().toLowerCase();
@@ -33,10 +43,30 @@ export function isLivePreviewFailedForPolling(preview: LivePreviewLike | null | 
   return Boolean(preview?.error || FAILED_PREVIEW_STATUSES.has(previewStatus) || FAILED_PREVIEW_STATUSES.has(platformStatus));
 }
 
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function setupStatusForPolling(run: RunLike) {
+  const result = recordValue(run.result);
+  const nestedResult = recordValue(result?.result);
+  const setup = recordValue(result?.article_system_setup) ?? recordValue(nestedResult?.article_system_setup);
+  return normalized(setup?.status as string | null | undefined);
+}
+
+export function isArticleSystemSetupTerminalRun(run: RunLike) {
+  if (run.workflow !== "article_system_setup") return false;
+  return (
+    isArticleSystemSetupTerminalStatus(run.status) ||
+    isArticleSystemSetupTerminalStatus(run.currentStep) ||
+    isArticleSystemSetupTerminalStatus(setupStatusForPolling(run)) ||
+    isLivePreviewFailedForPolling(run.livePreview)
+  );
+}
+
 export function shouldPollArticleSystemSetupRun(run: RunLike) {
   if (run.workflow !== "article_system_setup") return true;
-  if (isArticleSystemSetupTerminalStatus(run.status)) return false;
-  if (isLivePreviewFailedForPolling(run.livePreview)) return false;
+  if (isArticleSystemSetupTerminalRun(run)) return false;
   return true;
 }
 
@@ -46,6 +76,7 @@ export function statusPollRefreshKey(run: RunLike) {
       run.runId,
       normalized(run.status),
       run.currentStep ?? "",
+      setupStatusForPolling(run),
       normalized(run.livePreview?.status),
       normalized(run.livePreview?.platformStatus),
       run.error ?? run.livePreview?.error ?? "",

--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -3,6 +3,7 @@ import { redirect } from "react-router";
 
 import { getEnv } from "~/lib/env.server";
 import { getVibeMarketingRun, refreshVibeMarketingLivePreview } from "~/lib/vibe-marketing";
+import { shouldPollArticleSystemSetupRun } from "~/lib/vibe-marketing-run-polling";
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
 import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
@@ -18,6 +19,7 @@ function isDocumentNavigation(request: Request) {
 
 function shouldRefreshSetupLivePreview(run: VibeMarketingRunSummary) {
   if (run.workflow !== "article_system_setup") return false;
+  if (!shouldPollArticleSystemSetupRun(run)) return false;
   if (run.stale || run.retryAvailable) return false;
   if (TERMINAL_ATTENTION_STATUSES.has(String(run.status || "").trim().toLowerCase())) return false;
   if (run.livePreview?.previewUrl || run.livePreview?.error) return false;

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -43,7 +43,7 @@ import {
   updateVibeMarketingComponentComment,
 } from "~/lib/vibe-marketing";
 import {
-  isArticleSystemSetupTerminalStatus,
+  isArticleSystemSetupTerminalRun,
   shouldPollArticleSystemSetupRun,
   statusPollRefreshKey,
 } from "~/lib/vibe-marketing-run-polling";
@@ -219,6 +219,9 @@ function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
 }
 
 function shouldUseStatusPollResult(run: VibeMarketingRunSummary) {
+  if (isArticleSystemSetupTerminalRun(run)) {
+    return true;
+  }
   return !statusPollNeedsFullRefresh(run);
 }
 
@@ -3128,7 +3131,7 @@ export default function FounderToolsMarketingRun() {
   const isRunActionNeeded = ["awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const isArticleSystemSetupRun = workflow === "article_system_setup";
-  const setupTerminal = isArticleSystemSetupRun && isArticleSystemSetupTerminalStatus(run.status);
+  const setupTerminal = isArticleSystemSetupRun && isArticleSystemSetupTerminalRun(run);
   const setupPreviewActive = isArticleSystemSetupRun && !setupTerminal && hasActiveLivePreview(run.livePreview);
   const setupPreviewFailed = isArticleSystemSetupRun && (setupTerminal || isFailedArticlePreview(run.livePreview));
   const shouldPoll =

--- a/tests/vibe-marketing-run-polling.test.ts
+++ b/tests/vibe-marketing-run-polling.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isArticleSystemSetupTerminalRun,
   isArticleSystemSetupTerminalStatus,
   shouldPollArticleSystemSetupRun,
   statusPollRefreshKey,
@@ -16,6 +17,8 @@ describe("vibe marketing run polling", () => {
       }),
     ).toBe(false);
     expect(isArticleSystemSetupTerminalStatus("blocked_verification")).toBe(true);
+    expect(isArticleSystemSetupTerminalStatus("preview_failed")).toBe(true);
+    expect(isArticleSystemSetupTerminalStatus("fallback_ready")).toBe(true);
     expect(isArticleSystemSetupTerminalStatus("running")).toBe(false);
   });
 
@@ -48,6 +51,28 @@ describe("vibe marketing run polling", () => {
     });
 
     expect(second).toBe(first);
+  });
+
+  test("treats setup preview failures in current step and nested result as terminal", () => {
+    expect(
+      isArticleSystemSetupTerminalRun({
+        workflow: "article_system_setup",
+        status: "running",
+        currentStep: "preview_failed",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPollArticleSystemSetupRun({
+        workflow: "article_system_setup",
+        status: "running",
+        result: {
+          article_system_setup: {
+            status: "preview_failed",
+            error: "Directory browser verification failed before setup approval.",
+          },
+        },
+      }),
+    ).toBe(false);
   });
 
   test("still polls active article setup runs", () => {


### PR DESCRIPTION
## Summary
- treat preview_failed and fallback_ready article setup states as terminal
- stop run-page/status polling for failed setup previews
- accept terminal setup poll payloads without repeated full-route revalidation

## Validation
- bun test tests/vibe-marketing-run-polling.test.ts
- bun run typecheck