### PR TITLE
[codex] Add setup build cancel action

### DIFF
--- a/app/components/CancelSetupBuildButton.tsx
+++ b/app/components/CancelSetupBuildButton.tsx
@@ -1,0 +1,205 @@
+import { ArrowPathIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { clsx } from "clsx";
+import { Form } from "react-router";
+
+import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
+
+export const CANCEL_SETUP_BUILD_INTENT = "cancel-setup-build";
+
+const CANCELLABLE_SETUP_STATUSES = new Set([
+  "queued",
+  "pending",
+  "starting",
+  "processing",
+  "running",
+  "in_progress",
+  "preview_building",
+  "preview_verifying",
+  "repair_preview_building",
+  "blocked",
+  "blocked_verification",
+  "failed",
+  "preview_failed",
+  "fallback_ready",
+  "awaiting_confirmation",
+  "awaiting_approval",
+  "approval_required",
+]);
+
+const NON_CANCELLABLE_SETUP_STATUSES = new Set([
+  "cancelled",
+  "canceled",
+  "denied",
+  "completed",
+  "pr_created",
+  "setup_pr_created",
+]);
+
+function normalized(value: unknown) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function compactString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
+  const result = recordValue(run.result);
+  const nestedResult = recordValue(result.result);
+  const latestControl = recordValue(result.latest_control_response);
+
+  for (const key of keys) {
+    const direct = compactString(result[key]);
+    if (direct) return direct;
+    const nested = compactString(nestedResult[key]);
+    if (nested) return nested;
+    const latest = compactString(latestControl[key]);
+    if (latest) return latest;
+  }
+  return "";
+}
+
+function articleSystemSetupPayload(run: VibeMarketingRunSummary) {
+  const result = recordValue(run.result);
+  const direct = recordValue(result.article_system_setup);
+  if (Object.keys(direct).length) return direct;
+
+  const nested = recordValue(recordValue(result.result).article_system_setup);
+  if (Object.keys(nested).length) return nested;
+
+  return recordValue(recordValue(result.latest_control_response).article_system_setup);
+}
+
+function setupPayloadStatusCandidates(run: VibeMarketingRunSummary) {
+  const setup = articleSystemSetupPayload(run);
+  return [
+    setup.status,
+    setup.current_step,
+    setup.currentStep,
+    run.result?.setup_status,
+    run.result?.setupStatus,
+  ]
+    .map(normalized)
+    .filter(Boolean);
+}
+
+function runStatusCandidates(run: VibeMarketingRunSummary) {
+  return [run.result?.status, run.currentStep, run.status].map(normalized).filter(Boolean);
+}
+
+function hasNumberValue(value: unknown) {
+  if (typeof value === "number") return Number.isFinite(value);
+  return Boolean(compactString(value));
+}
+
+export function setupRunIdForSetupCancel(run: VibeMarketingRunSummary) {
+  const direct = stringResultValue(
+    run,
+    "setup_run_id",
+    "setupRunId",
+    "scaffold_job_id",
+    "scaffoldJobId",
+    "job_id",
+    "jobId",
+  );
+  if (direct) return direct;
+
+  const setup = articleSystemSetupPayload(run);
+  const setupRunId = compactString(setup.setup_run_id) || compactString(setup.setupRunId);
+  if (setupRunId) return setupRunId;
+
+  return run.workflow === "article_system_setup" ? run.runId : "";
+}
+
+export function hasArticleSetupPrEvidence(run: VibeMarketingRunSummary) {
+  if (compactString(run.prUrl)) return true;
+
+  const directPrUrl = stringResultValue(
+    run,
+    "pr_url",
+    "prUrl",
+    "pull_request_url",
+    "pullRequestUrl",
+    "setup_pr_url",
+    "setupPrUrl",
+    "setup_pull_request_url",
+    "setupPullRequestUrl",
+    "draft_pr_url",
+    "draftPrUrl",
+  );
+  if (directPrUrl) return true;
+
+  const setup = articleSystemSetupPayload(run);
+  if (["pr_created", "setup_pr_created"].includes(normalized(setup.status))) return true;
+
+  return [
+    setup.pr_url,
+    setup.prUrl,
+    setup.pull_request_url,
+    setup.pullRequestUrl,
+    setup.setup_pr_url,
+    setup.setupPrUrl,
+    setup.setup_pull_request_url,
+    setup.setupPullRequestUrl,
+    setup.pr_number,
+    setup.prNumber,
+    setup.setup_pr_number,
+    setup.setupPrNumber,
+    run.result?.pr_number,
+    run.result?.prNumber,
+    run.result?.setup_pr_number,
+    run.result?.setupPrNumber,
+  ].some(hasNumberValue);
+}
+
+export function canCancelSetupBuild(run: VibeMarketingRunSummary) {
+  if (!setupRunIdForSetupCancel(run)) return false;
+  if (hasArticleSetupPrEvidence(run)) return false;
+
+  const setupStatuses = setupPayloadStatusCandidates(run);
+  if (setupStatuses.some((status) => NON_CANCELLABLE_SETUP_STATUSES.has(status))) return false;
+  if (setupStatuses.some((status) => CANCELLABLE_SETUP_STATUSES.has(status))) return true;
+
+  if (run.workflow !== "article_system_setup") return false;
+  const runStatuses = runStatusCandidates(run);
+  if (runStatuses.some((status) => NON_CANCELLABLE_SETUP_STATUSES.has(status))) return false;
+  return runStatuses.some((status) => CANCELLABLE_SETUP_STATUSES.has(status));
+}
+
+export default function CancelSetupBuildButton({
+  run,
+  pending = false,
+  disabled = false,
+  className,
+}: {
+  run: VibeMarketingRunSummary;
+  pending?: boolean;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const setupRunId = setupRunIdForSetupCancel(run);
+  if (!setupRunId || !canCancelSetupBuild(run)) return null;
+
+  return (
+    <Form method="POST">
+      <input type="hidden" name="setupRunId" value={setupRunId} />
+      <button
+        type="submit"
+        name="intent"
+        value={CANCEL_SETUP_BUILD_INTENT}
+        disabled={disabled || pending}
+        className={clsx(
+          "inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50 sm:w-auto",
+          className,
+        )}
+      >
+        {pending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <TrashIcon className="h-4 w-4" />}
+        {pending ? "Cancelling..." : "Cancel setup build"}
+      </button>
+    </Form>
+  );
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -16,6 +16,7 @@ import { clsx } from "clsx";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
 import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
+import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
 import {
   CustomTopicDecisionCard,
   TopicDecisionCard,
@@ -754,6 +755,16 @@ export async function action({ request, context }: Route.ActionArgs) {
       return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(scanRunId)}`);
     }
 
+    if (intent === CANCEL_SETUP_BUILD_INTENT) {
+      const setupRunId = stringFromForm(formData, "setupRunId");
+      if (!setupRunId) return { intent, error: "No setup build was available to cancel." };
+      await controlVibeMarketingRun(env, request, setupRunId, "cancel", {
+        cleanup: true,
+        workflow: "article_system_setup",
+      });
+      return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
+    }
+
     if (intent === "start-discovery") {
       const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
       if (isArticleSystemSetupBlocked(bootstrap)) {
@@ -1219,7 +1230,16 @@ export default function FounderToolsMarketingCreate() {
     pendingArticleSystemScan && !pendingArticleSystemSetupRunId && SETUP_READY_STATUSES.has(pendingArticleSystemScan.status),
   );
   const setupProgressFailed = Boolean(setupProgressRun && SETUP_FAILED_STATUSES.has(setupProgressRun.status));
-  const setupProgressActionSlot = setupPublished ? (
+  const setupCancelRun = setupStatusRun ?? setupProgressRun;
+  const setupCancelButton =
+    setupCancelRun && canCancelSetupBuild(setupCancelRun) ? (
+      <CancelSetupBuildButton
+        run={setupCancelRun}
+        pending={pendingActions.isPending(CANCEL_SETUP_BUILD_INTENT)}
+        disabled={isSubmitting}
+      />
+    ) : null;
+  const setupProgressPrimaryActionSlot = setupPublished ? (
     <Link
       to="/founder-tools/marketing/create?step=research"
       className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700"
@@ -1276,6 +1296,12 @@ export default function FounderToolsMarketingCreate() {
         ? "Building preview..."
         : "Preparing setup..."}
     </button>
+  ) : null;
+  const setupProgressActionSlot = setupProgressPrimaryActionSlot || setupCancelButton ? (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+      {setupProgressPrimaryActionSlot}
+      {setupCancelButton}
+    </div>
   ) : null;
 
   return (

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -20,6 +20,7 @@ import ArticleRunStageProgress from "~/components/ArticleRunStageProgress";
 import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
 import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
+import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
@@ -360,6 +361,18 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } else if (intent === "cancel-scan") {
       await controlVibeMarketingRun(env, request, runId, "cancel", { cleanup: true, workflow: "repo_scan" });
       throw redirect("/founder-tools/marketing/create?step=articleSystem");
+    } else if (intent === CANCEL_SETUP_BUILD_INTENT) {
+      let setupRunId = stringFromForm(formData, "setupRunId");
+      if (!setupRunId) {
+        const currentRun = await getVibeMarketingRun(env, request, runId);
+        if (currentRun.workflow === "article_system_setup") setupRunId = runId;
+      }
+      if (!setupRunId) return { intent, error: "No setup build was available to cancel." };
+      await controlVibeMarketingRun(env, request, setupRunId, "cancel", {
+        cleanup: true,
+        workflow: "article_system_setup",
+      });
+      throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
     } else if (intent === "retry-scan") {
       const result = await controlVibeMarketingRun(env, request, runId, "resume", { workflow: "repo_scan" });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
@@ -943,6 +956,21 @@ function ArticleSystemScanFormPanel({
   );
 }
 
+function setupBuildCancelActionSlot(
+  run: VibeMarketingRunSummary,
+  isSubmitting: boolean,
+  isActionPending?: (...keys: string[]) => boolean,
+): ReactNode {
+  if (!canCancelSetupBuild(run)) return null;
+  return (
+    <CancelSetupBuildButton
+      run={run}
+      pending={isActionPending?.(CANCEL_SETUP_BUILD_INTENT) ?? false}
+      disabled={isSubmitting}
+    />
+  );
+}
+
 function ArticleSystemSetupPreviewPanel({
   run,
   sourceRun,
@@ -1137,7 +1165,10 @@ function ArticleSystemSetupPreviewPanel({
               isActionPending={isActionPending}
             />
           ) : (
-            <ArticlesSetupProgressCard run={run} />
+            <ArticlesSetupProgressCard
+              run={run}
+              actionSlot={setupBuildCancelActionSlot(run, isSubmitting, isActionPending)}
+            />
           )}
         </div>
       ) : null}
@@ -1186,9 +1217,13 @@ function ArticleSystemSetupPreviewPanel({
 function ArticleSetupGenerateDetail({
   run,
   sourceRun,
+  isSubmitting,
+  isActionPending,
 }: {
   run: VibeMarketingRunSummary;
   sourceRun?: VibeMarketingRunSummary | null;
+  isSubmitting: boolean;
+  isActionPending?: (...keys: string[]) => boolean;
 }) {
   const setup = articleSystemSetupPayload(run);
   const source = sourceRun ?? run;
@@ -1219,7 +1254,10 @@ function ArticleSetupGenerateDetail({
 
   return (
     <div className="space-y-5">
-      <ArticlesSetupProgressCard run={run} />
+      <ArticlesSetupProgressCard
+        run={run}
+        actionSlot={setupBuildCancelActionSlot(run, isSubmitting, isActionPending)}
+      />
       <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         <h2 className="text-lg font-black text-gray-950">Setup build details</h2>
         <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
@@ -1437,6 +1475,7 @@ function ArticleSystemSetupPreviewUnavailable({
             </button>
           </Form>
         ) : null}
+        {setupBuildCancelActionSlot(run, isSubmitting, isActionPending)}
       </div>
     </div>
   );
@@ -3869,7 +3908,7 @@ export default function FounderToolsMarketingRun() {
           isSetupPublishView ? (
             <ArticleSetupPublishDetail run={run} bootstrap={bootstrap} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
           ) : isSetupGenerateView ? (
-            <ArticleSetupGenerateDetail run={run} />
+            <ArticleSetupGenerateDetail run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
           ) : isSetupReviewView ? (
             <ArticleSystemSetupPreviewPanel
               run={run}


### PR DESCRIPTION
## Summary
- add a reusable Cancel setup build action for article setup runs
- wire cancel-setup-build into marketing run and create routes
- hide the action once setup is cancelled, completed, denied, or has PR evidence

## Validation
- bun run typecheck
- git diff --check