### PR TITLE
[codex] Complete draft article deletion

### DIFF
--- a/app/lib/vibe-marketing-draft-delete.ts
+++ b/app/lib/vibe-marketing-draft-delete.ts
@@ -1,0 +1,31 @@
+import type { VibeMarketingDraftArticle } from "~/types/vibe-marketing";
+
+function normalizeRunId(value: string | null | undefined) {
+  return String(value ?? "").trim();
+}
+
+export function hiddenDraftRunIdsAfterSubmit(current: string[], runId: string | null | undefined) {
+  const normalized = normalizeRunId(runId);
+  if (!normalized || current.includes(normalized)) return current;
+  return [...current, normalized];
+}
+
+export function restoreHiddenDraftRunId(current: string[], runId: string | null | undefined) {
+  const normalized = normalizeRunId(runId);
+  if (!normalized) return current;
+  return current.filter((item) => item !== normalized);
+}
+
+export function pruneHiddenDraftRunIds(current: string[], drafts: VibeMarketingDraftArticle[]) {
+  const visibleRunIds = new Set(drafts.map((draft) => draft.runId));
+  return current.filter((runId) => visibleRunIds.has(runId));
+}
+
+export function filterOptimisticallyDeletedDrafts(
+  drafts: VibeMarketingDraftArticle[],
+  hiddenRunIds: string[],
+) {
+  if (!hiddenRunIds.length) return drafts;
+  const hidden = new Set(hiddenRunIds.map(normalizeRunId).filter(Boolean));
+  return drafts.filter((draft) => !hidden.has(draft.runId));
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -304,6 +304,8 @@ export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
       asNullableString(payload.blockingCode) ??
       asNullableString(payload.blocking_code) ??
       blockingCodeFromPayload(result),
+    cancelledRunIds: asStringList(payload.cancelledRunIds ?? payload.cancelled_run_ids),
+    protectedRunIds: asStringList(payload.protectedRunIds ?? payload.protected_run_ids),
     artifacts: Array.isArray(payload.artifacts) ? payload.artifacts : [],
     previewUrl: asNullableString(payload.previewUrl) ?? asNullableString(payload.preview_url),
     prUrl: asNullableString(payload.prUrl) ?? asNullableString(payload.pr_url),

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -54,6 +54,12 @@ import {
   VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS,
   createVibeMarketingClientRequestId,
 } from "~/lib/vibe-marketing-billing";
+import {
+  filterOptimisticallyDeletedDrafts,
+  hiddenDraftRunIdsAfterSubmit,
+  pruneHiddenDraftRunIds,
+  restoreHiddenDraftRunId,
+} from "~/lib/vibe-marketing-draft-delete";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   controlVibeMarketingRun,
@@ -550,8 +556,13 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (!runId) {
         return { intent, error: "Choose a draft article to delete." };
       }
-      await controlVibeMarketingRun(env, request, runId, "cancel");
-      return { intent, runId };
+      const run = await controlVibeMarketingRun(env, request, runId, "cancel", { cancel_group: true });
+      return {
+        intent,
+        runId,
+        cancelledRunIds: run.cancelledRunIds ?? [],
+        protectedRunIds: run.protectedRunIds ?? [],
+      };
     }
 
     if (intent === "start-article") {
@@ -661,6 +672,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     const responseErrors = readableBackendErrors(error, { fallback });
     return {
       intent,
+      ...(intent === "delete-draft" ? { runId: stringFromForm(formData, "runId") } : {}),
       error: readableBackendError(error, { fallback }),
       errors: responseErrors,
     };
@@ -672,6 +684,12 @@ export async function action({ request, context }: Route.ActionArgs) {
 export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
   if (actionIntent(args.actionResult) === "start-content-island-discovery") {
     return false;
+  }
+  if (actionIntent(args.actionResult) === "delete-draft") {
+    if (actionError(args.actionResult)) return false;
+    return actionStringList(args.actionResult, "protectedRunIds", "protected_run_ids").length > 0
+      ? args.defaultShouldRevalidate
+      : false;
   }
   return args.defaultShouldRevalidate;
 }
@@ -686,6 +704,30 @@ function actionIntent(data: unknown): string | null {
   if (!data || typeof data !== "object" || !("intent" in data)) return null;
   const intent = (data as { intent?: unknown }).intent;
   return typeof intent === "string" ? intent : null;
+}
+
+function actionString(data: unknown, key: string): string {
+  if (!data || typeof data !== "object" || !(key in data)) return "";
+  const value = (data as Record<string, unknown>)[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function actionStringList(data: unknown, ...keys: string[]): string[] {
+  if (!data || typeof data !== "object") return [];
+  const payload = data as Record<string, unknown>;
+  for (const key of keys) {
+    const value = payload[key];
+    if (Array.isArray(value)) {
+      return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+    }
+    if (typeof value === "string") {
+      return value
+        .split(/[,\n]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+    }
+  }
+  return [];
 }
 
 function numericValue(value: unknown): number | null {
@@ -2613,7 +2655,7 @@ function DraftDeleteConfirmationModal({
       <div className="w-full max-w-md rounded-2xl border border-rose-100 bg-white p-5 shadow-2xl">
         <h2 id="draft-delete-confirmation-title" className="text-lg font-black text-slate-950">Delete draft article?</h2>
         <p className="mt-2 text-sm font-semibold leading-6 text-slate-600">
-          This cancels the article run and removes generated content for &quot;{draft.title}&quot;.
+          This cancels this draft and related retry attempts for &quot;{draft.title}&quot;.
         </p>
         <label className="mt-4 flex items-center gap-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-3 text-sm font-bold text-slate-600">
           <input
@@ -3131,6 +3173,7 @@ function ReturningTopicPickerPage({
   setupMergedNotice?: boolean;
 }) {
   const navigation = useNavigation();
+  const routeActionData = useActionData<typeof action>();
   const location = useLocation();
   const revalidator = useRevalidator();
   const restoreFetcher = useFetcher<TopicFeedbackActionData>();
@@ -3159,6 +3202,7 @@ function ReturningTopicPickerPage({
   const completedContentIslandDiscoveryRuns = useRef<Set<string>>(new Set());
   const contentIslandRefreshStartCount = useRef(0);
   const companyAvatarPreviewObjectUrl = useRef<string | null>(null);
+  const handledDeleteActionRef = useRef<unknown>(null);
   const articleFormRef = useRef<HTMLFormElement>(null);
   const activePillar = useMemo(
     () => bootstrap.topicPillars.find((pillar) => pillar.slug === activePillarSlug) ?? null,
@@ -3291,6 +3335,11 @@ function ReturningTopicPickerPage({
   const [draftDeleteRequest, setDraftDeleteRequest] = useState<{ runId: string; title: string } | null>(null);
   const [skipDeleteConfirmation, setSkipDeleteConfirmation] = useState(false);
   const [deletingDraftRunId, setDeletingDraftRunId] = useState<string | null>(null);
+  const [optimisticallyDeletedDraftRunIds, setOptimisticallyDeletedDraftRunIds] = useState<string[]>([]);
+  const visibleDraftArticles = useMemo(
+    () => filterOptimisticallyDeletedDrafts(bootstrap.draftArticles ?? [], optimisticallyDeletedDraftRunIds),
+    [bootstrap.draftArticles, optimisticallyDeletedDraftRunIds],
+  );
 
   const submitSelectedTopic = useCallback(() => {
     if (articleSubmitting || !selectedTopic) return;
@@ -3449,6 +3498,8 @@ function ReturningTopicPickerPage({
     if (String(navigation.formData?.get("intent") ?? "") !== "delete-draft") return;
     const runId = String(navigation.formData?.get("runId") ?? "").trim();
     setDeletingDraftRunId(runId || null);
+    setOptimisticallyDeletedDraftRunIds((current) => hiddenDraftRunIdsAfterSubmit(current, runId));
+    setDraftDeleteRequest((current) => (current?.runId === runId ? null : current));
   }, [navigation.formData, navigation.state]);
 
   useEffect(() => {
@@ -3457,10 +3508,44 @@ function ReturningTopicPickerPage({
   }, [deleteDraftSubmitting]);
 
   useEffect(() => {
+    setOptimisticallyDeletedDraftRunIds((current) => pruneHiddenDraftRunIds(current, bootstrap.draftArticles ?? []));
+  }, [bootstrap.draftArticles]);
+
+  useEffect(() => {
+    if (!routeActionData || handledDeleteActionRef.current === routeActionData) return;
+    if (actionIntent(routeActionData) !== "delete-draft") return;
+    handledDeleteActionRef.current = routeActionData;
+    pendingActions.clearPending();
+
+    const runId = actionString(routeActionData, "runId");
+    const deleteError = actionError(routeActionData);
+    if (deleteError) {
+      setOptimisticallyDeletedDraftRunIds((current) => restoreHiddenDraftRunId(current, runId));
+      setDeletingDraftRunId(null);
+      setToast({ kind: "error", message: deleteError });
+      return;
+    }
+
+    const protectedRunIds = actionStringList(routeActionData, "protectedRunIds", "protected_run_ids");
+    if (protectedRunIds.length) {
+      setOptimisticallyDeletedDraftRunIds((current) =>
+        protectedRunIds.reduce((next, protectedRunId) => restoreHiddenDraftRunId(next, protectedRunId), current),
+      );
+      setToast({
+        kind: "error",
+        message:
+          protectedRunIds.length === 1
+            ? "One related article attempt was not deleted because it already has publish evidence."
+            : `${protectedRunIds.length} related article attempts were not deleted because they already have publish evidence.`,
+      });
+    }
+  }, [pendingActions, routeActionData]);
+
+  useEffect(() => {
     if (!draftDeleteRequest) return;
-    const stillPresent = (bootstrap.draftArticles ?? []).some((draft) => draft.runId === draftDeleteRequest.runId);
+    const stillPresent = visibleDraftArticles.some((draft) => draft.runId === draftDeleteRequest.runId);
     if (!stillPresent) setDraftDeleteRequest(null);
-  }, [bootstrap.draftArticles, draftDeleteRequest]);
+  }, [draftDeleteRequest, visibleDraftArticles]);
 
   useEffect(() => {
     const data = contentIslandDiscoveryFetcher.data;
@@ -3967,7 +4052,7 @@ function ReturningTopicPickerPage({
           </section>
 
           <DraftArticlesCard
-            drafts={bootstrap.draftArticles ?? []}
+            drafts={visibleDraftArticles}
             submitting={isSubmitting}
             deletingRunId={deleteDraftSubmitting ? deletingDraftRunId : null}
             skipDeleteConfirmation={skipDeleteConfirmation}

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -56,6 +56,8 @@ export interface VibeMarketingRunSummary {
   errorCode?: string | null;
   blockingReason?: string | null;
   blockingCode?: string | null;
+  cancelledRunIds?: string[];
+  protectedRunIds?: string[];
   artifacts: unknown[];
   previewUrl?: string | null;
   prUrl?: string | null;

--- a/tests/vibe-marketing-draft-delete.test.ts
+++ b/tests/vibe-marketing-draft-delete.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  filterOptimisticallyDeletedDrafts,
+  hiddenDraftRunIdsAfterSubmit,
+  pruneHiddenDraftRunIds,
+  restoreHiddenDraftRunId,
+} from "../app/lib/vibe-marketing-draft-delete";
+import { normalizeMarketingRun } from "../app/lib/vibe-marketing";
+import type { VibeMarketingDraftArticle } from "../app/types/vibe-marketing";
+
+function draft(runId: string, sourceRunId = "source-one"): VibeMarketingDraftArticle {
+  return {
+    runId,
+    sourceRunId,
+    workflow: "article_generation",
+    status: "blocked",
+    title: `Draft ${runId}`,
+    targetKeyword: `keyword ${runId}`,
+    stageLabel: "Needs attention",
+    actionKind: "restart",
+    actionLabel: "Restart",
+    resumeAvailable: false,
+    restartAvailable: true,
+    updatedAt: "2026-06-01T00:00:00Z",
+    createdAt: "2026-06-01T00:00:00Z",
+  };
+}
+
+describe("vibe marketing draft deletion", () => {
+  test("preserves group cancel response fields on normalized runs", () => {
+    const run = normalizeMarketingRun({
+      runId: "draft-representative",
+      workflow: "article_generation",
+      domain: "mlai.au",
+      status: "cancelled",
+      cancelledRunIds: ["draft-a", "draft-b"],
+      protected_run_ids: ["draft-pr-open"],
+    });
+
+    expect(run.cancelledRunIds).toEqual(["draft-a", "draft-b"]);
+    expect(run.protectedRunIds).toEqual(["draft-pr-open"]);
+  });
+
+  test("hides a submitted draft immediately and restores it after an error", () => {
+    const drafts = [draft("draft-a"), draft("draft-b", "source-two")];
+    let hiddenRunIds = hiddenDraftRunIdsAfterSubmit([], "draft-a");
+
+    expect(filterOptimisticallyDeletedDrafts(drafts, hiddenRunIds).map((item) => item.runId)).toEqual(["draft-b"]);
+
+    hiddenRunIds = restoreHiddenDraftRunId(hiddenRunIds, "draft-a");
+
+    expect(filterOptimisticallyDeletedDrafts(drafts, hiddenRunIds).map((item) => item.runId)).toEqual([
+      "draft-a",
+      "draft-b",
+    ]);
+  });
+
+  test("keeps hidden ids only while the stale bootstrap still contains them", () => {
+    const hiddenRunIds = hiddenDraftRunIdsAfterSubmit([], "draft-a");
+
+    expect(pruneHiddenDraftRunIds(hiddenRunIds, [draft("draft-a")])).toEqual(["draft-a"]);
+    expect(pruneHiddenDraftRunIds(hiddenRunIds, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve draft group-cancel response ids in frontend normalization
- hide deleted draft cards optimistically and restore them on errors
- skip slow bootstrap revalidation for successful draft deletes unless protected attempts remain
- add focused tests for normalization and optimistic draft filtering

## Validation
- PASS: bun test tests/vibe-marketing-draft-delete.test.ts
- Note: full clean-main typecheck is currently blocked by unrelated Watt sandbox missing dependencies/types (`@monaco-editor/react`, `framer-motion`, `recharts`, Radix packages, etc.).