### PR TITLE
[codex] Add canonical article setup state

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -27,7 +27,7 @@ import ArticleSystemSurfaceSummary, {
   type SurfaceCandidate,
 } from "~/components/ArticleSystemSurfaceSummary";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
-import type { VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
+import type { VibeMarketingArticleSetupState, VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
 type ArticleSystemConnectionPanelProps = {
   bootstrap: VibeMarketingBootstrap;
@@ -40,9 +40,9 @@ type ArticleSystemConnectionPanelProps = {
   articleSurfacePlaceholder?: string;
   connectionError?: string | null;
   scanRun?: VibeMarketingRunSummary | null;
+  articleSetupState?: VibeMarketingArticleSetupState | null;
   framed?: boolean;
   showDenySetupAction?: boolean;
-  autoStartInventoryScan?: boolean;
 };
 
 const SCAN_RUNNING_STATUSES = new Set(["queued", "running", "pending", "starting"]);
@@ -436,11 +436,10 @@ export default function ArticleSystemConnectionPanel({
   articleSurfacePlaceholder = "https://example.com/articles or /articles",
   connectionError,
   scanRun,
+  articleSetupState,
   framed = true,
   showDenySetupAction = false,
-  autoStartInventoryScan = false,
 }: ArticleSystemConnectionPanelProps) {
-  const inventoryFetcher = useFetcher();
   const runStatusFetcher = useFetcher<VibeMarketingRunSummary>();
   const location = useLocation();
   const revalidator = useRevalidator();
@@ -453,21 +452,26 @@ export default function ArticleSystemConnectionPanel({
   const scaffoldReady = Boolean(bootstrap.checks.scaffold?.passed);
   const setupBlocked = Boolean(bootstrap.checks.scaffold?.setupBlocked);
   const requestedScanRunId = new URLSearchParams(location.search).get("scanRunId")?.trim() ?? "";
-  const currentScanRunId = requestedScanRunId || scanRun?.runId || "";
+  const currentScanRunId = requestedScanRunId || scanRun?.runId || articleSetupState?.scanRunId || "";
   const scanRunForCurrentId = !requestedScanRunId || scanRun?.runId === requestedScanRunId ? scanRun : null;
   const [polledScanRun, setPolledScanRun] = useState<VibeMarketingRunSummary | null>(null);
   const effectiveScanRun = polledScanRun?.runId === currentScanRunId ? polledScanRun : scanRunForCurrentId;
   const scanRunning = Boolean(effectiveScanRun && SCAN_RUNNING_STATUSES.has(effectiveScanRun.status));
   const scanFailed = Boolean(effectiveScanRun && SCAN_FAILED_STATUSES.has(effectiveScanRun.status));
-  const scanStale = Boolean(effectiveScanRun?.stale || effectiveScanRun?.staleReason === "scan_queue_not_started");
+  const canonicalScanComplete = articleSetupState?.scanStatus === "completed" && !articleSetupState.scanStale;
+  const scanStale = Boolean(effectiveScanRun?.stale || effectiveScanRun?.staleReason === "scan_queue_not_started" || articleSetupState?.scanStale);
   const scanNeedsSetupApproval = isScanAwaitingSetupApproval(effectiveScanRun);
-  const setupRunId = effectiveScanRun ? setupRunIdForRun(effectiveScanRun) : "";
+  const setupRunId = articleSetupState?.setupRunId || (effectiveScanRun ? setupRunIdForRun(effectiveScanRun) : "");
   const inventoryScan = isInventoryScan(effectiveScanRun);
   const setupTargetScan = isSetupTargetScan(effectiveScanRun);
   const inventoryProgressRun = effectiveScanRun && inventoryScan && !setupTargetScan ? effectiveScanRun : null;
-  const inventoryReady = Boolean(inventoryProgressRun?.status === "completed");
-  const setupTargetReady = Boolean(effectiveScanRun && setupTargetScan && (scanNeedsSetupApproval || setupRunId));
-  const scanStartPending = actionPending("start-scan") || inventoryFetcher.state !== "idle";
+  const inventoryReady = Boolean(inventoryProgressRun?.status === "completed" || (canonicalScanComplete && !articleSetupState?.setupRunId));
+  const setupTargetReady = Boolean(
+    articleSetupState?.setupRunId ||
+      articleSetupState?.routePath ||
+      (effectiveScanRun && setupTargetScan && (scanNeedsSetupApproval || setupRunId)),
+  );
+  const scanStartPending = actionPending("start-scan");
   const retryScanPending = actionPending("retry-scan");
   const cancelScanPending = actionPending("cancel-scan");
   const confirmSurfacePending = actionPending("confirm-article-surface");
@@ -609,19 +613,6 @@ export default function ArticleSystemConnectionPanel({
     lastTerminalRevalidationRef.current = key;
     revalidator.revalidate();
   }, [effectiveScanRun?.runId, effectiveScanRun?.status, effectiveScanRun?.updatedAt, revalidator, scanStale]);
-
-  useEffect(() => {
-    if (!autoStartInventoryScan || !connected || !selectedRepo || currentScanRunId || inventoryFetcher.state !== "idle") return;
-    const key = `vibe-marketing:auto-inventory-scan:${bootstrap.organization.id ?? "org"}:${selectedRepo}`;
-    if (typeof window !== "undefined" && window.sessionStorage.getItem(key) === "started") return;
-    if (typeof window !== "undefined") window.sessionStorage.setItem(key, "started");
-    const formData = new FormData();
-    formData.set("intent", "start-scan");
-    formData.set("scanPurpose", "inventory");
-    formData.set("articleSurfaceMode", "not_sure");
-    formData.set("githubRepo", selectedRepo);
-    void inventoryFetcher.submit(formData, { method: "POST" });
-  }, [autoStartInventoryScan, bootstrap.organization.id, connected, currentScanRunId, inventoryFetcher, selectedRepo]);
 
   useEffect(() => {
     if (!githubAuthWaiting || typeof window === "undefined") return;
@@ -1050,7 +1041,7 @@ export default function ArticleSystemConnectionPanel({
           </FlowStep>
         ) : null}
 
-        {connected && !currentScanRunId && !inventoryFetcher.data ? (
+        {connected && !currentScanRunId && !canonicalScanComplete ? (
           <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-500">
             Run the repository scan first. It is read-only and will not create branches, pull requests, or setup files.
           </div>

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -3,6 +3,7 @@ import { readableBackendErrors } from "~/lib/backend-error";
 import { hasAcceptedAutofillRun } from "~/lib/vibe-marketing-autofill-state";
 import type {
   VibeMarketingBootstrap,
+  VibeMarketingArticleSetupState,
   VibeMarketingComponentFeedback,
   VibeMarketingComponentCommentAnchor,
   VibeMarketingComponentCommentContext,
@@ -190,6 +191,57 @@ function normalizeStep(raw: unknown): VibeMarketingStepState {
   };
 }
 
+function normalizeArticleSetupState(raw: unknown): VibeMarketingArticleSetupState | null {
+  const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : null;
+  if (!payload) return null;
+  const repo = asNullableString(payload.repo) ?? asNullableString(payload.githubRepo) ?? asNullableString(payload.github_repo);
+  const scanRunId = asNullableString(payload.scanRunId) ?? asNullableString(payload.scan_run_id);
+  const setupRunId = asNullableString(payload.setupRunId) ?? asNullableString(payload.setup_run_id);
+  const source = asNullableString(payload.source);
+  if (!repo && !scanRunId && !setupRunId && source !== "none") return null;
+  return {
+    repo,
+    githubRepo: asNullableString(payload.githubRepo) ?? asNullableString(payload.github_repo) ?? repo,
+    defaultBranch: asNullableString(payload.defaultBranch) ?? asNullableString(payload.default_branch),
+    defaultBranchSha:
+      asNullableString(payload.defaultBranchSha) ??
+      asNullableString(payload.default_branch_sha) ??
+      asNullableString(payload.repoHeadSha) ??
+      asNullableString(payload.repo_head_sha),
+    lastScannedSha: asNullableString(payload.lastScannedSha) ?? asNullableString(payload.last_scanned_sha),
+    scanRunId,
+    scanStatus: asNullableString(payload.scanStatus) ?? asNullableString(payload.scan_status),
+    scanCompletedAt: asNullableString(payload.scanCompletedAt) ?? asNullableString(payload.scan_completed_at),
+    scanUpdatedAt: asNullableString(payload.scanUpdatedAt) ?? asNullableString(payload.scan_updated_at),
+    scanStale: asBoolean(payload.scanStale ?? payload.scan_stale),
+    scanNeedsRescan: asBoolean(payload.scanNeedsRescan ?? payload.scan_needs_rescan),
+    staleReason: asNullableString(payload.staleReason) ?? asNullableString(payload.stale_reason),
+    setupRunId,
+    setupStatus: asNullableString(payload.setupStatus) ?? asNullableString(payload.setup_status),
+    setupRunStatus: asNullableString(payload.setupRunStatus) ?? asNullableString(payload.setup_run_status),
+    setupCurrentStep: asNullableString(payload.setupCurrentStep) ?? asNullableString(payload.setup_current_step),
+    setupBlocked: asBoolean(payload.setupBlocked ?? payload.setup_blocked),
+    published: asBoolean(payload.published),
+    routePath: asNullableString(payload.routePath) ?? asNullableString(payload.route_path),
+    previewUrl: asNullableString(payload.previewUrl) ?? asNullableString(payload.preview_url),
+    fallbackPreviewUrl: asNullableString(payload.fallbackPreviewUrl) ?? asNullableString(payload.fallback_preview_url),
+    livePreviewUrl: asNullableString(payload.livePreviewUrl) ?? asNullableString(payload.live_preview_url),
+    prUrl: asNullableString(payload.prUrl) ?? asNullableString(payload.pr_url),
+    livePreview: normalizeLivePreview(payload.livePreview ?? payload.live_preview),
+    retryAvailable: asBoolean(payload.retryAvailable ?? payload.retry_available),
+    error: asNullableString(payload.error),
+    source: source ?? undefined,
+    updatedAt: asNullableString(payload.updatedAt) ?? asNullableString(payload.updated_at),
+    articleSurfaceMode: asNullableString(payload.articleSurfaceMode) ?? asNullableString(payload.article_surface_mode),
+    articleSurfaceHint:
+      payload.articleSurfaceHint && typeof payload.articleSurfaceHint === "object"
+        ? (payload.articleSurfaceHint as Record<string, unknown>)
+        : payload.article_surface_hint && typeof payload.article_surface_hint === "object"
+          ? (payload.article_surface_hint as Record<string, unknown>)
+          : null,
+  };
+}
+
 export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
   const payload = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
   return {
@@ -232,6 +284,7 @@ export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
       payload.result && typeof payload.result === "object"
         ? (payload.result as Record<string, unknown>)
         : {},
+    articleSetupState: normalizeArticleSetupState(payload.articleSetupState ?? payload.article_setup_state),
   };
 }
 
@@ -272,9 +325,9 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
       name: asNullableString(company.name) ?? "Company",
       domain: asNullableString(company.domain),
       companyLinkedInUrl: asNullableString(company.companyLinkedInUrl) ?? asNullableString(company.company_linkedin_url),
+      avatarUrl: asNullableString(company.avatarUrl) ?? asNullableString(company.avatar_url),
       location: asNullableString(company.location),
       abn: asNullableString(company.abn),
-      avatarUrl: asNullableString(company.avatarUrl) ?? asNullableString(company.avatar_url),
       organizationId: Number(company.organizationId ?? company.organization_id ?? 0) || null,
     },
     organization: {
@@ -323,6 +376,7 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
       payload.checks && typeof payload.checks === "object"
         ? (payload.checks as VibeMarketingBootstrap["checks"])
         : {},
+    articleSetupState: normalizeArticleSetupState(payload.articleSetupState ?? payload.article_setup_state),
     latestRuns,
     latestRunsByWorkflow,
     topicCandidates: Array.isArray(payload.topicCandidates)
@@ -915,6 +969,7 @@ const DEV_BOOTSTRAP: VibeMarketingBootstrap = {
     connectUrl: "http://localhost:8000/integrations/connect/google?scope=website_baseline&next=/founder-tools/marketing/create?step=baseline%26googleBaseline=refresh",
   },
   checks: {},
+  articleSetupState: null,
   latestRuns: [],
   latestRunsByWorkflow: {},
   topicCandidates: [],

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigate, useNavigation, useSearchParams } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useSearchParams } from "react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeftIcon,
@@ -46,7 +46,7 @@ import {
   startVibeMarketingDiscovery,
   startVibeMarketingScan,
 } from "~/lib/vibe-marketing";
-import type { VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
+import type { VibeMarketingArticleSetupState, VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
@@ -99,7 +99,7 @@ const CREATE_STEP_BY_WORKFLOW_STEP_ID: Record<string, VibeMarketingStepKey> = {
 
 const SETUP_POLLING_STATUSES = new Set(["queued", "pending", "starting", "running"]);
 const SETUP_READY_STATUSES = new Set(["awaiting_confirmation", "awaiting_approval", "approval_required"]);
-const SETUP_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "denied", "cancelled"]);
+const SETUP_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "preview_failed", "denied", "cancelled"]);
 
 type StepExplainer = {
   why: string;
@@ -348,6 +348,84 @@ function activeSetupProgressRun(
   return findSetupChildRun(setupRunId, parentScan.runId, latestRuns, polledChildRun) ?? parentScan;
 }
 
+function findRunById(runs: VibeMarketingRunSummary[], runId: string | null | undefined) {
+  const id = runId?.trim();
+  return id ? runs.find((run) => run.runId === id) ?? null : null;
+}
+
+function articleSetupStateHasSetupWork(state: VibeMarketingArticleSetupState | null | undefined) {
+  return Boolean(state?.setupRunId || state?.setupStatus || state?.setupBlocked || state?.routePath);
+}
+
+function runFromArticleSetupState(
+  state: VibeMarketingArticleSetupState | null | undefined,
+  bootstrap: VibeMarketingBootstrap,
+): VibeMarketingRunSummary | null {
+  if (!state) return null;
+  const setupRunId = state.setupRunId?.trim();
+  const scanRunId = state.scanRunId?.trim();
+  const runId = setupRunId || scanRunId;
+  if (!runId) return null;
+  const setupStatus = state.setupStatus || state.setupRunStatus;
+  const isSetupRun = Boolean(setupRunId);
+  const status = String(isSetupRun ? setupStatus || "queued" : state.scanStatus || "completed");
+  const currentStep = isSetupRun ? state.setupCurrentStep || setupStatus || status : state.scanStatus || status;
+  return {
+    runId,
+    workflow: isSetupRun ? "article_system_setup" : "repo_scan",
+    domain: bootstrap.organization.domain,
+    githubRepo: state.githubRepo || state.repo || bootstrap.settings.githubRepo,
+    sourceRunId: isSetupRun ? scanRunId || null : null,
+    status,
+    currentStep,
+    approvalState: null,
+    resumeAvailable: Boolean(state.retryAvailable),
+    createdAt: state.scanCompletedAt || state.updatedAt || undefined,
+    updatedAt: state.updatedAt || state.scanUpdatedAt || state.scanCompletedAt || undefined,
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: state.error ? [state.error] : [],
+    artifacts: [],
+    previewUrl: state.previewUrl,
+    prUrl: state.prUrl,
+    routePath: state.routePath,
+    diagnostics: {},
+    contentPackage: null,
+    componentManifest: null,
+    livePreview: state.livePreview ?? null,
+    componentFeedback: null,
+    workflowProgress: null,
+    publishChildStatus: null,
+    publishChildRecoverable: false,
+    publishChildWaitReason: null,
+    stale: Boolean(state.scanStale),
+    staleReason: state.staleReason,
+    retryAvailable: Boolean(state.retryAvailable),
+    result: {
+      status,
+      setup_run_id: setupRunId || undefined,
+      setupRunId: setupRunId || undefined,
+      scan_purpose: isSetupRun ? "setup" : undefined,
+      route_path: state.routePath || undefined,
+      article_surface_hint: state.articleSurfaceHint || undefined,
+      article_system_setup: isSetupRun
+        ? {
+            setup_run_id: setupRunId,
+            status: setupStatus || status,
+            current_step: state.setupCurrentStep || undefined,
+            preview_url: state.previewUrl || undefined,
+            fallback_preview_url: state.fallbackPreviewUrl || undefined,
+            live_preview_url: state.livePreviewUrl || undefined,
+            pr_url: state.prUrl || undefined,
+            error: state.error || undefined,
+          }
+        : undefined,
+    },
+    articleSetupState: state,
+  };
+}
+
 type ArticleDeliveryMode = "review_draft" | "publish_code" | "content_only";
 
 function effectiveArticleDeliveryMode(bootstrap: VibeMarketingBootstrap): ArticleDeliveryMode {
@@ -387,7 +465,9 @@ function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMark
   const contentOnlyAllowedStep = ["research", "chooseArticle"].includes(requested);
   const repoArticleAllowedStep = ["github", "scan", "articleSystem"].includes(requested);
   const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
-  const articleSystemSetupAllowedStep = scanRunHasPendingArticleSystemSetup(latestScan) && ["writeCheck", "editArticle", "reviewPublish"].includes(requested);
+  const articleSystemSetupAllowedStep =
+    (articleSetupStateHasSetupWork(bootstrap.articleSetupState) || scanRunHasPendingArticleSystemSetup(latestScan)) &&
+    ["writeCheck", "editArticle", "reviewPublish"].includes(requested);
 
   if (
     requestedWorkflowStep?.status === "locked" &&
@@ -415,16 +495,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   if (isArticleSystemSetupBlocked(bootstrap) && ["research", "chooseArticle"].includes(requestedStep)) {
     url.searchParams.set("step", "articleSystem");
     throw redirect(`${url.pathname}?${url.searchParams.toString()}`);
-  }
-  if (["writeCheck", "editArticle", "reviewPublish"].includes(requestedStep)) {
-    const latestSetupScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
-    if (scanRunHasPendingArticleSystemSetup(latestSetupScan)) {
-      const setupRunId = latestSetupScan ? setupRunIdForRun(latestSetupScan) : "";
-      if (setupRunId) {
-        throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
-      }
-      throw redirect("/founder-tools/marketing/create?step=articleSystem");
-    }
   }
   let githubRepos: VibeMarketingGithubReposResponse = {
     status: "unavailable",
@@ -857,7 +927,6 @@ function PanelHeader({
 export default function FounderToolsMarketingCreate() {
   const { bootstrap, githubRepos } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap);
   const requestedStep = normalizeStep(searchParams.get("step"), activeStep);
   const shouldRefreshGoogleBaseline = searchParams.get("googleBaseline") === "refresh";
@@ -884,13 +953,24 @@ export default function FounderToolsMarketingCreate() {
   const setupChildProgressAtRef = useRef(Date.now());
   const setupChildProgressSignatureRef = useRef("");
   const [pageVisible, setPageVisible] = useState(true);
-  const latestScan = bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
-  const bootstrapPendingArticleSystemScan = scanRunHasPendingArticleSystemSetup(latestScan) ? latestScan : null;
+  const articleSetupState = bootstrap.articleSetupState ?? null;
+  const canonicalScanRun =
+    findRunById(bootstrap.latestRuns, articleSetupState?.scanRunId) ??
+    runFromArticleSetupState(
+      articleSetupState?.scanRunId && !articleSetupState?.setupRunId ? articleSetupState : null,
+      bootstrap,
+    );
+  const latestScan = canonicalScanRun ?? bootstrap.latestRuns.find((run) => ["repo_scan", "content_factory_scan"].includes(run.workflow));
+  const bootstrapPendingArticleSystemScan =
+    scanRunHasPendingArticleSystemSetup(latestScan) || articleSetupStateHasSetupWork(articleSetupState)
+      ? latestScan ?? runFromArticleSetupState(articleSetupState, bootstrap)
+      : null;
   const [polledSetupScan, setPolledSetupScan] = useState<VibeMarketingRunSummary | null>(null);
   const [polledSetupChildRun, setPolledSetupChildRun] = useState<VibeMarketingRunSummary | null>(null);
   const pendingArticleSystemScan =
     polledSetupScan?.runId === bootstrapPendingArticleSystemScan?.runId ? polledSetupScan : bootstrapPendingArticleSystemScan;
-  const pendingArticleSystemSetupRunId = pendingArticleSystemScan ? setupRunIdForRun(pendingArticleSystemScan) : "";
+  const pendingArticleSystemSetupRunId =
+    articleSetupState?.setupRunId?.trim() || (pendingArticleSystemScan ? setupRunIdForRun(pendingArticleSystemScan) : "");
   const setupChildRun = pendingArticleSystemScan
     ? findSetupChildRun(
         pendingArticleSystemSetupRunId,
@@ -899,7 +979,12 @@ export default function FounderToolsMarketingCreate() {
         polledSetupChildRun?.runId === pendingArticleSystemSetupRunId ? polledSetupChildRun : null,
       )
     : null;
-  const setupProgressRun = activeSetupProgressRun(pendingArticleSystemScan, bootstrap.latestRuns, setupChildRun);
+  const canonicalSetupRun =
+    findRunById(bootstrap.latestRuns, pendingArticleSystemSetupRunId) ??
+    (polledSetupChildRun?.runId === pendingArticleSystemSetupRunId ? polledSetupChildRun : null) ??
+    runFromArticleSetupState(articleSetupStateHasSetupWork(articleSetupState) ? articleSetupState : null, bootstrap);
+  const setupProgressRun =
+    canonicalSetupRun ?? activeSetupProgressRun(pendingArticleSystemScan, bootstrap.latestRuns, setupChildRun);
   const pendingSetupStepActive = Boolean(setupProgressRun && ["writeCheck", "editArticle", "reviewPublish"].includes(activeStep));
   const articleSetupFlowActive = isRepoArticleStep || pendingSetupStepActive;
   const latestDiscovery = bootstrap.latestRuns.find((run) => ["auto_discovery", "content_factory_discovery", "daily_discovery"].includes(run.workflow));
@@ -1083,11 +1168,6 @@ export default function FounderToolsMarketingCreate() {
   ]);
 
   useEffect(() => {
-    if (!pendingArticleSystemSetupRunId || activeStep !== "articleSystem") return;
-    navigate(`/founder-tools/marketing/runs/${encodeURIComponent(pendingArticleSystemSetupRunId)}`, { replace: true });
-  }, [activeStep, navigate, pendingArticleSystemSetupRunId]);
-
-  useEffect(() => {
     const selectionStillValid =
       selectedTopicCandidateId === "__custom__" ||
       selectableTopicCandidates.some((candidate) => candidate.id === selectedTopicCandidateId);
@@ -1107,8 +1187,9 @@ export default function FounderToolsMarketingCreate() {
   const setupPreviewRunId = setupChildRun?.runId || pendingArticleSystemSetupRunId;
   const setupBlocked = isArticleSystemSetupBlocked(bootstrap);
   const setupPublished = isArticleSystemPublished(bootstrap);
-  const setupChildStatus = setupChildRun
-    ? stringResultValue(setupChildRun, "status", "setupStatus", "setup_status") || setupChildRun.currentStep || setupChildRun.status
+  const setupStatusRun = setupChildRun ?? (setupProgressRun?.workflow === "article_system_setup" ? setupProgressRun : null);
+  const setupChildStatus = setupStatusRun
+    ? stringResultValue(setupStatusRun, "status", "setupStatus", "setup_status") || setupStatusRun.currentStep || setupStatusRun.status
     : "";
   const setupManualMergeRequired = Boolean(setupBlocked && setupChildStatus === "manual_merge_required");
   const setupVerifying = Boolean(
@@ -1123,11 +1204,11 @@ export default function FounderToolsMarketingCreate() {
       pendingArticleSystemScan.status === "completed",
   );
   const setupPreviewReady = Boolean(
-    setupChildRun &&
+    setupStatusRun &&
       !setupPublished &&
       !setupVerifying &&
       !setupManualMergeRequired &&
-      hasExactArticleSystemSetupPreview(setupChildRun),
+      hasExactArticleSystemSetupPreview(setupStatusRun),
   );
   const setupLegacyNeedsPreview = Boolean(
     pendingArticleSystemScan && !pendingArticleSystemSetupRunId && SETUP_READY_STATUSES.has(pendingArticleSystemScan.status),
@@ -1242,8 +1323,8 @@ export default function FounderToolsMarketingCreate() {
               articleSurfacePlaceholder="https://www.mlai.au/articles or /articles"
               connectionError={githubConnectError}
               scanRun={latestScan}
+              articleSetupState={articleSetupState}
               framed={false}
-              autoStartInventoryScan
             />
 
             {activeStep === "articleSystem" && setupProgressRun ? (

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -42,11 +42,6 @@ import {
   startVibeMarketingArticle,
   updateVibeMarketingComponentComment,
 } from "~/lib/vibe-marketing";
-import {
-  isArticleSystemSetupTerminalRun,
-  shouldPollArticleSystemSetupRun,
-  statusPollRefreshKey,
-} from "~/lib/vibe-marketing-run-polling";
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
 import type {
   VibeMarketingComponentManifestItem,
@@ -70,6 +65,8 @@ const POLLING_STATUSES = new Set([
 ]);
 const LIVE_PREVIEW_ACTIVE_STATUSES = new Set(["queued", "pending", "preparing", "starting", "building", "running"]);
 const LIVE_PREVIEW_FAILURE_STATUSES = new Set(["failed", "blocked", "expired", "cancelled", "canceled", "timeout", "timed_out"]);
+const ARTICLE_SETUP_ACTIVE_STATUSES = new Set(["queued", "pending", "processing", "running", "in_progress", "preview_building"]);
+const ARTICLE_SETUP_FAILED_STATUSES = new Set(["failed", "blocked", "preview_failed", "fallback_ready"]);
 
 const DISCOVERY_WORKFLOWS = new Set(["auto_discovery", "content_factory_discovery", "daily_discovery"]);
 const SCAN_WORKFLOWS = new Set(["repo_scan", "content_factory_scan"]);
@@ -206,6 +203,9 @@ function hasPendingArticlePreview(run: VibeMarketingRunSummary) {
 }
 
 function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
+  if (run.workflow === "article_system_setup" && isActiveArticleSystemSetupRun(run)) {
+    return false;
+  }
   if (run.status === "awaiting_confirmation" || run.status === "awaiting_approval" || run.status === "approval_required") {
     return true;
   }
@@ -216,13 +216,6 @@ function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
     return true;
   }
   return false;
-}
-
-function shouldUseStatusPollResult(run: VibeMarketingRunSummary) {
-  if (isArticleSystemSetupTerminalRun(run)) {
-    return true;
-  }
-  return !statusPollNeedsFullRefresh(run);
 }
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
@@ -761,6 +754,32 @@ function articleSystemSetupPayload(run: VibeMarketingRunSummary) {
   return {};
 }
 
+function articleSystemSetupStatus(run: VibeMarketingRunSummary) {
+  const setup = articleSystemSetupPayload(run);
+  return String(
+    setup.status ??
+      run.result?.["setup_status"] ??
+      run.result?.["setupStatus"] ??
+      run.result?.["status"] ??
+      run.currentStep ??
+      run.status ??
+      "",
+  )
+    .trim()
+    .toLowerCase();
+}
+
+function isActiveArticleSystemSetupRun(run: VibeMarketingRunSummary) {
+  if (run.workflow !== "article_system_setup") return false;
+  const setupStatus = articleSystemSetupStatus(run);
+  return ARTICLE_SETUP_ACTIVE_STATUSES.has(setupStatus) || POLLING_STATUSES.has(run.status);
+}
+
+function articleSystemSetupFailureStep(run: VibeMarketingRunSummary) {
+  const setup = articleSystemSetupPayload(run);
+  return String(setup.failure_step ?? setup.failureStep ?? run.result?.["failure_step"] ?? run.result?.["failureStep"] ?? "").trim();
+}
+
 function articleSurfaceRouteFromRun(run: VibeMarketingRunSummary) {
   const direct = run.routePath?.trim() || stringResultValue(run, "route_path", "routePath");
   if (direct) return direct;
@@ -800,6 +819,7 @@ function ArticleSystemScanFormPanel({
       articleSurfaceDefault={articleSurfaceRouteFromRun(run) || "/articles"}
       articleSurfacePlaceholder="/articles"
       scanRun={run}
+      articleSetupState={bootstrap.articleSetupState}
       showDenySetupAction
     />
   );
@@ -1049,10 +1069,12 @@ function ArticleSystemSetupPreviewUnavailable({
 }) {
   const preview = run.livePreview;
   const diagnosticFallbackUrl = String(fallbackPreviewUrl || fallbackLivePreviewUrl(preview) || "").trim();
-  const previewStatus = String(preview?.status || run.status || "building").replace(/_/g, " ");
-  const terminalFailure = isFailedArticlePreview(preview) || ["blocked", "failed"].includes(run.status);
-  const previewActive = !terminalFailure && hasActiveLivePreview(preview);
   const setup = articleSystemSetupPayload(run);
+  const setupStatus = articleSystemSetupStatus(run);
+  const setupActive = isActiveArticleSystemSetupRun(run);
+  const previewStatus = String(setupStatus || preview?.status || run.status || "building").replace(/_/g, " ");
+  const terminalFailure = !setupActive && (isFailedArticlePreview(preview) || ["blocked", "failed"].includes(run.status) || ARTICLE_SETUP_FAILED_STATUSES.has(setupStatus));
+  const previewActive = setupActive || (!terminalFailure && hasActiveLivePreview(preview));
   const currentErrorCode = String(
     run.errorCode ||
       stringResultValue(run, "error_code", "errorCode") ||
@@ -1069,7 +1091,8 @@ function ArticleSystemSetupPreviewUnavailable({
       "",
   ).trim();
   const previewError = String(preview?.error || "").trim();
-  const rawError = terminalFailure ? currentRunError || previewError : previewError || currentRunError;
+  const failureStep = articleSystemSetupFailureStep(run);
+  const rawError = terminalFailure ? currentRunError || previewError || currentErrorCode : previewError || currentRunError;
   const isGithubAppWriteAccessError =
     currentErrorCode === "GITHUB_APP_WRITE_ACCESS_REQUIRED" ||
     (!currentErrorCode && /GITHUB_APP_WRITE_ACCESS_REQUIRED|Write access denied|Contents:\s*Read\/Write|Pull requests:\s*Read\/Write/i.test(rawError));
@@ -1077,8 +1100,11 @@ function ArticleSystemSetupPreviewUnavailable({
   const fallbackMessage = diagnosticFallbackUrl
     ? "A diagnostic fallback preview is available, but it is not the real deployed Next.js page and cannot be approved."
     : "";
+  const setupRetryable = Boolean(run.stale || run.retryAvailable || run.resumeAvailable);
+  const retryIntent = setupRetryable ? "resume" : "start-live-preview";
+  const actionRetryPending = isActionPending?.(retryIntent) ?? isSubmitting;
   const error = fallbackMessage ||
-    (previewActive
+    (previewActive || actionRetryPending
     ? ""
     : isGithubAppWriteAccessError
       ? "MLAI Tools can read this repository, but needs Contents: Read/Write and Pull requests: Read/Write to create the setup PR."
@@ -1086,9 +1112,8 @@ function ArticleSystemSetupPreviewUnavailable({
         ? "Content Factory found a Next.js App Router project but could not confirm a root app/layout.* file from the latest repository context. Re-run the repository scan, then retry setup."
       : rawError || (terminalFailure ? "The articles setup build did not advance." : ""));
   const logsUrl = preview?.logsUrl || preview?.builderRunUrl;
-  const setupRetryable = Boolean(run.stale || run.retryAvailable || run.resumeAvailable);
-  const retryIntent = setupRetryable ? "resume" : "start-live-preview";
-  const retryPreviewPending = previewActive || (isActionPending?.(retryIntent) ?? isSubmitting);
+  const retryPreviewPending = previewActive || actionRetryPending;
+  const setupRunning = retryPreviewPending || setupActive;
   const githubAccessHref = `/founder-tools/marketing/github-connect?forceReconnect=true&returnTo=${encodeURIComponent(`/founder-tools/marketing/runs/${run.runId}`)}`;
   if (previewUrl) return null;
   return (
@@ -1096,20 +1121,29 @@ function ArticleSystemSetupPreviewUnavailable({
       "rounded-xl border px-4 py-5 text-sm font-semibold",
       diagnosticFallbackUrl
         ? "border-amber-200 bg-amber-50 text-amber-900"
-        : error
+          : error
           ? "border-red-200 bg-red-50 text-red-800"
           : "border-violet-100 bg-violet-50 text-violet-800",
     )}>
       <p className="font-black">
         {diagnosticFallbackUrl
           ? "Exact articles preview is not ready"
+          : setupRunning
+            ? "Articles setup is running"
           : error
           ? setupRetryable
             ? "Articles setup build did not advance"
             : "Articles setup preview could not be prepared"
           : "Articles setup preview is being built"}
       </p>
-      <p className="mt-1">{previewActive ? "Waiting for GitHub Actions to finish. Refreshing this page is safe." : `Preview status: ${previewStatus}. Refreshing this page is safe.`}</p>
+      <p className="mt-1">
+        {setupRunning
+          ? `Current setup step: ${previewStatus || "running"}. Refreshing this page is safe.`
+          : previewActive
+            ? "Waiting for GitHub Actions to finish. Refreshing this page is safe."
+            : `Preview status: ${previewStatus}. Refreshing this page is safe.`}
+      </p>
+      {failureStep && error ? <p className="mt-2 text-xs font-black uppercase">Failed step: {failureStep.replace(/_/g, " ")}</p> : null}
       {error ? <p className="mt-2 break-words font-mono text-xs">{error}</p> : null}
       <div className="mt-4 flex flex-col gap-2 sm:flex-row">
         {diagnosticFallbackUrl ? (
@@ -2961,7 +2995,6 @@ function prNumberFromPullUrl(url: string) {
 }
 
 function hasPublishHandoffEvidence(run: VibeMarketingRunSummary) {
-  if (run.workflow === "article_system_setup") return false;
   return Boolean(
     publishPrUrlForRun(run) ||
       publishPreviewUrlForRun(run) ||
@@ -3035,9 +3068,10 @@ function workflowProgressForRunPage(
     const activeStepId = setupWorkflowStepIdForRun(run);
     const setupStatus = (stringResultValue(run, "status", "setupStatus", "setup_status") || run.currentStep || run.status || "").toLowerCase();
     const manualMergeRequired = setupStatus === "manual_merge_required";
-    const setupTerminal = isTerminalAttentionStatus(run.status);
+    const setupActive = isActiveArticleSystemSetupRun(run);
+    const setupTerminal = !setupActive && isTerminalAttentionStatus(run.status);
     const setupPreviewActive = !setupTerminal && hasActiveLivePreview(run.livePreview);
-    const setupFailed = !setupPreviewActive && (isFailedArticlePreview(run.livePreview) || setupTerminal);
+    const setupFailed = !setupActive && !setupPreviewActive && (isFailedArticlePreview(run.livePreview) || setupTerminal || ARTICLE_SETUP_FAILED_STATUSES.has(setupStatus));
     const setupComplete = (run.status === "completed" || run.approvalState === "approved") && !manualMergeRequired;
     const reviewReady = activeStepId === "review" || setupComplete;
     return {
@@ -3122,7 +3156,6 @@ export default function FounderToolsMarketingRun() {
   const [pageVisible, setPageVisible] = useState(true);
   const run = polledRun ?? loaderRun;
   const [selectedComponent, setSelectedComponent] = useState<VibeMarketingComponentManifestItem | null>(null);
-  const statusUrl = `/founder-tools/marketing/runs/${encodeURIComponent(loaderRun.runId)}/status`;
   const workflow = String(run.workflow ?? "");
   const isScanRun = SCAN_WORKFLOWS.has(workflow);
   const isSetupScanContext = isScanRun && isSetupScanRun(run);
@@ -3131,16 +3164,20 @@ export default function FounderToolsMarketingRun() {
   const isRunActionNeeded = ["awaiting_confirmation", "awaiting_delivery_mode", "awaiting_approval", "approval_required"].includes(run.status);
   const isScanCompleted = isScanRun && run.status === "completed";
   const isArticleSystemSetupRun = workflow === "article_system_setup";
-  const setupTerminal = isArticleSystemSetupRun && isArticleSystemSetupTerminalRun(run);
-  const setupPreviewActive = isArticleSystemSetupRun && !setupTerminal && hasActiveLivePreview(run.livePreview);
-  const setupPreviewFailed = isArticleSystemSetupRun && (setupTerminal || isFailedArticlePreview(run.livePreview));
-  const shouldPoll =
-    shouldPollArticleSystemSetupRun(run) &&
-    ((POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
-      setupPreviewActive ||
-      hasPendingArticlePreview(run) ||
-      hasPublishHandoffEvidence(run));
   const setupRun = isArticleSystemSetupRun ? run : loaderSetupRun;
+  const activeSetupRun = setupRun && isActiveArticleSystemSetupRun(setupRun) ? setupRun : null;
+  const setupRunActive = isArticleSystemSetupRun ? isActiveArticleSystemSetupRun(run) : Boolean(activeSetupRun);
+  const pollRunId = activeSetupRun?.runId ?? loaderRun.runId;
+  const statusUrl = `/founder-tools/marketing/runs/${encodeURIComponent(pollRunId)}/status`;
+  const setupTerminal = ["blocked", "failed", "cancelled", "canceled"].includes(run.status);
+  const setupPreviewActive = isArticleSystemSetupRun && !setupTerminal && hasActiveLivePreview(run.livePreview);
+  const setupPreviewFailed = isArticleSystemSetupRun && !setupRunActive && (setupTerminal || isFailedArticlePreview(run.livePreview));
+  const shouldPoll =
+    setupRunActive ||
+    (POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
+    setupPreviewActive ||
+    hasPendingArticlePreview(run) ||
+    hasPublishHandoffEvidence(run);
   const isArticleWorkflowRun = isArticleWorkflow(workflow);
   const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
   const hasArticlePreview = hasReadyArticlePreview(run);
@@ -3150,7 +3187,7 @@ export default function FounderToolsMarketingRun() {
     run.status === "awaiting_confirmation" &&
     !setupBlocked;
   const isPublishApproval = isPublishApprovalGate(run);
-  const effectiveSetupPreviewRun = setupRun?.livePreview?.previewUrl || setupRun?.previewUrl ? setupRun : isScanRun && setupRunIdForRun(run) ? run : setupRun;
+  const effectiveSetupPreviewRun = setupRun ?? (isScanRun && setupRunIdForRun(run) ? run : null);
   const showRunAttentionBanner = RESUMABLE_ATTENTION_STATUSES.has(run.status);
   const canResume = Boolean(run.resumeAvailable && RESUMABLE_ATTENTION_STATUSES.has(run.status));
   const discoveryCandidates = useMemo(
@@ -3211,7 +3248,7 @@ export default function FounderToolsMarketingRun() {
 
   useEffect(() => {
     setPolledRun(null);
-  }, [loaderRun.currentStep, loaderRun.runId, loaderRun.status, loaderRun.updatedAt]);
+  }, [loaderRun.currentStep, loaderRun.runId, loaderRun.status, loaderRun.updatedAt, loaderSetupRun?.runId, loaderSetupRun?.status, loaderSetupRun?.updatedAt]);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -3225,12 +3262,12 @@ export default function FounderToolsMarketingRun() {
     if (
       runStatusFetcher.state !== "idle" ||
       !runStatusFetcher.data?.runId ||
-      runStatusFetcher.data.runId !== loaderRun.runId
+      runStatusFetcher.data.runId !== pollRunId
     ) {
       return;
     }
-    if (!shouldUseStatusPollResult(runStatusFetcher.data)) {
-      const refreshKey = statusPollRefreshKey(runStatusFetcher.data);
+    if (statusPollNeedsFullRefresh(runStatusFetcher.data)) {
+      const refreshKey = `${runStatusFetcher.data.runId}:${runStatusFetcher.data.status}:${runStatusFetcher.data.updatedAt ?? ""}:${runStatusFetcher.data.currentStep ?? ""}`;
       if (statusRefreshRef.current !== refreshKey) {
         statusRefreshRef.current = refreshKey;
         setPolledRun(null);
@@ -3239,7 +3276,7 @@ export default function FounderToolsMarketingRun() {
       return;
     }
     setPolledRun(runStatusFetcher.data);
-  }, [loaderRun.runId, revalidator, runStatusFetcher.data, runStatusFetcher.state]);
+  }, [pollRunId, revalidator, runStatusFetcher.data, runStatusFetcher.state]);
 
   useEffect(() => {
     const data = previewStartFetcher.data;
@@ -3285,9 +3322,9 @@ export default function FounderToolsMarketingRun() {
   }, [run]);
 
   useEffect(() => {
-    if (!shouldPoll || !loaderRun.runId || runStatusFetcher.state !== "idle") return;
+    if (!shouldPoll || !pollRunId || runStatusFetcher.state !== "idle") return;
     if (!pageVisible) return;
-    const hasLoadedCurrentRun = runStatusFetcher.data?.runId === loaderRun.runId;
+    const hasLoadedCurrentRun = runStatusFetcher.data?.runId === pollRunId;
     const idleMs = Date.now() - lastProgressAtRef.current;
     const pollDelay = !hasLoadedCurrentRun ? 0 : idleMs > 60_000 ? 15_000 : idleMs > 10_000 ? 5_000 : 2_500;
     const timer = window.setTimeout(
@@ -3297,7 +3334,7 @@ export default function FounderToolsMarketingRun() {
       pollDelay,
     );
     return () => window.clearTimeout(timer);
-  }, [loaderRun.runId, pageVisible, runStatusFetcher, runStatusFetcher.data?.runId, runStatusFetcher.state, shouldPoll, statusUrl]);
+  }, [pageVisible, pollRunId, runStatusFetcher, runStatusFetcher.data?.runId, runStatusFetcher.state, shouldPoll, statusUrl]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -60,7 +60,44 @@ export interface VibeMarketingRunSummary {
   retryAvailable?: boolean;
   queueName?: string | null;
   queuedAt?: string | null;
+  resumeGeneration?: number | null;
+  isCurrentAttempt?: boolean;
+  failureStep?: string | null;
   result?: Record<string, unknown>;
+  articleSetupState?: VibeMarketingArticleSetupState | null;
+}
+
+export interface VibeMarketingArticleSetupState {
+  repo?: string | null;
+  githubRepo?: string | null;
+  defaultBranch?: string | null;
+  defaultBranchSha?: string | null;
+  lastScannedSha?: string | null;
+  scanRunId?: string | null;
+  scanStatus?: VibeMarketingRunStatus | null;
+  scanCompletedAt?: string | null;
+  scanUpdatedAt?: string | null;
+  scanStale?: boolean;
+  scanNeedsRescan?: boolean;
+  staleReason?: string | null;
+  setupRunId?: string | null;
+  setupStatus?: VibeMarketingRunStatus | string | null;
+  setupRunStatus?: VibeMarketingRunStatus | string | null;
+  setupCurrentStep?: string | null;
+  setupBlocked?: boolean;
+  published?: boolean;
+  routePath?: string | null;
+  previewUrl?: string | null;
+  fallbackPreviewUrl?: string | null;
+  livePreviewUrl?: string | null;
+  prUrl?: string | null;
+  livePreview?: VibeMarketingLivePreview | null;
+  retryAvailable?: boolean;
+  error?: string | null;
+  source?: "config" | "scan_run" | "setup_run" | "none" | string;
+  updatedAt?: string | null;
+  articleSurfaceMode?: string | null;
+  articleSurfaceHint?: Record<string, unknown> | null;
 }
 
 export interface VibeMarketingAutofillSource {
@@ -155,9 +192,9 @@ export interface VibeMarketingCompany {
   name: string;
   domain?: string | null;
   companyLinkedInUrl?: string | null;
+  avatarUrl?: string | null;
   location?: string | null;
   abn?: string | null;
-  avatarUrl?: string | null;
   organizationId?: number | null;
 }
 
@@ -593,6 +630,7 @@ export interface VibeMarketingBootstrap {
   websiteBaseline: VibeMarketingWebsiteBaseline;
   googleBaselineConnection: VibeMarketingGoogleBaselineConnection;
   checks: Record<string, VibeMarketingCheck>;
+  articleSetupState?: VibeMarketingArticleSetupState | null;
   latestRuns: VibeMarketingRunSummary[];
   latestRunsByWorkflow: Record<string, VibeMarketingRunSummary>;
   topicCandidates: VibeMarketingTopicCandidate[];


### PR DESCRIPTION
## Summary
- Consume backend `articleSetupState` in the Vibe Marketing create and run routes.
- Render scan/setup/build status from the canonical state across step changes, refreshes, and run detail views.
- Remove automatic setup-run navigation and automatic inventory scan startup.

## Validation
- `PATH=/Users/samdonegan/Documents/Code/mlai-au/node_modules/.bin:$PATH bun run typecheck` from the clean PR worktree.
- Browser checked the local flow on `localhost:5173` after backend/content-factory restart: reloads and route changes preserved setup status and created no new runs.