### PR TITLE
[codex] Add Roo billing metadata to article starts

### DIFF
--- a/app/lib/vibe-marketing-billing.ts
+++ b/app/lib/vibe-marketing-billing.ts
@@ -1,0 +1,16 @@
+export const VIBE_MARKETING_ARTICLE_JOB_COST_POINTS = 6;
+export const VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS = 1;
+
+function randomIdPart() {
+  const runtimeCrypto = globalThis.crypto;
+  if (typeof runtimeCrypto?.randomUUID === "function") {
+    return runtimeCrypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createVibeMarketingClientRequestId(prefix: string, scope = "") {
+  const cleanPrefix = prefix.trim() || "vibe-marketing";
+  const cleanScope = scope.trim();
+  return [cleanPrefix, cleanScope, randomIdPart()].filter(Boolean).join(":");
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -29,6 +29,10 @@ import { readableBackendError } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
+import {
+  VIBE_MARKETING_ARTICLE_JOB_COST_POINTS,
+  createVibeMarketingClientRequestId,
+} from "~/lib/vibe-marketing-billing";
 import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import { combineCompanyContext as combineStartupCompanyContext } from "~/lib/vibe-marketing-startup-setup";
 import {
@@ -489,7 +493,13 @@ export async function loader({ request, context }: Route.LoaderArgs) {
       };
     }
   }
-  return { bootstrap, githubRepos };
+  return {
+    bootstrap,
+    githubRepos,
+    billingRequestIds: {
+      articleJob: createVibeMarketingClientRequestId("vibe-article-job"),
+    },
+  };
 }
 
 export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
@@ -784,6 +794,8 @@ export async function action({ request, context }: Route.ActionArgs) {
         };
       }
       const result = await startVibeMarketingArticle(env, request, {
+        clientRequestId: stringFromForm(formData, "clientRequestId"),
+        client_request_id: stringFromForm(formData, "clientRequestId"),
         topic,
         targetKeyword,
         customTitle: customTitle || selectedCandidate?.title || "",
@@ -911,7 +923,7 @@ function PanelHeader({
 }
 
 export default function FounderToolsMarketingCreate() {
-  const { bootstrap, githubRepos } = useLoaderData<typeof loader>();
+  const { bootstrap, githubRepos, billingRequestIds } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
   const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap);
   const requestedStep = normalizeStep(searchParams.get("step"), activeStep);
@@ -1403,6 +1415,7 @@ export default function FounderToolsMarketingCreate() {
               ) : null}
               <Form method="POST" className="space-y-5">
                 <input type="hidden" name="intent" value="start-article" />
+                <input type="hidden" name="clientRequestId" value={billingRequestIds.articleJob} />
                 <input type="hidden" name="sourceDiscoveryRunId" value={latestDiscovery?.runId ?? ""} />
                 {!isCustomArticleSelected ? <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} /> : null}
                 {!isCustomArticleSelected ? <input type="hidden" name="deliveryModeExplicit" value="false" /> : null}
@@ -1489,7 +1502,7 @@ export default function FounderToolsMarketingCreate() {
                     </div>
                     <button type="submit" disabled={isSubmitting || !bootstrap.checks.baseline?.passed} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
                       {articleStartPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                      {articleStartPending ? "Starting article..." : "Generate draft article"}
+                      {articleStartPending ? "Starting article..." : `Generate draft article (${VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} pts)`}
                     </button>
                   </div>
                 </div>

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -25,6 +25,10 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
 import { getEnv } from "~/lib/env.server";
+import {
+  VIBE_MARKETING_ARTICLE_JOB_COST_POINTS,
+  createVibeMarketingClientRequestId,
+} from "~/lib/vibe-marketing-billing";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   articleReviewApproveIntentForRun,
@@ -294,7 +298,15 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       setupRun = null;
     }
   }
-  return { run, bootstrap, setupRun, githubRepos };
+  return {
+    run,
+    bootstrap,
+    setupRun,
+    githubRepos,
+    billingRequestIds: {
+      articleJob: createVibeMarketingClientRequestId("vibe-article-job", runId),
+    },
+  };
 }
 
 export async function action({ request, params, context }: Route.ActionArgs) {
@@ -501,6 +513,8 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         return { intent, error: "Choose a discovered topic or enter a custom title or keyword before generating an article." };
       }
       const result = await startVibeMarketingArticle(env, request, {
+        clientRequestId: stringFromForm(formData, "clientRequestId"),
+        client_request_id: stringFromForm(formData, "clientRequestId"),
         topic,
         targetKeyword,
         customTitle,
@@ -3610,7 +3624,7 @@ function workflowProgressForRunPage(
 }
 
 export default function FounderToolsMarketingRun() {
-  const { run: loaderRun, bootstrap, setupRun: loaderSetupRun, githubRepos } = useLoaderData<typeof loader>();
+  const { run: loaderRun, bootstrap, setupRun: loaderSetupRun, githubRepos, billingRequestIds } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const location = useLocation();
@@ -3874,6 +3888,7 @@ export default function FounderToolsMarketingRun() {
               {discoveryCandidates.length > 0 && selectedDiscoveryCandidate ? (
                 <Form method="POST" className="mt-4 space-y-4">
                   <input type="hidden" name="intent" value="start-article" />
+                  <input type="hidden" name="clientRequestId" value={billingRequestIds.articleJob} />
                   <input type="hidden" name="candidateTitle" value={selectedDiscoveryCandidate.title} />
                   <input type="hidden" name="candidateKeyword" value={selectedDiscoveryCandidate.keyword} />
                   <input type="hidden" name="sourceRunId" value={selectedDiscoveryCandidate.sourceRunId ?? run.runId} />
@@ -3898,7 +3913,7 @@ export default function FounderToolsMarketingRun() {
                       </div>
                       <button type="submit" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50">
                         {pendingActions.isPending("start-article") ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                        {pendingActions.isPending("start-article") ? "Starting article..." : "Generate draft article"}
+                        {pendingActions.isPending("start-article") ? "Starting article..." : `Generate draft article (${VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} pts)`}
                       </button>
                     </div>
                   </div>

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -48,6 +48,11 @@ import {
   isAutofillStatusPollFailure,
 } from "~/lib/vibe-marketing-autofill-state";
 import { shouldShowVibeMarketingTopicPicker } from "~/lib/vibe-marketing-landing";
+import {
+  VIBE_MARKETING_ARTICLE_JOB_COST_POINTS,
+  VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS,
+  createVibeMarketingClientRequestId,
+} from "~/lib/vibe-marketing-billing";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   controlVibeMarketingRun,
@@ -277,11 +282,25 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   }
 
   if (!vibeContext.appUser) {
-    return { bootstrap: emptyBootstrapFromProfile(vibeContext.profile), hasFounderCompany: false };
+    return {
+      bootstrap: emptyBootstrapFromProfile(vibeContext.profile),
+      hasFounderCompany: false,
+      billingRequestIds: {
+        articleJob: createVibeMarketingClientRequestId("vibe-article-job"),
+        contentIslandTopics: createVibeMarketingClientRequestId("vibe-content-island-topics"),
+      },
+    };
   }
 
   const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
-  return { bootstrap, hasFounderCompany: true };
+  return {
+    bootstrap,
+    hasFounderCompany: true,
+    billingRequestIds: {
+      articleJob: createVibeMarketingClientRequestId("vibe-article-job"),
+      contentIslandTopics: createVibeMarketingClientRequestId("vibe-content-island-topics"),
+    },
+  };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -471,6 +490,8 @@ export async function action({ request, context }: Route.ActionArgs) {
         pillar.topicCandidates.find((candidate) => candidate.pillarKeyword)?.pillarKeyword ||
         pillar.name;
       const run = await startVibeMarketingDiscovery(env, request, {
+        clientRequestId: stringFromForm(formData, "clientRequestId"),
+        client_request_id: stringFromForm(formData, "clientRequestId"),
         contentIslandSlug: pillar.slug,
         content_island_slug: pillar.slug,
         contentIslandName: pillar.name,
@@ -566,6 +587,8 @@ export async function action({ request, context }: Route.ActionArgs) {
       }
 
       const result = await startVibeMarketingArticle(env, request, {
+        clientRequestId: stringFromForm(formData, "clientRequestId"),
+        client_request_id: stringFromForm(formData, "clientRequestId"),
         topic,
         targetKeyword,
         customTitle: customTitle || selectedCandidate?.title || "",
@@ -2327,7 +2350,7 @@ function TopicRow({
               : rowTheme?.idleButton ?? "bg-violet-50 text-violet-700 hover:bg-violet-100",
           )}
         >
-          {selected ? "Continue" : "Select"}
+          {selected ? `Continue (${VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} pts)` : "Select"}
           {selected && submitting ? (
             <Loader2 className={clsx("h-4 w-4 animate-spin", rowTheme?.arrow ?? "text-violet-500")} />
           ) : (
@@ -2987,7 +3010,7 @@ function TopicPillarsSection({
                   </>
                 ) : (
                   <>
-                    Generate
+                    Generate ({VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS} pt)
                     <ArrowRight className={clsx("h-4 w-4", theme.arrow)} />
                   </>
                 )}
@@ -3032,11 +3055,13 @@ function TopicPillarsSection({
 
 function ReturningTopicPickerPage({
   bootstrap,
+  billingRequestIds,
   error,
   errorIntent,
   setupMergedNotice = false,
 }: {
   bootstrap: VibeMarketingBootstrap;
+  billingRequestIds: { articleJob: string; contentIslandTopics: string };
   error: string | null;
   errorIntent?: string | null;
   setupMergedNotice?: boolean;
@@ -3255,6 +3280,7 @@ function ReturningTopicPickerPage({
     setContentIslandRefreshRunId(null);
     const formData = new FormData();
     formData.set("intent", "start-content-island-discovery");
+    formData.set("clientRequestId", `${billingRequestIds.contentIslandTopics}:${pillar.slug}`);
     formData.set("contentIslandSlug", pillar.slug);
     formData.set("contentIslandName", pillar.name);
     formData.set("contentIslandKeyword", pillar.topicCandidates.find((candidate) => candidate.pillarKeyword)?.pillarKeyword ?? pillar.name);
@@ -3536,6 +3562,7 @@ function ReturningTopicPickerPage({
         <div className="space-y-5">
           <Form ref={articleFormRef} method="POST" className="space-y-5">
             <input type="hidden" name="intent" value="start-article" />
+            <input type="hidden" name="clientRequestId" value={billingRequestIds.articleJob} />
             <input type="hidden" name="topicCandidateId" value={activeTab === "choose" ? selectedTopicId : "__custom__"} />
             <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} />
             <input type="hidden" name="deliveryModeExplicit" value="false" />
@@ -3913,7 +3940,7 @@ function ReturningTopicPickerPage({
 }
 
 export default function FounderToolsMarketing() {
-  const { bootstrap } = useLoaderData<typeof loader>();
+  const { bootstrap, billingRequestIds } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const location = useLocation();
   const error = actionError(actionData);
@@ -3924,7 +3951,13 @@ export default function FounderToolsMarketing() {
   return (
     <div className="min-h-screen bg-[#fbfaf8]">
       {shouldShowTopicPicker ? (
-        <ReturningTopicPickerPage bootstrap={bootstrap} error={error} errorIntent={errorIntent} setupMergedNotice={setupMergedNotice} />
+        <ReturningTopicPickerPage
+          bootstrap={bootstrap}
+          billingRequestIds={billingRequestIds}
+          error={error}
+          errorIntent={errorIntent}
+          setupMergedNotice={setupMergedNotice}
+        />
       ) : (
         <VibeMarketingStartupBaselineSetup bootstrap={bootstrap} error={error} />
       )}

--- a/tests/vibe-marketing-billing.test.ts
+++ b/tests/vibe-marketing-billing.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  VIBE_MARKETING_ARTICLE_JOB_COST_POINTS,
+  VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS,
+  createVibeMarketingClientRequestId,
+} from "../app/lib/vibe-marketing-billing";
+
+describe("vibe marketing billing", () => {
+  test("exposes current Roo point costs", () => {
+    expect(VIBE_MARKETING_ARTICLE_JOB_COST_POINTS).toBe(6);
+    expect(VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS).toBe(1);
+  });
+
+  test("creates scoped client request ids for paid actions", () => {
+    const id = createVibeMarketingClientRequestId("vibe-content-island-topics", "ai-growth");
+
+    expect(id.startsWith("vibe-content-island-topics:ai-growth:")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- show 6-point article job and 1-point content-island topic generation costs in Vibe Marketing
- send stable clientRequestId values for paid article starts and content-island topic generation
- keep draft/restart continuation UI free of new-charge copy

## Validation
- bun test tests/vibe-marketing-billing.test.ts
- bun run typecheck using the main checkout node_modules symlink for dependency resolution