### PR TITLE
Custom-topic research flow (UI)

### DIFF
--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/founder-tools.marketing.create";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useSearchParams } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useRevalidator, useSearchParams } from "react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeftIcon,
@@ -14,6 +14,7 @@ import {
 import { clsx } from "clsx";
 
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
+import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
 import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
 import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
@@ -433,13 +434,23 @@ function isArticleSystemPublished(bootstrap: VibeMarketingBootstrap) {
   );
 }
 
-function resolveActiveStep(value: string | null | undefined, bootstrap: VibeMarketingBootstrap): VibeMarketingStepKey {
+function resolveActiveStep(
+  value: string | null | undefined,
+  bootstrap: VibeMarketingBootstrap,
+  options: { hasResearchRun?: boolean } = {},
+): VibeMarketingStepKey {
   const requiredStep =
     createStepForWorkflowStep(bootstrap.workflowProgress?.currentStepId) ??
     normalizeStep(bootstrap.currentGuidedStep, "startupDetails");
   const requested = normalizeStep(value, requiredStep);
   if (isArticleSystemSetupBlocked(bootstrap) && ["research", "chooseArticle"].includes(requested)) {
     return "articleSystem";
+  }
+  // Custom-topic research routes here with ?researchRunId=… to show progress and the resulting
+  // candidates. Honour that target even while choose_topic is still locked (no candidates yet),
+  // otherwise the lock-gate below would bounce it back to the research step mid-research.
+  if (requested === "chooseArticle" && options.hasResearchRun) {
+    return "chooseArticle";
   }
   const requestedWorkflowStepId = WORKFLOW_STEP_ID_BY_CREATE_STEP[requested];
   const requestedWorkflowStep = bootstrap.workflowProgress?.steps?.find((step) => step.id === requestedWorkflowStepId);
@@ -482,7 +493,9 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     repos: [],
     repositories: [],
   };
-  const activeStep = resolveActiveStep(url.searchParams.get("step"), bootstrap);
+  const activeStep = resolveActiveStep(url.searchParams.get("step"), bootstrap, {
+    hasResearchRun: Boolean(url.searchParams.get("researchRunId")?.trim()),
+  });
   if (activeStep === "articleSystem" || requestedStep === "articleSystem") {
     try {
       githubRepos = await getVibeMarketingGithubRepos(env, request);
@@ -939,7 +952,9 @@ function PanelHeader({
 export default function FounderToolsMarketingCreate() {
   const { bootstrap, githubRepos, billingRequestIds } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
-  const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap);
+  const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap, {
+    hasResearchRun: Boolean(searchParams.get("researchRunId")?.trim()),
+  });
   const requestedStep = normalizeStep(searchParams.get("step"), activeStep);
   const shouldRefreshGoogleBaseline = searchParams.get("googleBaseline") === "refresh";
   const actionData = useActionData<typeof action>();
@@ -1034,10 +1049,14 @@ export default function FounderToolsMarketingCreate() {
   const buildArticleSystemPreviewPending = pendingActions.isPending("build-article-system-preview");
   const saveDailyPending = pendingActions.isPending("save-daily");
   const dailyReplayPending = pendingActions.isPending("daily-replay");
-  const selectableTopicCandidates = useMemo(
-    () => bootstrap.topicCandidates.filter((candidate) => !candidate.alreadyWritten).slice(0, 5),
-    [bootstrap.topicCandidates],
-  );
+  const researchRunId = searchParams.get("researchRunId")?.trim() ?? "";
+  const selectableTopicCandidates = useMemo(() => {
+    const available = bootstrap.topicCandidates.filter((candidate) => !candidate.alreadyWritten);
+    const scoped = researchRunId
+      ? available.filter((candidate) => candidate.sourceRunId === researchRunId)
+      : available;
+    return scoped.slice(0, 5);
+  }, [bootstrap.topicCandidates, researchRunId]);
   const alreadyWrittenCandidates = useMemo(() => {
     const candidates = [...bootstrap.hiddenTopicCandidates, ...bootstrap.topicCandidates].filter(
       (candidate) => candidate.alreadyWritten,
@@ -1058,6 +1077,62 @@ export default function FounderToolsMarketingCreate() {
     [selectableTopicCandidates, selectedTopicCandidateId],
   );
   const isCustomArticleSelected = selectedTopicCandidateId === "__custom__";
+
+  // Custom-topic research lands here with ?researchRunId=…; poll until it produces candidates,
+  // then render them scoped to that run (selectableTopicCandidates already filters by sourceRunId).
+  const researchStatusFetcher = useFetcher<VibeMarketingRunSummary>();
+  const researchRevalidator = useRevalidator();
+  const polledResearchRun =
+    researchStatusFetcher.data && researchStatusFetcher.data.runId === researchRunId
+      ? researchStatusFetcher.data
+      : null;
+  const researchRun = polledResearchRun ?? findRunById(bootstrap.latestRuns, researchRunId);
+  const researchStatus = String(researchRun?.status ?? "").trim().toLowerCase();
+  const researchFailed = ["failed", "blocked", "blocked_verification", "denied", "cancelled", "canceled"].includes(
+    researchStatus,
+  );
+  const researchCandidates = researchRunId ? selectableTopicCandidates : [];
+  const researchRunReady = ["completed", "awaiting_confirmation", "awaiting_approval", "approval_required"].includes(
+    researchStatus,
+  );
+  // Revalidate the loader exactly once after the run finishes so freshly materialized
+  // candidates load in; the ref stops the 3s poll from re-triggering it every tick.
+  const researchRevalidatedRunRef = useRef<string | null>(null);
+  // Show progress while the run is in flight or settling, then fall through to the candidate
+  // list (or empty state) once it has finished and reloaded — so it never spins forever.
+  const researchSettled =
+    researchFailed ||
+    (researchRunReady && researchRevalidatedRunRef.current === researchRunId && researchRevalidator.state === "idle");
+  const researchActive = Boolean(researchRunId) && researchCandidates.length === 0 && !researchSettled;
+
+  useEffect(() => {
+    if (!researchRunId || researchFailed || researchRunReady || researchCandidates.length > 0) return;
+    const statusPath = `/founder-tools/marketing/runs/${encodeURIComponent(researchRunId)}/status`;
+    researchStatusFetcher.load(statusPath);
+    const intervalId = window.setInterval(() => {
+      if (researchStatusFetcher.state === "idle") {
+        researchStatusFetcher.load(statusPath);
+      }
+    }, 3000);
+    return () => window.clearInterval(intervalId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [researchRunId, researchFailed, researchRunReady, researchCandidates.length]);
+
+  useEffect(() => {
+    if (!researchRunId || !researchRunReady || researchCandidates.length > 0) return;
+    if (researchRevalidatedRunRef.current === researchRunId) return;
+    researchRevalidatedRunRef.current = researchRunId;
+    if (researchRevalidator.state === "idle") {
+      researchRevalidator.revalidate();
+    }
+  }, [researchRunId, researchRunReady, researchCandidates.length, researchRevalidator]);
+
+  useEffect(() => {
+    if (!researchRunId || researchCandidates.length === 0) return;
+    setSelectedTopicCandidateId((current) =>
+      researchCandidates.some((candidate) => candidate.id === current) ? current : researchCandidates[0].id,
+    );
+  }, [researchRunId, researchCandidates]);
   const selectedTopicLabel = selectedTopicCandidate?.title ?? "Custom article";
   const githubReadyForPublishing = isGithubPublishingReady(bootstrap);
   const effectiveDeliveryMode = effectiveArticleDeliveryMode(bootstrap);
@@ -1418,6 +1493,30 @@ export default function FounderToolsMarketingCreate() {
                   </div>
                 </div>
               </div>
+              {researchActive ? (
+                researchRun ? (
+                  <MarketingRunProgressCard
+                    run={researchRun}
+                    title="Researching your topic"
+                    currentStepLabel="Finding the strongest keywords and titles for your idea…"
+                  />
+                ) : (
+                  <div className="flex items-center gap-3 rounded-2xl border border-violet-100 bg-violet-50/60 px-5 py-6 text-sm font-black text-slate-700">
+                    <ArrowPathIcon className="h-4 w-4 animate-spin text-violet-600" />
+                    Starting research…
+                  </div>
+                )
+              ) : (
+                <>
+                  {researchRunId && researchFailed ? (
+                    <div className="mb-5 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-800">
+                      Research could not complete. Try a different angle or keyword from the{" "}
+                      <Link to="/founder-tools/marketing" className="font-black text-rose-900 underline">
+                        custom topic form
+                      </Link>
+                      .
+                    </div>
+                  ) : null}
               {!bootstrap.checks.baseline?.passed ? (
                 <div className="mb-5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-800">
                   Run or skip the website baseline before generating an article.
@@ -1519,6 +1618,8 @@ export default function FounderToolsMarketingCreate() {
                   </div>
                 </div>
               </Form>
+                </>
+              )}
             </>
           ) : null}
 

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -527,6 +527,40 @@ export async function action({ request, context }: Route.ActionArgs) {
       };
     }
 
+    if (intent === "research-custom-topic") {
+      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      if (isArticleSystemSetupBlocked(bootstrap)) {
+        return { intent, error: "Merge the articles setup PR before researching topics. If you merged it in GitHub, refresh merge status." };
+      }
+      const customTitle = stringFromForm(formData, "customTitle");
+      const targetKeyword = stringFromForm(formData, "targetKeyword");
+      const articleContext = stringFromForm(formData, "articleContext");
+      if (!customTitle && !targetKeyword) {
+        return { intent, error: "Add an article title/angle or a target keyword to research." };
+      }
+      const run = await startVibeMarketingDiscovery(env, request, {
+        clientRequestId: stringFromForm(formData, "clientRequestId"),
+        client_request_id: stringFromForm(formData, "clientRequestId"),
+        customTopicTitle: customTitle,
+        custom_topic_title: customTitle,
+        customTopicKeyword: targetKeyword,
+        custom_topic_keyword: targetKeyword,
+        customTopicContext: articleContext,
+        custom_topic_context: articleContext,
+        requestedTopicCount: 4,
+        requested_topic_count: 4,
+      });
+      if (run.runId) {
+        throw redirect(
+          `/founder-tools/marketing/create?step=chooseArticle&researchRunId=${encodeURIComponent(run.runId)}`,
+        );
+      }
+      return {
+        intent,
+        error: run.error || run.errors?.[0] || "Research could not start. Please try again.",
+      };
+    }
+
     if (intent === "start-discovery" || intent === "discovery") {
       const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
       if (isArticleSystemSetupBlocked(bootstrap)) {
@@ -3319,6 +3353,7 @@ function ReturningTopicPickerPage({
     : submittedContentIslandSlug || null;
   const articleSubmitting = pendingActions.isPending("start-article");
   const discoverySubmitting = pendingActions.isPending("start-discovery", "discovery");
+  const customResearchPending = pendingActions.isPending("research-custom-topic");
   const deleteDraftSubmitting = pendingActions.isPending("delete-draft");
   const restoreBusy = restoreFetcher.state !== "idle";
   const visibleTopics = topics.slice(0, visibleCount);
@@ -3735,7 +3770,9 @@ function ReturningTopicPickerPage({
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(440px,0.92fr)] xl:items-start">
         <div className="space-y-5">
           <Form ref={articleFormRef} method="POST" className="space-y-5">
-            <input type="hidden" name="intent" value="start-article" />
+            {activeTab === "choose" ? (
+              <input type="hidden" name="intent" value="start-article" />
+            ) : null}
             <input type="hidden" name="clientRequestId" value={billingRequestIds.articleJob} />
             <input type="hidden" name="topicCandidateId" value={activeTab === "choose" ? selectedTopicId : "__custom__"} />
             <input type="hidden" name="deliveryModeExplicit" value="false" />
@@ -3953,6 +3990,21 @@ function ReturningTopicPickerPage({
                       className="w-full resize-none rounded-lg border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-violet-400 focus:ring-4 focus:ring-violet-100"
                     />
                   </FormField>
+                </div>
+                <div className="mt-6 flex flex-col gap-3 border-t border-slate-100 pt-5 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-sm font-semibold text-slate-500">
+                    We'll research the strongest keywords and titles for your idea, then let you pick one before writing.
+                  </p>
+                  <button
+                    type="submit"
+                    name="intent"
+                    value="research-custom-topic"
+                    disabled={isSubmitting}
+                    className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
+                  >
+                    {customResearchPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                    {customResearchPending ? "Researching..." : "Research this topic"}
+                  </button>
                 </div>
               </>
             )}


### PR DESCRIPTION
## What

Frontend for the **custom-topic research** flow. Previously the dashboard's custom-idea tab had inputs but no way forward. Now a founder enters an idea, it's researched, and they pick from run-scoped topic candidates before generating — matching the existing "choose a topic" pattern.

## Changes
**Dashboard ([founder-tools.marketing.tsx](app/routes/founder-tools.marketing.tsx))**
- "Research this topic" button on the custom tab → fires a seeded discovery (`research-custom-topic`) and routes to `…/create?step=chooseArticle&researchRunId=<id>`
- **Intent-collision fix**: the hidden `start-article` input now renders only on the choose tab, so the custom tab's button actually submits the research intent (it was being shadowed)

**Create flow ([founder-tools.marketing.create.tsx](app/routes/founder-tools.marketing.create.tsx))**
- `chooseArticle` polls the run, shows a progress card while researching, then renders run-scoped `TopicDecisionCard`s; settles to the list on completion (no infinite spinner) and surfaces failures
- `resolveActiveStep` honours an intentional `chooseArticle?researchRunId` route even while `choose_topic` is locked, so the research view isn't bounced back to the research step

## Verification
- `react-router typegen` + `tsc --noEmit` → 0 errors
- Driven live in a stub preview: chooseArticle renders via the bypass, loading card shows mid-research (SSR), completed run settles to the candidate list, no console errors

Part of a cross-repo feature ([content-factory #393](https://github.com/MLAI-AUS-Inc/content-factory/pull/393), [mlai-backend #389](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/389)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)