### PR TITLE
[codex] Remove duplicate article setup continue CTA

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1486,15 +1486,6 @@ export default function ArticleSystemConnectionPanel({
           </div>
         ) : null}
 
-        {connected && scaffoldReady && !setupBlocked && !setupTargetReady && !inventoryReady ? (
-          <Link
-            to="/founder-tools/marketing/create?step=research"
-            className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-6 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700"
-          >
-            Continue
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        ) : null}
       </div>
     </section>
   );

--- a/tests/article-system-connection-panel.test.ts
+++ b/tests/article-system-connection-panel.test.ts
@@ -162,4 +162,22 @@ describe("article system connection panel", () => {
     expect(markup).toContain("Reset articles setup");
     expect(markup).toContain("value=\"reset-article-setup\"");
   });
+
+  test("does not render the old standalone Continue CTA when scaffold is ready without a selected target", () => {
+    const markup = renderPanel({
+      bootstrap: baseBootstrap({
+        checks: {
+          github: { passed: true },
+          scaffold: { passed: true, setupBlocked: false },
+        },
+      }),
+      articleSetupState: null,
+      scanRun: null,
+    });
+
+    expect(markup).toContain("Reset articles setup");
+    expect(markup).toContain("value=\"reset-article-setup\"");
+    expect(markup).not.toContain(">Continue<");
+    expect(markup).not.toContain("/founder-tools/marketing/create?step=research");
+  });
 });


### PR DESCRIPTION
## Summary
- Remove the extra standalone purple Continue CTA from the article setup panel so the Next action row remains the canonical next-step control.
- Add a component regression test for the scaffold-ready/no-selected-target state that previously rendered the duplicate CTA.

## Validation
- `bun test tests/article-system-connection-steps.test.ts tests/article-system-connection-panel.test.ts`
- `bun run typecheck` was attempted; current `main` fails on unrelated Watt sandbox files/missing packages (`@monaco-editor/react`, `framer-motion`, `recharts`, Radix sandbox packages, `zustand`).
