### PR TITLE
[codex] Prevent article preview from opening publish step

### DIFF
--- a/app/lib/vibe-marketing-run-view.ts
+++ b/app/lib/vibe-marketing-run-view.ts
@@ -1,0 +1,191 @@
+import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
+
+const ARTICLE_WORKFLOWS = new Set([
+  "article_generation",
+  "content_factory_article",
+  "direct_generate",
+  "confirmed_topic",
+  "article_revision",
+]);
+const ARTICLE_GENERATION_WORKFLOWS = new Set([
+  "article_generation",
+  "content_factory_article",
+  "direct_generate",
+  "confirmed_topic",
+  "article_revision",
+]);
+const DISCOVERY_WORKFLOWS = new Set(["auto_discovery", "content_factory_discovery", "daily_discovery"]);
+const SCAN_WORKFLOWS = new Set(["repo_scan", "content_factory_scan"]);
+const POLLING_STATUSES = new Set([
+  "queued",
+  "pending",
+  "starting",
+  "processing",
+  "running",
+  "in_progress",
+  "preview_building",
+  "preview_verifying",
+  "repair_preview_building",
+  "awaiting_confirmation",
+  "awaiting_delivery_mode",
+  "awaiting_approval",
+  "approval_required",
+]);
+const APPROVAL_GATE_STATUSES = new Set(["awaiting_approval", "approval_required"]);
+
+export type ArticleSetupStepViewForRun = "generate" | "review" | "publish";
+
+function isArticleWorkflow(workflow: string | null | undefined) {
+  return ARTICLE_WORKFLOWS.has(String(workflow ?? ""));
+}
+
+function stringResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
+  for (const key of keys) {
+    const value = run.result?.[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    const nestedResult = run.result?.["result"];
+    if (nestedResult && typeof nestedResult === "object") {
+      const nestedValue = (nestedResult as Record<string, unknown>)[key];
+      if (typeof nestedValue === "string" && nestedValue.trim()) return nestedValue.trim();
+    }
+    const latestControl = run.result?.["latest_control_response"];
+    if (latestControl && typeof latestControl === "object") {
+      const latestValue = (latestControl as Record<string, unknown>)[key];
+      if (typeof latestValue === "string" && latestValue.trim()) return latestValue.trim();
+    }
+  }
+  return "";
+}
+
+function boolResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
+  for (const key of keys) {
+    const value = run.result?.[key];
+    if (typeof value === "boolean") return value;
+    const nestedResult = run.result?.["result"];
+    if (nestedResult && typeof nestedResult === "object") {
+      const nestedValue = (nestedResult as Record<string, unknown>)[key];
+      if (typeof nestedValue === "boolean") return nestedValue;
+    }
+    const latestControl = run.result?.["latest_control_response"];
+    if (latestControl && typeof latestControl === "object") {
+      const latestValue = (latestControl as Record<string, unknown>)[key];
+      if (typeof latestValue === "boolean") return latestValue;
+    }
+  }
+  return false;
+}
+
+function normalized(value: string | null | undefined) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+export function publishPrUrlForRun(run: VibeMarketingRunSummary) {
+  return run.prUrl?.trim() || stringResultValue(run, "pr_url", "prUrl", "pull_request_url", "pullRequestUrl", "draft_pr_url", "draftPrUrl");
+}
+
+function rawPreviewUrlForRun(run: VibeMarketingRunSummary) {
+  return run.previewUrl?.trim() || stringResultValue(run, "preview_url", "previewUrl", "article_url", "articleUrl", "url");
+}
+
+function isRunApprovalRequired(run: VibeMarketingRunSummary) {
+  return run.approvalState === "approval_required" || APPROVAL_GATE_STATUSES.has(run.status);
+}
+
+function hasPublishChildReference(run: VibeMarketingRunSummary) {
+  return Boolean(
+    stringResultValue(run, "publish_child_run_id", "promoted_publish_job_id", "promote_bundle_requested_at") ||
+      boolResultValue(run, "publish_handoff_pending"),
+  );
+}
+
+function hasArticleReviewPreviewMarker(run: VibeMarketingRunSummary) {
+  if (!isArticleWorkflow(run.workflow)) return false;
+  const reviewSurfaceKind = normalized(stringResultValue(run, "review_surface_kind", "reviewSurfaceKind"));
+  const resultStatus = normalized(stringResultValue(run, "status", "final_status", "finalStatus"));
+  return (
+    reviewSurfaceKind === "component_live_preview" ||
+    resultStatus === "preview_ready" ||
+    normalized(run.currentStep) === "await_review" ||
+    normalized(run.currentStep) === "await_publish_approval"
+  );
+}
+
+export function articleReviewPreviewUrlForRun(run: VibeMarketingRunSummary) {
+  if (!isArticleWorkflow(run.workflow)) return "";
+  const livePreviewUrl = String(run.livePreview?.previewUrl ?? "").trim();
+  if (run.livePreview?.available && livePreviewUrl) return livePreviewUrl;
+  if (hasArticleReviewPreviewMarker(run) || isRunApprovalRequired(run)) return rawPreviewUrlForRun(run);
+  return "";
+}
+
+export function isArticleReviewPreviewReady(run: VibeMarketingRunSummary) {
+  return Boolean(
+    isArticleWorkflow(run.workflow) &&
+      run.componentManifest &&
+      articleReviewPreviewUrlForRun(run) &&
+      !publishPrUrlForRun(run) &&
+      !hasPublishChildReference(run) &&
+      (hasArticleReviewPreviewMarker(run) || isRunApprovalRequired(run)),
+  );
+}
+
+export function publishPreviewUrlForRun(run: VibeMarketingRunSummary) {
+  const previewUrl = rawPreviewUrlForRun(run);
+  if (!previewUrl) return "";
+  if (hasArticleReviewPreviewMarker(run)) return "";
+  return previewUrl;
+}
+
+export function hasPublishHandoffEvidence(run: VibeMarketingRunSummary) {
+  if (isArticleReviewPreviewReady(run)) return false;
+  return Boolean(
+    publishPrUrlForRun(run) ||
+      publishPreviewUrlForRun(run) ||
+      hasPublishChildReference(run) ||
+      run.workflowProgress?.currentStepId === "publish" ||
+      run.workflowProgress?.currentStepId === "automation",
+  );
+}
+
+export function isPublishApprovalGate(run: VibeMarketingRunSummary) {
+  return Boolean(
+    isArticleWorkflow(run.workflow) &&
+      isRunApprovalRequired(run) &&
+      !isArticleReviewPreviewReady(run) &&
+      (publishPreviewUrlForRun(run) || publishPrUrlForRun(run)),
+  );
+}
+
+export function articleReviewApproveIntentForRun(run: VibeMarketingRunSummary, fallbackIntent: string | null | undefined) {
+  return isArticleReviewPreviewReady(run) && isRunApprovalRequired(run) ? "approve" : fallbackIntent || "promote-bundle";
+}
+
+export function articleReviewApproveLabelForRun(run: VibeMarketingRunSummary) {
+  return isArticleReviewPreviewReady(run) && isRunApprovalRequired(run)
+    ? { idle: "Approve article and create PR", pending: "Approving..." }
+    : { idle: "Accept article and continue", pending: "Continuing..." };
+}
+
+export function viewedWorkflowStepIdForRun(
+  run: VibeMarketingRunSummary,
+  requestedSetupStep?: ArticleSetupStepViewForRun | null,
+  setupWorkflowStepId?: string | null,
+) {
+  const workflow = String(run.workflow ?? "");
+  if (DISCOVERY_WORKFLOWS.has(workflow)) {
+    return run.status === "awaiting_confirmation" ? "choose_topic" : "research";
+  }
+  if (SCAN_WORKFLOWS.has(workflow)) return "article_system";
+  if (workflow === "article_system_setup") return requestedSetupStep ?? setupWorkflowStepId ?? "generate";
+  if (workflow === "website_baseline") return "baseline";
+  if (workflow === "article_revision") return hasPublishHandoffEvidence(run) ? "publish" : "revise";
+  if (ARTICLE_GENERATION_WORKFLOWS.has(workflow)) {
+    if (isArticleReviewPreviewReady(run)) return "review";
+    if (hasPublishHandoffEvidence(run)) return "publish";
+    if (POLLING_STATUSES.has(run.status)) return "generate";
+    if (run.componentManifest) return "review";
+    if (run.contentPackage?.contentPackaged) return "package";
+    return "generate";
+  }
+  return run.workflowProgress?.currentStepId ?? null;
+}

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -27,6 +27,16 @@ import { TopicDecisionCard } from "~/components/TopicDecisionCard";
 import { getEnv } from "~/lib/env.server";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
