### PR TITLE
[codex] Add article setup reset controls

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   LockKeyhole,
   Plus,
+  RotateCcw,
   Search,
   ShieldCheck,
   UserCheck,
@@ -34,6 +35,7 @@ import {
   type ArticleSystemScaffoldStatus,
   type ArticleSystemConnectionStepState,
 } from "~/lib/article-system-connection-steps";
+import { runFailureGuidance } from "~/lib/vibe-marketing-run-failures";
 import { repoScanProgressRefreshKey } from "~/lib/vibe-marketing-run-polling";
 import type { VibeMarketingArticleSetupState, VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
@@ -339,24 +341,28 @@ function FlowStep({
   }, [resetKey, stepState.defaultExpanded]);
 
   const isLocked = stepState.status === "locked";
-  const statusLabel = {
+  const statusLabel = stepState.attentionLabel || {
     active: "Current",
     blocked: "Needs attention",
     complete: "Complete",
     locked: "Not ready yet",
   }[stepState.status];
-  const numberTone = {
-    active: "bg-violet-600 text-white",
-    blocked: "bg-red-600 text-white",
-    complete: "bg-emerald-600 text-white",
-    locked: "bg-slate-200 text-slate-500",
-  }[stepState.status];
-  const statusTone = {
-    active: "bg-violet-50 text-violet-700 ring-violet-100",
-    blocked: "bg-red-50 text-red-700 ring-red-100",
-    complete: "bg-emerald-50 text-emerald-700 ring-emerald-100",
-    locked: "bg-slate-100 text-slate-500 ring-slate-200",
-  }[stepState.status];
+  const numberTone = stepState.attention
+    ? "bg-amber-500 text-white"
+    : {
+        active: "bg-violet-600 text-white",
+        blocked: "bg-red-600 text-white",
+        complete: "bg-emerald-600 text-white",
+        locked: "bg-slate-200 text-slate-500",
+      }[stepState.status];
+  const statusTone = stepState.attention
+    ? "bg-amber-50 text-amber-800 ring-amber-200"
+    : {
+        active: "bg-violet-50 text-violet-700 ring-violet-100",
+        blocked: "bg-red-50 text-red-700 ring-red-100",
+        complete: "bg-emerald-50 text-emerald-700 ring-emerald-100",
+        locked: "bg-slate-100 text-slate-500 ring-slate-200",
+      }[stepState.status];
 
   return (
     <div className="relative pl-12">
@@ -627,6 +633,9 @@ export default function ArticleSystemConnectionPanel({
   const scanFailed = Boolean(effectiveScanRun && SCAN_FAILED_STATUSES.has(effectiveScanRun.status));
   const canonicalScanComplete = articleSetupState?.scanStatus === "completed" && !articleSetupState.scanStale;
   const scanStale = Boolean(effectiveScanRun?.stale || effectiveScanRun?.staleReason === "scan_queue_not_started" || articleSetupState?.scanStale);
+  const scanFailureGuidance = effectiveScanRun && (scanFailed || scanStale) ? runFailureGuidance(effectiveScanRun) : null;
+  const manualFallbackReady = Boolean(scanFailureGuidance);
+  const savedSurfaceUrl = articleSetupState?.routePath || articleSetupHintValue(articleSetupState);
   const scanNeedsSetupApproval = isScanAwaitingSetupApproval(effectiveScanRun);
   const setupRunId = articleSetupState?.setupRunId || (effectiveScanRun ? setupRunIdForRun(effectiveScanRun) : "");
   const inventoryScan = isInventoryScan(effectiveScanRun);
@@ -639,15 +648,19 @@ export default function ArticleSystemConnectionPanel({
       articleSetupState?.routePath ||
       (effectiveScanRun && setupTargetScan && (scanNeedsSetupApproval || setupRunId)),
   );
+  const persistedSetupReady = Boolean(articleSetupState?.setupRunId || articleSetupState?.routePath);
+  const persistedSetupIsStale = Boolean(persistedSetupReady && (scanFailed || scanStale));
   const scanStartPending = actionPending("start-scan");
   const retryScanPending = actionPending("retry-scan");
   const cancelScanPending = actionPending("cancel-scan");
+  const resetArticleSetupPending = actionPending("reset-article-setup");
   const confirmSurfacePending = actionPending("confirm-article-surface");
   const createSurfacePending = actionPending("create-article-surface");
   const [selectedChoiceId, setSelectedChoiceId] = useState("");
   const [manualArticleRoute, setManualArticleRoute] = useState("");
   const [manualRouteError, setManualRouteError] = useState("");
   const [createNewPath, setCreateNewPath] = useState(articleSurfaceDefault || "/articles");
+  const [changingSavedLocation, setChangingSavedLocation] = useState(false);
   const lastScanProgressSignatureRef = useRef("");
   const lastScanProgressAtRef = useRef(Date.now());
   const lastTerminalRevalidationRef = useRef("");
@@ -684,8 +697,9 @@ export default function ArticleSystemConnectionPanel({
   const saveIntent = selectedMode === "create" ? "create-article-surface" : "confirm-article-surface";
   const savePending = confirmSurfacePending || createSurfacePending;
   const scanLoading = Boolean(currentScanRunId && !effectiveScanRun);
-  const savedSurfaceUrl = articleSetupState?.routePath || articleSetupHintValue(articleSetupState);
   const displayedSurfaceUrl = selectedSurfaceUrl || savedSurfaceUrl;
+  const showSavedSetup = setupTargetReady && !changingSavedLocation;
+  const locationChooserReady = Boolean(inventoryReady || changingSavedLocation || manualFallbackReady);
   const scaffoldCheck = bootstrap.checks.scaffold;
   const scaffoldExplicitReady = Boolean(
     scaffoldCheck?.generationReady ||
@@ -750,10 +764,12 @@ export default function ArticleSystemConnectionPanel({
     scanRunning,
     scanFailed,
     scanStale,
-    inventoryReady,
-    setupTargetReady,
+    inventoryReady: locationChooserReady,
+    setupTargetReady: showSavedSetup,
+    persistedSetupIsStale: showSavedSetup && persistedSetupIsStale,
     selectedSurfaceUrl,
     scaffoldStatus,
+    setupSurfaceUrl: displayedSurfaceUrl,
   });
 
   useEffect(() => {
@@ -761,6 +777,7 @@ export default function ArticleSystemConnectionPanel({
     setManualArticleRoute("");
     setManualRouteError("");
     setCreateNewPath(articleSurfaceDefault || "/articles");
+    setChangingSavedLocation(false);
   }, [articleSurfaceDefault, effectiveScanRun?.runId]);
 
   useEffect(() => {
@@ -1049,6 +1066,13 @@ export default function ArticleSystemConnectionPanel({
         <ReassuranceStrip />
       </div>
 
+      {persistedSetupIsStale ? (
+        <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm font-semibold leading-6 text-amber-900">
+          Your last articles/blogs setup is saved, but the latest repository scan needs attention. Re-scan to refresh the choices, or change the saved
+          location and rebuild the setup preview.
+        </div>
+      ) : null}
+
       <div className="mt-6 space-y-5">
         <FlowStep
           number={1}
@@ -1221,8 +1245,15 @@ export default function ArticleSystemConnectionPanel({
               ) : null}
             </>
           ) : setupTargetReady ? (
-            <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm font-semibold leading-6 text-emerald-800">
-              Repository scan completed previously and an articles/blogs location is already saved.
+            <div
+              className={clsx(
+                "rounded-2xl border p-4 text-sm font-semibold leading-6",
+                persistedSetupIsStale ? "border-amber-200 bg-amber-50 text-amber-900" : "border-emerald-100 bg-emerald-50 text-emerald-800",
+              )}
+            >
+              {persistedSetupIsStale
+                ? "A previous articles/blogs location is saved, but the latest scan did not complete cleanly."
+                : "Repository scan completed previously and an articles/blogs location is already saved."}
             </div>
           ) : (
             <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm font-semibold leading-6 text-slate-600">
@@ -1237,22 +1268,61 @@ export default function ArticleSystemConnectionPanel({
           description="Pick the route we found, paste a path manually, or create a new articles directory."
           stepState={stepStates.chooseLocation}
         >
-          {setupTargetReady && !inventoryReady ? (
+          {showSavedSetup && !inventoryReady ? (
             <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-              <div className="flex gap-3">
-                <span className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
-                  <CheckCircle2 className="h-6 w-6" />
-                </span>
-                <div>
-                  <p className="text-sm font-black text-slate-950">Articles route selected</p>
-                  <p className="mt-1 text-sm font-semibold text-slate-600">
-                    {displayedSurfaceUrl ? `Articles route selected: ${displayedSurfaceUrl}` : "The saved articles route will be used for article drafts and previews."}
-                  </p>
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="flex gap-3">
+                  <span className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
+                    <CheckCircle2 className="h-6 w-6" />
+                  </span>
+                  <div>
+                    <p className="text-sm font-black text-slate-950">Articles/blogs location already selected</p>
+                    {displayedSurfaceUrl ? (
+                      <p className="mt-1 break-all text-sm font-semibold text-slate-600">Public route: {displayedSurfaceUrl}</p>
+                    ) : (
+                      <p className="mt-1 text-sm font-semibold text-amber-800">Saved location could not be resolved. Re-scan to refresh your choices.</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row lg:flex-col">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setChangingSavedLocation(true);
+                      setSelectedChoiceId("");
+                      setManualArticleRoute(displayedSurfaceUrl || "");
+                      setManualRouteError("");
+                    }}
+                    className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-black text-slate-700 shadow-sm transition hover:bg-slate-50"
+                  >
+                    Change location
+                  </button>
+                  <Form method="POST">
+                    <input type="hidden" name="intent" value="start-scan" />
+                    <input type="hidden" name="scanPurpose" value="inventory" />
+                    <input type="hidden" name="articleSurfaceMode" value="not_sure" />
+                    <input type="hidden" name="githubRepo" value={selectedRepo} />
+                    <button
+                      type="submit"
+                      disabled={scanStartPending || scanRunning || !selectedRepo}
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-4 py-2.5 text-sm font-black text-violet-700 shadow-sm transition hover:bg-violet-50 disabled:opacity-50"
+                    >
+                      {scanStartPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+                      {scanStartPending ? "Starting scan..." : "Re-scan repository"}
+                    </button>
+                  </Form>
                 </div>
               </div>
             </div>
-          ) : inventoryReady ? (
+          ) : locationChooserReady ? (
             <div className="space-y-3">
+              {manualFallbackReady && scanFailureGuidance ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm font-semibold leading-6 text-amber-900">
+                  <p className="font-black">Scan issue: {scanFailureGuidance.reason}</p>
+                  <p className="mt-1">Next step: {scanFailureGuidance.nextStep}</p>
+                  <p className="mt-1">You can still paste the known public articles/blogs route below, or create a new articles directory.</p>
+                </div>
+              ) : null}
               {publicRouteCandidates.length ? (
                 publicRouteCandidates.map((candidate) => (
                   <SurfaceChoiceCard
@@ -1382,6 +1452,49 @@ export default function ArticleSystemConnectionPanel({
           </div>
           <div className="mt-4 flex-shrink-0 sm:mt-0">{scaffoldAction}</div>
         </div>
+
+        {setupTargetReady || scaffoldReady ? (
+          <div className="rounded-2xl border border-red-100 bg-red-50 p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-black text-red-900">Reset articles setup</p>
+                <p className="mt-1 text-sm font-semibold leading-6 text-red-800">
+                  Clear the saved articles/blogs setup for this repository and start the setup flow again.
+                </p>
+              </div>
+              <Form
+                method="POST"
+                onSubmit={(event) => {
+                  if (typeof window !== "undefined" && !window.confirm("Reset the saved articles setup for this repository?")) {
+                    event.preventDefault();
+                  }
+                }}
+              >
+                <input type="hidden" name="githubRepo" value={selectedRepo} />
+                <button
+                  type="submit"
+                  name="intent"
+                  value="reset-article-setup"
+                  disabled={resetArticleSetupPending || !selectedRepo}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-3 text-sm font-black text-red-700 shadow-sm transition hover:bg-red-100 disabled:opacity-50 sm:w-auto"
+                >
+                  {resetArticleSetupPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCcw className="h-4 w-4" />}
+                  {resetArticleSetupPending ? "Resetting..." : "Reset articles setup"}
+                </button>
+              </Form>
+            </div>
+          </div>
+        ) : null}
+
+        {connected && scaffoldReady && !setupBlocked && !setupTargetReady && !inventoryReady ? (
+          <Link
+            to="/founder-tools/marketing/create?step=research"
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700"
+          >
+            Continue
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        ) : null}
       </div>
     </section>
   );

--- a/app/components/MarketingRunProgressCard.tsx
+++ b/app/components/MarketingRunProgressCard.tsx
@@ -1,6 +1,7 @@
 import { ArrowPathIcon, ExclamationTriangleIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
 import type { ReactNode } from "react";
+import { runFailureGuidance } from "~/lib/vibe-marketing-run-failures";
 import type { VibeMarketingRunSummary, VibeMarketingScanProgress } from "~/types/vibe-marketing";
 
 export type MarketingRunProgressTheme = {
@@ -35,6 +36,8 @@ function labelForCurrentStep(step: string) {
 }
 
 function shortErrorMessage(run: VibeMarketingRunSummary, error: string) {
+  const guidance = runFailureGuidance(run);
+  if (guidance.specific) return guidance.summary;
   if (["repo_scan", "content_factory_scan"].includes(run.workflow)) {
     return "Repository scan failed. Retry the scan or choose a different repository.";
   }
@@ -132,6 +135,10 @@ export default function MarketingRunProgressCard({
   const completedSegmentClassName = theme?.completedSegmentClassName ?? "bg-violet-600";
   const activeSegmentClassName = theme?.activeSegmentClassName ?? "animate-pulse bg-violet-300";
   const pendingSegmentClassName = theme?.pendingSegmentClassName ?? "bg-white";
+  const failureGuidance = attentionState ? runFailureGuidance(run) : null;
+  const failureReason = failureGuidance?.reason ?? "";
+  const rawError = run.errors[0] ?? "";
+  const showFailureDetails = Boolean(failureGuidance || rawError);
 
   return (
     <div
@@ -194,10 +201,13 @@ export default function MarketingRunProgressCard({
           <p className="mt-2 text-xs font-medium text-gray-500">
             {progressFooter}
           </p>
-          {run.errors.length > 0 ? (
+          {showFailureDetails ? (
             <details className="mt-3 rounded-xl border border-red-200 bg-white/80 px-4 py-3 text-sm text-red-700">
-              <summary className="cursor-pointer font-bold">{shortErrorMessage(run, run.errors[0])}</summary>
-              <p className="mt-2 break-words font-mono text-xs leading-5 text-red-600">{run.errors[0]}</p>
+              <summary className="cursor-pointer font-bold">{shortErrorMessage(run, rawError)}</summary>
+              {failureReason ? <p className="mt-2 font-semibold leading-6">{failureReason}</p> : null}
+              {failureGuidance?.nextStep ? <p className="mt-2 font-semibold leading-6">Next step: {failureGuidance.nextStep}</p> : null}
+              {failureGuidance?.code ? <p className="mt-2 text-xs font-black uppercase tracking-wide text-red-500">{failureGuidance.code.replace(/_/g, " ")}</p> : null}
+              {rawError && rawError !== failureReason ? <p className="mt-2 break-words font-mono text-xs leading-5 text-red-600">{rawError}</p> : null}
             </details>
           ) : null}
         </div>

--- a/app/lib/article-system-connection-steps.ts
+++ b/app/lib/article-system-connection-steps.ts
@@ -19,6 +19,8 @@ export type ArticleSystemConnectionStepState = {
   defaultExpanded: boolean;
   disabled: boolean;
   unavailableReason: string;
+  attention?: boolean;
+  attentionLabel?: string;
 };
 
 export type ArticleSystemConnectionStepInput = {
@@ -30,8 +32,10 @@ export type ArticleSystemConnectionStepInput = {
   scanStale?: boolean;
   inventoryReady?: boolean;
   setupTargetReady?: boolean;
+  persistedSetupIsStale?: boolean;
   selectedSurfaceUrl?: string | null;
   scaffoldStatus?: ArticleSystemScaffoldStatus;
+  setupSurfaceUrl?: string | null;
 };
 
 export function articleSystemScaffoldActionLabel(status: ArticleSystemScaffoldStatus) {
@@ -48,9 +52,17 @@ export function articleSystemScaffoldActionLabel(status: ArticleSystemScaffoldSt
 export function articleSystemConnectionStepStates(input: ArticleSystemConnectionStepInput): Record<ArticleSystemConnectionStepId, ArticleSystemConnectionStepState> {
   const hasScanRun = Boolean(input.currentScanRunId?.trim());
   const hasSelectedSurface = Boolean(input.selectedSurfaceUrl?.trim());
+  const hasSetupSurface = Boolean(input.setupSurfaceUrl?.trim());
+  const persistedSetupIsStale = Boolean(input.persistedSetupIsStale && input.setupTargetReady);
   const scanLoadingOrRunning = Boolean(input.scanLoading || input.scanRunning || (hasScanRun && !input.inventoryReady && !input.setupTargetReady && !input.scanFailed && !input.scanStale));
   const scanBlocked = Boolean(input.scanFailed || input.scanStale);
   const hasSetupTarget = Boolean(input.setupTargetReady || hasSelectedSurface);
+  const staleSetupAttention = persistedSetupIsStale
+    ? {
+        attention: true,
+        attentionLabel: "Saved setup needs refresh",
+      }
+    : {};
 
   const connect: ArticleSystemConnectionStepState = input.connected
     ? {
@@ -124,9 +136,13 @@ export function articleSystemConnectionStepStates(input: ArticleSystemConnection
     chooseLocation = {
       id: "chooseLocation",
       status: "complete",
-      defaultExpanded: Boolean(input.inventoryReady && hasSelectedSurface),
+      defaultExpanded: Boolean(
+        (input.inventoryReady && hasSelectedSurface) ||
+          (input.setupTargetReady && (!input.inventoryReady || !hasSetupSurface || persistedSetupIsStale)),
+      ),
       disabled: false,
       unavailableReason: "",
+      ...staleSetupAttention,
     };
   } else if (input.inventoryReady) {
     chooseLocation = {
@@ -156,8 +172,8 @@ export function articleSystemConnectionStepStates(input: ArticleSystemConnection
       defaultExpanded: false,
       disabled: true,
       unavailableReason: input.connected
-        ? "Choose an articles route before building the articles scaffold."
-        : "Connect GitHub and choose an articles route before building the articles scaffold.",
+        ? "Choose an articles/blogs location before building the setup preview."
+        : "Connect GitHub and choose an articles/blogs location before building the setup preview.",
     };
   } else if (input.scaffoldStatus === "ready" || input.scaffoldStatus === "legacy_ready") {
     buildSetup = {
@@ -166,6 +182,7 @@ export function articleSystemConnectionStepStates(input: ArticleSystemConnection
       defaultExpanded: true,
       disabled: false,
       unavailableReason: "",
+      ...staleSetupAttention,
     };
   } else if (input.scaffoldStatus === "failed") {
     buildSetup = {
@@ -174,6 +191,7 @@ export function articleSystemConnectionStepStates(input: ArticleSystemConnection
       defaultExpanded: true,
       disabled: false,
       unavailableReason: "",
+      ...staleSetupAttention,
     };
   } else {
     buildSetup = {
@@ -182,6 +200,7 @@ export function articleSystemConnectionStepStates(input: ArticleSystemConnection
       defaultExpanded: true,
       disabled: false,
       unavailableReason: "",
+      ...staleSetupAttention,
     };
   }
 

--- a/app/lib/vibe-marketing-run-failures.ts
+++ b/app/lib/vibe-marketing-run-failures.ts
@@ -1,0 +1,114 @@
+import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
+
+type FailureRecord = Record<string, unknown>;
+
+const FAILURE_NESTED_KEYS = [
+  "result",
+  "latest_control_response",
+  "latestControlResponse",
+  "article_system_setup",
+  "articleSystemSetup",
+  "article_system_readiness",
+  "articleSystemReadiness",
+  "model_adapter_report",
+  "modelAdapterReport",
+  "diagnostics",
+  "content_factory_response",
+  "contentFactoryResponse",
+  "livePreview",
+  "live_preview",
+  "proof",
+  "nativePreviewFailure",
+  "native_preview_failure",
+];
+
+function asRecord(value: unknown): FailureRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as FailureRecord) : {};
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function collectFailureRecords(value: unknown, seen = new Set<unknown>(), depth = 0): FailureRecord[] {
+  const record = asRecord(value);
+  if (!Object.keys(record).length || seen.has(record) || depth > 4) return [];
+  seen.add(record);
+  const records = [record];
+  for (const key of FAILURE_NESTED_KEYS) {
+    records.push(...collectFailureRecords(record[key], seen, depth + 1));
+  }
+  return records;
+}
+
+function firstRecordString(records: FailureRecord[], keys: string[]): string {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = cleanString(record[key]);
+      if (value) return value;
+    }
+  }
+  return "";
+}
+
+export function blockingReasonFromPayload(value: unknown): string {
+  return firstRecordString(collectFailureRecords(value), [
+    "blockingReason",
+    "blocking_reason",
+    "modelAdapterBlockingReason",
+    "model_adapter_blocking_reason",
+    "manualReason",
+    "manual_reason",
+  ]);
+}
+
+export function blockingCodeFromPayload(value: unknown): string {
+  return firstRecordString(collectFailureRecords(value), [
+    "blockingCode",
+    "blocking_code",
+    "modelAdapterBlockingCode",
+    "model_adapter_blocking_code",
+    "errorCode",
+    "error_code",
+  ]);
+}
+
+function firstRunError(run: VibeMarketingRunSummary): string {
+  return cleanString(run.errors?.find((error) => cleanString(error))) || cleanString(run.livePreview?.error);
+}
+
+function nextStepForFailure(code: string, reason: string, run: VibeMarketingRunSummary): string {
+  const normalizedCode = code.toUpperCase();
+  const reasonText = reason.toLowerCase();
+  if (run.stale || run.staleReason === "scan_queue_not_started") {
+    return "Retry the scan, or cancel it and start again.";
+  }
+  if (
+    normalizedCode.includes("UNSUPPORTED_RUNTIME") ||
+    reasonText.includes("build script") ||
+    reasonText.includes("build or preview command")
+  ) {
+    return "Add or expose a package build script, then re-scan. If you already know the public articles/blogs route, paste it manually in the setup flow.";
+  }
+  if (normalizedCode.includes("ROUTE") || normalizedCode.includes("SURFACE") || normalizedCode.includes("HINT")) {
+    return "Paste the public articles/blogs route manually in the setup flow, or add a conventional route and re-scan.";
+  }
+  return "Review the failed step, then re-scan. If you already know the public articles/blogs route, paste it manually in the setup flow.";
+}
+
+export function runFailureGuidance(run: VibeMarketingRunSummary) {
+  const code = cleanString(run.blockingCode) || blockingCodeFromPayload(run) || cleanString(run.errorCode);
+  const reason = cleanString(run.blockingReason) || blockingReasonFromPayload(run) || firstRunError(run);
+  const isScanRun = ["repo_scan", "content_factory_scan"].includes(run.workflow);
+  const title = isScanRun ? "Repository scan needs attention" : "Run needs attention";
+  const fallbackReason = isScanRun
+    ? "Repository scan failed before Content Factory could prove the articles/blogs setup path."
+    : "This run failed before it could complete.";
+  return {
+    code,
+    reason: reason || fallbackReason,
+    nextStep: nextStepForFailure(code, reason, run),
+    summary: `${title}: ${reason || fallbackReason}`,
+    specific: Boolean(code || reason),
+  };
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1,6 +1,7 @@
 import { createApiClient, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
 import { readableBackendErrors } from "~/lib/backend-error";
 import { hasAcceptedAutofillRun } from "~/lib/vibe-marketing-autofill-state";
+import { blockingCodeFromPayload, blockingReasonFromPayload } from "~/lib/vibe-marketing-run-failures";
 import type {
   VibeMarketingBootstrap,
   VibeMarketingArticleSetupState,
@@ -294,6 +295,15 @@ export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
     steps: Array.isArray(payload.steps) ? payload.steps.map(normalizeStep) : [],
     warnings: asStringList(payload.warnings),
     errors: asStringList(payload.errors),
+    errorCode: asNullableString(payload.errorCode) ?? asNullableString(payload.error_code) ?? asNullableString(result.errorCode) ?? asNullableString(result.error_code),
+    blockingReason:
+      asNullableString(payload.blockingReason) ??
+      asNullableString(payload.blocking_reason) ??
+      blockingReasonFromPayload(result),
+    blockingCode:
+      asNullableString(payload.blockingCode) ??
+      asNullableString(payload.blocking_code) ??
+      blockingCodeFromPayload(result),
     artifacts: Array.isArray(payload.artifacts) ? payload.artifacts : [],
     previewUrl: asNullableString(payload.previewUrl) ?? asNullableString(payload.preview_url),
     prUrl: asNullableString(payload.prUrl) ?? asNullableString(payload.pr_url),
@@ -1590,6 +1600,12 @@ export function startVibeMarketingScan(env: Env, request: Request, body: Record<
 
 export function startVibeMarketingArticleSystemSetup(env: Env, request: Request, body: Record<string, unknown>) {
   return startMarketingRun(env, request, "article-system-setup", body);
+}
+
+export async function resetVibeMarketingArticleSetup(env: Env, request: Request, body: Record<string, unknown>) {
+  const client = createApiClient(env, request);
+  const response = await client.post(`${BASE_PATH}/article-setup/reset`, body);
+  return response.data as Record<string, unknown>;
 }
 
 export function startVibeMarketingDiscovery(env: Env, request: Request, body: Record<string, unknown>) {

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -43,6 +43,7 @@ import {
   getVibeMarketingBootstrap,
   replayVibeMarketingDaily,
   refreshVibeMarketingBaselineGoogle,
+  resetVibeMarketingArticleSetup,
   saveVibeMarketingSettings,
   skipVibeMarketingBaseline,
   startVibeMarketingArticle,
@@ -724,6 +725,16 @@ export async function action({ request, context }: Route.ActionArgs) {
       return redirect("/founder-tools/marketing/create?step=articleSystem");
     }
 
+    if (intent === "reset-article-setup") {
+      const githubRepo = stringFromForm(formData, "githubRepo");
+      if (!githubRepo) return { intent, error: "Choose a GitHub repository before resetting articles setup." };
+      await resetVibeMarketingArticleSetup(env, request, {
+        githubRepo,
+        github_repo: githubRepo,
+      });
+      return redirect("/founder-tools/marketing/create?step=articleSystem");
+    }
+
     if (intent === "build-article-system-preview") {
       const scanRunId = stringFromForm(formData, "scanRunId");
       if (!scanRunId) {
@@ -848,6 +859,7 @@ function actionIntentStep(intent?: string | null): VibeMarketingStepKey | null {
   if (intent === "start-scan") return "articleSystem";
   if (intent === "confirm-article-surface" || intent === "create-article-surface") return "articleSystem";
   if (intent === "save-article-system") return "articleSystem";
+  if (intent === "reset-article-setup") return "articleSystem";
   if (intent === "start-discovery") return "research";
   if (intent === "start-article") return "chooseArticle";
   if (intent === "save-startup-details" || intent === "start-autofill") return "startupDetails";

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -54,6 +54,8 @@ export interface VibeMarketingRunSummary {
   warnings: string[];
   errors: string[];
   errorCode?: string | null;
+  blockingReason?: string | null;
+  blockingCode?: string | null;
   artifacts: unknown[];
   previewUrl?: string | null;
   prUrl?: string | null;

--- a/tests/article-system-connection-panel.test.ts
+++ b/tests/article-system-connection-panel.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+import ArticleSystemConnectionPanel from "../app/components/ArticleSystemConnectionPanel";
+import type {
+  VibeMarketingArticleSetupState,
+  VibeMarketingBootstrap,
+  VibeMarketingGithubReposResponse,
+  VibeMarketingRunSummary,
+} from "../app/types/vibe-marketing";
+
+function baseBootstrap(overrides: Partial<VibeMarketingBootstrap> = {}): VibeMarketingBootstrap {
+  return {
+    company: {
+      id: "company-1",
+      name: "StatDoctor",
+      domain: "statdoctor.app",
+      organizationId: 1,
+    },
+    organization: {
+      id: 1,
+      name: "StatDoctor",
+      domain: "statdoctor.app",
+      competitors: [],
+      seedKeywords: [],
+    },
+    settings: {
+      githubRepo: "DrAnuG1995/website",
+      dailyDiscoveryEnabled: false,
+      githubConnectionState: "connected",
+    },
+    startupProfile: {
+      founderNames: [],
+    },
+    websiteBaseline: {},
+    googleBaselineConnection: {
+      connected: false,
+      hasBaselineScopes: false,
+    },
+    checks: {
+      github: { passed: true },
+      scaffold: { passed: true, setupRunId: "setup-old-1", setupStatus: "completed" },
+    },
+    articleSetupState: null,
+    latestRuns: [],
+    latestRunsByWorkflow: {},
+    topicCandidates: [],
+    topicPillars: [],
+    hiddenTopicCandidates: [],
+    declinedTopicFeedback: [],
+    draftArticles: [],
+    writtenTopics: [],
+    publishEvidence: {},
+    guidedSteps: [],
+    workflowProgress: null,
+    ...overrides,
+  };
+}
+
+function githubRepos(): VibeMarketingGithubReposResponse {
+  return {
+    status: "connected",
+    connectionState: "connected",
+    githubRepo: "DrAnuG1995/website",
+    repos: [
+      {
+        fullName: "DrAnuG1995/website",
+        owner: "DrAnuG1995",
+        name: "website",
+        defaultBranch: "main",
+      },
+    ],
+  };
+}
+
+function blockedScanRun(): VibeMarketingRunSummary {
+  return {
+    runId: "scan-failed-fresh",
+    workflow: "repo_scan",
+    domain: "statdoctor.app",
+    githubRepo: "DrAnuG1995/website",
+    status: "blocked",
+    currentStep: "validate_plan",
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: ["No build script was found for the repository web app."],
+    blockingReason: "No build script was found for the repository web app.",
+    blockingCode: "ARTICLE_DIRECTORY_UNSUPPORTED_RUNTIME",
+    artifacts: [],
+    diagnostics: {},
+    result: {
+      scan_purpose: "inventory",
+      blocking_reason: "No build script was found for the repository web app.",
+      blocking_code: "ARTICLE_DIRECTORY_UNSUPPORTED_RUNTIME",
+    },
+  };
+}
+
+function staleArticleSetupState(): VibeMarketingArticleSetupState {
+  return {
+    repo: "DrAnuG1995/website",
+    githubRepo: "DrAnuG1995/website",
+    scanRunId: "scan-failed-fresh",
+    scanStatus: "blocked",
+    scanStale: false,
+    setupRunId: "setup-old-1",
+    setupStatus: "completed",
+    setupRunStatus: "completed",
+    generationReady: true,
+    published: true,
+    routePath: "/articles",
+    source: "config",
+  };
+}
+
+function renderPanel({
+  bootstrap = baseBootstrap(),
+  articleSetupState = staleArticleSetupState(),
+  scanRun = blockedScanRun(),
+}: {
+  bootstrap?: VibeMarketingBootstrap;
+  articleSetupState?: VibeMarketingArticleSetupState | null;
+  scanRun?: VibeMarketingRunSummary | null;
+} = {}) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/founder-tools/marketing/create",
+        element: createElement(ArticleSystemConnectionPanel, {
+          bootstrap: { ...bootstrap, articleSetupState },
+          githubRepos: githubRepos(),
+          isSubmitting: false,
+          isActionPending: () => false,
+          repoSelection: "DrAnuG1995/website",
+          articleSetupState,
+          scanRun,
+          framed: false,
+        }),
+      },
+    ],
+    {
+      initialEntries: ["/founder-tools/marketing/create?step=articleSystem"],
+    },
+  );
+
+  return renderToStaticMarkup(createElement(RouterProvider, { router }));
+}
+
+describe("article system connection panel", () => {
+  test("shows stale saved route with change, re-scan, and reset controls", () => {
+    const markup = renderPanel();
+
+    expect(markup).toContain("Saved setup needs refresh");
+    expect(markup).toContain("Your last articles/blogs setup is saved");
+    expect(markup).toContain("Articles/blogs location already selected");
+    expect(markup).toContain("Public route: /articles");
+    expect(markup).toContain("Change location");
+    expect(markup).toContain("Re-scan repository");
+    expect(markup).toContain("Reset articles setup");
+    expect(markup).toContain("value=\"reset-article-setup\"");
+  });
+});

--- a/tests/article-system-connection-steps.test.ts
+++ b/tests/article-system-connection-steps.test.ts
@@ -31,7 +31,7 @@ describe("article system connection step states", () => {
     expect(steps.scan.status).toBe("active");
     expect(steps.scan.defaultExpanded).toBe(true);
     expect(steps.chooseLocation.status).toBe("complete");
-    expect(steps.chooseLocation.defaultExpanded).toBe(false);
+    expect(steps.chooseLocation.defaultExpanded).toBe(true);
     expect(steps.buildSetup.status).toBe("active");
     expect(steps.buildSetup.defaultExpanded).toBe(true);
   });
@@ -125,5 +125,56 @@ describe("article system connection step states", () => {
     expect(steps.scan.defaultExpanded).toBe(true);
     expect(steps.chooseLocation.status).toBe("locked");
     expect(steps.chooseLocation.unavailableReason).toContain("scan issue");
+  });
+
+  test("marks a saved setup as needing refresh when the current scan failed", () => {
+    const steps = articleSystemConnectionStepStates({
+      connected: true,
+      currentScanRunId: "scan-5",
+      scanFailed: true,
+      setupTargetReady: true,
+      setupSurfaceUrl: "/articles",
+      persistedSetupIsStale: true,
+      scaffoldStatus: "ready_to_build",
+    });
+
+    expect(steps.scan.status).toBe("blocked");
+    expect(steps.chooseLocation.status).toBe("complete");
+    expect(steps.chooseLocation.attention).toBe(true);
+    expect(steps.chooseLocation.attentionLabel).toBe("Saved setup needs refresh");
+    expect(steps.chooseLocation.defaultExpanded).toBe(true);
+    expect(steps.buildSetup.status).toBe("active");
+    expect(steps.buildSetup.attention).toBe(true);
+  });
+
+  test("returns to choose location after reset clears the saved setup", () => {
+    const steps = articleSystemConnectionStepStates({
+      connected: true,
+      currentScanRunId: "scan-after-reset",
+      inventoryReady: true,
+      setupTargetReady: false,
+      persistedSetupIsStale: false,
+      selectedSurfaceUrl: null,
+      setupSurfaceUrl: null,
+    });
+
+    expect(steps.scan.status).toBe("complete");
+    expect(steps.chooseLocation.status).toBe("active");
+    expect(steps.chooseLocation.disabled).toBe(false);
+    expect(steps.chooseLocation.attention).toBeUndefined();
+    expect(steps.chooseLocation.defaultExpanded).toBe(true);
+    expect(steps.buildSetup.status).toBe("locked");
+    expect(steps.buildSetup.disabled).toBe(true);
+  });
+
+  test("expands a saved setup when the saved route cannot be resolved", () => {
+    const steps = articleSystemConnectionStepStates({
+      connected: true,
+      setupTargetReady: true,
+      scaffoldStatus: "ready_to_build",
+    });
+
+    expect(steps.chooseLocation.status).toBe("complete");
+    expect(steps.chooseLocation.defaultExpanded).toBe(true);
   });
 });

--- a/tests/vibe-marketing-scan-progress.test.ts
+++ b/tests/vibe-marketing-scan-progress.test.ts
@@ -107,4 +107,28 @@ describe("vibe marketing scan progress", () => {
     expect(markup).toContain("78% complete");
     expect((markup.match(/aria-label="Scan phase/g) ?? []).length).toBe(9);
   });
+
+  test("renders specific scan blocking reason and next step", () => {
+    const run = normalizeMarketingRun({
+      runId: "scan-blocked-1",
+      workflow: "repo_scan",
+      domain: "statdoctor.app",
+      status: "blocked",
+      result: {
+        blocking_reason: "No build script was found for the repository web app.",
+        blocking_code: "ARTICLE_DIRECTORY_UNSUPPORTED_RUNTIME",
+      },
+      errors: ["No build script was found for the repository web app."],
+    });
+
+    const markup = renderToStaticMarkup(createElement(MarketingRunProgressCard, { run }));
+
+    expect(run.blockingReason).toBe("No build script was found for the repository web app.");
+    expect(run.blockingCode).toBe("ARTICLE_DIRECTORY_UNSUPPORTED_RUNTIME");
+    expect(markup).toContain("Repository scan needs attention");
+    expect(markup).toContain("No build script was found for the repository web app.");
+    expect(markup).toContain("Next step:");
+    expect(markup).toContain("Add or expose a package build script");
+    expect(markup).not.toContain("Repository scan failed. Retry the scan or choose a different repository.");
+  });
 });


### PR DESCRIPTION
## Summary
- Add reset controls to the article system setup flow for stale saved article/blog locations.
- Normalize blocking reason/code from scan payloads and show recovery guidance in scan progress UI.
- Add frontend regression coverage for reset state, scan failure guidance, and setup step expansion.

## Validation
- bun test tests/article-system-connection-panel.test.ts tests/article-system-connection-steps.test.ts tests/vibe-marketing-scan-progress.test.ts
- bun run typecheck
- git diff --cached --check
