### PR TITLE
Skip run-route revalidation on view-only navigation

### DIFF
--- a/app/lib/vibe-marketing-step-revalidation.ts
+++ b/app/lib/vibe-marketing-step-revalidation.ts
@@ -57,3 +57,63 @@ export function shouldSkipVibeMarketingCreateRevalidation({
   }
   return isVibeMarketingCreateViewNavigation(currentUrl, nextUrl);
 }
+
+const RUN_FLOW_PATH_PREFIX = "/founder-tools/marketing/runs/";
+// View-only params on the run page: switching these renders a different sub-view
+// from data the loader already returned, so no refetch is needed.
+const RUN_VIEW_ONLY_SEARCH_PARAMS = new Set(["setupStep"]);
+
+function searchParamsWithout(url: URL, omit: Set<string>) {
+  const params = new URLSearchParams(url.search);
+  for (const key of omit) {
+    params.delete(key);
+  }
+  params.sort();
+  return params.toString();
+}
+
+function searchParamsChanged(currentUrl: URL, nextUrl: URL, keys: Set<string>) {
+  for (const key of keys) {
+    if (currentUrl.searchParams.get(key) !== nextUrl.searchParams.get(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isVibeMarketingRunViewNavigation(currentUrl: URL, nextUrl: URL) {
+  const currentPathname = normalizePathname(currentUrl.pathname);
+  const nextPathname = normalizePathname(nextUrl.pathname);
+  // Must stay on the exact same run (the runId is part of the pathname).
+  if (currentPathname !== nextPathname) {
+    return false;
+  }
+  if (!currentPathname.startsWith(RUN_FLOW_PATH_PREFIX)) {
+    return false;
+  }
+  // Only skip when a view-only param actually changed. A same-URL
+  // revalidator.revalidate() (the status poll's full-refresh trigger) leaves
+  // every param identical, so this returns false and the run still refreshes.
+  if (!searchParamsChanged(currentUrl, nextUrl, RUN_VIEW_ONLY_SEARCH_PARAMS)) {
+    return false;
+  }
+  // ...and nothing outside the view-only set differs.
+  return (
+    searchParamsWithout(currentUrl, RUN_VIEW_ONLY_SEARCH_PARAMS) ===
+    searchParamsWithout(nextUrl, RUN_VIEW_ONLY_SEARCH_PARAMS)
+  );
+}
+
+export function shouldSkipVibeMarketingRunRevalidation({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  actionResult,
+  actionStatus,
+}: ShouldRevalidateFunctionArgs) {
+  // Never skip a revalidation that follows a mutation/action.
+  if (formMethod || actionResult !== undefined || actionStatus !== undefined) {
+    return false;
+  }
+  return isVibeMarketingRunViewNavigation(currentUrl, nextUrl);
+}

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/founder-tools.marketing.run";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useRevalidator } from "react-router";
+import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLocation, useNavigation, useRevalidator, type ShouldRevalidateFunctionArgs } from "react-router";
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
@@ -39,6 +39,7 @@ import {
   publishPrUrlForRun,
   viewedWorkflowStepIdForRun,
 } from "~/lib/vibe-marketing-run-view";
+import { shouldSkipVibeMarketingRunRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import {
   connectVibeMarketingGithub,
   controlVibeMarketingRun,
@@ -325,6 +326,17 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       articleJob: createVibeMarketingClientRequestId("vibe-article-job", runId),
     },
   };
+}
+
+export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
+  // Switching the run-page sub-view (?setupStep=...) on the same run renders from
+  // data the loader already returned. Skipping revalidation there avoids re-running
+  // the heavy loader (bootstrap + full run + setup run + repos). Poll-driven
+  // revalidator.revalidate() and post-action revalidations are NOT skipped.
+  if (shouldSkipVibeMarketingRunRevalidation(args)) {
+    return false;
+  }
+  return args.defaultShouldRevalidate;
 }
 
 export async function action({ request, params, context }: Route.ActionArgs) {

--- a/tests/vibe-marketing-run-revalidation.test.ts
+++ b/tests/vibe-marketing-run-revalidation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isVibeMarketingRunViewNavigation,
+  shouldSkipVibeMarketingRunRevalidation,
+} from "../app/lib/vibe-marketing-step-revalidation";
+
+const RUN = "/founder-tools/marketing/runs/run-123";
+
+function url(path: string) {
+  return new URL(path, "https://app.test");
+}
+
+function args(current: string, next: string, extra: Record<string, unknown> = {}) {
+  return {
+    currentUrl: url(current),
+    nextUrl: url(next),
+    currentParams: {},
+    nextParams: {},
+    defaultShouldRevalidate: true,
+    ...extra,
+  } as unknown as Parameters<typeof shouldSkipVibeMarketingRunRevalidation>[0];
+}
+
+describe("vibe marketing run revalidation", () => {
+  test("skips when only setupStep changes on the same run", () => {
+    expect(
+      isVibeMarketingRunViewNavigation(url(`${RUN}?setupStep=generate`), url(`${RUN}?setupStep=review`)),
+    ).toBe(true);
+    expect(
+      shouldSkipVibeMarketingRunRevalidation(args(`${RUN}?setupStep=generate`, `${RUN}?setupStep=review`)),
+    ).toBe(true);
+  });
+
+  test("does NOT skip a same-URL revalidation (status poll refresh must run)", () => {
+    expect(
+      isVibeMarketingRunViewNavigation(url(`${RUN}?setupStep=review`), url(`${RUN}?setupStep=review`)),
+    ).toBe(false);
+    expect(
+      shouldSkipVibeMarketingRunRevalidation(args(`${RUN}?setupStep=review`, `${RUN}?setupStep=review`)),
+    ).toBe(false);
+  });
+
+  test("does NOT skip plain run load with no params (e.g. revalidate during generation)", () => {
+    expect(shouldSkipVibeMarketingRunRevalidation(args(RUN, RUN))).toBe(false);
+  });
+
+  test("does NOT skip when navigating to a different run", () => {
+    expect(
+      shouldSkipVibeMarketingRunRevalidation(
+        args(`${RUN}?setupStep=generate`, "/founder-tools/marketing/runs/run-999?setupStep=generate"),
+      ),
+    ).toBe(false);
+  });
+
+  test("does NOT skip when a non-view param also changes", () => {
+    expect(
+      shouldSkipVibeMarketingRunRevalidation(args(`${RUN}?setupStep=generate`, `${RUN}?setupStep=review&other=1`)),
+    ).toBe(false);
+  });
+
+  test("does NOT skip after a form action", () => {
+    expect(
+      shouldSkipVibeMarketingRunRevalidation(
+        args(`${RUN}?setupStep=generate`, `${RUN}?setupStep=review`, { formMethod: "POST" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("does NOT skip after an action result", () => {
+    expect(
+      shouldSkipVibeMarketingRunRevalidation(
+        args(`${RUN}?setupStep=generate`, `${RUN}?setupStep=review`, { actionResult: { ok: true } }),
+      ),
+    ).toBe(false);
+  });
+
+  test("does NOT treat non-run paths as run view navigation", () => {
+    expect(
+      isVibeMarketingRunViewNavigation(
+        url("/founder-tools/marketing/create?setupStep=generate"),
+        url("/founder-tools/marketing/create?setupStep=review"),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
The marketing run page (wizard step 4) renders on a route with **no `shouldRevalidate`**, so every navigation re-runs the full loader: `getVibeMarketingBootstrap` + the `view=full` run fetch + a second full setup-run fetch + repos. Switching the on-page sub-view (`?setupStep=generate|review|publish`) on the same run triggers that whole reload even though the data is identical.

## What
Add `shouldRevalidate` to the run route that skips the loader when **only** the view-only `setupStep` param changes on the **same** run. Everything else defers to the default:
- Poll-driven `revalidator.revalidate()` → same URL, no view-param change → **not skipped** (the run keeps refreshing live).
- Post-action revalidation (`formMethod`/`actionResult`) → **not skipped**.
- Cross-run navigation / plain loads → **not skipped**.

Logic lives in `app/lib/vibe-marketing-step-revalidation.ts` (mirrors the existing create-route helper) with unit tests.

## Verification
- `bun test` on the new suite + existing `vibe-marketing-run-polling` / `vibe-marketing-run-view`: **17 pass, 0 fail**.
- `tsc`: 0 errors in the changed files.

## Note
This complements the backend bootstrap-cache PR. It does not change the status-poll cadence; the poll already updates the page cheaply and only triggers a full refresh at meaningful transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)