### PR TITLE
[codex] Add Watt The Hack track tabs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,6 @@
+- [x] Add Watt The Hack track sidebar routes
+- [x] Add Watt The Hack track placeholder pages
+- [x] Run Watt The Hack track tab verification
 - [x] Lower Watt dashboard resource illustration to panel base
 - [x] Keep collapsed Watt sidebar illustration visible and enlarge collapsed logo
 - [x] Restyle Watt announcements as green accent panel

--- a/app/components/GenericHackathonAppLayout.tsx
+++ b/app/components/GenericHackathonAppLayout.tsx
@@ -4,9 +4,12 @@ import {
   ArrowLeftOnRectangleIcon,
   Bars3Icon,
   BookOpenIcon,
+  BuildingOffice2Icon,
   ChevronDownIcon,
   DocumentTextIcon,
   HomeIcon,
+  HomeModernIcon,
+  PresentationChartBarIcon,
   UserGroupIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
@@ -44,6 +47,13 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
     { name: "Profile & Team", href: `${config.basePath}/profile`, icon: UserGroupIcon },
     { name: "Submissions", href: `${config.basePath}/submissions`, icon: DocumentTextIcon },
     { name: "Resources", href: `${config.basePath}/resources`, icon: BookOpenIcon },
+    ...(isWattTheme
+      ? [
+          { name: "Base44 (Pitching) Track", href: `${config.basePath}/base44-pitching`, icon: PresentationChartBarIcon },
+          { name: "City Of Melbourne (Advanced) Track", href: `${config.basePath}/city-of-melbourne-advanced`, icon: BuildingOffice2Icon },
+          { name: "Smart Home (Beginner) Track", href: `${config.basePath}/smart-home-beginner`, icon: HomeModernIcon },
+        ]
+      : []),
   ].map((item) => ({
     ...item,
     current: location.pathname === item.href,
@@ -150,15 +160,15 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
                       item.current
                         ? "bg-[#e6efd7] text-[#155420]"
                         : "text-[#354031] hover:bg-[#fbf6e9] hover:text-[#155420]",
-                      "group flex h-[52px] items-center rounded-xl px-3 text-sm font-black leading-6 transition-all duration-200",
+                      "group flex min-h-[52px] items-center rounded-xl px-3 py-2 text-sm font-black leading-6 transition-all duration-200",
                       mobile || expanded ? "justify-start gap-x-3" : "justify-center gap-x-0",
                     )}
                   >
                     <item.icon className="h-7 w-7 shrink-0 stroke-[1.7]" aria-hidden="true" />
                     <span
                       className={classNames(
-                        "overflow-hidden whitespace-nowrap transition-all duration-300 ease-in-out",
-                        mobile || expanded ? "ml-1 w-auto opacity-100" : "ml-0 w-0 opacity-0",
+                        "min-w-0 overflow-hidden transition-all duration-300 ease-in-out",
+                        mobile || expanded ? "ml-1 w-full whitespace-normal opacity-100" : "ml-0 w-0 whitespace-nowrap opacity-0",
                       )}
                     >
                       {item.name}

--- a/app/components/WattTrackPlaceholder.tsx
+++ b/app/components/WattTrackPlaceholder.tsx
@@ -1,0 +1,16 @@
+import { wattClasses } from "~/lib/watt-theme";
+
+export default function WattTrackPlaceholder() {
+  return (
+    <div className={wattClasses.page}>
+      <div className="mx-auto max-w-7xl">
+        <section
+          aria-label="Track placeholder"
+          className={`${wattClasses.panelStrong} flex min-h-[420px] items-center justify-center p-6 sm:p-10`}
+        >
+          <p className="text-lg font-black text-[#121e16]">add content here</p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -61,6 +61,9 @@ export default [
     route("team", "routes/watt-the-hack.team.tsx"),
     route("submissions", "routes/watt-the-hack.submissions.tsx"),
     route("resources", "routes/watt-the-hack.resources.tsx"),
+    route("base44-pitching", "routes/watt-the-hack.base44-pitching.tsx"),
+    route("city-of-melbourne-advanced", "routes/watt-the-hack.city-of-melbourne-advanced.tsx"),
+    route("smart-home-beginner", "routes/watt-the-hack.smart-home-beginner.tsx"),
   ]),
 
   // Hackathon pages

--- a/app/routes/watt-the-hack.base44-pitching.tsx
+++ b/app/routes/watt-the-hack.base44-pitching.tsx
@@ -1,0 +1,5 @@
+import WattTrackPlaceholder from "~/components/WattTrackPlaceholder";
+
+export default function WattTheHackBase44PitchingTrack() {
+  return <WattTrackPlaceholder />;
+}

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced.tsx
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced.tsx
@@ -1,0 +1,5 @@
+import WattTrackPlaceholder from "~/components/WattTrackPlaceholder";
+
+export default function WattTheHackCityOfMelbourneAdvancedTrack() {
+  return <WattTrackPlaceholder />;
+}

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -1,0 +1,5 @@
+import WattTrackPlaceholder from "~/components/WattTrackPlaceholder";
+
+export default function WattTheHackSmartHomeBeginnerTrack() {
+  return <WattTrackPlaceholder />;
+}


### PR DESCRIPTION
## Summary
- Adds three Watt The Hack sidebar entries for Base44, City Of Melbourne, and Smart Home tracks.
- Registers authenticated child routes for each track under `/watt-the-hack`.
- Adds a shared Watt-styled placeholder surface that displays `add content here`.

## Validation
- `git diff --check`
- `bun run typecheck`
- Local browser smoke test in dev auth/stub mode confirmed sidebar labels, navigation, active state, and placeholder rendering.