### PR TITLE
[codex] Fix MLAI topic selection drift

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -384,13 +384,13 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
     latestRuns,
     latestRunsByWorkflow,
     topicCandidates: Array.isArray(payload.topicCandidates)
-      ? payload.topicCandidates.map(normalizeTopicCandidate)
+      ? canonicalizeTopicCandidates(payload.topicCandidates.map(normalizeTopicCandidate), "topic")
       : [],
     topicPillars: Array.isArray(rawTopicPillars)
       ? rawTopicPillars.map(normalizeTopicPillar).filter((pillar): pillar is VibeMarketingTopicPillar => Boolean(pillar))
       : [],
     hiddenTopicCandidates: Array.isArray(payload.hiddenTopicCandidates)
-      ? payload.hiddenTopicCandidates.map(normalizeTopicCandidate)
+      ? canonicalizeTopicCandidates(payload.hiddenTopicCandidates.map(normalizeTopicCandidate), "hidden")
       : [],
     declinedTopicFeedback: Array.isArray(rawDeclinedTopicFeedback)
       ? rawDeclinedTopicFeedback
@@ -451,6 +451,11 @@ function normalizeStartupProfile(payload: Record<string, unknown>): VibeMarketin
 function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
   const payload = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
   const keyword = asNullableString(payload.keyword) ?? asNullableString(payload.target_keyword) ?? "Topic";
+  const rawCandidateId =
+    asNullableString(payload.rawCandidateId) ??
+    asNullableString(payload.raw_candidate_id) ??
+    asNullableString(payload.id) ??
+    keyword;
   const normalizePaaQuestions = (value: unknown): VibeMarketingTopicCandidate["paaQuestions"] => {
     if (!Array.isArray(value)) return [];
     return value
@@ -465,7 +470,8 @@ function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
       .filter((item) => item.question);
   };
   return {
-    id: String(payload.id ?? keyword),
+    id: rawCandidateId,
+    rawCandidateId,
     keyword,
     title:
       asNullableString(payload.title) ??
@@ -512,6 +518,49 @@ function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
   };
 }
 
+function topicCandidateIdPart(value: unknown, fallback = "topic"): string {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || fallback;
+}
+
+export function stableTopicCandidateId(candidate: Pick<VibeMarketingTopicCandidate, "id" | "rawCandidateId" | "keyword" | "title" | "sourceRunId" | "source">, namespace = "topic"): string {
+  const namespacePart = topicCandidateIdPart(namespace);
+  if ((!candidate.rawCandidateId || candidate.rawCandidateId === candidate.id) && candidate.id?.startsWith(`${namespacePart}:`)) {
+    return candidate.id;
+  }
+  const keywordPart = topicCandidateIdPart(candidate.keyword || candidate.title);
+  const sourceRunId = candidate.sourceRunId?.trim();
+  if (sourceRunId) {
+    return `${namespacePart}:run:${topicCandidateIdPart(sourceRunId, "source")}:${keywordPart}`;
+  }
+  const rawId = candidate.rawCandidateId || candidate.id;
+  if (rawId) {
+    return `${namespacePart}:${topicCandidateIdPart(rawId, "candidate")}:${keywordPart}`;
+  }
+  return `${namespacePart}:${topicCandidateIdPart(candidate.source, "candidate")}:${keywordPart}`;
+}
+
+export function canonicalizeTopicCandidates(
+  candidates: VibeMarketingTopicCandidate[],
+  namespace = "topic",
+): VibeMarketingTopicCandidate[] {
+  const seen = new Map<string, number>();
+  return candidates.map((candidate) => {
+    const baseId = stableTopicCandidateId(candidate, namespace);
+    const nextCount = (seen.get(baseId) ?? 0) + 1;
+    seen.set(baseId, nextCount);
+    return {
+      ...candidate,
+      rawCandidateId: candidate.rawCandidateId ?? candidate.id,
+      id: nextCount === 1 ? baseId : `${baseId}:${nextCount}`,
+    };
+  });
+}
+
 function normalizeTopicPillar(raw: unknown): VibeMarketingTopicPillar | null {
   const payload = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
   if (!payload) return null;
@@ -529,7 +578,7 @@ function normalizeTopicPillar(raw: unknown): VibeMarketingTopicPillar | null {
     colorKey: asNullableString(payload.colorKey) ?? asNullableString(payload.color_key) ?? "purple",
     source: asNullableString(payload.source) ?? "semantic_cluster",
     topicCandidates: Array.isArray(rawCandidates)
-      ? rawCandidates.map(normalizeTopicCandidate)
+      ? canonicalizeTopicCandidates(rawCandidates.map(normalizeTopicCandidate), `pillar:${slug}`)
       : [],
   };
 }

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -756,11 +756,12 @@ export async function action({ request, context }: Route.ActionArgs) {
         };
       }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
