### PR TITLE
[codex] Render active setup retries from canonical state

### DIFF
--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -97,7 +97,7 @@ const CREATE_STEP_BY_WORKFLOW_STEP_ID: Record<string, VibeMarketingStepKey> = {
   automation: "dailyAutomation",
 };
 
-const SETUP_POLLING_STATUSES = new Set(["queued", "pending", "starting", "running"]);
+const SETUP_POLLING_STATUSES = new Set(["queued", "pending", "starting", "processing", "running", "in_progress", "preview_building"]);
 const SETUP_READY_STATUSES = new Set(["awaiting_confirmation", "awaiting_approval", "approval_required"]);
 const SETUP_FAILED_STATUSES = new Set(["failed", "blocked", "blocked_verification", "preview_failed", "denied", "cancelled"]);
 
@@ -366,7 +366,12 @@ function runFromArticleSetupState(
   const scanRunId = state.scanRunId?.trim();
   const runId = setupRunId || scanRunId;
   if (!runId) return null;
-  const setupStatus = state.setupStatus || state.setupRunStatus;
+  const setupRunStatus = state.setupRunStatus?.trim();
+  const rawSetupStatus = state.setupStatus?.trim();
+  const setupStatus =
+    setupRunStatus && SETUP_POLLING_STATUSES.has(setupRunStatus)
+      ? setupRunStatus
+      : rawSetupStatus || setupRunStatus;
   const isSetupRun = Boolean(setupRunId);
   const status = String(isSetupRun ? setupStatus || "queued" : state.scanStatus || "completed");
   const currentStep = isSetupRun ? state.setupCurrentStep || setupStatus || status : state.scanStatus || status;

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -57,7 +57,12 @@ import type {
 
 const POLLING_STATUSES = new Set([
   "queued",
+  "pending",
+  "starting",
+  "processing",
   "running",
+  "in_progress",
+  "preview_building",
   "awaiting_confirmation",
   "awaiting_delivery_mode",
   "awaiting_approval",
@@ -772,7 +777,25 @@ function articleSystemSetupStatus(run: VibeMarketingRunSummary) {
 function isActiveArticleSystemSetupRun(run: VibeMarketingRunSummary) {
   if (run.workflow !== "article_system_setup") return false;
   const setupStatus = articleSystemSetupStatus(run);
-  return ARTICLE_SETUP_ACTIVE_STATUSES.has(setupStatus) || POLLING_STATUSES.has(run.status);
+  const setupStep = articleSystemSetupCurrentStep(run).toLowerCase();
+  return (
+    ARTICLE_SETUP_ACTIVE_STATUSES.has(run.status) ||
+    ARTICLE_SETUP_ACTIVE_STATUSES.has(setupStatus) ||
+    ARTICLE_SETUP_ACTIVE_STATUSES.has(setupStep) ||
+    POLLING_STATUSES.has(run.status)
+  );
+}
+
+function articleSystemSetupCurrentStep(run: VibeMarketingRunSummary) {
+  const setup = articleSystemSetupPayload(run);
+  return String(
+    setup.current_step ??
+      setup.currentStep ??
+      run.result?.["current_step"] ??
+      run.result?.["currentStep"] ??
+      run.currentStep ??
+      "",
+  ).trim();
 }
 
 function articleSystemSetupFailureStep(run: VibeMarketingRunSummary) {
@@ -1072,7 +1095,12 @@ function ArticleSystemSetupPreviewUnavailable({
   const setup = articleSystemSetupPayload(run);
   const setupStatus = articleSystemSetupStatus(run);
   const setupActive = isActiveArticleSystemSetupRun(run);
-  const previewStatus = String(setupStatus || preview?.status || run.status || "building").replace(/_/g, " ");
+  const setupCurrentStep = articleSystemSetupCurrentStep(run);
+  const previewStatus = String(
+    setupActive
+      ? setupCurrentStep || run.currentStep || run.status || "running"
+      : setupStatus || preview?.status || run.status || "building",
+  ).replace(/_/g, " ");
   const terminalFailure = !setupActive && (isFailedArticlePreview(preview) || ["blocked", "failed"].includes(run.status) || ARTICLE_SETUP_FAILED_STATUSES.has(setupStatus));
   const previewActive = setupActive || (!terminalFailure && hasActiveLivePreview(preview));
   const currentErrorCode = String(


### PR DESCRIPTION
## Summary
- Treat active setup run status as authoritative over stale preview_failed metadata.
- Continue polling active setup retries from canonical backend state.
- Show active setup progress/current step while retry work is running.

## Validation
- bun run typecheck