### PR TITLE
[codex] Fix StatDoctor exact preview starts

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -798,6 +798,12 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     renderMode: asNullableString(payload.renderMode) ?? asNullableString(payload.render_mode),
     renderConfidence: asNullableString(payload.renderConfidence) ?? asNullableString(payload.render_confidence),
     fallbackReason: asNullableString(payload.fallbackReason) ?? asNullableString(payload.fallback_reason),
+    previewUnavailableReason:
+      asNullableString(payload.previewUnavailableReason) ??
+      asNullableString(payload.preview_unavailable_reason) ??
+      asNullableString(asObjectRecord(payload.proof)?.previewUnavailableReason) ??
+      asNullableString(asObjectRecord(payload.proof)?.preview_unavailable_reason),
+    proof: asObjectRecord(payload.proof),
     nativePreviewFailure: asObjectRecord(payload.nativePreviewFailure ?? payload.native_preview_failure),
     visualFallback: asObjectRecord(payload.visualFallback ?? payload.visual_fallback),
     platformProvider: asNullableString(payload.platformProvider) ?? asNullableString(payload.platform_provider),

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -794,6 +794,7 @@ export async function action({ request, context }: Route.ActionArgs) {
           error: "Choose a discovered topic or enter a custom title or keyword before generating an article.",
         };
       }