+      const isCustomTopic = !topicCandidateId || topicCandidateId === "__custom__";
       const selectedCandidate =
-        topicCandidateId && topicCandidateId !== "__custom__"
+        !isCustomTopic
           ? bootstrap.topicCandidates.find((candidate) => candidate.id === topicCandidateId) ?? null
           : null;
-      if (topicCandidateId && topicCandidateId !== "__custom__" && !selectedCandidate) {
+      if (!isCustomTopic && !selectedCandidate) {
         return {
           intent,
           error: "That topic is no longer available. Choose a pending topic or enter a custom article.",
@@ -792,7 +793,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         deliveryMode: stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap),
         deliveryModeExplicit: stringFromForm(formData, "deliveryModeExplicit") === "true",
         deliveryModeConfirmed: true,
-        sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
+        sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       return redirect("/founder-tools/marketing/create?step=writeCheck");

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -52,6 +52,7 @@ import {
   startVibeMarketingLivePreview,
   startVibeMarketingArticle,
   updateVibeMarketingComponentComment,
+  canonicalizeTopicCandidates,
 } from "~/lib/vibe-marketing";
 import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
 import type {
@@ -486,8 +487,9 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         return { intent, error: "Merge the articles setup PR before generating articles. If you merged it in GitHub, refresh merge status." };
       }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
+      const isCustomTopic = !topicCandidateId || topicCandidateId === "__custom__";
       const selectedCandidate =
-        topicCandidateId && topicCandidateId !== "__custom__"
+        !isCustomTopic
           ? bootstrap.topicCandidates.find((candidate) => candidate.id === topicCandidateId) ?? null
           : null;
       const candidateTitle = stringFromForm(formData, "candidateTitle");
@@ -508,7 +510,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         deliveryMode: stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap),
         deliveryModeExplicit: stringFromForm(formData, "deliveryModeExplicit") === "true",
         deliveryModeConfirmed: true,
-        sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceRunId") || runId,
+        sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceRunId") || runId,
       });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
     }
@@ -608,10 +610,10 @@ function topicCandidatesFromRun(run: { result?: Record<string, unknown>; runId: 
     );
     appendCandidateSource(rawCandidates, mapping.selected);
   }
