### PR TITLE
[codex] Add Watt The Hack frontend app

### DIFF
--- a/app/components/GenericHackathonAppLayout.tsx
+++ b/app/components/GenericHackathonAppLayout.tsx
@@ -1,0 +1,195 @@
+import { Fragment, useState } from "react";
+import { Dialog, Menu, Transition } from "@headlessui/react";
+import {
+  ArrowLeftOnRectangleIcon,
+  Bars3Icon,
+  BookOpenIcon,
+  ChevronDownIcon,
+  DocumentTextIcon,
+  HomeIcon,
+  UserGroupIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { Form, Link, useLocation } from "react-router";
+import { generateAvatarUrl, getInitials } from "~/lib/avatar";
+import type { User } from "~/types/user";
+
+interface GenericHackathonAppLayoutProps {
+  children: React.ReactNode;
+  user: User;
+  config: {
+    name: string;
+    slug: string;
+    basePath: string;
+    accentClass?: string;
+  };
+}
+
+function classNames(...classes: (string | false | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function GenericHackathonAppLayout({ children, user, config }: GenericHackathonAppLayoutProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const location = useLocation();
+  const fullName = user.full_name || user.email || "User";
+  const avatarUrl = user.avatar_url || generateAvatarUrl(getInitials(fullName));
+
+  const navigation = [
+    { name: "Dashboard", href: `${config.basePath}/dashboard`, icon: HomeIcon },
+    { name: "Profile & Team", href: `${config.basePath}/profile`, icon: UserGroupIcon },
+    { name: "Submissions", href: `${config.basePath}/submissions`, icon: DocumentTextIcon },
+    { name: "Resources", href: `${config.basePath}/resources`, icon: BookOpenIcon },
+  ].map((item) => ({
+    ...item,
+    current: location.pathname === item.href,
+  }));
+
+  const sidebar = (
+    <div className="flex grow flex-col gap-y-6 overflow-y-auto bg-[#10231f] px-5 pb-4">
+      <div className="flex h-16 shrink-0 items-center">
+        <Link to={`${config.basePath}/dashboard`} className="flex items-center gap-3" onClick={() => setSidebarOpen(false)}>
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#9fe870] text-sm font-black text-[#10231f]">
+            W
+          </span>
+          <span className="text-sm font-semibold text-white">{config.name}</span>
+        </Link>
+      </div>
+      <nav className="flex flex-1 flex-col">
+        <ul className="flex flex-1 flex-col gap-y-7">
+          <li>
+            <ul className="-mx-2 space-y-1">
+              {navigation.map((item) => (
+                <li key={item.name}>
+                  <Link
+                    to={item.href}
+                    onClick={() => setSidebarOpen(false)}
+                    className={classNames(
+                      item.current
+                        ? "bg-white/10 text-[#9fe870]"
+                        : "text-white/72 hover:bg-white/8 hover:text-white",
+                      "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition",
+                    )}
+                  >
+                    <item.icon className="h-6 w-6 shrink-0" aria-hidden="true" />
+                    {item.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </li>
+          <li className="mt-auto">
+            <Link
+              to="/hackathons"
+              className="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-white/70 hover:bg-white/8 hover:text-white"
+            >
+              <ArrowLeftOnRectangleIcon className="h-6 w-6 shrink-0" aria-hidden="true" />
+              Back to MLAI
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-[#f5f1e8]">
+      <Transition.Root show={sidebarOpen} as={Fragment}>
+        <Dialog as="div" className="relative z-50 lg:hidden" onClose={setSidebarOpen}>
+          <Transition.Child
+            as={Fragment}
+            enter="transition-opacity ease-linear duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition-opacity ease-linear duration-300"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black/70" />
+          </Transition.Child>
+          <div className="fixed inset-0 flex">
+            <Transition.Child
+              as={Fragment}
+              enter="transition ease-in-out duration-300 transform"
+              enterFrom="-translate-x-full"
+              enterTo="translate-x-0"
+              leave="transition ease-in-out duration-300 transform"
+              leaveFrom="translate-x-0"
+              leaveTo="-translate-x-full"
+            >
+              <Dialog.Panel className="relative mr-16 flex w-full max-w-xs flex-1">
+                <button
+                  type="button"
+                  className="absolute left-full top-0 flex w-16 justify-center pt-5"
+                  onClick={() => setSidebarOpen(false)}
+                >
+                  <span className="sr-only">Close sidebar</span>
+                  <XMarkIcon className="h-6 w-6 text-white" aria-hidden="true" />
+                </button>
+                {sidebar}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition.Root>
+
+      <aside className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+        {sidebar}
+      </aside>
+
+      <div className="lg:pl-72">
+        <header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-black/10 bg-white/90 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
+          <button type="button" className="-m-2.5 p-2.5 text-gray-700 lg:hidden" onClick={() => setSidebarOpen(true)}>
+            <span className="sr-only">Open sidebar</span>
+            <Bars3Icon className="h-6 w-6" aria-hidden="true" />
+          </button>
+          <div className="flex flex-1 items-center justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#1f6f54]">Hackathon</p>
+              <h1 className="text-base font-semibold text-gray-950">{config.name}</h1>
+            </div>
+            <Menu as="div" className="relative">
+              <Menu.Button className="-m-1.5 flex items-center p-1.5">
+                <span className="sr-only">Open user menu</span>
+                <img alt="" src={avatarUrl} className="h-8 w-8 rounded-full bg-gray-50 object-cover ring-1 ring-black/10" />
+                <span className="hidden lg:flex lg:items-center">
+                  <span className="ml-4 text-sm font-semibold leading-6 text-gray-900">{fullName}</span>
+                  <ChevronDownIcon className="ml-2 h-5 w-5 text-gray-400" aria-hidden="true" />
+                </span>
+              </Menu.Button>
+              <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+              >
+                <Menu.Items className="absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-black/5 focus:outline-none">
+                  <Menu.Item>
+                    {({ focus }) => (
+                      <Link to={`${config.basePath}/profile`} className={classNames(focus && "bg-gray-50", "block px-3 py-1 text-sm leading-6 text-gray-900")}>
+                        Profile
+                      </Link>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item>
+                    {({ focus }) => (
+                      <Form method="post" action="/platform/logout">
+                        <button type="submit" className={classNames(focus && "bg-gray-50", "block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900")}>
+                          Sign out
+                        </button>
+                      </Form>
+                    )}
+                  </Menu.Item>
+                </Menu.Items>
+              </Transition>
+            </Menu>
+          </div>
+        </header>
+        <main>{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/lib/auth-return.ts
+++ b/app/lib/auth-return.ts
@@ -2,7 +2,8 @@ export type AuthReturnAppName =
   | "esafety"
   | "hospital"
   | "founder-tools"
-  | "vibe-raising";
+  | "vibe-raising"
+  | "watt-the-hack";
 
 const LEGACY_FOUNDER_NEXT_PATHS: Record<string, string> = {
   "/vibe-raising": "/founder-tools",
@@ -25,6 +26,7 @@ function pathWithSearchAndHash(url: URL) {
 export function getDefaultAuthNext(app: AuthReturnAppName | string | null | undefined, fallback = "/hackathons"): string {
   if (app === "hospital") return "/hospital/app";
   if (app === "esafety") return "/esafety/dashboard";
+  if (app === "watt-the-hack") return "/watt-the-hack/dashboard";
   if (isFounderToolsApp(app)) return "/founder-tools";
   return fallback;
 }

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,7 +1,7 @@
 import { axiosInstance, API_URL, shouldUseDevAuthBypass, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "./api";
 import axios from "axios";
 
-export type AuthAppName = "esafety" | "hospital" | "founder-tools" | "vibe-raising";
+export type AuthAppName = "esafety" | "hospital" | "founder-tools" | "vibe-raising" | "watt-the-hack";
 type GetCurrentUserOptions = {
     allowDevBypass?: boolean;
 };
@@ -17,6 +17,8 @@ function resolveAuthApp(body: {
         body.app ||
         (body.next?.startsWith("/esafety")
             ? "esafety"
+            : body.next?.startsWith("/watt-the-hack")
+              ? "watt-the-hack"
             : body.next?.startsWith("/founder-tools") || body.next?.startsWith("/vibe-raising")
               ? "founder-tools"
               : "hospital")
@@ -110,6 +112,7 @@ export async function verifyMagicLinkWithCookies(
 // logged-in user while keeping backend calls enabled. VITE_STUB_BACKEND=true
 // also uses this user and stubs API responses.
 const DEV_AUTH_STUB: Record<string, unknown> | null = {
+    id: 1,
     full_name: "Dr Sam Donegan",
     email: "sam@supportsorted.com.au",
     role: "participant",
@@ -173,7 +176,8 @@ export async function createUser(env: Env, body: {
     next?: string;
 }) {
     const client = getAxios(env);
-    const response = await client.post("/api/v1/auth/create-user/", body);
+    const app = resolveAuthApp(body);
+    const response = await client.post("/api/v1/auth/create-user/", { ...body, app });
     return response.data;
 }
 

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -1,0 +1,137 @@
+import { createApiClient, getBaseUrl } from "~/lib/api";
+import type { Announcement } from "~/components/Announcements";
+import type { Hackathon } from "~/services/hackathon";
+
+export const WATT_THE_HACK_SLUG = "watt-the-hack";
+
+export interface GenericHackathonMember {
+  id: number;
+  email: string;
+  full_name: string;
+  avatar_url?: string | null;
+  role: string;
+}
+
+export interface GenericHackathonTeam {
+  id: number;
+  team_id: number;
+  code: string;
+  team_name: string;
+  avatar_url?: string | null;
+  member_count: number;
+  members: GenericHackathonMember[];
+}
+
+export interface GenericHackathonSubmission {
+  id: number;
+  title: string;
+  summary: string;
+  repository_url?: string | null;
+  demo_url?: string | null;
+  slides_url?: string | null;
+  attachment_url?: string | null;
+  attachment_name?: string;
+  attachment_content_type?: string;
+  attachment_size?: number | null;
+  team: GenericHackathonTeam;
+  submitted_by: {
+    id: number;
+    email: string;
+    full_name: string;
+    avatar_url?: string | null;
+  };
+  submitted_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GenericHackathonResource {
+  id: number;
+  title: string;
+  summary: string;
+  body?: string;
+  url?: string | null;
+  category?: string;
+  order: number;
+}
+
+function appPath(slug: string, path: string) {
+  return `/api/v1/hackathons/${slug}/app/${path}`;
+}
+
+function cookieHeaders(request?: Request) {
+  const headers: Record<string, string> = {};
+  const cookie = request?.headers.get("Cookie");
+  if (cookie) headers.Cookie = cookie;
+  return headers;
+}
+
+function errorMessage(data: unknown, fallback: string) {
+  if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    const detail = record.detail ?? record.error ?? record.message;
+    if (typeof detail === "string" && detail.trim()) return detail.trim();
+  }
+  return fallback;
+}
+
+export async function getGenericHackathon(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<Hackathon> {
+  const client = createApiClient(env, request);
+  const response = await client.get(`/api/v1/hackathons/${slug}/`);
+  return response.data;
+}
+
+export async function getGenericCurrentTeam(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonTeam | null> {
+  const client = createApiClient(env, request);
+  const response = await client.get(appPath(slug, "team/"));
+  return response.data ?? null;
+}
+
+export async function getGenericTeams(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonTeam[]> {
+  const client = createApiClient(env, request);
+  const response = await client.get(appPath(slug, "teams/"));
+  return response.data || [];
+}
+
+export async function createGenericTeam(env: Env, request: Request, slug: string, teamName: string): Promise<GenericHackathonTeam> {
+  const client = createApiClient(env, request);
+  const response = await client.post(appPath(slug, "teams/"), { team_name: teamName });
+  return response.data.team;
+}
+
+export async function joinGenericTeam(env: Env, request: Request, slug: string, code: string): Promise<GenericHackathonTeam> {
+  const client = createApiClient(env, request);
+  const response = await client.post(appPath(slug, "teams/join/"), { code });
+  return response.data;
+}
+
+export async function getGenericSubmissions(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonSubmission[]> {
+  const client = createApiClient(env, request);
+  const response = await client.get(appPath(slug, "submissions/"));
+  return response.data || [];
+}
+
+export async function createGenericSubmission(env: Env, request: Request, slug: string, formData: FormData): Promise<GenericHackathonSubmission> {
+  const response = await fetch(`${getBaseUrl(env)}${appPath(slug, "submissions/")}`, {
+    method: "POST",
+    headers: cookieHeaders(request),
+    body: formData,
+  });
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(errorMessage(data, "Submission failed."));
+  }
+  return data as GenericHackathonSubmission;
+}
+
+export async function getGenericAnnouncements(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<Announcement[]> {
+  const client = createApiClient(env, request);
+  const response = await client.get(appPath(slug, "announcements/"));
+  return response.data || [];
+}
+
+export async function getGenericResources(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonResource[]> {
+  const client = createApiClient(env, request);
+  const response = await client.get(appPath(slug, "resources/"));
+  return response.data || [];
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -82,7 +82,8 @@ export default function Layout() {
   const isFounderToolsApp =
     location.pathname === "/founder-tools" ||
     location.pathname.startsWith("/founder-tools/");
-  const isAppRoute = isEsafetyApp || isHospitalApp || isVibeRaisingLegacyApp || isFounderToolsApp;
+  const isWattTheHackApp = location.pathname.startsWith("/watt-the-hack");
+  const isAppRoute = isEsafetyApp || isHospitalApp || isVibeRaisingLegacyApp || isFounderToolsApp || isWattTheHackApp;
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -53,6 +53,16 @@ export default [
     route("profile", "routes/hospital.app.profile.tsx"),
   ]),
 
+  // Watt The Hack generic hackathon app routes
+  route("/watt-the-hack", "routes/watt-the-hack.tsx", [
+    index("routes/watt-the-hack._index.tsx"),
+    route("dashboard", "routes/watt-the-hack.dashboard.tsx"),
+    route("profile", "routes/watt-the-hack.profile.tsx"),
+    route("team", "routes/watt-the-hack.team.tsx"),
+    route("submissions", "routes/watt-the-hack.submissions.tsx"),
+    route("resources", "routes/watt-the-hack.resources.tsx"),
+  ]),
+
   // Hackathon pages
   route("/hackathon", "routes/article-link-cleanups.tsx", { id: "cleanup-hackathon-singular" }),
   route("/hackathons", "routes/hackathons.tsx"),

--- a/app/routes/hackathons.tsx
+++ b/app/routes/hackathons.tsx
@@ -1,5 +1,6 @@
 const AI_HOSPITAL_STATIC = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Screenshot%202025-11-25%20at%2011.24.04%E2%80%AFam.png?alt=media&token=b23e69c8-f0c7-4f76-8439-49ae8056c987";
 const ESAFETY_STATIC = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Gemini_Generated_Image_3lirg63lirg63lir-min.jpg?alt=media&token=714825f8-44bf-4ad3-ad5c-561c9dc0d504";
+const WATT_THE_HACK_STATIC = "https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?auto=format&fit=crop&w=1200&q=80";
 
 export default function Hackathons() {
     return (
@@ -14,7 +15,26 @@ export default function Hackathons() {
                     </p>
                 </div>
 
-                <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-12 max-w-5xl mx-auto">
+                <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 lg:gap-8 max-w-6xl mx-auto">
+                    {/* Watt The Hack Card */}
+                    <a
+                        href="/platform/login?app=watt-the-hack&next=/watt-the-hack/dashboard"
+                        className="group relative aspect-video overflow-hidden rounded-2xl bg-white shadow-lg transition hover:-translate-y-1 hover:shadow-xl"
+                    >
+                        <img
+                            src={WATT_THE_HACK_STATIC}
+                            alt="Watt The Hack"
+                            className="absolute inset-0 h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
+                        />
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/30 to-transparent" />
+                        <div className="absolute bottom-0 left-0 right-0 z-10 p-6 text-white">
+                            <h3 className="text-2xl font-bold">Watt The Hack</h3>
+                            <p className="mt-2 text-sm text-gray-200">
+                                Build practical AI and software projects for a cleaner, smarter energy future.
+                            </p>
+                        </div>
+                    </a>
+
                     {/* Medhack: Frontiers Card — Disabled */}
                     <div
                         className="group relative aspect-video overflow-hidden rounded-2xl bg-white shadow-lg grayscale opacity-75 cursor-not-allowed"

--- a/app/routes/platform.login.tsx
+++ b/app/routes/platform.login.tsx
@@ -16,7 +16,7 @@ export const meta: Route.MetaFunction = () => [
 
 function parseAuthApp(value: string | null): AuthAppName | null {
     if (value === "vibe-raising") return "founder-tools";
-    return value === "esafety" || value === "hospital" || value === "founder-tools"
+    return value === "esafety" || value === "hospital" || value === "founder-tools" || value === "watt-the-hack"
         ? value
         : null;
 }
@@ -267,6 +267,7 @@ export default function PlatformLogin() {
     const getWelcomeText = () => {
         if (app === "esafety") return "Sign in to eSafety Hackathon";
         if (app === "hospital") return "Sign in to Medhack: Frontiers";
+        if (app === "watt-the-hack") return "Sign in to Watt The Hack";
         if (app === "founder-tools") return "Sign in to Founder Tools";
         return "Welcome!";
     };
@@ -274,6 +275,9 @@ export default function PlatformLogin() {
     const getSupportText = () => {
         if (app === "founder-tools") {
             return "Use your email to sign in to Founder Tools. If you do not have an account yet, we will ask for a few extra details before sending the magic link.";
+        }
+        if (app === "watt-the-hack") {
+            return "Use your email to sign in. If you do not have an account yet, we will ask for a few extra details before sending the magic link.";
         }
 
         return "Provide your email to create your account";

--- a/app/routes/watt-the-hack._index.tsx
+++ b/app/routes/watt-the-hack._index.tsx
@@ -1,0 +1,11 @@
+import type { Route } from "./+types/watt-the-hack._index";
+import { redirect } from "react-router";
+
+
+export function loader({}: Route.LoaderArgs) {
+  return redirect("/watt-the-hack/dashboard");
+}
+
+export default function WattTheHackIndex() {
+  return null;
+}

--- a/app/routes/watt-the-hack.dashboard.tsx
+++ b/app/routes/watt-the-hack.dashboard.tsx
@@ -1,0 +1,200 @@
+import type { Route } from "./+types/watt-the-hack.dashboard";
+import { Link, redirect, useLoaderData } from "react-router";
+import {
+  ArrowTopRightOnSquareIcon,
+  DocumentTextIcon,
+  UserGroupIcon,
+} from "@heroicons/react/24/outline";
+import Announcements from "~/components/Announcements";
+import { getCurrentUser } from "~/lib/auth";
+import { getEnv } from "~/lib/env.server";
+import {
+  getGenericAnnouncements,
+  getGenericCurrentTeam,
+  getGenericHackathon,
+  getGenericResources,
+  getGenericSubmissions,
+  WATT_THE_HACK_SLUG,
+  type GenericHackathonResource,
+  type GenericHackathonSubmission,
+  type GenericHackathonTeam,
+} from "~/lib/generic-hackathon";
+import type { Hackathon } from "~/services/hackathon";
+
+const FALLBACK_HACKATHON: Hackathon = {
+  name: "Watt The Hack",
+  slug: WATT_THE_HACK_SLUG,
+  description: "Build practical AI and software projects for a cleaner, smarter energy future.",
+  start_date: "2026-06-01",
+  end_date: "2026-12-31",
+};
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  let user = null;
+  try {
+    user = await getCurrentUser(env, request);
+  } catch (error) {
+    console.warn("Treating Watt The Hack auth lookup failure as logged out.", error);
+  }
+  if (!user) {
+    throw redirect("/platform/login?app=watt-the-hack&next=/watt-the-hack/dashboard");
+  }
+
+  const [hackathon, announcements, team, submissions, resources] = await Promise.all([
+    getGenericHackathon(env, request).catch(() => FALLBACK_HACKATHON),
+    getGenericAnnouncements(env, request).catch(() => []),
+    getGenericCurrentTeam(env, request).catch(() => null),
+    getGenericSubmissions(env, request).catch(() => []),
+    getGenericResources(env, request).catch(() => []),
+  ]);
+
+  return {
+    hackathon,
+    announcements,
+    team,
+    latestSubmission: submissions[0] ?? null,
+    resources: resources.slice(0, 3),
+  };
+}
+
+function StatCard({ label, value, icon: Icon }: { label: string; value: string; icon: typeof UserGroupIcon }) {
+  return (
+    <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-3">
+        <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#e6f8d8] text-[#24523f]">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div>
+          <p className="text-sm text-gray-500">{label}</p>
+          <p className="text-lg font-semibold text-gray-950">{value}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TeamPanel({ team }: { team: GenericHackathonTeam | null }) {
+  return (
+    <div className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-950">Team</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            {team ? `${team.team_name} (${team.code})` : "Create or join a team before submitting."}
+          </p>
+        </div>
+        <Link to="/watt-the-hack/profile" className="rounded-md bg-[#10231f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#1d3c35]">
+          Manage
+        </Link>
+      </div>
+      {team && (
+        <div className="mt-5 flex flex-wrap gap-2">
+          {team.members.map((member) => (
+            <span key={member.id} className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700">
+              {member.full_name || member.email}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SubmissionPanel({ submission }: { submission: GenericHackathonSubmission | null }) {
+  return (
+    <div className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-950">Latest Submission</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            {submission ? submission.title : "No project submitted yet."}
+          </p>
+        </div>
+        <Link to="/watt-the-hack/submissions" className="rounded-md bg-[#9fe870] px-3 py-2 text-sm font-semibold text-[#10231f] hover:bg-[#b2f38a]">
+          Submit
+        </Link>
+      </div>
+      {submission && (
+        <p className="mt-4 line-clamp-3 text-sm leading-6 text-gray-600">{submission.summary}</p>
+      )}
+    </div>
+  );
+}
+
+function ResourcesPanel({ resources }: { resources: GenericHackathonResource[] }) {
+  return (
+    <div className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-950">Resources</h2>
+        <Link to="/watt-the-hack/resources" className="text-sm font-semibold text-[#1f6f54] hover:text-[#10231f]">
+          View all
+        </Link>
+      </div>
+      <div className="mt-4 space-y-3">
+        {resources.length > 0 ? resources.map((resource) => (
+          <Link key={resource.id} to="/watt-the-hack/resources" className="block rounded-md border border-black/8 p-3 hover:bg-gray-50">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-medium text-gray-950">{resource.title}</p>
+                <p className="mt-1 text-sm text-gray-600">{resource.summary}</p>
+              </div>
+              <ArrowTopRightOnSquareIcon className="mt-1 h-4 w-4 text-gray-400" aria-hidden="true" />
+            </div>
+          </Link>
+        )) : (
+          <p className="text-sm text-gray-600">Resources will appear here when they are published.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function WattTheHackDashboard() {
+  const { hackathon, announcements, team, latestSubmission, resources } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <section className="relative overflow-hidden rounded-lg bg-[#10231f] px-6 py-8 text-white shadow-sm sm:px-8">
+          <img
+            src="https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?auto=format&fit=crop&w=1600&q=80"
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover opacity-25"
+          />
+          <div className="absolute inset-0 bg-gradient-to-r from-[#10231f] via-[#10231f]/90 to-[#10231f]/40" />
+          <div className="relative max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[#9fe870]">Participant Dashboard</p>
+            <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-5xl">{hackathon.name}</h1>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-white/78">{hackathon.description}</p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link to="/watt-the-hack/profile" className="rounded-md bg-[#9fe870] px-4 py-2 text-sm font-semibold text-[#10231f] hover:bg-[#b2f38a]">
+                Profile & Team
+              </Link>
+              <Link to="/watt-the-hack/submissions" className="rounded-md border border-white/30 px-4 py-2 text-sm font-semibold text-white hover:bg-white/10">
+                Submit Project
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <StatCard label="Team Status" value={team ? "Joined" : "Not joined"} icon={UserGroupIcon} />
+          <StatCard label="Members" value={team ? String(team.member_count) : "0"} icon={UserGroupIcon} />
+          <StatCard label="Submission" value={latestSubmission ? "Received" : "Not submitted"} icon={DocumentTextIcon} />
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-6">
+            <Announcements announcements={announcements} />
+            <ResourcesPanel resources={resources} />
+          </div>
+          <div className="space-y-6">
+            <TeamPanel team={team} />
+            <SubmissionPanel submission={latestSubmission} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/watt-the-hack.profile.tsx
+++ b/app/routes/watt-the-hack.profile.tsx
@@ -1,0 +1,258 @@
+import type { Route } from "./+types/watt-the-hack.profile";
+import { Form, redirect, useActionData, useLoaderData } from "react-router";
+import { getCurrentUser, updateUser } from "~/lib/auth";
+import { getInitials, generateAvatarUrl } from "~/lib/avatar";
+import { getEnv } from "~/lib/env.server";
+import {
+  createGenericTeam,
+  getGenericCurrentTeam,
+  getGenericTeams,
+  joinGenericTeam,
+  WATT_THE_HACK_SLUG,
+  type GenericHackathonTeam,
+} from "~/lib/generic-hackathon";
+import type { User } from "~/types/user";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  let user = null;
+  try {
+    user = await getCurrentUser(env, request);
+  } catch (error) {
+    console.warn("Treating Watt The Hack auth lookup failure as logged out.", error);
+  }
+  if (!user) {
+    throw redirect("/platform/login?app=watt-the-hack&next=/watt-the-hack/profile");
+  }
+
+  const [currentTeam, teams] = await Promise.all([
+    getGenericCurrentTeam(env, request).catch(() => null),
+    getGenericTeams(env, request).catch(() => []),
+  ]);
+
+  return { user: user as User, currentTeam, teams };
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  const env = getEnv(context);
+  const formData = await request.formData();
+  const intent = formData.get("intent")?.toString();
+
+  try {
+    if (intent === "create_team") {
+      const teamName = String(formData.get("team_name") || "").trim();
+      if (!teamName) return { error: "Team name is required." };
+      await createGenericTeam(env, request, WATT_THE_HACK_SLUG, teamName);
+      return { success: "Team created." };
+    }
+
+    if (intent === "join_team") {
+      const code = String(formData.get("code") || "").trim();
+      if (!code) return { error: "Team code or name is required." };
+      await joinGenericTeam(env, request, WATT_THE_HACK_SLUG, code);
+      return { success: "Team joined." };
+    }
+
+    if (intent === "update_profile") {
+      formData.set("app", WATT_THE_HACK_SLUG);
+      formData.delete("intent");
+      await updateUser(env, formData, request);
+      return { success: "Profile updated." };
+    }
+  } catch (error: any) {
+    const detail = error?.response?.data?.error || error?.response?.data?.detail || error?.message;
+    return { error: detail || "Request failed." };
+  }
+
+  return { error: "Unsupported action." };
+}
+
+function TeamCard({ team }: { team: GenericHackathonTeam | null }) {
+  if (!team) {
+    return (
+      <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+        You are not on a Watt The Hack team yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-950">{team.team_name}</h2>
+          <p className="mt-1 text-sm text-gray-500">Team code: {team.code}</p>
+        </div>
+        <span className="rounded-full bg-[#e6f8d8] px-3 py-1 text-sm font-semibold text-[#24523f]">
+          {team.member_count}/6 members
+        </span>
+      </div>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        {team.members.map((member) => (
+          <div key={member.id} className="flex items-center gap-3 rounded-md bg-gray-50 p-3">
+            <img
+              alt=""
+              src={member.avatar_url || generateAvatarUrl(getInitials(member.full_name || member.email))}
+              className="h-9 w-9 rounded-full object-cover"
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-gray-950">{member.full_name || member.email}</p>
+              <p className="truncate text-xs text-gray-500">{member.email}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function WattTheHackProfile() {
+  const { user, currentTeam, teams } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const avatarUrl = user.avatar_url || generateAvatarUrl(getInitials(user.full_name || user.email));
+
+  return (
+    <div className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[1fr_420px]">
+        <section className="rounded-lg border border-black/10 bg-white shadow-sm">
+          <div className="border-b border-black/10 px-6 py-5">
+            <div className="flex items-center gap-4">
+              <img alt="" src={avatarUrl} className="h-14 w-14 rounded-full object-cover ring-1 ring-black/10" />
+              <div>
+                <h1 className="text-2xl font-bold text-gray-950">Profile</h1>
+                <p className="text-sm text-gray-600">Update your participant details.</p>
+              </div>
+            </div>
+          </div>
+
+          <Form method="post" encType="multipart/form-data" className="space-y-6 px-6 py-6">
+            <input type="hidden" name="intent" value="update_profile" />
+            <input type="hidden" name="app" value={WATT_THE_HACK_SLUG} />
+
+            {actionData?.success && (
+              <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">{actionData.success}</div>
+            )}
+            {actionData?.error && (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{actionData.error}</div>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">First name</span>
+                <input
+                  name="first_name"
+                  defaultValue={(user as any).first_name || ""}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Last name</span>
+                <input
+                  name="last_name"
+                  defaultValue={(user as any).last_name || ""}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Email</span>
+              <input
+                name="email"
+                type="email"
+                defaultValue={user.email}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Phone</span>
+              <input
+                name="phone"
+                defaultValue={(user as any).phone || ""}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">About</span>
+              <textarea
+                name="about"
+                rows={5}
+                defaultValue={(user as any).about || ""}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+              />
+            </label>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Profile image</span>
+                <input name="avatar" type="file" accept="image/*" className="mt-1 block w-full text-sm text-gray-700" />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Team image</span>
+                <input name="team_avatar" type="file" accept="image/*" className="mt-1 block w-full text-sm text-gray-700" />
+              </label>
+            </div>
+
+            <div className="flex justify-end">
+              <button type="submit" className="rounded-md bg-[#10231f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1d3c35]">
+                Save profile
+              </button>
+            </div>
+          </Form>
+        </section>
+
+        <aside className="space-y-6">
+          <TeamCard team={currentTeam} />
+
+          <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-950">Create a Team</h2>
+            <Form method="post" className="mt-4 flex gap-2">
+              <input type="hidden" name="intent" value="create_team" />
+              <input
+                name="team_name"
+                placeholder="Team name"
+                className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+              />
+              <button type="submit" className="rounded-md bg-[#9fe870] px-3 py-2 text-sm font-semibold text-[#10231f] hover:bg-[#b2f38a]">
+                Create
+              </button>
+            </Form>
+          </div>
+
+          <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-gray-950">Join a Team</h2>
+            <Form method="post" className="mt-4 flex gap-2">
+              <input type="hidden" name="intent" value="join_team" />
+              <input
+                name="code"
+                list="watt-team-list"
+                placeholder="TEAM1 or team name"
+                className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+              />
+              <datalist id="watt-team-list">
+                {teams.map((team) => (
+                  <option key={team.id} value={team.code}>{team.team_name}</option>
+                ))}
+              </datalist>
+              <button type="submit" className="rounded-md border border-black/10 bg-white px-3 py-2 text-sm font-semibold text-gray-950 hover:bg-gray-50">
+                Join
+              </button>
+            </Form>
+            {teams.length > 0 && (
+              <div className="mt-4 space-y-2">
+                {teams.slice(0, 6).map((team) => (
+                  <div key={team.id} className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm">
+                    <span className="font-medium text-gray-800">{team.team_name}</span>
+                    <span className="text-gray-500">{team.code}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/watt-the-hack.resources.tsx
+++ b/app/routes/watt-the-hack.resources.tsx
@@ -1,0 +1,102 @@
+import type { Route } from "./+types/watt-the-hack.resources";
+import { redirect, useLoaderData } from "react-router";
+import ReactMarkdown from "react-markdown";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { getCurrentUser } from "~/lib/auth";
+import { getEnv } from "~/lib/env.server";
+import { getGenericResources, type GenericHackathonResource } from "~/lib/generic-hackathon";
+
+const FALLBACK_RESOURCES: GenericHackathonResource[] = [
+  {
+    id: -1,
+    title: "Submission Guide",
+    summary: "Submit a title, summary, and links that make the project easy to evaluate.",
+    body: "Include the problem, who it helps, what you built, and how judges can try it. Repository, demo, and slide links are all optional but useful.",
+    category: "Getting Started",
+    order: 10,
+  },
+  {
+    id: -2,
+    title: "Team Formation",
+    summary: "Create a team or join one with its team code.",
+    body: "You need to belong to a team before submitting. A team can have up to six members.",
+    category: "Getting Started",
+    order: 20,
+  },
+  {
+    id: -3,
+    title: "Judging Criteria",
+    summary: "Projects should be clear, useful, credible, and demonstrable.",
+    body: "Focus on a well-defined problem, practical execution, impact, and a demo or evidence that the project works.",
+    category: "Judging",
+    order: 30,
+  },
+];
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  let user = null;
+  try {
+    user = await getCurrentUser(env, request);
+  } catch (error) {
+    console.warn("Treating Watt The Hack auth lookup failure as logged out.", error);
+  }
+  if (!user) {
+    throw redirect("/platform/login?app=watt-the-hack&next=/watt-the-hack/resources");
+  }
+  const resources = await getGenericResources(env, request).catch(() => []);
+  return { resources: resources.length > 0 ? resources : FALLBACK_RESOURCES };
+}
+
+export default function WattTheHackResources() {
+  const { resources } = useLoaderData<typeof loader>();
+  const grouped = resources.reduce<Record<string, GenericHackathonResource[]>>((acc, resource) => {
+    const category = resource.category || "General";
+    acc[category] = acc[category] || [];
+    acc[category].push(resource);
+    return acc;
+  }, {});
+
+  return (
+    <div className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl space-y-8">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-[#1f6f54]">Resources</p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-950">Watt The Hack Resources</h1>
+          <p className="mt-3 max-w-2xl text-gray-600">
+            Guides, references, and challenge material for participants.
+          </p>
+        </div>
+
+        {Object.entries(grouped).map(([category, items]) => (
+          <section key={category} className="space-y-4">
+            <h2 className="text-xl font-semibold text-gray-950">{category}</h2>
+            <div className="grid gap-4 md:grid-cols-2">
+              {items.map((resource) => (
+                <article key={resource.id} className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-lg font-semibold text-gray-950">{resource.title}</h3>
+                      <p className="mt-2 text-sm leading-6 text-gray-600">{resource.summary}</p>
+                    </div>
+                    {resource.url && (
+                      <a href={resource.url} target="_blank" rel="noopener noreferrer" className="text-[#1f6f54] hover:text-[#10231f]">
+                        <span className="sr-only">Open {resource.title}</span>
+                        <ArrowTopRightOnSquareIcon className="h-5 w-5" aria-hidden="true" />
+                      </a>
+                    )}
+                  </div>
+                  {resource.body && (
+                    <div className="prose prose-sm mt-4 max-w-none text-gray-700">
+                      <ReactMarkdown>{resource.body}</ReactMarkdown>
+                    </div>
+                  )}
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/watt-the-hack.submissions.tsx
+++ b/app/routes/watt-the-hack.submissions.tsx
@@ -1,0 +1,204 @@
+import type { Route } from "./+types/watt-the-hack.submissions";
+import { Form, Link, redirect, useActionData, useLoaderData } from "react-router";
+import {
+  ArrowDownTrayIcon,
+  ArrowTopRightOnSquareIcon,
+  DocumentTextIcon,
+} from "@heroicons/react/24/outline";
+import { getCurrentUser } from "~/lib/auth";
+import { getEnv } from "~/lib/env.server";
+import {
+  createGenericSubmission,
+  getGenericCurrentTeam,
+  getGenericSubmissions,
+  WATT_THE_HACK_SLUG,
+} from "~/lib/generic-hackathon";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  let user = null;
+  try {
+    user = await getCurrentUser(env, request);
+  } catch (error) {
+    console.warn("Treating Watt The Hack auth lookup failure as logged out.", error);
+  }
+  if (!user) {
+    throw redirect("/platform/login?app=watt-the-hack&next=/watt-the-hack/submissions");
+  }
+
+  const [team, submissions] = await Promise.all([
+    getGenericCurrentTeam(env, request).catch(() => null),
+    getGenericSubmissions(env, request).catch(() => []),
+  ]);
+
+  return { team, submissions };
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  const env = getEnv(context);
+  const formData = await request.formData();
+  formData.delete("intent");
+
+  try {
+    const submission = await createGenericSubmission(env, request, WATT_THE_HACK_SLUG, formData);
+    return { success: `Submission received: ${submission.title}` };
+  } catch (error: any) {
+    return { error: error?.message || "Submission failed." };
+  }
+}
+
+function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat("en-AU", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export default function WattTheHackSubmissions() {
+  const { team, submissions } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+
+  return (
+    <div className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[420px_1fr]">
+        <section className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+          <div className="flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#e6f8d8] text-[#24523f]">
+              <DocumentTextIcon className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div>
+              <h1 className="text-xl font-bold text-gray-950">Project Submission</h1>
+              <p className="text-sm text-gray-600">Submit your team project.</p>
+            </div>
+          </div>
+
+          {!team ? (
+            <div className="mt-6 rounded-md bg-amber-50 p-4 text-sm text-amber-900">
+              Join or create a team before submitting.{" "}
+              <Link to="/watt-the-hack/profile" className="font-semibold underline underline-offset-2">
+                Go to profile and team
+              </Link>
+            </div>
+          ) : (
+            <Form method="post" encType="multipart/form-data" className="mt-6 space-y-4">
+              <input type="hidden" name="intent" value="submit_project" />
+              {actionData?.success && (
+                <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">{actionData.success}</div>
+              )}
+              {actionData?.error && (
+                <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{actionData.error}</div>
+              )}
+
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Project title</span>
+                <input
+                  name="title"
+                  required
+                  maxLength={180}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Summary</span>
+                <textarea
+                  name="summary"
+                  required
+                  rows={6}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Repository URL</span>
+                <input
+                  name="repository_url"
+                  type="url"
+                  placeholder="https://github.com/..."
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Demo URL</span>
+                <input
+                  name="demo_url"
+                  type="url"
+                  placeholder="https://..."
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Slides URL</span>
+                <input
+                  name="slides_url"
+                  type="url"
+                  placeholder="https://..."
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Attachment</span>
+                <input name="attachment" type="file" className="mt-1 block w-full text-sm text-gray-700" />
+                <span className="mt-1 block text-xs text-gray-500">Optional. PDF, deck, document, image, zip, CSV, or video up to 20MB.</span>
+              </label>
+              <button type="submit" className="w-full rounded-md bg-[#10231f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1d3c35]">
+                Submit project
+              </button>
+            </Form>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-black/10 bg-white shadow-sm">
+          <div className="border-b border-black/10 px-6 py-5">
+            <h2 className="text-xl font-bold text-gray-950">Submission History</h2>
+            <p className="text-sm text-gray-600">
+              {team ? `Showing submissions for ${team.team_name}.` : "Team submissions will appear here."}
+            </p>
+          </div>
+          <div className="divide-y divide-black/8">
+            {submissions.length > 0 ? submissions.map((submission) => (
+              <article key={submission.id} className="p-6">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-950">{submission.title}</h3>
+                    <p className="mt-1 text-sm text-gray-500">{formatDate(submission.submitted_at)}</p>
+                    <p className="mt-3 max-w-3xl text-sm leading-6 text-gray-700">{submission.summary}</p>
+                  </div>
+                  {submission.attachment_url && (
+                    <a
+                      href={submission.attachment_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 rounded-md border border-black/10 px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-50"
+                    >
+                      <ArrowDownTrayIcon className="h-4 w-4" aria-hidden="true" />
+                      Attachment
+                    </a>
+                  )}
+                </div>
+                <div className="mt-4 flex flex-wrap gap-3">
+                  {submission.repository_url && <ExternalLink href={submission.repository_url} label="Repository" />}
+                  {submission.demo_url && <ExternalLink href={submission.demo_url} label="Demo" />}
+                  {submission.slides_url && <ExternalLink href={submission.slides_url} label="Slides" />}
+                </div>
+              </article>
+            )) : (
+              <div className="p-6 text-sm text-gray-600">No submissions yet.</div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function ExternalLink({ href, label }: { href: string; label: string }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm font-semibold text-[#1f6f54] hover:text-[#10231f]">
+      {label}
+      <ArrowTopRightOnSquareIcon className="h-4 w-4" aria-hidden="true" />
+    </a>
+  );
+}

--- a/app/routes/watt-the-hack.team.tsx
+++ b/app/routes/watt-the-hack.team.tsx
@@ -1,0 +1,11 @@
+import type { Route } from "./+types/watt-the-hack.team";
+import { redirect } from "react-router";
+
+
+export function loader({}: Route.LoaderArgs) {
+  return redirect("/watt-the-hack/profile");
+}
+
+export default function WattTheHackTeamRedirect() {
+  return null;
+}

--- a/app/routes/watt-the-hack.tsx
+++ b/app/routes/watt-the-hack.tsx
@@ -1,0 +1,42 @@
+import type { Route } from "./+types/watt-the-hack";
+import { Outlet, redirect, useLoaderData } from "react-router";
+import GenericHackathonAppLayout from "~/components/GenericHackathonAppLayout";
+import { getCurrentUser } from "~/lib/auth";
+import { getEnv } from "~/lib/env.server";
+import { WATT_THE_HACK_SLUG } from "~/lib/generic-hackathon";
+import type { User } from "~/types/user";
+
+const BASE_PATH = "/watt-the-hack";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const env = getEnv(context);
+  let user = null;
+  try {
+    user = await getCurrentUser(env, request);
+  } catch (error) {
+    console.warn("Treating Watt The Hack auth lookup failure as logged out.", error);
+  }
+  if (!user) {
+    const pathname = new URL(request.url).pathname;
+    const next = pathname === BASE_PATH ? `${BASE_PATH}/dashboard` : pathname;
+    throw redirect(`/platform/login?app=${WATT_THE_HACK_SLUG}&next=${encodeURIComponent(next)}`);
+  }
+  return { user: user as User };
+}
+
+export default function WattTheHackApp() {
+  const { user } = useLoaderData<typeof loader>();
+
+  return (
+    <GenericHackathonAppLayout
+      user={user}
+      config={{
+        name: "Watt The Hack",
+        slug: WATT_THE_HACK_SLUG,
+        basePath: BASE_PATH,
+      }}
+    >
+      <Outlet />
+    </GenericHackathonAppLayout>
+  );
+}

--- a/app/types/user.ts
+++ b/app/types/user.ts
@@ -14,6 +14,7 @@ export interface Team {
 export type UserRole = 'admin' | 'participant' | 'professional';
 
 export interface User {
+    id?: number;
     full_name: string;
     email: string;
     role: UserRole;


### PR DESCRIPTION
## Summary
- Add the `/watt-the-hack` authenticated app route tree and generic hackathon layout.
- Add dashboard, profile/team, submissions, and resources screens backed by generic hackathon API helpers.
- Extend shared auth routing and `/hackathons` CTA for the Watt magic-link flow.

## Validation
- `bun install --frozen-lockfile`
- `bun run typecheck`