### PR TITLE
Route WTH submissions through server proxy; repoint admin origin to mlai.au

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -64,6 +64,7 @@ export default [
     route("base44-pitching", "routes/watt-the-hack.base44-pitching.tsx"),
     route("city-of-melbourne-advanced", "routes/watt-the-hack.city-of-melbourne-advanced.tsx"),
     route("city-of-melbourne-advanced-submit", "routes/watt-the-hack.city-of-melbourne-advanced-submit.tsx"),
+    route("city-of-melbourne-advanced-submit-data", "routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts"),
     route("city-of-melbourne-advanced-leaderboard", "routes/watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx"),
     route("city-of-melbourne-advanced-leaderboard-data", "routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts"),
     route("smart-home-beginner", "routes/watt-the-hack.smart-home-beginner.tsx"),

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts
@@ -25,8 +25,8 @@ interface AdminProxyEnv {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context) as unknown as AdminProxyEnv;
-  // Default to the public Cloudflare-proxied subdomain (TLS handled by CF).
-  const base = env.WTH_ADMIN_URL || "https://eval.eliascorp.org";
+  // Default to the MLAI-owned Cloudflare-proxied subdomain (TLS handled by CF).
+  const base = env.WTH_ADMIN_URL || "https://eval.mlai.au";
   // No Host override needed for a real public origin; only used for the
   // legacy IP + resolveOverride fallback.
   const host = env.WTH_ADMIN_HOST ?? "";

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts
@@ -1,0 +1,129 @@
+import type { Route } from "./+types/watt-the-hack.city-of-melbourne-advanced-submit-data";
+import { getEnv } from "~/lib/env.server";
+
+/**
+ * Server-side submission proxy (mirrors the leaderboard proxy).
+ *
+ * The browser POSTs the packaged controller (a small zip) to this SAME-ORIGIN
+ * endpoint; the Cloudflare worker forwards it to the admin eval cluster and
+ * returns the cluster's response verbatim. This keeps the admin origin off the
+ * public client bundle, avoids a cross-origin request (so the team token is
+ * never sent from the browser to a third-party domain and there is no CORS
+ * preflight), and reuses the same `WTH_ADMIN_URL` config as the leaderboard.
+ *
+ * The team token is still supplied by the founder in the browser (it has to be —
+ * they type it), so the proxy cannot hide it from the client. What it does do is
+ * keep that credential inside the mlai.au origin: browser -> mlai.au worker (TLS,
+ * same-origin) -> admin cluster (server-to-server, TLS), instead of the browser
+ * shipping it straight to a separate eval domain.
+ *
+ * Config via Cloudflare env (shared with the leaderboard proxy):
+ *   WTH_ADMIN_URL   origin to forward to. RECOMMENDED: an MLAI-owned subdomain
+ *                   pointed at the eval ingress, e.g. "https://eval.mlai.au".
+ *   WTH_ADMIN_HOST  optional ingress Host header for the IP + resolveOverride
+ *                   fallback (only used when it differs from the URL host).
+ */
+interface AdminProxyEnv {
+  WTH_ADMIN_URL?: string;
+  WTH_ADMIN_HOST?: string;
+}
+
+const JSON_HEADERS = { "Content-Type": "application/json; charset=utf-8" } as const;
+
+export async function action({ request, context }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return new Response(JSON.stringify({ detail: "Method not allowed" }), {
+      status: 405,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  const env = getEnv(context) as unknown as AdminProxyEnv;
+  // Default to the MLAI-owned Cloudflare-proxied subdomain (TLS handled by CF).
+  const base = env.WTH_ADMIN_URL || "https://eval.mlai.au";
+  // No Host override needed for a real public origin; only used for the
+  // legacy IP + resolveOverride fallback.
+  const host = env.WTH_ADMIN_HOST ?? "";
+
+  // Parse the incoming multipart upload and rebuild it for the upstream. The
+  // submission is just a few text files zipped together, so buffering it in the
+  // worker is cheap and lets fetch set the multipart boundary for us.
+  let incoming: FormData;
+  try {
+    incoming = await request.formData();
+  } catch {
+    return new Response(JSON.stringify({ detail: "Invalid submission payload" }), {
+      status: 400,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  const teamId = incoming.get("team_id");
+  const file = incoming.get("file");
+  const token = request.headers.get("X-Team-Token") ?? "";
+
+  if (typeof teamId !== "string" || !teamId) {
+    return new Response(JSON.stringify({ detail: "Missing team_id" }), {
+      status: 400,
+      headers: JSON_HEADERS,
+    });
+  }
+  if (!file || typeof file === "string") {
+    return new Response(JSON.stringify({ detail: "Missing submission file" }), {
+      status: 400,
+      headers: JSON_HEADERS,
+    });
+  }
+  if (!token) {
+    return new Response(JSON.stringify({ detail: "Missing team token" }), {
+      status: 401,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  const outgoing = new FormData();
+  outgoing.append("team_id", teamId);
+  outgoing.append("file", file, "submission.zip");
+
+  const baseUrl = new URL(base);
+  const init: RequestInit & { cf?: Record<string, unknown> } = {
+    method: "POST",
+    headers: { "X-Team-Token": token },
+    body: outgoing,
+    signal: AbortSignal.timeout(20000), // uploads are small; don't hang the worker
+  };
+
+  let target: string;
+  if (host && host !== baseUrl.host) {
+    // Keep the ingress Host in the URL and connect to the LB IP at the edge.
+    // (`Host` cannot be set as a request header — it is stripped — so this is the
+    // supported technique. resolveOverride requires `host` to be in your CF zone.)
+    target = `${baseUrl.protocol}//${host}/submissions`;
+    init.cf = { resolveOverride: baseUrl.hostname };
+  } else {
+    // Clean path: WTH_ADMIN_URL is a real reachable origin (e.g. https://eval.mlai.au).
+    target = `${baseUrl.origin}/submissions`;
+  }
+
+  try {
+    const upstream = await fetch(target, init);
+    const body = await upstream.text();
+    // Forward the cluster's status + body so the client keeps seeing real
+    // validation errors (e.g. a 401 bad-token or 400 with a `detail` message).
+    return new Response(body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("Content-Type") ?? "application/json; charset=utf-8",
+      },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ detail: "Submission service unreachable", error: String(err) }),
+      {
+        status: 502,
+        headers: JSON_HEADERS,
+      },
+    );
+  }
+}

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-submit.tsx
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-submit.tsx
@@ -3,7 +3,10 @@ import { ArrowUpTrayIcon, CheckCircleIcon, ExclamationTriangleIcon, CodeBracketI
 import JSZip from "jszip";
 import { wattClasses, wattImages } from "~/lib/watt-theme";
 
-const ADMIN_URL = import.meta.env.VITE_WTH_ADMIN_URL || "https://api.watt-the-hack.com";
+// Same-origin worker proxy. It forwards the upload to the WTH admin eval cluster
+// server-side (see routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts),
+// so the admin origin/credentials are never exposed to the browser.
+const SUBMIT_ENDPOINT = "/watt-the-hack/city-of-melbourne-advanced-submit-data";
 
 const SCENARIOS = [
   { id: "duck_curve", name: "Level 1: The Duck Curve" },
@@ -66,7 +69,7 @@ export default function WattTheHackSubmissionPortal() {
       formData.append("team_id", teamId);
       formData.append("file", zipBlob, "submission.zip");
 
-      const res = await fetch(`${ADMIN_URL}/submissions`, {
+      const res = await fetch(SUBMIT_ENDPOINT, {
         method: "POST",
         headers: {
           "X-Team-Token": teamToken,

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -6,7 +6,7 @@ declare namespace Cloudflare {
 		mainModule: typeof import("./workers/app");
 	}
 	interface Env {
-		WTH_ADMIN_URL: "https://eval.eliascorp.org";
+		WTH_ADMIN_URL: "https://eval.mlai.au";
 		VALUE_FROM_CLOUDFLARE: string;
 		BACKEND_BASE_URL: string;
 		VITE_API_URL: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,7 @@
     "BACKEND_BASE_URL": "https://api.mlai.au",
     "VITE_GOOGLE_CLIENT_ID": "",
     "VITE_ENABLE_FOUNDER_TOOLS_DISCOVER": "false",
-    "WTH_ADMIN_URL": "https://eval.eliascorp.org"
+    "WTH_ADMIN_URL": "https://eval.mlai.au"
   },
   "routes": [
     {


### PR DESCRIPTION
## What

Fixes the admin-URL inconsistency introduced with the City of Melbourne advanced-track leaderboard (#905).

**Before:** the submit page POSTed (with the team token) **directly from the browser** to `api.watt-the-hack.com` via an **undefined** `VITE_WTH_ADMIN_URL` (so it always hit that hardcoded fallback), while the leaderboard proxied `eval.eliascorp.org` (the original author's personal domain). Two different backends; `VITE_WTH_ADMIN_URL` was never set anywhere.

## Changes

- **Server-side submit proxy** — new resource route `app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts` (an `action`) mirroring the existing leaderboard-data proxy. The browser now POSTs **same-origin**; the worker forwards the upload to `${WTH_ADMIN_URL}/submissions` and returns the cluster's real status/body so client error handling is unchanged.
- Submit route now posts to the proxy; the dead client-side `VITE_WTH_ADMIN_URL` is removed. Submit and leaderboard now resolve from the **same** `WTH_ADMIN_URL`, server-side.
- **Repointed `WTH_ADMIN_URL`** off the personal `eval.eliascorp.org` to the MLAI-owned `eval.mlai.au` — in `wrangler.jsonc`, `worker-configuration.d.ts`, and both proxy defaults.

## Security note (team token)

The team token is user-entered, so a proxy can't hide it from the client. What it does fix: the token is no longer shipped from the browser to a **third-party origin** — it stays same-origin (browser → mlai.au worker over TLS → admin cluster, server-to-server). It also keeps the admin origin out of the client bundle and drops the CORS preflight.

## ⚠️ Before relying on this in prod

`eval.mlai.au` **does not resolve yet**. Confirm it is the intended production admin endpoint and provision DNS to the eval ingress, then run a live end-to-end submission + leaderboard test. Until then, both flows will fail against the new origin (as they would have against the personal domain too).

## Verification

- `bun run typecheck` ✅
- `bunx react-router build` ✅ (exit 0; new route present in the server build manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