+  articleReviewApproveIntentForRun,
+  articleReviewApproveLabelForRun,
+  hasPublishHandoffEvidence,
+  isArticleReviewPreviewReady,
+  isPublishApprovalGate,
+  publishPreviewUrlForRun,
+  publishPrUrlForRun,
+  viewedWorkflowStepIdForRun,
+} from "~/lib/vibe-marketing-run-view";
+import {
   connectVibeMarketingGithub,
   controlVibeMarketingRun,
   acceptVibeMarketingComponentRevision,
@@ -2076,7 +2086,9 @@ function LiveArticlePreviewPanel({
   isActionPending?: (...keys: string[]) => boolean;
 }) {
   const publishStep = run.workflowProgress?.steps.find((step) => step.id === "publish");
-  const acceptArticleIntent = publishStep?.primaryAction?.intent ?? "promote-bundle";
+  const acceptArticleIntent = articleReviewApproveIntentForRun(run, publishStep?.primaryAction?.intent);
+  const acceptArticleLabel = articleReviewApproveLabelForRun(run);
+  const reviewApprovalReady = isArticleReviewPreviewReady(run);
 
   return (
     <section className="space-y-5">
@@ -2101,13 +2113,13 @@ function LiveArticlePreviewPanel({
             reviewState.latestBatch?.status !== "accepted" &&
             Boolean(reviewState.batchId);
           const canAcceptArticleForPublish = Boolean(
-            run.status === "completed" &&
-              run.contentPackage?.contentPackaged &&
+            (run.status === "completed" || reviewApprovalReady) &&
+              (run.contentPackage?.contentPackaged || reviewApprovalReady) &&
               reviewState.canRenderPreview &&
               reviewState.draftComments.length === 0 &&
               !canAcceptRevision &&
               !reviewState.hasPendingRevisionBatch &&
-              publishStep?.status === "ready" &&
+              (reviewApprovalReady || publishStep?.status === "ready") &&
               acceptArticleIntent,
           );
           const acceptArticlePending = isActionPending?.(acceptArticleIntent) ?? isSubmitting;
@@ -2125,7 +2137,7 @@ function LiveArticlePreviewPanel({
                     className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
                   >
                     {acceptArticlePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                    {acceptArticlePending ? "Continuing..." : "Accept article and continue"}
+                    {acceptArticlePending ? acceptArticleLabel.pending : acceptArticleLabel.idle}
                   </button>
                 </Form>
               ) : null}
@@ -3278,6 +3290,7 @@ function ArticleWorkflowPrimaryAction({
   const publishUrl = publishPreviewUrlForRun(run) || publishPrUrlForRun(run);
   const buttonClass = "inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-black shadow-sm transition disabled:opacity-50";
 
+  if (isArticleReviewPreviewReady(run)) return null;
   if (isPublishApprovalGate(run)) return null;
 
   if (publishStep?.status === "ready" && publishStep.primaryAction?.intent) {
@@ -3449,28 +3462,9 @@ function setupRunIdForRun(run: VibeMarketingRunSummary) {
   return typeof setupRunId === "string" && setupRunId.trim() ? setupRunId.trim() : "";
 }
 
-function publishPrUrlForRun(run: VibeMarketingRunSummary) {
-  return run.prUrl?.trim() || stringResultValue(run, "pr_url", "prUrl", "pull_request_url", "pullRequestUrl", "draft_pr_url", "draftPrUrl");
-}
-
-function publishPreviewUrlForRun(run: VibeMarketingRunSummary) {
-  return run.previewUrl?.trim() || stringResultValue(run, "preview_url", "previewUrl", "article_url", "articleUrl", "url");
-}
-
 function prNumberFromPullUrl(url: string) {
   const match = url.match(/\/pull\/(\d+)/);
   return match?.[1] ?? "";
-}
-
-function hasPublishHandoffEvidence(run: VibeMarketingRunSummary) {
-  return Boolean(
-    publishPrUrlForRun(run) ||
-      publishPreviewUrlForRun(run) ||
-      stringResultValue(run, "publish_child_run_id", "promoted_publish_job_id", "promote_bundle_requested_at") ||
-      run.result?.["publish_handoff_pending"] === true ||
-      run.workflowProgress?.currentStepId === "publish" ||
-      run.workflowProgress?.currentStepId === "automation",
-  );
 }
 
 function deliveryModeForRun(run: VibeMarketingRunSummary, bootstrap: VibeMarketingBootstrap) {
@@ -3479,19 +3473,6 @@ function deliveryModeForRun(run: VibeMarketingRunSummary, bootstrap: VibeMarketi
     return runMode;
   }
   return effectiveArticleDeliveryMode(bootstrap);
-}
-
-function hasReviewTarget(run: VibeMarketingRunSummary) {
-  return Boolean(publishPreviewUrlForRun(run) || publishPrUrlForRun(run));
-}
-
-function isRunApprovalRequired(run: VibeMarketingRunSummary) {
-  return run.approvalState === "approval_required" || APPROVAL_GATE_STATUSES.has(run.status);
-}
-
-function isPublishApprovalGate(run: VibeMarketingRunSummary) {
-  const workflow = String(run.workflow ?? "");
-  return isArticleWorkflow(workflow) && isRunApprovalRequired(run) && hasReviewTarget(run);
 }
 
 function isSetupScanRun(run: VibeMarketingRunSummary) {
@@ -3512,25 +3493,6 @@ function setupWorkflowStepIdForRun(run: VibeMarketingRunSummary) {
 function setupStepViewFromSearch(search: string): ArticleSetupStepView | null {
   const value = new URLSearchParams(search).get("setupStep");
   return value && SETUP_STEP_VIEW_VALUES.has(value) ? (value as ArticleSetupStepView) : null;
-}
-
-function viewedWorkflowStepIdForRun(run: VibeMarketingRunSummary, requestedSetupStep?: ArticleSetupStepView | null) {
-  const workflow = String(run.workflow ?? "");
-  if (DISCOVERY_WORKFLOWS.has(workflow)) {
-    return run.status === "awaiting_confirmation" ? "choose_topic" : "research";
-  }
-  if (SCAN_WORKFLOWS.has(workflow)) return "article_system";
-  if (workflow === "article_system_setup") return requestedSetupStep ?? setupWorkflowStepIdForRun(run);
-  if (workflow === "website_baseline") return "baseline";
-  if (workflow === "article_revision") return hasPublishHandoffEvidence(run) ? "publish" : "revise";
-  if (isArticleWorkflow(workflow)) {
-    if (hasPublishHandoffEvidence(run)) return "publish";
-    if (POLLING_STATUSES.has(run.status)) return "generate";
-    if (run.componentManifest) return "review";
-    if (run.contentPackage?.contentPackaged) return "package";
-    return "generate";
-  }
-  return run.workflowProgress?.currentStepId ?? null;
 }
 
 function workflowProgressForRunPage(
@@ -3679,7 +3641,7 @@ export default function FounderToolsMarketingRun() {
     [discoveryCandidates, selectedDiscoveryCandidateId],
   );
   const requestedSetupStep = isArticleSystemSetupRun ? setupStepViewFromSearch(location.search) : null;
-  const viewedWorkflowStepId = viewedWorkflowStepIdForRun(run, requestedSetupStep);
+  const viewedWorkflowStepId = viewedWorkflowStepIdForRun(run, requestedSetupStep, setupWorkflowStepIdForRun(run));
   const workflowProgress = workflowProgressForRunPage(run, bootstrap.workflowProgress);
   const deliveryMode = deliveryModeForRun(run, bootstrap);
   const directPublishMode = deliveryMode === "publish_code";

--- a/tests/vibe-marketing-run-view.test.ts
+++ b/tests/vibe-marketing-run-view.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  articleReviewApproveIntentForRun,
+  articleReviewApproveLabelForRun,
+  hasPublishHandoffEvidence,
+  isArticleReviewPreviewReady,
+  isPublishApprovalGate,
+  publishPreviewUrlForRun,
+  viewedWorkflowStepIdForRun,
+} from "../app/lib/vibe-marketing-run-view";
+import type { VibeMarketingRunSummary } from "../app/types/vibe-marketing";
+
+function articleRun(overrides: Partial<VibeMarketingRunSummary> = {}): VibeMarketingRunSummary {
+  return {
+    runId: "article-review-source",
+    workflow: "article_generation",
+    domain: "mlai.au",
+    status: "approval_required",
+    currentStep: "await_review",
+    approvalState: "approval_required",
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: [],
+    artifacts: [],
+    diagnostics: {},
+    previewUrl: "https://preview.example/articles/generated",
+    componentManifest: {
+      components: [{ id: "title", type: "title", label: "Title" }],
+    },
+    contentPackage: { title: "Generated article", contentPackaged: true },
+    livePreview: {
+      available: true,
+      status: "ready",
+      previewUrl: "https://preview.example/articles/generated",
+      exactRender: true,
+    },
+    workflowProgress: {
+      currentStepId: "publish",
+      steps: [
+        { id: "review", label: "Generate, review & revise", phase: "article", status: "ready", href: "/review" },
+        {
+          id: "publish",
+          label: "Publish & automate",
+          phase: "article",
+          status: "ready",
+          href: "/publish",
+          primaryAction: { label: "Publish to website", intent: "promote-bundle" },
+        },
+      ],
+    },
+    result: {
+      status: "preview_ready",
+      review_surface_kind: "component_live_preview",
+      preview_url: "https://preview.example/articles/generated",
+      promote_bundle_url: "/api/runs/article-review-source/promote-bundle",
+    },
+    ...overrides,
+  };
+}
+
+describe("vibe marketing run view state", () => {
+  test("keeps approval-ready article previews on the review step", () => {
+    const run = articleRun();
+
+    expect(isArticleReviewPreviewReady(run)).toBe(true);
+    expect(hasPublishHandoffEvidence(run)).toBe(false);
+    expect(viewedWorkflowStepIdForRun(run)).toBe("review");
+    expect(publishPreviewUrlForRun(run)).toBe("");
+    expect(isPublishApprovalGate(run)).toBe(false);
+  });
+
+  test("uses semantic approve for the iframe approval button", () => {
+    const run = articleRun();
+
+    expect(articleReviewApproveIntentForRun(run, "promote-bundle")).toBe("approve");
+    expect(articleReviewApproveLabelForRun(run)).toEqual({
+      idle: "Approve article and create PR",
+      pending: "Approving...",
+    });
+  });
+
+  test("moves to publish only after publish child or PR evidence exists", () => {
+    expect(
+      viewedWorkflowStepIdForRun(
+        articleRun({
+          result: {
+            status: "preview_ready",
+            review_surface_kind: "component_live_preview",
+            preview_url: "https://preview.example/articles/generated",
+            publish_child_run_id: "article-publish-child",
+          },
+        }),
+      ),
+    ).toBe("publish");
+
+    expect(
+      viewedWorkflowStepIdForRun(
+        articleRun({
+          prUrl: "https://github.com/MLAI-AUS-Inc/mlai-au/pull/123",
+          result: {
+            status: "preview_ready",
+            review_surface_kind: "component_live_preview",
+            preview_url: "https://preview.example/articles/generated",
+          },
+        }),
+      ),
+    ).toBe("publish");
+  });
+});


### PR DESCRIPTION
## Summary
- separates article review preview state from publish evidence
- keeps preview-ready approval-required article runs on the generate/review/revise step
- makes the iframe green button submit `approve` before the PR step can begin

## Validation
- `bun test tests/vibe-marketing-run-view.test.ts`
- `bun run typecheck`