+      const deliveryModeExplicit = stringFromForm(formData, "deliveryModeExplicit") === "true";
       const result = await startVibeMarketingArticle(env, request, {
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
@@ -803,9 +804,9 @@ export async function action({ request, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title ?? "",
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap),
-        deliveryModeExplicit: stringFromForm(formData, "deliveryModeExplicit") === "true",
-        deliveryModeConfirmed: true,
+        deliveryMode: deliveryModeExplicit ? stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap) : undefined,
+        deliveryModeExplicit,
+        deliveryModeConfirmed: deliveryModeExplicit,
         sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
@@ -1417,7 +1418,6 @@ export default function FounderToolsMarketingCreate() {
                 <input type="hidden" name="intent" value="start-article" />
                 <input type="hidden" name="clientRequestId" value={billingRequestIds.articleJob} />
                 <input type="hidden" name="sourceDiscoveryRunId" value={latestDiscovery?.runId ?? ""} />
-                {!isCustomArticleSelected ? <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} /> : null}
                 {!isCustomArticleSelected ? <input type="hidden" name="deliveryModeExplicit" value="false" /> : null}
                 <TopicMetricExplainerStrip />
                 <div className="grid gap-3">

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -172,6 +172,22 @@ function isFailedArticlePreview(preview: VibeMarketingRunSummary["livePreview"] 
   return Boolean(preview?.error || LIVE_PREVIEW_FAILURE_STATUSES.has(previewStatus) || LIVE_PREVIEW_FAILURE_STATUSES.has(platformStatus));
 }
 
+function previewUnavailableReason(preview: VibeMarketingRunSummary["livePreview"] | null | undefined) {
+  const proof = preview?.proof && typeof preview.proof === "object" ? (preview.proof as Record<string, unknown>) : {};
+  return String(
+    preview?.previewUnavailableReason ??
+      proof.previewUnavailableReason ??
+      proof.preview_unavailable_reason ??
+      "",
+  )
+    .trim()
+    .toLowerCase();
+}
+
+function isContentOnlyNoRenderPreview(preview: VibeMarketingRunSummary["livePreview"] | null | undefined) {
+  return previewUnavailableReason(preview) === "content_only_no_render_artifact";
+}
+
 function hasActiveLivePreview(preview: VibeMarketingRunSummary["livePreview"] | null | undefined) {
   const previewStatus = String(preview?.status ?? "").trim().toLowerCase();
   const platformStatus = String(preview?.platformStatus ?? "").trim().toLowerCase();
@@ -252,6 +268,9 @@ function hasPendingArticlePreview(run: VibeMarketingRunSummary) {
     return false;
   }
   const preview = run.livePreview;
+  if (isContentOnlyNoRenderPreview(preview)) {
+    return false;
+  }
   if (isFailedArticlePreview(preview)) {
     return false;
   }
@@ -479,7 +498,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       if (result.runId) {
         throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       }
-    } else if (["approve", "deny", "resume", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
+    } else if (["approve", "deny", "resume", "restart", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
       const sourceRunId = stringFromForm(formData, "sourceRunId");
       const controlRunId = intent === "promote-bundle" || intent === "publish-pr" ? sourceRunId || runId : runId;
       const result = await controlVibeMarketingRun(env, request, controlRunId, intent, sourceRunId ? { sourceRunId } : {});
@@ -512,6 +531,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       if (!topic && !targetKeyword) {
         return { intent, error: "Choose a discovered topic or enter a custom title or keyword before generating an article." };
       }
+      const deliveryModeExplicit = stringFromForm(formData, "deliveryModeExplicit") === "true";
       const result = await startVibeMarketingArticle(env, request, {
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
@@ -521,9 +541,9 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title || candidateTitle,
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap),
-        deliveryModeExplicit: stringFromForm(formData, "deliveryModeExplicit") === "true",
-        deliveryModeConfirmed: true,
+        deliveryMode: deliveryModeExplicit ? stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap) : undefined,
+        deliveryModeExplicit,
+        deliveryModeConfirmed: deliveryModeExplicit,
         sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceRunId") || runId,
       });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
@@ -2232,6 +2252,7 @@ function ArticlePreviewEmptyState({
   const hasManifest = Boolean(run.componentManifest);
   const hostedPreview = preview?.previewMode === "platform_deployment";
   const failed = isFailedArticlePreview(preview);
+  const contentOnlyNoRender = isContentOnlyNoRenderPreview(preview);
   const retryablePreviewCodes = new Set([
     "clone_auth_failed",
     "dev_server_startup_failed",
@@ -2246,15 +2267,18 @@ function ArticlePreviewEmptyState({
     "unsupported_runtime_for_v1",
   ]);
   const nativeRetryable = typeof nativePreviewFailure.retryable === "boolean" ? nativePreviewFailure.retryable : undefined;
-  const retryable = preview?.retryable !== false && nativeRetryable !== false ? true : retryablePreviewCodes.has(previewErrorCode);
+  const retryable = !contentOnlyNoRender && (preview?.retryable !== false && nativeRetryable !== false ? true : retryablePreviewCodes.has(previewErrorCode));
   const statusLabel = previewStatus ? previewStatus.replace(/_/g, " ") : "not started";
   const failedPhase = String(preview?.failedPhase || nativePreviewFailure.failedPhase || nativePreviewFailure.failed_phase || "").trim();
   const failedCommand = String(
     preview?.failedCommand || nativePreviewFailure.failedCommand || nativePreviewFailure.failed_command || "",
   ).trim();
   const displayError =
-    String(preview?.error || nativeError || "The article preview could not be prepared. Retry the preview when the generator is available.").trim();
+    contentOnlyNoRender
+      ? "Content-only article runs package markdown and metadata but do not produce repo file overrides for component live preview."
+      : String(preview?.error || nativeError || "The article preview could not be prepared. Retry the preview when the generator is available.").trim();
   const retryPreviewPending = isActionPending?.("start-live-preview") ?? isSubmitting;
+  const restartPreviewPending = isActionPending?.("restart") ?? isSubmitting;
   const diagnosticRows = [
     failedPhase ? ["Phase", failedPhase] : null,
     failedCommand ? ["Command", failedCommand] : null,
@@ -2270,7 +2294,7 @@ function ArticlePreviewEmptyState({
       "",
   ).trim();
 
-  if (failed) {
+  if (failed || contentOnlyNoRender) {
     return (
       <section className="rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-800">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -2307,7 +2331,20 @@ function ArticlePreviewEmptyState({
               ) : null}
             </div>
           </div>
-          {retryable ? (
+          {contentOnlyNoRender ? (
+            <Form method="POST">
+              <button
+                type="submit"
+                name="intent"
+                value="restart"
+                disabled={restartPreviewPending}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-800 shadow-sm transition hover:bg-red-100 disabled:opacity-50 sm:w-auto"
+              >
+                {restartPreviewPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
+                {restartPreviewPending ? "Regenerating..." : "Regenerate with exact preview"}
+              </button>
+            </Form>
+          ) : retryable ? (
             <Form method="POST">
               <input type="hidden" name="force" value="true" />
               <button
@@ -3892,7 +3929,6 @@ export default function FounderToolsMarketingRun() {
                   <input type="hidden" name="candidateTitle" value={selectedDiscoveryCandidate.title} />
                   <input type="hidden" name="candidateKeyword" value={selectedDiscoveryCandidate.keyword} />
                   <input type="hidden" name="sourceRunId" value={selectedDiscoveryCandidate.sourceRunId ?? run.runId} />
-                  <input type="hidden" name="deliveryMode" value={effectiveArticleDeliveryMode(bootstrap)} />
                   <input type="hidden" name="deliveryModeExplicit" value="false" />
                   <div className="grid gap-3">
                     {discoveryCandidates.slice(0, 5).map((candidate, index) => (

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -586,6 +586,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         return { intent, error: "Choose a topic or enter a custom article idea before generating." };
       }
 
+      const deliveryModeExplicit = stringFromForm(formData, "deliveryModeExplicit") === "true";
       const result = await startVibeMarketingArticle(env, request, {
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
@@ -595,9 +596,9 @@ export async function action({ request, context }: Route.ActionArgs) {
         selectedTitle: selectedCandidate?.title ?? "",
         topicCandidateId,
         context: stringFromForm(formData, "articleContext"),
-        deliveryMode: stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap),
-        deliveryModeExplicit: stringFromForm(formData, "deliveryModeExplicit") === "true",
-        deliveryModeConfirmed: true,
+        deliveryMode: deliveryModeExplicit ? stringFromForm(formData, "deliveryMode") || effectiveArticleDeliveryMode(bootstrap) : undefined,
+        deliveryModeExplicit,
+        deliveryModeConfirmed: deliveryModeExplicit,
         sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
 
@@ -3564,7 +3565,6 @@ function ReturningTopicPickerPage({
             <input type="hidden" name="intent" value="start-article" />
             <input type="hidden" name="clientRequestId" value={billingRequestIds.articleJob} />
             <input type="hidden" name="topicCandidateId" value={activeTab === "choose" ? selectedTopicId : "__custom__"} />
-            <input type="hidden" name="deliveryMode" value={effectiveDeliveryMode} />
             <input type="hidden" name="deliveryModeExplicit" value="false" />
             <input type="hidden" name="sourceDiscoveryRunId" value={activeTab === "choose" ? selectedTopic?.sourceRunId ?? "" : ""} />
             {activeTab === "choose" ? (

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -435,6 +435,8 @@ export interface VibeMarketingLivePreview {
   renderMode?: string | null;
   renderConfidence?: string | null;
   fallbackReason?: string | null;
+  previewUnavailableReason?: string | null;
+  proof?: Record<string, unknown>;
   nativePreviewFailure?: Record<string, unknown>;
   visualFallback?: {
     cssSources?: string[];


### PR DESCRIPTION
## Summary
- Stop sending hidden deliveryMode=content_only for normal discovered-topic article starts.
- Keep explicit advanced delivery mode support with deliveryModeExplicit/deliveryModeConfirmed.
- Show Regenerate with exact preview for content_only_no_render_artifact instead of polling a missing preview.

## Validation
- bun test tests/vibe-marketing-run-view.test.ts tests/vibe-marketing-run-polling.test.ts
- bun run typecheck