-  return rawCandidates
+  const candidates = rawCandidates
     .map((raw, index): VibeMarketingTopicCandidate | null => {
       if (typeof raw === "string") {
-        return { id: String(index), keyword: raw, title: raw, sourceRunId: run.runId };
+        return { id: String(index), rawCandidateId: String(index), keyword: raw, title: raw, sourceRunId: run.runId };
       }
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
       const payload = raw as Record<string, unknown>;
@@ -632,6 +634,7 @@ function topicCandidatesFromRun(run: { result?: Record<string, unknown>; runId: 
       if (!keyword && !title) return null;
       return {
         id: asString(payload.id) || asString(payload.keyword_id) || String(index),
+        rawCandidateId: asString(payload.id) || asString(payload.keyword_id) || String(index),
         keyword: keyword || title,
         title: title || keyword,
         reason: asString(payload.reason) || asString(payload.selection_reason) || asString(payload.rationale),
@@ -650,6 +653,7 @@ function topicCandidatesFromRun(run: { result?: Record<string, unknown>; runId: 
       };
     })
     .filter((candidate): candidate is VibeMarketingTopicCandidate => candidate !== null);
+  return canonicalizeTopicCandidates(candidates, "topic");
 }
 
 function StepStatusDot({ status }: { status: string }) {

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -538,16 +538,17 @@ export async function action({ request, context }: Route.ActionArgs) {
         return { intent, error: "Merge the articles setup PR before generating articles. If you merged it in GitHub, refresh merge status." };
       }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
+      const isCustomTopic = !topicCandidateId || topicCandidateId === "__custom__";
       const candidatePool = [
         ...bootstrap.topicCandidates,
         ...bootstrap.topicPillars.flatMap((pillar) => pillar.topicCandidates),
       ];
       const selectedCandidate =
-        topicCandidateId && topicCandidateId !== "__custom__"
+        !isCustomTopic
           ? candidatePool.find((candidate) => candidate.id === topicCandidateId) ?? null
           : null;
 
-      if (topicCandidateId && topicCandidateId !== "__custom__" && !selectedCandidate) {
+      if (!isCustomTopic && !selectedCandidate) {
         return { intent, error: "That topic is no longer available. Choose another topic or enter a custom one." };
       }
 
@@ -574,7 +575,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         deliveryMode: stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap),
         deliveryModeExplicit: stringFromForm(formData, "deliveryModeExplicit") === "true",
         deliveryModeConfirmed: true,
-        sourceRunId: selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
+        sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
 
       if (result.runId) {
@@ -3538,7 +3539,7 @@ function ReturningTopicPickerPage({
             <input type="hidden" name="topicCandidateId" value={activeTab === "choose" ? selectedTopicId : "__custom__"} />
             <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} />
             <input type="hidden" name="deliveryModeExplicit" value="false" />
-            <input type="hidden" name="sourceDiscoveryRunId" value={selectedTopic?.sourceRunId ?? ""} />
+            <input type="hidden" name="sourceDiscoveryRunId" value={activeTab === "choose" ? selectedTopic?.sourceRunId ?? "" : ""} />
             {activeTab === "choose" ? (
               <>
                 <input type="hidden" name="targetKeyword" value={selectedTopic?.keyword ?? ""} />

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -260,6 +260,7 @@ export interface VibeMarketingCheck {
 
 export interface VibeMarketingTopicCandidate {
   id: string;
+  rawCandidateId?: string | null;
   keyword: string;
   title: string;
   reason?: string | null;

--- a/tests/vibe-marketing-topic-selection.test.ts
+++ b/tests/vibe-marketing-topic-selection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { canonicalizeTopicCandidates } from "../app/lib/vibe-marketing";
+import type { VibeMarketingTopicCandidate } from "../app/types/vibe-marketing";
+
+function candidate(overrides: Partial<VibeMarketingTopicCandidate>): VibeMarketingTopicCandidate {
+  return {
+    id: "0",
+    rawCandidateId: "0",
+    keyword: "tech central sydney",
+    title: "Tech Central Sydney",
+    ...overrides,
+  };
+}
+
+describe("vibe marketing topic selection", () => {
+  test("gives duplicate raw candidate ids stable unique ids", () => {
+    const candidates = canonicalizeTopicCandidates(
+      [
+        candidate({
+          id: "2",
+          rawCandidateId: "2",
+          keyword: "tech central sydney",
+          title: "Tech Central Sydney",
+          sourceRunId: "run-tech-central",
+        }),
+        candidate({
+          id: "2",
+          rawCandidateId: "2",
+          keyword: "how do ai detectors work",
+          title: "How Do AI Detectors Work",
+          sourceRunId: "run-ai-detectors",
+        }),
+      ],
+      "topic",
+    );
+
+    expect(candidates[0].id).toBe("topic:run:run-tech-central:tech-central-sydney");
+    expect(candidates[1].id).toBe("topic:run:run-ai-detectors:how-do-ai-detectors-work");
+    expect(new Set(candidates.map((item) => item.id)).size).toBe(2);
+    expect(candidates[1].rawCandidateId).toBe("2");
+  });
+});


### PR DESCRIPTION
## Summary
- canonicalize Vibe Marketing topic candidate IDs so duplicated raw IDs cannot resolve to the first row
- preserve raw candidate IDs separately for diagnostics
- keep custom topic starts from inheriting stale source discovery runs

## Validation
- bun test tests/vibe-marketing-topic-selection.test.ts
- bun run typecheck