### PR TITLE
[codex] Remove article setup technical details

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -21,7 +21,7 @@ import {
   UserCheck,
 } from "lucide-react";
 
-import ArticleSystemSurfaceSummary, {
+import {
   articleSurfaceCandidates,
   candidateLabel,
   isSelectablePublicRoute,
@@ -1401,7 +1401,15 @@ export default function ArticleSystemConnectionPanel({
                 You can change this anytime later from your project settings.
               </div>
 
-              {effectiveScanRun ? <ArticleSystemSurfaceSummary run={effectiveScanRun} /> : null}
+              {selectedSurfaceUrl ? (
+                <div className="flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-900">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-600" />
+                  <span>
+                    Selected <span className="break-all font-black">{selectedSurfaceUrl}</span>. Continue to step 4 below to build and preview the
+                    articles/blogs page.
+                  </span>
+                </div>
+              ) : null}
             </div>
           ) : (
             <DisabledLocationPreview />
@@ -1486,15 +1494,6 @@ export default function ArticleSystemConnectionPanel({
           </div>
         ) : null}
 
-        {connected && scaffoldReady && !setupBlocked && !setupTargetReady && !inventoryReady ? (
-          <Link
-            to="/founder-tools/marketing/create?step=research"
-            className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700"
-          >
-            Continue
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        ) : null}
       </div>
     </section>
   );

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -19,7 +19,6 @@ import { clsx } from "clsx";
 import ArticleRunStageProgress from "~/components/ArticleRunStageProgress";
 import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
-import ArticleSystemSurfaceSummary from "~/components/ArticleSystemSurfaceSummary";
 import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
@@ -1118,8 +1117,6 @@ function ArticleSystemSetupPreviewPanel({
           </div>
         </div>
       </div>
-
-      <ArticleSystemSurfaceSummary run={source} />
 
       {changedFiles.length ? (
         <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">


### PR DESCRIPTION
## Summary
- remove the article setup technical scan details render from the setup panel and run page
- keep the route-selection helpers while dropping the visible details disclosure from the flow
- add a selected-route confirmation that points users to step 4

## Validation
- python-style diff check: git diff --check
- attempted: react-router typegen && tsc -b --force; blocked by current-main Watt sandbox TypeScript/dependency errors unrelated to these files