### PR TITLE
[codex] Make fixed article review blocks commentable

### DIFF
--- a/app/components/articles/ArticleDisclaimer.tsx
+++ b/app/components/articles/ArticleDisclaimer.tsx
@@ -9,6 +9,9 @@ type ArticleDisclaimerProps = {
 export function ArticleDisclaimer({ className }: ArticleDisclaimerProps) {
   return (
     <section
+      data-cf-component-id="disclaimer"
+      data-cf-component-type="disclaimer"
+      data-cf-component-label="Disclaimer"
       className={clsx(
         'not-prose my-12 rounded-full bg-black px-6 sm:px-8 py-4 text-white flex items-center gap-4 border border-black',
         className,

--- a/app/components/articles/ArticleLayout.tsx
+++ b/app/components/articles/ArticleLayout.tsx
@@ -674,7 +674,12 @@ export function ArticleLayout({
                 </div>
               ) : null}
               {showCitations ? (
-                <section className="not-prose mt-10 rounded-[24px] border border-gray-400 bg-transparent p-6 sm:p-8">
+                <section
+                  data-cf-component-id="authoritative-references"
+                  data-cf-component-type="references"
+                  data-cf-component-label="Authoritative References"
+                  className="not-prose mt-10 rounded-[24px] border border-gray-400 bg-transparent p-6 sm:p-8"
+                >
                   <h2 className="text-base font-bold uppercase tracking-wide text-gray-700">Authoritative references</h2>
                   <ul className="mt-4 space-y-4 text-sm text-gray-800">
                     {DEFAULT_CITATIONS.map((citation) => (

--- a/app/components/articles/ArticleReferences.tsx
+++ b/app/components/articles/ArticleReferences.tsx
@@ -140,7 +140,13 @@ export function ArticleReferences({
   };
 
   return (
-    <section aria-labelledby={headingId} className="mt-2">
+    <section
+      aria-labelledby={headingId}
+      data-cf-component-id="references"
+      data-cf-component-type="references"
+      data-cf-component-label="Authoritative References"
+      className="mt-2"
+    >
       <div className="flex items-center justify-between gap-3 px-1 pb-0.5">
         <div className="flex flex-col">
           <h2 id={headingId} className="text-sm font-semibold text-slate-900">

--- a/app/components/articles/UpcomingEventsCTA.tsx
+++ b/app/components/articles/UpcomingEventsCTA.tsx
@@ -49,7 +49,12 @@ export default function UpcomingEventsCTA({
 
     if (upcomingEvents.length === 0) {
         return (
-            <div className={`relative overflow-hidden rounded-[32px] bg-[#4b1bd1] p-8 sm:p-10 shadow-[0_25px_80px_-30px_rgba(0,0,0,0.45)] ${className}`}>
+            <div
+                data-cf-component-id="events-cta"
+                data-cf-component-type="events-cta"
+                data-cf-component-label="Upcoming events CTA"
+                className={`relative overflow-hidden rounded-[32px] bg-[#4b1bd1] p-8 sm:p-10 shadow-[0_25px_80px_-30px_rgba(0,0,0,0.45)] ${className}`}
+            >
                 <div className="text-center text-white">
                     <h3 className="text-3xl font-semibold mb-2">Join our community events</h3>
                     <p className="text-white/85 mb-6">Stay tuned for upcoming AI and ML events in Australia.</p>
@@ -65,7 +70,12 @@ export default function UpcomingEventsCTA({
     }
 
     return (
-        <div className={`relative overflow-hidden rounded-[32px] bg-[#4b1bd1] p-6 sm:p-10 shadow-[0_25px_80px_-30px_rgba(0,0,0,0.45)] ${className}`}>
+        <div
+            data-cf-component-id="events-cta"
+            data-cf-component-type="events-cta"
+            data-cf-component-label="Upcoming events CTA"
+            className={`relative overflow-hidden rounded-[32px] bg-[#4b1bd1] p-6 sm:p-10 shadow-[0_25px_80px_-30px_rgba(0,0,0,0.45)] ${className}`}
+        >
             <div className="text-center mb-8 sm:mb-10 text-white">
                 <h3 className="text-3xl sm:text-4xl font-bold mb-3">Join our upcoming events</h3>
                 <p className="text-white/85 text-base sm:text-lg">Connect with the AI & ML community at our next gatherings.</p>

--- a/tests/article-review-boundaries.test.ts
+++ b/tests/article-review-boundaries.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..");
+
+function source(path: string) {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+describe("article review component boundaries", () => {
+  test("shared article components expose stable comment targets", () => {
+    expect(source("app/components/articles/ArticleDisclaimer.tsx")).toContain('data-cf-component-id="disclaimer"');
+    expect(source("app/components/articles/ArticleReferences.tsx")).toContain('data-cf-component-id="references"');
+    expect(source("app/components/articles/ArticleLayout.tsx")).toContain('data-cf-component-id="authoritative-references"');
+  });
+
+  test("upcoming events CTA exposes the same review target with or without events", () => {
+    const content = source("app/components/articles/UpcomingEventsCTA.tsx");
+
+    expect(content.match(/data-cf-component-id="events-cta"/g)?.length).toBe(2);
+    expect(content.match(/data-cf-component-type="events-cta"/g)?.length).toBe(2);
+    expect(content.match(/data-cf-component-label="Upcoming events CTA"/g)?.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds stable Content Factory review boundary attributes to shared article disclaimer, references, layout references, and events CTA components.
- Covers both empty and populated UpcomingEventsCTA branches.
- Adds a regression test for the fixed shared article review targets.

## Validation
- bun test tests/article-review-boundaries.test.ts tests/vibe-marketing-run-view.test.ts
