### PR TITLE
[codex] Style Watt The Hack app

### DIFF
--- a/app/components/Announcements.tsx
+++ b/app/components/Announcements.tsx
@@ -2,6 +2,7 @@ import { EllipsisVerticalIcon } from '@heroicons/react/20/solid'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
 import ReactMarkdown from 'react-markdown';
 import { useState } from 'react';
+import { wattClasses } from '~/lib/watt-theme';
 
 export interface Announcement {
     id: string
@@ -18,68 +19,76 @@ export interface Announcement {
 
 interface AnnouncementsProps {
     announcements: Announcement[]
+    variant?: "default" | "watt"
 }
 
-export default function Announcements({ announcements }: AnnouncementsProps) {
+export default function Announcements({ announcements, variant = "default" }: AnnouncementsProps) {
     // Take only the first 3 announcements
     const recentAnnouncements = announcements.slice(0, 3)
+    const isWatt = variant === "watt"
 
     return (
-        <div className="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5">
-            <div className="p-6 border-b border-gray-200">
-                <h2 className="text-lg font-semibold text-gray-900">Announcements</h2>
+        <div className={isWatt ? wattClasses.panel : "bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5"}>
+            <div className={isWatt ? "border-b border-[#e7dfcf] p-6" : "p-6 border-b border-gray-200"}>
+                <p className={isWatt ? wattClasses.eyebrow : "hidden"}>Updates</p>
+                <h2 className={isWatt ? "mt-1 text-xl font-black text-[#20231d]" : "text-lg font-semibold text-gray-900"}>Announcements</h2>
             </div>
-            <ul role="list" className="divide-y divide-gray-200">
+            <ul role="list" className={isWatt ? "divide-y divide-[#e7dfcf]" : "divide-y divide-gray-200"}>
                 {recentAnnouncements.map((announcement) => (
-                    <AnnouncementItem key={announcement.id} announcement={announcement} />
+                    <AnnouncementItem key={announcement.id} announcement={announcement} variant={variant} />
                 ))}
             </ul>
         </div>
     )
 }
 
-function AnnouncementItem({ announcement }: { announcement: Announcement }) {
+function AnnouncementItem({ announcement, variant }: { announcement: Announcement; variant: "default" | "watt" }) {
     const [isExpanded, setIsExpanded] = useState(false);
     const maxLength = 300; // Character limit for truncation
     const shouldTruncate = announcement.body.length > maxLength;
+    const isWatt = variant === "watt";
 
     const displayedBody = isExpanded || !shouldTruncate
         ? announcement.body
         : announcement.body.slice(0, maxLength) + "...";
 
     return (
-        <li className="px-6 py-6">
+        <li className={isWatt ? "px-5 py-5 sm:px-6" : "px-6 py-6"}>
             <article aria-labelledby={'announcement-title-' + announcement.id}>
                 <div className="flex space-x-3">
                     <div className="shrink-0">
-                        <img alt="" src={announcement.author.imageUrl} className="size-10 rounded-full" />
+                        <img
+                            alt=""
+                            src={announcement.author.imageUrl}
+                            className={isWatt ? "size-10 rounded-full border border-[#c9dbb8] bg-[#dfead1] object-cover" : "size-10 rounded-full"}
+                        />
                     </div>
                     <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-gray-900">
-                            <a href={announcement.author.href} className="hover:underline">
+                        <p className={isWatt ? "text-sm font-black text-[#20231d]" : "text-sm font-medium text-gray-900"}>
+                            <a href={announcement.author.href} className={isWatt ? "hover:text-[#1f5b2c]" : "hover:underline"}>
                                 {announcement.author.name}
                             </a>
                         </p>
-                        <p className="text-sm text-gray-500">
+                        <p className={isWatt ? "text-sm text-[#6f756c]" : "text-sm text-gray-500"}>
                             <time dateTime={announcement.datetime}>{timeAgo(announcement.datetime)}</time>
                         </p>
                     </div>
                     <div className="flex shrink-0 self-center">
                         <Menu as="div" className="relative inline-block text-left">
-                            <MenuButton className="relative flex items-center rounded-full text-gray-400 hover:text-gray-600">
+                            <MenuButton className={isWatt ? "relative flex items-center rounded-full text-[#6f756c] hover:bg-[#dfead1] hover:text-[#1f5b2c]" : "relative flex items-center rounded-full text-gray-400 hover:text-gray-600"}>
                                 <span className="absolute -inset-2" />
                                 <span className="sr-only">Open options</span>
                                 <EllipsisVerticalIcon aria-hidden="true" className="size-5" />
                             </MenuButton>
                             <MenuItems
                                 transition
-                                className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 transition focus:outline-none data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75 data-[enter]:ease-out data-[leave]:ease-in"
+                                className={isWatt ? "absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-2xl border border-[#e7dfcf] bg-[#fffdf7] shadow-[0_18px_42px_rgba(67,54,33,0.12)] transition focus:outline-none data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75 data-[enter]:ease-out data-[leave]:ease-in" : "absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 transition focus:outline-none data-[closed]:scale-95 data-[closed]:transform data-[closed]:opacity-0 data-[enter]:duration-100 data-[leave]:duration-75 data-[enter]:ease-out data-[leave]:ease-in"}
                             >
                                 <div className="py-1">
                                     <MenuItem>
                                         <a
                                             href="#"
-                                            className="flex px-4 py-2 text-sm text-gray-700 data-[focus]:bg-gray-100 data-[focus]:text-gray-900 data-[focus]:outline-none"
+                                            className={isWatt ? "flex px-4 py-2 text-sm font-bold text-[#394033] data-[focus]:bg-[#dfead1] data-[focus]:text-[#1f5b2c] data-[focus]:outline-none" : "flex px-4 py-2 text-sm text-gray-700 data-[focus]:bg-gray-100 data-[focus]:text-gray-900 data-[focus]:outline-none"}
                                         >
                                             Report content
                                         </a>
@@ -89,10 +98,10 @@ function AnnouncementItem({ announcement }: { announcement: Announcement }) {
                         </Menu>
                     </div>
                 </div>
-                <h3 id={'announcement-title-' + announcement.id} className="mt-4 text-base font-medium text-gray-900">
+                <h3 id={'announcement-title-' + announcement.id} className={isWatt ? "mt-4 text-base font-black text-[#20231d]" : "mt-4 text-base font-medium text-gray-900"}>
                     {announcement.title}
                 </h3>
-                <div className="mt-2 text-sm text-gray-700 prose prose-sm max-w-none">
+                <div className={isWatt ? "prose prose-sm mt-2 max-w-none text-sm text-[#394033] prose-a:text-[#1f5b2c] prose-strong:text-[#20231d]" : "mt-2 text-sm text-gray-700 prose prose-sm max-w-none"}>
                     <ReactMarkdown>
                         {displayedBody}
                     </ReactMarkdown>
@@ -100,7 +109,7 @@ function AnnouncementItem({ announcement }: { announcement: Announcement }) {
                 {shouldTruncate && (
                     <button
                         onClick={() => setIsExpanded(!isExpanded)}
-                        className="mt-2 text-sm font-medium text-blue-600 hover:text-blue-500 hover:underline focus:outline-none"
+                        className={isWatt ? "mt-2 text-sm font-black text-[#1f5b2c] hover:text-[#3d7339] hover:underline focus:outline-none" : "mt-2 text-sm font-medium text-blue-600 hover:text-blue-500 hover:underline focus:outline-none"}
                     >
                         {isExpanded ? "Show less" : "Show more"}
                     </button>

--- a/app/components/GenericHackathonAppLayout.tsx
+++ b/app/components/GenericHackathonAppLayout.tsx
@@ -12,6 +12,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { Form, Link, useLocation } from "react-router";
 import { generateAvatarUrl, getInitials } from "~/lib/avatar";
+import { wattBackgroundStyle, wattClasses, wattImages } from "~/lib/watt-theme";
 import type { User } from "~/types/user";
 
 interface GenericHackathonAppLayoutProps {
@@ -22,6 +23,7 @@ interface GenericHackathonAppLayoutProps {
     slug: string;
     basePath: string;
     accentClass?: string;
+    theme?: "default" | "watt";
   };
 }
 
@@ -34,6 +36,7 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
   const location = useLocation();
   const fullName = user.full_name || user.email || "User";
   const avatarUrl = user.avatar_url || generateAvatarUrl(getInitials(fullName));
+  const isWattTheme = config.theme === "watt";
 
   const navigation = [
     { name: "Dashboard", href: `${config.basePath}/dashboard`, icon: HomeIcon },
@@ -45,7 +48,7 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
     current: location.pathname === item.href,
   }));
 
-  const sidebar = (
+  const defaultSidebar = (
     <div className="flex grow flex-col gap-y-6 overflow-y-auto bg-[#10231f] px-5 pb-4">
       <div className="flex h-16 shrink-0 items-center">
         <Link to={`${config.basePath}/dashboard`} className="flex items-center gap-3" onClick={() => setSidebarOpen(false)}>
@@ -92,8 +95,67 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
     </div>
   );
 
+  const wattSidebar = (
+    <div className="flex grow flex-col gap-y-6 overflow-y-auto border-r border-[rgba(91,82,56,0.14)] bg-[rgba(255,253,247,0.96)] px-5 pb-5 shadow-[14px_0_36px_rgba(67,54,33,0.06)]">
+      <div className="flex min-h-28 shrink-0 flex-col justify-center border-b border-[#e7dfcf] py-5">
+        <Link to={`${config.basePath}/dashboard`} className="block" onClick={() => setSidebarOpen(false)}>
+          <img
+            src={wattImages.logoDesktop}
+            alt="Watt The Hack"
+            className="hidden h-16 w-full object-contain object-left sm:block"
+          />
+          <img
+            src={wattImages.logoMobile}
+            alt="Watt The Hack"
+            className="h-16 w-auto object-contain sm:hidden"
+          />
+        </Link>
+        <div className="mt-4 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.16em] text-[#6f756c]">
+          <img src={wattImages.mlaiLogo} alt="" className="h-6 w-6 rounded-md object-contain" />
+          <span>MLAI Hackathon</span>
+        </div>
+      </div>
+      <nav className="flex flex-1 flex-col">
+        <ul className="flex flex-1 flex-col gap-y-7">
+          <li>
+            <ul className="-mx-2 space-y-1.5">
+              {navigation.map((item) => (
+                <li key={item.name}>
+                  <Link
+                    to={item.href}
+                    onClick={() => setSidebarOpen(false)}
+                    className={classNames(
+                      item.current
+                        ? "border-[#c9dbb8] bg-[#dfead1] text-[#1f5b2c] shadow-[0_10px_24px_rgba(31,91,44,0.08)]"
+                        : "border-transparent text-[#394033] hover:border-[#e7dfcf] hover:bg-[#fbf7ea] hover:text-[#1f5b2c]",
+                      "group flex items-center gap-x-3 rounded-2xl border px-3 py-2.5 text-sm font-black leading-6 transition",
+                    )}
+                  >
+                    <item.icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+                    {item.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </li>
+          <li className="mt-auto">
+            <Link
+              to="/hackathons"
+              className="group -mx-2 flex items-center gap-x-3 rounded-2xl border border-[#e7dfcf] bg-[#fbf7ea] px-3 py-2.5 text-sm font-black leading-6 text-[#394033] transition hover:border-[#3d7339]/35 hover:bg-[#dfead1] hover:text-[#1f5b2c]"
+            >
+              <ArrowLeftOnRectangleIcon className="h-5 w-5 shrink-0" aria-hidden="true" />
+              Back to MLAI
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+
+  const sidebar = isWattTheme ? wattSidebar : defaultSidebar;
+
   return (
-    <div className="min-h-screen bg-[#f5f1e8]">
+    <div className={isWattTheme ? wattClasses.appShell : "min-h-screen bg-[#f5f1e8]"} style={isWattTheme ? wattBackgroundStyle : undefined}>
       <Transition.Root show={sidebarOpen} as={Fragment}>
         <Dialog as="div" className="relative z-50 lg:hidden" onClose={setSidebarOpen}>
           <Transition.Child
@@ -105,7 +167,7 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-black/70" />
+            <div className={isWattTheme ? "fixed inset-0 bg-[#20231d]/55 backdrop-blur-sm" : "fixed inset-0 bg-black/70"} />
           </Transition.Child>
           <div className="fixed inset-0 flex">
             <Transition.Child
@@ -138,23 +200,54 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
       </aside>
 
       <div className="lg:pl-72">
-        <header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-black/10 bg-white/90 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
-          <button type="button" className="-m-2.5 p-2.5 text-gray-700 lg:hidden" onClick={() => setSidebarOpen(true)}>
+        <header
+          className={classNames(
+            isWattTheme
+              ? "sticky top-0 z-40 flex h-20 shrink-0 items-center gap-x-4 border-b border-[#e7dfcf] bg-[rgba(255,253,247,0.82)] px-4 shadow-[0_12px_28px_rgba(67,54,33,0.06)] backdrop-blur-xl sm:gap-x-6 sm:px-6 lg:px-8"
+              : "sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-black/10 bg-white/90 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8",
+          )}
+        >
+          <button
+            type="button"
+            className={classNames(
+              isWattTheme
+                ? "-m-2.5 rounded-full p-2.5 text-[#1f5b2c] transition hover:bg-[#dfead1]"
+                : "-m-2.5 p-2.5 text-gray-700",
+              "lg:hidden",
+            )}
+            onClick={() => setSidebarOpen(true)}
+          >
             <span className="sr-only">Open sidebar</span>
             <Bars3Icon className="h-6 w-6" aria-hidden="true" />
           </button>
           <div className="flex flex-1 items-center justify-between">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[#1f6f54]">Hackathon</p>
-              <h1 className="text-base font-semibold text-gray-950">{config.name}</h1>
+              <p className={isWattTheme ? wattClasses.eyebrow : "text-xs font-semibold uppercase tracking-[0.24em] text-[#1f6f54]"}>
+                Hackathon
+              </p>
+              <h1 className={isWattTheme ? "text-base font-black text-[#20231d]" : "text-base font-semibold text-gray-950"}>{config.name}</h1>
             </div>
             <Menu as="div" className="relative">
-              <Menu.Button className="-m-1.5 flex items-center p-1.5">
+              <Menu.Button
+                className={classNames(
+                  isWattTheme
+                    ? "-m-1.5 flex items-center rounded-full p-1.5 transition hover:bg-[#fbf7ea]"
+                    : "-m-1.5 flex items-center p-1.5",
+                )}
+              >
                 <span className="sr-only">Open user menu</span>
-                <img alt="" src={avatarUrl} className="h-8 w-8 rounded-full bg-gray-50 object-cover ring-1 ring-black/10" />
+                <img
+                  alt=""
+                  src={avatarUrl}
+                  className={classNames(
+                    isWattTheme
+                      ? "h-9 w-9 rounded-full bg-[#fbf7ea] object-cover ring-2 ring-[#dfead1]"
+                      : "h-8 w-8 rounded-full bg-gray-50 object-cover ring-1 ring-black/10",
+                  )}
+                />
                 <span className="hidden lg:flex lg:items-center">
-                  <span className="ml-4 text-sm font-semibold leading-6 text-gray-900">{fullName}</span>
-                  <ChevronDownIcon className="ml-2 h-5 w-5 text-gray-400" aria-hidden="true" />
+                  <span className={isWattTheme ? "ml-4 text-sm font-black leading-6 text-[#20231d]" : "ml-4 text-sm font-semibold leading-6 text-gray-900"}>{fullName}</span>
+                  <ChevronDownIcon className={isWattTheme ? "ml-2 h-5 w-5 text-[#6f756c]" : "ml-2 h-5 w-5 text-gray-400"} aria-hidden="true" />
                 </span>
               </Menu.Button>
               <Transition
@@ -166,10 +259,26 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-black/5 focus:outline-none">
+                <Menu.Items
+                  className={classNames(
+                    isWattTheme
+                      ? "absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-2xl border border-[#e7dfcf] bg-[#fffdf7] py-2 shadow-[0_18px_42px_rgba(67,54,33,0.12)] focus:outline-none"
+                      : "absolute right-0 z-10 mt-2.5 w-48 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-black/5 focus:outline-none",
+                  )}
+                >
                   <Menu.Item>
                     {({ focus }) => (
-                      <Link to={`${config.basePath}/profile`} className={classNames(focus && "bg-gray-50", "block px-3 py-1 text-sm leading-6 text-gray-900")}>
+                      <Link
+                        to={`${config.basePath}/profile`}
+                        className={classNames(
+                          isWattTheme
+                            ? focus && "bg-[#dfead1] text-[#1f5b2c]"
+                            : focus && "bg-gray-50",
+                          isWattTheme
+                            ? "block px-4 py-2 text-sm font-bold leading-6 text-[#394033]"
+                            : "block px-3 py-1 text-sm leading-6 text-gray-900",
+                        )}
+                      >
                         Profile
                       </Link>
                     )}
@@ -177,7 +286,17 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
                   <Menu.Item>
                     {({ focus }) => (
                       <Form method="post" action="/platform/logout">
-                        <button type="submit" className={classNames(focus && "bg-gray-50", "block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900")}>
+                        <button
+                          type="submit"
+                          className={classNames(
+                            isWattTheme
+                              ? focus && "bg-[#dfead1] text-[#1f5b2c]"
+                              : focus && "bg-gray-50",
+                            isWattTheme
+                              ? "block w-full px-4 py-2 text-left text-sm font-bold leading-6 text-[#394033]"
+                              : "block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900",
+                          )}
+                        >
                           Sign out
                         </button>
                       </Form>

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -75,16 +75,26 @@ function errorMessage(data: unknown, fallback: string) {
   return fallback;
 }
 
+function asGenericTeam(data: unknown): GenericHackathonTeam | null {
+  if (!data || Array.isArray(data) || typeof data !== "object") return null;
+  const record = data as Partial<GenericHackathonTeam>;
+  if (!Array.isArray(record.members)) return null;
+  return record as GenericHackathonTeam;
+}
+
 export async function getGenericHackathon(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<Hackathon> {
   const client = createApiClient(env, request);
   const response = await client.get(`/api/v1/hackathons/${slug}/`);
+  if (!response.data || Array.isArray(response.data) || typeof response.data.name !== "string") {
+    throw new Error("Invalid hackathon response.");
+  }
   return response.data;
 }
 
 export async function getGenericCurrentTeam(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonTeam | null> {
   const client = createApiClient(env, request);
   const response = await client.get(appPath(slug, "team/"));
-  return response.data ?? null;
+  return asGenericTeam(response.data);
 }
 
 export async function getGenericTeams(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonTeam[]> {

--- a/app/lib/watt-theme.ts
+++ b/app/lib/watt-theme.ts
@@ -1,0 +1,67 @@
+export const wattImages = {
+  logoDesktop:
+    "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/watt-the-hack%2F8.png?alt=media&token=7ac0834c-73a9-48be-94d1-97d529c9dac3",
+  logoMobile:
+    "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/watt-the-hack%2F11.png?alt=media&token=f2c2d8b0-53f3-4929-94de-6874c9f25547",
+  mlaiLogo:
+    "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/MLAI_Logo_NoText%20(1).png?alt=media&token=072e5f99-b2c8-42c1-a34a-364651aa711c",
+  hero:
+    "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/watt-the-hack%2FChatGPT%20Image%20May%2021%2C%202026%2C%2010_48_11%20PM%20(1).png?alt=media&token=5e39b6e6-7b02-471c-866f-5d18aae506fe",
+} as const;
+
+export const wattPalette = {
+  background: "#f7f2e8",
+  foreground: "#20231d",
+  paper: "#fffdf7",
+  paperSoft: "#fbf7ea",
+  green: "#3d7339",
+  greenDark: "#1f5b2c",
+  greenSoft: "#dfead1",
+  lime: "#b8d86b",
+  gold: "#f2c34c",
+  red: "#df5047",
+  muted: "#6f756c",
+  line: "#e7dfcf",
+} as const;
+
+export const wattBackgroundStyle = {
+  background:
+    "radial-gradient(circle at 14% 8%, rgba(255, 255, 255, 0.95), transparent 24rem), linear-gradient(180deg, #f8f3e9 0%, #fffdf7 40%, #f7f2e8 100%)",
+} as const;
+
+export const wattClasses = {
+  appShell: "min-h-screen text-[#20231d]",
+  page: "px-4 py-8 sm:px-6 lg:px-8",
+  panel:
+    "rounded-[1.25rem] border border-[rgba(91,82,56,0.14)] bg-[rgba(255,253,247,0.94)] shadow-[0_18px_48px_rgba(67,54,33,0.07),0_2px_8px_rgba(67,54,33,0.04)]",
+  panelSoft:
+    "rounded-[1.25rem] border border-[#e7dfcf] bg-[#fbf7ea] shadow-[0_16px_38px_rgba(67,54,33,0.06)]",
+  panelStrong:
+    "rounded-[1.5rem] border border-[rgba(91,82,56,0.14)] bg-[#fffdf7] shadow-[0_22px_60px_rgba(67,54,33,0.09),0_2px_8px_rgba(67,54,33,0.05)]",
+  divider: "border-[#e7dfcf]",
+  eyebrow: "text-xs font-black uppercase tracking-[0.22em] text-[#52763a]",
+  title: "font-black tracking-tight text-[#20231d]",
+  muted: "text-[#6f756c]",
+  label: "text-sm font-bold text-[#394033]",
+  input:
+    "mt-1 block w-full rounded-[0.85rem] border border-[#e7dfcf] bg-[#fffdf7] px-3 py-2 text-[#20231d] shadow-sm outline-none transition placeholder:text-[#8a8477] focus:border-[#3d7339] focus:ring-2 focus:ring-[#3d7339]/20",
+  inputBare:
+    "block w-full rounded-[0.85rem] border border-[#e7dfcf] bg-[#fffdf7] px-3 py-2 text-[#20231d] shadow-sm outline-none transition placeholder:text-[#8a8477] focus:border-[#3d7339] focus:ring-2 focus:ring-[#3d7339]/20",
+  fileInput:
+    "mt-1 block w-full rounded-[0.85rem] border border-[#e7dfcf] bg-[#fffdf7] px-3 py-2 text-sm text-[#394033] file:mr-3 file:rounded-full file:border-0 file:bg-[#dfead1] file:px-3 file:py-1.5 file:text-sm file:font-bold file:text-[#1f5b2c]",
+  buttonPrimary:
+    "inline-flex items-center justify-center rounded-full bg-[#3f783c] px-4 py-2 text-sm font-black text-white shadow-[0_10px_22px_rgba(31,91,44,0.2)] transition hover:bg-[#316b35] focus:outline-none focus:ring-2 focus:ring-[#3d7339]/30",
+  buttonYellow:
+    "inline-flex items-center justify-center rounded-full bg-[#f5d84f] px-4 py-2 text-sm font-black text-[#1e321d] shadow-[0_10px_22px_rgba(118,91,12,0.16)] transition hover:bg-[#f2c34c] focus:outline-none focus:ring-2 focus:ring-[#f2c34c]/40",
+  buttonOutline:
+    "inline-flex items-center justify-center rounded-full border border-[#d8cfbd] bg-[rgba(255,253,247,0.9)] px-4 py-2 text-sm font-black text-[#20231d] transition hover:border-[#3d7339]/35 hover:bg-[#fbf7ea] focus:outline-none focus:ring-2 focus:ring-[#3d7339]/20",
+  iconTile:
+    "flex h-11 w-11 items-center justify-center rounded-2xl border border-[#c9dbb8] bg-[#dfead1] text-[#1f5b2c]",
+  chip:
+    "inline-flex items-center rounded-full border border-[#c9dbb8] bg-[#dfead1] px-3 py-1 text-sm font-bold text-[#1f5b2c]",
+  smallChip:
+    "inline-flex items-center rounded-full border border-[#e7dfcf] bg-[#fffdf7] px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-[#52763a]",
+  successAlert: "rounded-[0.9rem] border border-[#3d7339]/20 bg-[#edf5df] p-3 text-sm font-medium text-[#1f5b2c]",
+  errorAlert: "rounded-[0.9rem] border border-[#df5047]/25 bg-[#fff1ef] p-3 text-sm font-medium text-[#9f2f28]",
+  warningAlert: "rounded-[0.9rem] border border-[#f2c34c]/50 bg-[#fff8dc] p-4 text-sm font-medium text-[#6f4b08]",
+} as const;

--- a/app/routes/watt-the-hack.dashboard.tsx
+++ b/app/routes/watt-the-hack.dashboard.tsx
@@ -19,6 +19,7 @@ import {
   type GenericHackathonSubmission,
   type GenericHackathonTeam,
 } from "~/lib/generic-hackathon";
+import { wattClasses, wattImages } from "~/lib/watt-theme";
 import type { Hackathon } from "~/services/hackathon";
 
 const FALLBACK_HACKATHON: Hackathon = {
@@ -60,14 +61,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
 function StatCard({ label, value, icon: Icon }: { label: string; value: string; icon: typeof UserGroupIcon }) {
   return (
-    <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
+    <div className={`${wattClasses.panel} p-5`}>
       <div className="flex items-center gap-3">
-        <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#e6f8d8] text-[#24523f]">
+        <span className={wattClasses.iconTile}>
           <Icon className="h-5 w-5" aria-hidden="true" />
         </span>
         <div>
-          <p className="text-sm text-gray-500">{label}</p>
-          <p className="text-lg font-semibold text-gray-950">{value}</p>
+          <p className="text-sm font-medium text-[#6f756c]">{label}</p>
+          <p className="text-lg font-black text-[#20231d]">{value}</p>
         </div>
       </div>
     </div>
@@ -76,22 +77,22 @@ function StatCard({ label, value, icon: Icon }: { label: string; value: string; 
 
 function TeamPanel({ team }: { team: GenericHackathonTeam | null }) {
   return (
-    <div className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+    <div className={`${wattClasses.panel} p-6`}>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-lg font-semibold text-gray-950">Team</h2>
-          <p className="mt-1 text-sm text-gray-600">
+          <h2 className="text-lg font-black text-[#20231d]">Team</h2>
+          <p className="mt-1 text-sm text-[#6f756c]">
             {team ? `${team.team_name} (${team.code})` : "Create or join a team before submitting."}
           </p>
         </div>
-        <Link to="/watt-the-hack/profile" className="rounded-md bg-[#10231f] px-3 py-2 text-sm font-semibold text-white hover:bg-[#1d3c35]">
+        <Link to="/watt-the-hack/profile" className={wattClasses.buttonPrimary}>
           Manage
         </Link>
       </div>
       {team && (
         <div className="mt-5 flex flex-wrap gap-2">
           {team.members.map((member) => (
-            <span key={member.id} className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700">
+            <span key={member.id} className={wattClasses.chip}>
               {member.full_name || member.email}
             </span>
           ))}
@@ -103,20 +104,20 @@ function TeamPanel({ team }: { team: GenericHackathonTeam | null }) {
 
 function SubmissionPanel({ submission }: { submission: GenericHackathonSubmission | null }) {
   return (
-    <div className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+    <div className={`${wattClasses.panel} p-6`}>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-lg font-semibold text-gray-950">Latest Submission</h2>
-          <p className="mt-1 text-sm text-gray-600">
+          <h2 className="text-lg font-black text-[#20231d]">Latest Submission</h2>
+          <p className="mt-1 text-sm text-[#6f756c]">
             {submission ? submission.title : "No project submitted yet."}
           </p>
         </div>
-        <Link to="/watt-the-hack/submissions" className="rounded-md bg-[#9fe870] px-3 py-2 text-sm font-semibold text-[#10231f] hover:bg-[#b2f38a]">
+        <Link to="/watt-the-hack/submissions" className={wattClasses.buttonYellow}>
           Submit
         </Link>
       </div>
       {submission && (
-        <p className="mt-4 line-clamp-3 text-sm leading-6 text-gray-600">{submission.summary}</p>
+        <p className="mt-4 line-clamp-3 text-sm leading-6 text-[#6f756c]">{submission.summary}</p>
       )}
     </div>
   );
@@ -124,26 +125,26 @@ function SubmissionPanel({ submission }: { submission: GenericHackathonSubmissio
 
 function ResourcesPanel({ resources }: { resources: GenericHackathonResource[] }) {
   return (
-    <div className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+    <div className={`${wattClasses.panel} p-6`}>
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-gray-950">Resources</h2>
-        <Link to="/watt-the-hack/resources" className="text-sm font-semibold text-[#1f6f54] hover:text-[#10231f]">
+        <h2 className="text-lg font-black text-[#20231d]">Resources</h2>
+        <Link to="/watt-the-hack/resources" className="text-sm font-black text-[#1f5b2c] hover:text-[#3d7339]">
           View all
         </Link>
       </div>
       <div className="mt-4 space-y-3">
         {resources.length > 0 ? resources.map((resource) => (
-          <Link key={resource.id} to="/watt-the-hack/resources" className="block rounded-md border border-black/8 p-3 hover:bg-gray-50">
+          <Link key={resource.id} to="/watt-the-hack/resources" className="block rounded-2xl border border-[#e7dfcf] bg-[#fffdf7] p-3 transition hover:border-[#c9dbb8] hover:bg-[#dfead1]/45">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="font-medium text-gray-950">{resource.title}</p>
-                <p className="mt-1 text-sm text-gray-600">{resource.summary}</p>
+                <p className="font-black text-[#20231d]">{resource.title}</p>
+                <p className="mt-1 text-sm text-[#6f756c]">{resource.summary}</p>
               </div>
-              <ArrowTopRightOnSquareIcon className="mt-1 h-4 w-4 text-gray-400" aria-hidden="true" />
+              <ArrowTopRightOnSquareIcon className="mt-1 h-4 w-4 text-[#1f5b2c]" aria-hidden="true" />
             </div>
           </Link>
         )) : (
-          <p className="text-sm text-gray-600">Resources will appear here when they are published.</p>
+          <p className="text-sm text-[#6f756c]">Resources will appear here when they are published.</p>
         )}
       </div>
     </div>
@@ -154,24 +155,25 @@ export default function WattTheHackDashboard() {
   const { hackathon, announcements, team, latestSubmission, resources } = useLoaderData<typeof loader>();
 
   return (
-    <div className="px-4 py-8 sm:px-6 lg:px-8">
+    <div className={wattClasses.page}>
       <div className="mx-auto max-w-7xl space-y-8">
-        <section className="relative overflow-hidden rounded-lg bg-[#10231f] px-6 py-8 text-white shadow-sm sm:px-8">
+        <section className="relative overflow-hidden rounded-[1.5rem] bg-[#1f5b2c] px-6 py-8 text-white shadow-[0_24px_60px_rgba(31,91,44,0.18)] sm:px-8">
           <img
-            src="https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?auto=format&fit=crop&w=1600&q=80"
+            src={wattImages.hero}
             alt=""
-            className="absolute inset-0 h-full w-full object-cover opacity-25"
+            className="absolute inset-0 h-full w-full object-cover opacity-40"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-[#10231f] via-[#10231f]/90 to-[#10231f]/40" />
+          <div className="absolute inset-0 bg-gradient-to-r from-[#1f5b2c] via-[#245f2e]/88 to-[#f2c34c]/25" />
+          <div className="absolute -bottom-28 -right-20 h-64 w-64 rounded-full bg-[#f2c34c]/35 blur-3xl" />
           <div className="relative max-w-3xl">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[#9fe870]">Participant Dashboard</p>
+            <p className="text-sm font-black uppercase tracking-[0.3em] text-[#f5d84f]">Participant Dashboard</p>
             <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-5xl">{hackathon.name}</h1>
             <p className="mt-4 max-w-2xl text-base leading-7 text-white/78">{hackathon.description}</p>
             <div className="mt-6 flex flex-wrap gap-3">
-              <Link to="/watt-the-hack/profile" className="rounded-md bg-[#9fe870] px-4 py-2 text-sm font-semibold text-[#10231f] hover:bg-[#b2f38a]">
+              <Link to="/watt-the-hack/profile" className="inline-flex items-center justify-center rounded-full bg-[#f5d84f] px-4 py-2 text-sm font-black text-[#1e321d] shadow-[0_12px_26px_rgba(0,0,0,0.18)] transition hover:bg-[#f2c34c]">
                 Profile & Team
               </Link>
-              <Link to="/watt-the-hack/submissions" className="rounded-md border border-white/30 px-4 py-2 text-sm font-semibold text-white hover:bg-white/10">
+              <Link to="/watt-the-hack/submissions" className="inline-flex items-center justify-center rounded-full border border-white/35 bg-white/10 px-4 py-2 text-sm font-black text-white backdrop-blur transition hover:bg-white/18">
                 Submit Project
               </Link>
             </div>
@@ -186,7 +188,7 @@ export default function WattTheHackDashboard() {
 
         <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
           <div className="space-y-6">
-            <Announcements announcements={announcements} />
+            <Announcements announcements={announcements} variant="watt" />
             <ResourcesPanel resources={resources} />
           </div>
           <div className="space-y-6">

--- a/app/routes/watt-the-hack.profile.tsx
+++ b/app/routes/watt-the-hack.profile.tsx
@@ -1,5 +1,8 @@
 import type { Route } from "./+types/watt-the-hack.profile";
-import { Form, redirect, useActionData, useLoaderData } from "react-router";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { Form, redirect, useActionData, useFetcher, useLoaderData } from "react-router";
+import { InformationCircleIcon, PencilIcon, UserGroupIcon } from "@heroicons/react/24/outline";
+import AvatarModal from "~/components/AvatarModal";
 import { getCurrentUser, updateUser } from "~/lib/auth";
 import { getInitials, generateAvatarUrl } from "~/lib/avatar";
 import { getEnv } from "~/lib/env.server";
@@ -9,9 +12,39 @@ import {
   getGenericTeams,
   joinGenericTeam,
   WATT_THE_HACK_SLUG,
+  type GenericHackathonMember,
   type GenericHackathonTeam,
 } from "~/lib/generic-hackathon";
+import { wattClasses } from "~/lib/watt-theme";
 import type { User } from "~/types/user";
+
+interface WattUser extends User {
+  first_name?: string;
+  last_name?: string;
+  phone?: string;
+  about?: string;
+  personas?: string[];
+}
+
+type ActionResult = {
+  success?: boolean | string;
+  profileUpdated?: boolean;
+  error?: string;
+};
+
+const PERSONA_OPTIONS = [
+  { id: "hacker", label: "I am a Hacker", description: "You build things. You love code and technical challenges." },
+  { id: "hustler", label: "I am a Hustler", description: "You sell things. You focus on business, marketing, and growth." },
+  { id: "hipster", label: "I am a Hipster", description: "You design things. You care about UX, UI, and aesthetics." },
+  { id: "healer", label: "I am a Healer", description: "You heal people. You bring clinical or health domain expertise." },
+] as const;
+
+const PERSONA_CONFIG: Record<string, { label: string; color: string }> = {
+  hacker: { label: "Hacker", color: "border-[#c9dbb8] bg-[#dfead1] text-[#1f5b2c]" },
+  hustler: { label: "Hustler", color: "border-[#f2c34c]/60 bg-[#fff8dc] text-[#6f4b08]" },
+  hipster: { label: "Hipster", color: "border-[#df5047]/25 bg-[#fff1ef] text-[#9f2f28]" },
+  healer: { label: "Healer", color: "border-[#c9dbb8] bg-[#edf5df] text-[#1f5b2c]" },
+};
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
@@ -30,229 +63,599 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     getGenericTeams(env, request).catch(() => []),
   ]);
 
-  return { user: user as User, currentTeam, teams };
+  return { user: user as WattUser, currentTeam, teams };
 }
 
-export async function action({ request, context }: Route.ActionArgs) {
+export async function action({ request, context }: Route.ActionArgs): Promise<ActionResult | null> {
   const env = getEnv(context);
   const formData = await request.formData();
   const intent = formData.get("intent")?.toString();
 
   try {
     if (intent === "create_team") {
-      const teamName = String(formData.get("team_name") || "").trim();
+      const teamName = String(formData.get("name") || formData.get("team_name") || "").trim();
       if (!teamName) return { error: "Team name is required." };
       await createGenericTeam(env, request, WATT_THE_HACK_SLUG, teamName);
-      return { success: "Team created." };
+      return { success: true };
     }
 
     if (intent === "join_team") {
       const code = String(formData.get("code") || "").trim();
       if (!code) return { error: "Team code or name is required." };
       await joinGenericTeam(env, request, WATT_THE_HACK_SLUG, code);
-      return { success: "Team joined." };
+      return { success: true };
     }
 
     if (intent === "update_profile") {
       formData.set("app", WATT_THE_HACK_SLUG);
       formData.delete("intent");
       await updateUser(env, formData, request);
-      return { success: "Profile updated." };
+      return { success: true, profileUpdated: true };
     }
   } catch (error: any) {
     const detail = error?.response?.data?.error || error?.response?.data?.detail || error?.message;
     return { error: detail || "Request failed." };
   }
 
-  return { error: "Unsupported action." };
+  return null;
 }
 
-function TeamCard({ team }: { team: GenericHackathonTeam | null }) {
-  if (!team) {
-    return (
-      <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
-        You are not on a Watt The Hack team yet.
-      </div>
-    );
-  }
+function personaLabel(persona: string) {
+  return PERSONA_CONFIG[persona.toLowerCase()]?.label || persona;
+}
 
-  return (
-    <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-950">{team.team_name}</h2>
-          <p className="mt-1 text-sm text-gray-500">Team code: {team.code}</p>
-        </div>
-        <span className="rounded-full bg-[#e6f8d8] px-3 py-1 text-sm font-semibold text-[#24523f]">
-          {team.member_count}/6 members
-        </span>
-      </div>
-      <div className="mt-5 grid gap-3 sm:grid-cols-2">
-        {team.members.map((member) => (
-          <div key={member.id} className="flex items-center gap-3 rounded-md bg-gray-50 p-3">
-            <img
-              alt=""
-              src={member.avatar_url || generateAvatarUrl(getInitials(member.full_name || member.email))}
-              className="h-9 w-9 rounded-full object-cover"
-            />
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium text-gray-950">{member.full_name || member.email}</p>
-              <p className="truncate text-xs text-gray-500">{member.email}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+function personaClass(persona: string) {
+  return PERSONA_CONFIG[persona.toLowerCase()]?.color || "border-[#e7dfcf] bg-[#fffdf7] text-[#6f756c]";
 }
 
 export default function WattTheHackProfile() {
-  const { user, currentTeam, teams } = useLoaderData<typeof loader>();
-  const actionData = useActionData<typeof action>();
-  const avatarUrl = user.avatar_url || generateAvatarUrl(getInitials(user.full_name || user.email));
+  const { user: initialUser, currentTeam, teams } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>() as ActionResult | undefined;
+  const fetcher = useFetcher<ActionResult>();
+
+  const [firstName, setFirstName] = useState(initialUser.first_name || "");
+  const [lastName, setLastName] = useState(initialUser.last_name || "");
+  const [email, setEmail] = useState(initialUser.email || "");
+  const [phone, setPhone] = useState(initialUser.phone || "");
+  const [about, setAbout] = useState(initialUser.about || "");
+  const [personas, setPersonas] = useState<string[]>(initialUser.personas || []);
+
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [isAvatarModalOpen, setIsAvatarModalOpen] = useState(false);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [previewAvatarUrl, setPreviewAvatarUrl] = useState<string | null>(null);
+
+  const [teamAvatarFile, setTeamAvatarFile] = useState<File | null>(null);
+  const [previewTeamAvatarUrl, setPreviewTeamAvatarUrl] = useState<string | null>(null);
+  const [isTeamAvatarModalOpen, setIsTeamAvatarModalOpen] = useState(false);
+
+  const [joinSearch, setJoinSearch] = useState("");
+  const [isJoinDropdownOpen, setIsJoinDropdownOpen] = useState(false);
+  const joinDropdownRef = useRef<HTMLDivElement>(null);
+
+  const filteredTeams = teams.filter((team) =>
+    team.team_name.toLowerCase().includes(joinSearch.toLowerCase()),
+  );
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (joinDropdownRef.current && !joinDropdownRef.current.contains(event.target as Node)) {
+        setIsJoinDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    setFirstName(initialUser.first_name || "");
+    setLastName(initialUser.last_name || "");
+    setEmail(initialUser.email || "");
+    setPhone(initialUser.phone || "");
+    setAbout(initialUser.about || "");
+    setPersonas(initialUser.personas || []);
+  }, [initialUser]);
+
+  useEffect(() => {
+    return () => {
+      if (previewAvatarUrl) URL.revokeObjectURL(previewAvatarUrl);
+      if (previewTeamAvatarUrl) URL.revokeObjectURL(previewTeamAvatarUrl);
+    };
+  }, [previewAvatarUrl, previewTeamAvatarUrl]);
+
+  useEffect(() => {
+    const data = fetcher.data;
+    if (fetcher.state === "idle" && data) {
+      if (data.success && data.profileUpdated) {
+        setMessage("Profile updated successfully.");
+        setError("");
+        setAvatarFile(null);
+        setTeamAvatarFile(null);
+      } else if (data.error) {
+        setMessage("");
+        setError(data.error);
+      }
+    }
+  }, [fetcher.state, fetcher.data]);
+
+  const teamName = currentTeam?.team_name || "";
+  const memberCount = currentTeam?.member_count ?? currentTeam?.members?.length ?? 0;
+  const isValidTeamSize = memberCount >= 2 && memberCount <= 6;
+  const teamMembers = currentTeam?.members || [];
+
+  const fullName = initialUser.full_name || [initialUser.first_name, initialUser.last_name].filter(Boolean).join(" ") || initialUser.email;
+  const isSaving = fetcher.state !== "idle";
+  const avatarUrl = previewAvatarUrl || initialUser.avatar_url || generateAvatarUrl(getInitials(fullName));
+  const teamAvatarUrl = previewTeamAvatarUrl || currentTeam?.avatar_url || generateAvatarUrl(getInitials(teamName || "Team"));
+  const profileFetcherData = fetcher.data;
+
+  const handleAvatarSave = async (file: File) => {
+    if (previewAvatarUrl) URL.revokeObjectURL(previewAvatarUrl);
+    setAvatarFile(file);
+    setPreviewAvatarUrl(URL.createObjectURL(file));
+    setIsAvatarModalOpen(false);
+  };
+
+  const handleTeamAvatarSave = async (file: File) => {
+    if (previewTeamAvatarUrl) URL.revokeObjectURL(previewTeamAvatarUrl);
+    setTeamAvatarFile(file);
+    setPreviewTeamAvatarUrl(URL.createObjectURL(file));
+    setIsTeamAvatarModalOpen(false);
+  };
+
+  const handleProfileSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage("");
+    setError("");
+
+    if (!firstName || !lastName || !email) {
+      setError("First name, last name, and email are required.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("intent", "update_profile");
+    formData.append("app", WATT_THE_HACK_SLUG);
+    formData.append("first_name", firstName);
+    formData.append("last_name", lastName);
+    formData.append("email", email);
+    if (phone) formData.append("phone", phone);
+    if (about) formData.append("about", about);
+    personas.forEach((persona) => formData.append("personas", persona));
+    if (avatarFile) formData.append("avatar", avatarFile);
+    if (teamAvatarFile) formData.append("team_avatar", teamAvatarFile);
+
+    fetcher.submit(formData, {
+      method: "post",
+      encType: "multipart/form-data",
+    });
+  };
 
   return (
-    <div className="px-4 py-8 sm:px-6 lg:px-8">
-      <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[1fr_420px]">
-        <section className="rounded-lg border border-black/10 bg-white shadow-sm">
-          <div className="border-b border-black/10 px-6 py-5">
-            <div className="flex items-center gap-4">
-              <img alt="" src={avatarUrl} className="h-14 w-14 rounded-full object-cover ring-1 ring-black/10" />
-              <div>
-                <h1 className="text-2xl font-bold text-gray-950">Profile</h1>
-                <p className="text-sm text-gray-600">Update your participant details.</p>
+    <div className={wattClasses.page}>
+      <main className="mx-auto max-w-7xl">
+        <div className="md:flex md:items-center md:justify-between md:space-x-5">
+          <div className="flex items-center space-x-5">
+            <div className="shrink-0">
+              <div className="relative">
+                <img
+                  alt=""
+                  src={avatarUrl}
+                  className="size-16 rounded-full object-cover ring-2 ring-[#dfead1]"
+                />
+                <span aria-hidden="true" className="absolute inset-0 rounded-full shadow-inner" />
+                <button
+                  type="button"
+                  className="absolute inset-0 flex cursor-pointer items-center justify-center rounded-full bg-[#20231d]/55 opacity-0 transition-opacity hover:opacity-100"
+                  onClick={() => setIsAvatarModalOpen(true)}
+                >
+                  <span className="sr-only">Update profile image</span>
+                  <PencilIcon className="h-6 w-6 text-white" aria-hidden="true" />
+                </button>
               </div>
             </div>
+            <div>
+              <p className={wattClasses.eyebrow}>Profile & Team</p>
+              <h1 className="text-2xl font-black text-[#20231d]">{fullName}</h1>
+              <p className="text-sm font-medium text-[#6f756c]">
+                {teamName ? `Member of ${teamName}` : "No team yet"}
+              </p>
+            </div>
           </div>
+        </div>
 
-          <Form method="post" encType="multipart/form-data" className="space-y-6 px-6 py-6">
-            <input type="hidden" name="intent" value="update_profile" />
-            <input type="hidden" name="app" value={WATT_THE_HACK_SLUG} />
+        <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-flow-col-dense lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2 lg:col-start-1">
+            <section aria-labelledby="team-management-title" className={wattClasses.panel}>
+              <div className="px-4 py-5 sm:px-6">
+                <h2 id="team-management-title" className="text-lg font-black leading-6 text-[#20231d]">
+                  {teamName ? "Change Team" : "Create or Join a Team"}
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm text-[#6f756c]">
+                  {teamName
+                    ? "Create a new team or switch to an existing one."
+                    : "You need a team to participate in the hackathon."}
+                </p>
+              </div>
+              <div className="border-t border-[#e7dfcf] px-4 py-5 sm:px-6">
+                {actionData?.error && (
+                  <div className={`mb-4 ${wattClasses.errorAlert}`}>{actionData.error}</div>
+                )}
+                {actionData?.success && !actionData?.profileUpdated && (
+                  <div className={`mb-4 ${wattClasses.successAlert}`}>Team operation successful.</div>
+                )}
 
-            {actionData?.success && (
-              <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">{actionData.success}</div>
-            )}
-            {actionData?.error && (
-              <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{actionData.error}</div>
-            )}
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <label className="block">
-                <span className="text-sm font-medium text-gray-700">First name</span>
-                <input
-                  name="first_name"
-                  defaultValue={(user as any).first_name || ""}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-                />
-              </label>
-              <label className="block">
-                <span className="text-sm font-medium text-gray-700">Last name</span>
-                <input
-                  name="last_name"
-                  defaultValue={(user as any).last_name || ""}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-                />
-              </label>
-            </div>
-
-            <label className="block">
-              <span className="text-sm font-medium text-gray-700">Email</span>
-              <input
-                name="email"
-                type="email"
-                defaultValue={user.email}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-              />
-            </label>
-
-            <label className="block">
-              <span className="text-sm font-medium text-gray-700">Phone</span>
-              <input
-                name="phone"
-                defaultValue={(user as any).phone || ""}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-              />
-            </label>
-
-            <label className="block">
-              <span className="text-sm font-medium text-gray-700">About</span>
-              <textarea
-                name="about"
-                rows={5}
-                defaultValue={(user as any).about || ""}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 shadow-sm focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-              />
-            </label>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <label className="block">
-                <span className="text-sm font-medium text-gray-700">Profile image</span>
-                <input name="avatar" type="file" accept="image/*" className="mt-1 block w-full text-sm text-gray-700" />
-              </label>
-              <label className="block">
-                <span className="text-sm font-medium text-gray-700">Team image</span>
-                <input name="team_avatar" type="file" accept="image/*" className="mt-1 block w-full text-sm text-gray-700" />
-              </label>
-            </div>
-
-            <div className="flex justify-end">
-              <button type="submit" className="rounded-md bg-[#10231f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1d3c35]">
-                Save profile
-              </button>
-            </div>
-          </Form>
-        </section>
-
-        <aside className="space-y-6">
-          <TeamCard team={currentTeam} />
-
-          <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-950">Create a Team</h2>
-            <Form method="post" className="mt-4 flex gap-2">
-              <input type="hidden" name="intent" value="create_team" />
-              <input
-                name="team_name"
-                placeholder="Team name"
-                className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-              />
-              <button type="submit" className="rounded-md bg-[#9fe870] px-3 py-2 text-sm font-semibold text-[#10231f] hover:bg-[#b2f38a]">
-                Create
-              </button>
-            </Form>
-          </div>
-
-          <div className="rounded-lg border border-black/10 bg-white p-5 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-950">Join a Team</h2>
-            <Form method="post" className="mt-4 flex gap-2">
-              <input type="hidden" name="intent" value="join_team" />
-              <input
-                name="code"
-                list="watt-team-list"
-                placeholder="TEAM1 or team name"
-                className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
-              />
-              <datalist id="watt-team-list">
-                {teams.map((team) => (
-                  <option key={team.id} value={team.code}>{team.team_name}</option>
-                ))}
-              </datalist>
-              <button type="submit" className="rounded-md border border-black/10 bg-white px-3 py-2 text-sm font-semibold text-gray-950 hover:bg-gray-50">
-                Join
-              </button>
-            </Form>
-            {teams.length > 0 && (
-              <div className="mt-4 space-y-2">
-                {teams.slice(0, 6).map((team) => (
-                  <div key={team.id} className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm">
-                    <span className="font-medium text-gray-800">{team.team_name}</span>
-                    <span className="text-gray-500">{team.code}</span>
+                <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+                  <div>
+                    <h3 className="mb-4 text-sm font-bold text-[#6f756c]">Create a new team</h3>
+                    <Form method="post">
+                      <div>
+                        <label htmlFor="team-name" className={wattClasses.label}>
+                          Team Name
+                        </label>
+                        <input
+                          type="text"
+                          name="name"
+                          id="team-name"
+                          required
+                          className={wattClasses.input}
+                          placeholder="Enter team name"
+                        />
+                      </div>
+                      <div className="mt-4">
+                        <button type="submit" name="intent" value="create_team" className={wattClasses.buttonPrimary}>
+                          Create Team
+                        </button>
+                      </div>
+                    </Form>
                   </div>
-                ))}
+
+                  <div className="border-t border-[#e7dfcf] pt-8 md:border-l md:border-t-0 md:pl-8 md:pt-0">
+                    <h3 className="mb-4 text-sm font-bold text-[#6f756c]">Join an existing team</h3>
+                    <Form method="post">
+                      <div>
+                        <label htmlFor="team-code" className={wattClasses.label}>
+                          Team Name
+                        </label>
+                        <div className="mt-2" ref={joinDropdownRef}>
+                          <div className="relative">
+                            <input
+                              type="text"
+                              name="code"
+                              id="team-code"
+                              required
+                              value={joinSearch}
+                              onChange={(event) => {
+                                setJoinSearch(event.target.value);
+                                setIsJoinDropdownOpen(true);
+                              }}
+                              onFocus={() => setIsJoinDropdownOpen(true)}
+                              placeholder="Start typing team name..."
+                              autoComplete="off"
+                              className={wattClasses.inputBare}
+                            />
+                            {isJoinDropdownOpen && filteredTeams.length > 0 && (
+                              <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-2xl border border-[#e7dfcf] bg-[#fffdf7] py-1 shadow-[0_18px_42px_rgba(67,54,33,0.14)]">
+                                {filteredTeams.map((team) => (
+                                  <li
+                                    key={team.team_id ?? team.id ?? team.team_name}
+                                    onMouseDown={(event) => {
+                                      event.preventDefault();
+                                      setJoinSearch(team.team_name);
+                                      setIsJoinDropdownOpen(false);
+                                    }}
+                                    className="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-[#dfead1]"
+                                  >
+                                    <img
+                                      src={team.avatar_url || generateAvatarUrl(getInitials(team.team_name))}
+                                      alt=""
+                                      className="h-8 w-8 shrink-0 rounded-full object-cover ring-1 ring-[#c9dbb8]"
+                                    />
+                                    <div className="min-w-0">
+                                      <p className="truncate text-sm font-black text-[#20231d]">{team.team_name}</p>
+                                      <p className="text-xs text-[#6f756c]">
+                                        {team.member_count} member{team.member_count !== 1 ? "s" : ""}
+                                        {team.member_count >= 6 && " (full)"}
+                                      </p>
+                                    </div>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                            {isJoinDropdownOpen && joinSearch && filteredTeams.length === 0 && (
+                              <div className="absolute z-20 mt-1 w-full rounded-2xl border border-[#e7dfcf] bg-[#fffdf7] px-3 py-3 shadow-[0_18px_42px_rgba(67,54,33,0.14)]">
+                                <p className="text-sm text-[#6f756c]">No teams found matching &ldquo;{joinSearch}&rdquo;</p>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="mt-4">
+                        <button type="submit" name="intent" value="join_team" className={wattClasses.buttonOutline}>
+                          Join Team
+                        </button>
+                      </div>
+                    </Form>
+                  </div>
+                </div>
               </div>
-            )}
+            </section>
+
+            <section aria-labelledby="applicant-information-title" className={wattClasses.panelStrong}>
+              <div className="px-4 py-5 sm:px-6">
+                <h2 id="applicant-information-title" className="text-lg font-black leading-6 text-[#20231d]">
+                  Profile Information
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm text-[#6f756c]">Personal details and application.</p>
+              </div>
+              <div className="border-t border-[#e7dfcf] px-4 py-5 sm:px-6">
+                <fetcher.Form onSubmit={handleProfileSubmit}>
+                  <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-6">
+                    <div className="sm:col-span-3">
+                      <label htmlFor="first-name" className={wattClasses.label}>
+                        First name
+                      </label>
+                      <input
+                        id="first-name"
+                        name="first-name"
+                        type="text"
+                        value={firstName}
+                        onChange={(event) => setFirstName(event.target.value)}
+                        autoComplete="given-name"
+                        className={wattClasses.input}
+                      />
+                    </div>
+
+                    <div className="sm:col-span-3">
+                      <label htmlFor="last-name" className={wattClasses.label}>
+                        Last name
+                      </label>
+                      <input
+                        id="last-name"
+                        name="last-name"
+                        type="text"
+                        value={lastName}
+                        onChange={(event) => setLastName(event.target.value)}
+                        autoComplete="family-name"
+                        className={wattClasses.input}
+                      />
+                    </div>
+
+                    <div className="sm:col-span-3">
+                      <label htmlFor="email" className={wattClasses.label}>
+                        Email address
+                      </label>
+                      <input
+                        id="email"
+                        name="email"
+                        type="email"
+                        value={email}
+                        onChange={(event) => setEmail(event.target.value)}
+                        autoComplete="email"
+                        className={wattClasses.input}
+                      />
+                    </div>
+
+                    <div className="sm:col-span-3">
+                      <label htmlFor="phone" className={wattClasses.label}>
+                        Phone
+                      </label>
+                      <div className="mt-2 flex rounded-[0.85rem] border border-[#e7dfcf] bg-[#fffdf7] shadow-sm transition focus-within:border-[#3d7339] focus-within:ring-2 focus-within:ring-[#3d7339]/20">
+                        <div className="flex select-none items-center rounded-l-[0.85rem] border-r border-[#e7dfcf] bg-[#fbf7ea] px-3 text-[#6f756c] sm:text-sm">
+                          +61
+                        </div>
+                        <input
+                          id="phone"
+                          name="phone"
+                          type="text"
+                          value={phone}
+                          onChange={(event) => setPhone(event.target.value)}
+                          autoComplete="tel"
+                          className="block min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-[#20231d] outline-none placeholder:text-[#8a8477] focus:ring-0 sm:text-sm sm:leading-6"
+                          placeholder="4XX XXX XXX"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="sm:col-span-6">
+                      <label htmlFor="about" className={wattClasses.label}>
+                        About
+                      </label>
+                      <textarea
+                        id="about"
+                        name="about"
+                        rows={3}
+                        value={about}
+                        onChange={(event) => setAbout(event.target.value)}
+                        className={wattClasses.input}
+                      />
+                    </div>
+
+                    <div className="sm:col-span-6">
+                      <div className="mb-2 flex items-center gap-2">
+                        <label className={wattClasses.label}>My Persona</label>
+                        <div className="group relative flex items-center">
+                          <InformationCircleIcon className="h-4 w-4 cursor-help text-[#6f756c]" />
+                          <div className="absolute bottom-full left-1/2 z-10 mb-2 hidden w-64 -translate-x-1/2 rounded-2xl border border-[#e7dfcf] bg-[#20231d] px-3 py-2 text-xs text-white shadow-lg group-hover:block">
+                            {PERSONA_OPTIONS.map((option) => (
+                              <p key={option.id} className="mb-1 last:mb-0">
+                                <strong>{personaLabel(option.id)}:</strong> {option.description}
+                              </p>
+                            ))}
+                            <div className="absolute left-1/2 top-full -mt-1 h-2 w-2 -translate-x-1/2 rotate-45 bg-[#20231d]" />
+                          </div>
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        {PERSONA_OPTIONS.map((option) => (
+                          <div key={option.id} className="relative flex items-start">
+                            <div className="flex h-6 items-center">
+                              <input
+                                id={option.id}
+                                name="personas"
+                                type="checkbox"
+                                checked={personas.includes(option.id)}
+                                onChange={(event) => {
+                                  if (event.target.checked) {
+                                    setPersonas([...personas, option.id]);
+                                  } else {
+                                    setPersonas(personas.filter((persona) => persona !== option.id));
+                                  }
+                                }}
+                                className="h-4 w-4 rounded border-[#d8cfbd] bg-[#fffdf7] text-[#3d7339] focus:ring-[#3d7339]"
+                              />
+                            </div>
+                            <div className="ml-3 text-sm leading-6">
+                              <label htmlFor={option.id} className="font-bold text-[#20231d]">
+                                {option.label}
+                              </label>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-6 flex flex-wrap items-center justify-end gap-x-6 gap-y-3">
+                    {message && <p className="text-sm font-bold text-[#1f5b2c]">{message}</p>}
+                    {error && <p className="text-sm font-bold text-[#9f2f28]">{error}</p>}
+                    {profileFetcherData?.error && <p className="text-sm font-bold text-[#9f2f28]">{profileFetcherData.error}</p>}
+                    <button type="submit" disabled={isSaving} className={`${wattClasses.buttonPrimary} disabled:opacity-50`}>
+                      {isSaving ? "Saving..." : "Save Profile"}
+                    </button>
+                  </div>
+                </fetcher.Form>
+              </div>
+            </section>
           </div>
-        </aside>
-      </div>
+
+          <section aria-labelledby="timeline-title" className="lg:col-span-1 lg:col-start-3">
+            <div className={wattClasses.panel}>
+              {teamName ? (
+                <>
+                  <div
+                    className={`flex items-center justify-between rounded-t-[1.25rem] border-b px-4 py-3 sm:px-6 ${
+                      isValidTeamSize ? "border-[#c9dbb8] bg-[#dfead1]" : "border-[#f2c34c]/50 bg-[#fff8dc]"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className={`flex h-2 w-2 rounded-full ${isValidTeamSize ? "bg-[#1f5b2c]" : "bg-[#f2c34c]"}`} />
+                      <span className={`text-sm font-black ${isValidTeamSize ? "text-[#1f5b2c]" : "text-[#6f4b08]"}`}>
+                        {isValidTeamSize ? "Team Ready" : "Forming Team"}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 text-xs font-bold text-[#6f756c]">
+                      <span>{memberCount}/6</span>
+                      <span className="hidden sm:inline">members</span>
+                      <div className="group relative flex items-center">
+                        <InformationCircleIcon className="h-4 w-4 cursor-help text-[#6f756c]" />
+                        <div className="absolute bottom-full right-0 z-10 mb-2 hidden w-48 rounded-2xl bg-[#20231d] px-2 py-1 text-xs text-white shadow-lg group-hover:block">
+                          Teams must have between 2 and 6 members.
+                          <div className="absolute right-1 top-full -mt-1 h-2 w-2 rotate-45 bg-[#20231d]" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="px-4 py-5 sm:px-6">
+                    <div className="flex flex-col items-center border-b border-[#e7dfcf] pb-6">
+                      <div className="relative inline-block">
+                        <img
+                          className="h-24 w-24 rounded-2xl object-cover ring-1 ring-[#c9dbb8]"
+                          src={teamAvatarUrl}
+                          alt={teamName}
+                        />
+                        <button
+                          type="button"
+                          className="absolute inset-0 flex cursor-pointer items-center justify-center rounded-2xl bg-[#20231d]/55 opacity-0 transition-opacity hover:opacity-100"
+                          onClick={() => setIsTeamAvatarModalOpen(true)}
+                        >
+                          <span className="sr-only">Update team logo</span>
+                          <PencilIcon className="h-6 w-6 text-white" aria-hidden="true" />
+                        </button>
+                      </div>
+                      <h2 id="timeline-title" className="mt-3 text-center text-xl font-black text-[#20231d]">
+                        {teamName}
+                      </h2>
+                    </div>
+
+                    <h3 className="mt-6 text-sm font-bold text-[#6f756c]">Team Members</h3>
+                    <div className="mt-4 flow-root">
+                      <ul role="list" className="-my-5 divide-y divide-[#e7dfcf]">
+                        {teamMembers.length > 0 ? (
+                          teamMembers.map((member: GenericHackathonMember & { personas?: string[] }, index: number) => {
+                            const memberInitials = getInitials(member.full_name || member.email);
+                            const memberAvatarUrl = member.avatar_url || generateAvatarUrl(memberInitials);
+                            return (
+                              <li key={member.id ?? index} className="py-4">
+                                <div className="flex items-center space-x-4">
+                                  <div className="shrink-0">
+                                    <img
+                                      className="h-10 w-10 rounded-full object-cover ring-1 ring-[#c9dbb8]"
+                                      src={memberAvatarUrl}
+                                      alt={member.full_name || member.email}
+                                    />
+                                  </div>
+                                  <div className="min-w-0 flex-1">
+                                    <p className="truncate text-sm font-black text-[#20231d]">{member.full_name || member.email}</p>
+                                    <div className="mt-1 flex flex-wrap gap-1">
+                                      {member.personas && member.personas.length > 0 ? (
+                                        member.personas.map((persona) => (
+                                          <span
+                                            key={persona}
+                                            className={`inline-flex items-center rounded-full border px-2 py-1 text-xs font-bold ${personaClass(persona)}`}
+                                          >
+                                            {personaLabel(persona)}
+                                          </span>
+                                        ))
+                                      ) : (
+                                        <span className="text-xs italic text-[#6f756c]">{member.role || "Participant"}</span>
+                                      )}
+                                    </div>
+                                  </div>
+                                </div>
+                              </li>
+                            );
+                          })
+                        ) : (
+                          <li className="py-4">
+                            <p className="text-sm text-[#6f756c]">No team members yet.</p>
+                          </li>
+                        )}
+                      </ul>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="px-4 py-5 text-center sm:px-6">
+                  <div className="mb-3 inline-flex rounded-full bg-[#dfead1] p-3">
+                    <UserGroupIcon className="h-8 w-8 text-[#1f5b2c]" aria-hidden="true" />
+                  </div>
+                  <h2 id="timeline-title" className="text-lg font-black text-[#20231d]">No Team Yet</h2>
+                  <p className="mt-2 text-sm text-[#6f756c]">
+                    Create or join a team using the form on the left to get started.
+                  </p>
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <AvatarModal
+        isOpen={isAvatarModalOpen}
+        onClose={() => setIsAvatarModalOpen(false)}
+        onSave={handleAvatarSave}
+        initialImage={avatarUrl}
+      />
+      <AvatarModal
+        isOpen={isTeamAvatarModalOpen}
+        onClose={() => setIsTeamAvatarModalOpen(false)}
+        onSave={handleTeamAvatarSave}
+        initialImage={teamAvatarUrl}
+        title="Update Team Logo"
+      />
     </div>
   );
 }

--- a/app/routes/watt-the-hack.resources.tsx
+++ b/app/routes/watt-the-hack.resources.tsx
@@ -5,6 +5,7 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import { getCurrentUser } from "~/lib/auth";
 import { getEnv } from "~/lib/env.server";
 import { getGenericResources, type GenericHackathonResource } from "~/lib/generic-hackathon";
+import { wattClasses } from "~/lib/watt-theme";
 
 const FALLBACK_RESOURCES: GenericHackathonResource[] = [
   {
@@ -58,36 +59,36 @@ export default function WattTheHackResources() {
   }, {});
 
   return (
-    <div className="px-4 py-8 sm:px-6 lg:px-8">
+    <div className={wattClasses.page}>
       <div className="mx-auto max-w-6xl space-y-8">
         <div>
-          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-[#1f6f54]">Resources</p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-950">Watt The Hack Resources</h1>
-          <p className="mt-3 max-w-2xl text-gray-600">
+          <p className={wattClasses.eyebrow}>Resources</p>
+          <h1 className="mt-2 text-3xl font-black tracking-tight text-[#20231d]">Watt The Hack Resources</h1>
+          <p className="mt-3 max-w-2xl text-[#6f756c]">
             Guides, references, and challenge material for participants.
           </p>
         </div>
 
         {Object.entries(grouped).map(([category, items]) => (
           <section key={category} className="space-y-4">
-            <h2 className="text-xl font-semibold text-gray-950">{category}</h2>
+            <h2 className="text-xl font-black text-[#20231d]">{category}</h2>
             <div className="grid gap-4 md:grid-cols-2">
               {items.map((resource) => (
-                <article key={resource.id} className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+                <article key={resource.id} className={`${wattClasses.panel} p-6`}>
                   <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <h3 className="text-lg font-semibold text-gray-950">{resource.title}</h3>
-                      <p className="mt-2 text-sm leading-6 text-gray-600">{resource.summary}</p>
+                    <div className="min-w-0">
+                      <h3 className="text-lg font-black text-[#20231d]">{resource.title}</h3>
+                      <p className="mt-2 text-sm leading-6 text-[#6f756c]">{resource.summary}</p>
                     </div>
                     {resource.url && (
-                      <a href={resource.url} target="_blank" rel="noopener noreferrer" className="text-[#1f6f54] hover:text-[#10231f]">
+                      <a href={resource.url} target="_blank" rel="noopener noreferrer" className="shrink-0 rounded-full border border-[#c9dbb8] bg-[#dfead1] p-2 text-[#1f5b2c] transition hover:bg-[#b8d86b]">
                         <span className="sr-only">Open {resource.title}</span>
                         <ArrowTopRightOnSquareIcon className="h-5 w-5" aria-hidden="true" />
                       </a>
                     )}
                   </div>
                   {resource.body && (
-                    <div className="prose prose-sm mt-4 max-w-none text-gray-700">
+                    <div className="prose prose-sm mt-4 max-w-none text-[#394033] prose-a:text-[#1f5b2c] prose-strong:text-[#20231d]">
                       <ReactMarkdown>{resource.body}</ReactMarkdown>
                     </div>
                   )}

--- a/app/routes/watt-the-hack.submissions.tsx
+++ b/app/routes/watt-the-hack.submissions.tsx
@@ -13,6 +13,7 @@ import {
   getGenericSubmissions,
   WATT_THE_HACK_SLUG,
 } from "~/lib/generic-hackathon";
+import { wattClasses } from "~/lib/watt-theme";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
@@ -63,23 +64,24 @@ export default function WattTheHackSubmissions() {
   const actionData = useActionData<typeof action>();
 
   return (
-    <div className="px-4 py-8 sm:px-6 lg:px-8">
+    <div className={wattClasses.page}>
       <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[420px_1fr]">
-        <section className="rounded-lg border border-black/10 bg-white p-6 shadow-sm">
+        <section className={`${wattClasses.panelStrong} p-6`}>
           <div className="flex items-center gap-3">
-            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#e6f8d8] text-[#24523f]">
+            <span className={wattClasses.iconTile}>
               <DocumentTextIcon className="h-5 w-5" aria-hidden="true" />
             </span>
             <div>
-              <h1 className="text-xl font-bold text-gray-950">Project Submission</h1>
-              <p className="text-sm text-gray-600">Submit your team project.</p>
+              <p className={wattClasses.eyebrow}>Submissions</p>
+              <h1 className="text-xl font-black text-[#20231d]">Project Submission</h1>
+              <p className="text-sm text-[#6f756c]">Submit your team project.</p>
             </div>
           </div>
 
           {!team ? (
-            <div className="mt-6 rounded-md bg-amber-50 p-4 text-sm text-amber-900">
+            <div className={`mt-6 ${wattClasses.warningAlert}`}>
               Join or create a team before submitting.{" "}
-              <Link to="/watt-the-hack/profile" className="font-semibold underline underline-offset-2">
+              <Link to="/watt-the-hack/profile" className="font-black underline underline-offset-2">
                 Go to profile and team
               </Link>
             </div>
@@ -87,91 +89,91 @@ export default function WattTheHackSubmissions() {
             <Form method="post" encType="multipart/form-data" className="mt-6 space-y-4">
               <input type="hidden" name="intent" value="submit_project" />
               {actionData?.success && (
-                <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">{actionData.success}</div>
+                <div className={wattClasses.successAlert}>{actionData.success}</div>
               )}
               {actionData?.error && (
-                <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{actionData.error}</div>
+                <div className={wattClasses.errorAlert}>{actionData.error}</div>
               )}
 
               <label className="block">
-                <span className="text-sm font-medium text-gray-700">Project title</span>
+                <span className={wattClasses.label}>Project title</span>
                 <input
                   name="title"
                   required
                   maxLength={180}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                  className={wattClasses.input}
                 />
               </label>
               <label className="block">
-                <span className="text-sm font-medium text-gray-700">Summary</span>
+                <span className={wattClasses.label}>Summary</span>
                 <textarea
                   name="summary"
                   required
                   rows={6}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                  className={wattClasses.input}
                 />
               </label>
               <label className="block">
-                <span className="text-sm font-medium text-gray-700">Repository URL</span>
+                <span className={wattClasses.label}>Repository URL</span>
                 <input
                   name="repository_url"
                   type="url"
                   placeholder="https://github.com/..."
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                  className={wattClasses.input}
                 />
               </label>
               <label className="block">
-                <span className="text-sm font-medium text-gray-700">Demo URL</span>
+                <span className={wattClasses.label}>Demo URL</span>
                 <input
                   name="demo_url"
                   type="url"
                   placeholder="https://..."
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                  className={wattClasses.input}
                 />
               </label>
               <label className="block">
-                <span className="text-sm font-medium text-gray-700">Slides URL</span>
+                <span className={wattClasses.label}>Slides URL</span>
                 <input
                   name="slides_url"
                   type="url"
                   placeholder="https://..."
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-gray-950 focus:border-[#1f6f54] focus:outline-none focus:ring-1 focus:ring-[#1f6f54]"
+                  className={wattClasses.input}
                 />
               </label>
               <label className="block">
-                <span className="text-sm font-medium text-gray-700">Attachment</span>
-                <input name="attachment" type="file" className="mt-1 block w-full text-sm text-gray-700" />
-                <span className="mt-1 block text-xs text-gray-500">Optional. PDF, deck, document, image, zip, CSV, or video up to 20MB.</span>
+                <span className={wattClasses.label}>Attachment</span>
+                <input name="attachment" type="file" className={wattClasses.fileInput} />
+                <span className="mt-1 block text-xs text-[#6f756c]">Optional. PDF, deck, document, image, zip, CSV, or video up to 20MB.</span>
               </label>
-              <button type="submit" className="w-full rounded-md bg-[#10231f] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1d3c35]">
+              <button type="submit" className={`${wattClasses.buttonPrimary} w-full`}>
                 Submit project
               </button>
             </Form>
           )}
         </section>
 
-        <section className="rounded-lg border border-black/10 bg-white shadow-sm">
-          <div className="border-b border-black/10 px-6 py-5">
-            <h2 className="text-xl font-bold text-gray-950">Submission History</h2>
-            <p className="text-sm text-gray-600">
+        <section className={wattClasses.panel}>
+          <div className="border-b border-[#e7dfcf] px-6 py-5">
+            <h2 className="text-xl font-black text-[#20231d]">Submission History</h2>
+            <p className="text-sm text-[#6f756c]">
               {team ? `Showing submissions for ${team.team_name}.` : "Team submissions will appear here."}
             </p>
           </div>
-          <div className="divide-y divide-black/8">
+          <div className="divide-y divide-[#e7dfcf]">
             {submissions.length > 0 ? submissions.map((submission) => (
               <article key={submission.id} className="p-6">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h3 className="text-lg font-semibold text-gray-950">{submission.title}</h3>
-                    <p className="mt-1 text-sm text-gray-500">{formatDate(submission.submitted_at)}</p>
-                    <p className="mt-3 max-w-3xl text-sm leading-6 text-gray-700">{submission.summary}</p>
+                  <div className="min-w-0">
+                    <h3 className="text-lg font-black text-[#20231d]">{submission.title}</h3>
+                    <p className="mt-1 text-sm text-[#6f756c]">{formatDate(submission.submitted_at)}</p>
+                    <p className="mt-3 max-w-3xl text-sm leading-6 text-[#394033]">{submission.summary}</p>
                   </div>
                   {submission.attachment_url && (
                     <a
                       href={submission.attachment_url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 rounded-md border border-black/10 px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-50"
+                      className={`${wattClasses.buttonOutline} shrink-0 gap-2`}
                     >
                       <ArrowDownTrayIcon className="h-4 w-4" aria-hidden="true" />
                       Attachment
@@ -185,7 +187,7 @@ export default function WattTheHackSubmissions() {
                 </div>
               </article>
             )) : (
-              <div className="p-6 text-sm text-gray-600">No submissions yet.</div>
+              <div className="p-6 text-sm text-[#6f756c]">No submissions yet.</div>
             )}
           </div>
         </section>
@@ -196,7 +198,7 @@ export default function WattTheHackSubmissions() {
 
 function ExternalLink({ href, label }: { href: string; label: string }) {
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm font-semibold text-[#1f6f54] hover:text-[#10231f]">
+    <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm font-black text-[#1f5b2c] hover:text-[#3d7339]">
       {label}
       <ArrowTopRightOnSquareIcon className="h-4 w-4" aria-hidden="true" />
     </a>

--- a/app/routes/watt-the-hack.tsx
+++ b/app/routes/watt-the-hack.tsx
@@ -34,6 +34,7 @@ export default function WattTheHackApp() {
         name: "Watt The Hack",
         slug: WATT_THE_HACK_SLUG,
         basePath: BASE_PATH,
+        theme: "watt",
       }}
     >
       <Outlet />


### PR DESCRIPTION
## Summary
- restyle the authenticated Watt The Hack app shell, dashboard, resources, submissions, and announcements variant with Watt brand colors/assets
- update the Watt Profile & Team page to mirror the MedHack layout and field placement while keeping Watt styling
- add shared Watt theme constants and guard malformed local stub team responses

## Validation
- bun run typecheck
- NODE_OPTIONS='--max-old-space-size=8192' ./node_modules/.bin/react-router build
- browser checked /watt-the-hack/profile at desktop and mobile widths during implementation