### PR TITLE
Watt smart-home coding-blocks drag-and-drop UI (frontend)

### DIFF
--- a/app/components/SmartHomeController.tsx
+++ b/app/components/SmartHomeController.tsx
@@ -1,0 +1,229 @@
+import { useId, useRef, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { wattClasses } from "~/lib/watt-theme";
+import type { SmartHomeBlock, SmartHomeCatalog } from "~/lib/generic-hackathon";
+
+export type DeployFeedback = { ok: boolean; message: string } | null;
+
+type PlacedBlock = { instanceId: string; block: SmartHomeBlock };
+
+const GROUP_DOT: Record<string, string> = {
+  Appliances: "bg-[#a8c75b]",
+  "Battery & solar": "bg-[#f0c742]",
+  "EV charging": "bg-[#2f6f2c]",
+  "Climate & lights": "bg-[#64705f]",
+};
+
+function dotClass(group: string) {
+  return GROUP_DOT[group] ?? "bg-[#2f6f2c]";
+}
+
+function BlockCard({ block, className = "" }: { block: SmartHomeBlock; className?: string }) {
+  return (
+    <div className={`rounded-[0.85rem] border border-[#e8dfcf] bg-[#fffefa] px-3 py-2 text-left shadow-sm ${className}`}>
+      <div className="flex items-center gap-2">
+        <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${dotClass(block.group)}`} />
+        <span className="text-sm font-black text-[#121e16]">{block.label}</span>
+      </div>
+      <p className="mt-1 text-xs font-medium text-[#64705f]">{block.blurb}</p>
+    </div>
+  );
+}
+
+function PaletteBlock({ block, onAdd }: { block: SmartHomeBlock; onAdd: (block: SmartHomeBlock) => void }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `palette:${block.block_id}`,
+    data: { block },
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      onClick={() => onAdd(block)}
+      className="w-full cursor-grab touch-none rounded-[0.85rem] border border-[#e8dfcf] bg-[#fffefa] px-3 py-2 text-left shadow-sm transition hover:border-[#2f6f2c]/40 hover:bg-[#fbf6e9] focus:outline-none focus:ring-2 focus:ring-[#2f6f2c]/20 active:cursor-grabbing"
+      style={{ opacity: isDragging ? 0.4 : 1 }}
+      {...listeners}
+      {...attributes}
+    >
+      <div className="flex items-center gap-2">
+        <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${dotClass(block.group)}`} />
+        <span className="text-sm font-black text-[#121e16]">{block.label}</span>
+      </div>
+      <p className="mt-1 text-xs font-medium text-[#64705f]">{block.blurb}</p>
+    </button>
+  );
+}
+
+function Canvas({ placed, onRemove }: { placed: PlacedBlock[]; onRemove: (instanceId: string) => void }) {
+  const { setNodeRef, isOver } = useDroppable({ id: "canvas" });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`min-h-[14rem] rounded-[1rem] border-2 border-dashed p-3 transition ${
+        isOver ? "border-[#2f6f2c] bg-[#edf5df]" : "border-[#d8cfbd] bg-[#fbf6e9]"
+      }`}
+    >
+      {placed.length === 0 ? (
+        <div className="flex h-full min-h-[12rem] items-center justify-center px-6 text-center">
+          <p className="text-sm font-semibold text-[#64705f]">
+            Drag blocks here (or tap them) to build your smart-home program, then hit Deploy.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {placed.map((item) => (
+            <li key={item.instanceId} className="flex items-start gap-2">
+              <div className="flex-1">
+                <BlockCard block={item.block} />
+              </div>
+              <button
+                type="button"
+                onClick={() => onRemove(item.instanceId)}
+                aria-label={`Remove ${item.block.label}`}
+                className="mt-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#e8dfcf] bg-[#fffefa] text-[#9f2f28] transition hover:border-[#df5047]/40 hover:bg-[#fff1ef]"
+              >
+                &times;
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function SmartHomeController({
+  catalog,
+  onDeploy,
+  isDeploying,
+  feedback,
+}: {
+  catalog: SmartHomeCatalog;
+  onDeploy: (blockIds: string[]) => void;
+  isDeploying: boolean;
+  feedback: DeployFeedback;
+}) {
+  const [placed, setPlaced] = useState<PlacedBlock[]>([]);
+  const [activeBlock, setActiveBlock] = useState<SmartHomeBlock | null>(null);
+  const idPrefix = useId();
+  const nextId = useRef(0);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  const groups = catalog.groups.length
+    ? catalog.groups
+    : Array.from(new Set(catalog.blocks.map((block) => block.group)));
+  const hasCatalog = catalog.blocks.length > 0;
+
+  const addBlock = (block: SmartHomeBlock) =>
+    setPlaced((prev) => [...prev, { instanceId: `${idPrefix}-${nextId.current++}`, block }]);
+  const removeBlock = (instanceId: string) =>
+    setPlaced((prev) => prev.filter((item) => item.instanceId !== instanceId));
+  const clearAll = () => setPlaced([]);
+
+  function handleDragStart(event: DragStartEvent) {
+    const block = event.active.data.current?.block as SmartHomeBlock | undefined;
+    setActiveBlock(block ?? null);
+  }
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveBlock(null);
+    const block = event.active.data.current?.block as SmartHomeBlock | undefined;
+    if (event.over?.id === "canvas" && block) addBlock(block);
+  }
+
+  const blockIds = placed.map((item) => item.block.block_id);
+
+  return (
+    <section className={`${wattClasses.panel} p-6`}>
+      <p className={wattClasses.eyebrow}>Smart Home &middot; Beginner Track</p>
+      <h2 className="mt-2 text-lg font-black text-[#121e16]">Your Smart Home Controller</h2>
+      <p className="mt-1 text-sm font-medium text-[#64705f]">
+        Drag energy blocks into the controller, then{" "}
+        <span className="font-bold text-[#155420]">Deploy</span> &mdash; the house above updates in real time as
+        Unity applies them.
+      </p>
+
+      {!hasCatalog ? (
+        <div className={`${wattClasses.warningAlert} mt-4`}>
+          Couldn&rsquo;t load your blocks. Make sure you&rsquo;re signed in and on a Watt team, then refresh.
+        </div>
+      ) : (
+        <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <div className="mt-5 grid gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)]">
+            {/* Palette */}
+            <div>
+              <h3 className="text-xs font-black uppercase tracking-[0.18em] text-[#64705f]">Blocks</h3>
+              <div className="mt-3 space-y-4">
+                {groups.map((group) => {
+                  const groupBlocks = catalog.blocks.filter((block) => block.group === group);
+                  if (!groupBlocks.length) return null;
+                  return (
+                    <div key={group}>
+                      <div className="flex items-center gap-2">
+                        <span className={`h-2 w-2 rounded-full ${dotClass(group)}`} />
+                        <span className="text-xs font-bold uppercase tracking-[0.12em] text-[#354031]">{group}</span>
+                      </div>
+                      <div className="mt-2 grid gap-2">
+                        {groupBlocks.map((block) => (
+                          <PaletteBlock key={block.block_id} block={block} onAdd={addBlock} />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Controller */}
+            <div>
+              <div className="flex items-center justify-between">
+                <h3 className="text-xs font-black uppercase tracking-[0.18em] text-[#64705f]">
+                  Controller {placed.length > 0 ? `(${placed.length})` : ""}
+                </h3>
+                {placed.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={clearAll}
+                    className="text-xs font-bold text-[#9f2f28] hover:underline"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              <div className="mt-3">
+                <Canvas placed={placed} onRemove={removeBlock} />
+              </div>
+
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => onDeploy(blockIds)}
+                  disabled={isDeploying || placed.length === 0}
+                  className={`${wattClasses.buttonPrimary} px-6 py-2.5 disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  {isDeploying ? "Deploying…" : "Deploy to Smart Home"}
+                </button>
+                {feedback && (
+                  <span className={`text-sm font-semibold ${feedback.ok ? "text-[#155420]" : "text-[#9f2f28]"}`}>
+                    {feedback.message}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <DragOverlay>{activeBlock ? <BlockCard block={activeBlock} className="w-64 shadow-lg" /> : null}</DragOverlay>
+        </DndContext>
+      )}
+    </section>
+  );
+}

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -55,6 +55,12 @@ export interface GenericHackathonResource {
   order: number;
 }
 
+export interface WattUnitySession {
+  stream_url: string;
+  household_id: string;
+  expires_at: string;
+}
+
 function appPath(slug: string, path: string) {
   return `/api/v1/hackathons/${slug}/app/${path}`;
 }
@@ -144,4 +150,62 @@ export async function getGenericResources(env: Env, request: Request, slug = WAT
   const client = createApiClient(env, request);
   const response = await client.get(appPath(slug, "resources/"));
   return response.data || [];
+}
+
+export async function createWattUnitySession(env: Env, request: Request): Promise<WattUnitySession> {
+  const client = createApiClient(env, request);
+  const response = await client.post("/api/v1/hackathons/watt/unity-sessions/current/", {});
+  const data = response.data as Partial<WattUnitySession>;
+  if (!data || typeof data.stream_url !== "string" || typeof data.expires_at !== "string") {
+    throw new Error("Invalid Unity stream session response.");
+  }
+  return data as WattUnitySession;
+}
+
+// --- Smart Home (Beginner) coding-blocks challenge ---
+
+export interface SmartHomeBlock {
+  block_id: string;
+  group: string;
+  label: string;
+  blurb: string;
+}
+
+export interface SmartHomeCatalog {
+  groups: string[];
+  blocks: SmartHomeBlock[];
+}
+
+export interface SmartHomeDeployCommand {
+  command_id: string;
+  block_id: string;
+  action: string;
+  target_id: string;
+}
+
+export interface SmartHomeDeployResult {
+  household_id: string;
+  tick_seen: number;
+  deployed_count: number;
+  commands: SmartHomeDeployCommand[];
+}
+
+export async function getSmartHomeBlocks(env: Env, request: Request): Promise<SmartHomeCatalog> {
+  const client = createApiClient(env, request);
+  const response = await client.get("/api/v1/hackathons/watt/smart-home/blocks/");
+  const data = (response.data ?? {}) as Partial<SmartHomeCatalog>;
+  return {
+    groups: Array.isArray(data.groups) ? data.groups.map((group) => String(group)) : [],
+    blocks: Array.isArray(data.blocks) ? (data.blocks as SmartHomeBlock[]) : [],
+  };
+}
+
+export async function deploySmartHome(
+  env: Env,
+  request: Request,
+  blockIds: string[],
+): Promise<SmartHomeDeployResult> {
+  const client = createApiClient(env, request);
+  const response = await client.post("/api/v1/hackathons/watt/smart-home/deploy/", { blocks: blockIds });
+  return response.data as SmartHomeDeployResult;
 }

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -1,5 +1,201 @@
-import WattTrackPlaceholder from "~/components/WattTrackPlaceholder";
+import type { Route } from "./+types/watt-the-hack.smart-home-beginner";
+import { useEffect, useMemo, useState } from "react";
+import { useFetcher, useLoaderData, type ShouldRevalidateFunctionArgs } from "react-router";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import {
+  createWattUnitySession,
+  deploySmartHome,
+  getSmartHomeBlocks,
+  type SmartHomeCatalog,
+  type WattUnitySession,
+} from "~/lib/generic-hackathon";
+import { getEnv } from "~/lib/env.server";
+import { wattClasses } from "~/lib/watt-theme";
+import { SmartHomeController, type DeployFeedback } from "~/components/SmartHomeController";
+
+type StreamData = {
+  session: WattUnitySession | null;
+  error: string | null;
+};
+
+const EMPTY_CATALOG: SmartHomeCatalog = { groups: [], blocks: [] };
+
+function errorMessage(error: unknown, fallback: string) {
+  const maybe = error as { response?: { data?: unknown }; message?: string } | null | undefined;
+  const data = maybe?.response?.data;
+  if (data && typeof data === "object") {
+    const detail = (data as Record<string, unknown>).error ?? (data as Record<string, unknown>).detail;
+    if (typeof detail === "string" && detail.trim()) return detail.trim();
+  }
+  if (typeof maybe?.message === "string" && maybe.message.trim()) return maybe.message.trim();
+  return fallback;
+}
+
+async function loadSession(request: Request, context: Route.LoaderArgs["context"]): Promise<StreamData> {
+  const env = getEnv(context);
+  try {
+    return { session: await createWattUnitySession(env, request), error: null };
+  } catch (error) {
+    return { session: null, error: errorMessage(error, "Unable to start your Smart Home stream.") };
+  }
+}
+
+async function loadCatalog(request: Request, context: Route.LoaderArgs["context"]): Promise<SmartHomeCatalog> {
+  const env = getEnv(context);
+  try {
+    return await getSmartHomeBlocks(env, request);
+  } catch {
+    return EMPTY_CATALOG;
+  }
+}
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const [stream, catalog] = await Promise.all([
+    loadSession(request, context),
+    loadCatalog(request, context),
+  ]);
+  return { ...stream, catalog };
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  const env = getEnv(context);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") || "reconnect");
+
+  if (intent === "deploy") {
+    let blockIds: string[] = [];
+    try {
+      const parsed = JSON.parse(String(formData.get("blocks") || "[]"));
+      if (Array.isArray(parsed)) blockIds = parsed.map((value) => String(value));
+    } catch {
+      blockIds = [];
+    }
+    try {
+      const result = await deploySmartHome(env, request, blockIds);
+      return { kind: "deploy" as const, result, error: null as string | null };
+    } catch (error) {
+      return {
+        kind: "deploy" as const,
+        result: null,
+        error: errorMessage(error, "Couldn't deploy to your Smart Home."),
+      };
+    }
+  }
+
+  const stream = await loadSession(request, context);
+  return { kind: "session" as const, ...stream };
+}
+
+// Our reconnect/deploy fetcher POSTs manage their own state; never re-run the loader for them
+// (revalidation would re-mint a fresh Unity stream session/ticket on every Deploy).
+export function shouldRevalidate({ formData, defaultShouldRevalidate }: ShouldRevalidateFunctionArgs) {
+  if (formData) return false;
+  return defaultShouldRevalidate;
+}
 
 export default function WattTheHackSmartHomeBeginnerTrack() {
-  return <WattTrackPlaceholder />;
+  const initialData = useLoaderData<typeof loader>();
+  const reconnectFetcher = useFetcher<typeof action>();
+  const deployFetcher = useFetcher<typeof action>();
+  const [session, setSession] = useState<WattUnitySession | null>(initialData.session);
+  const [error, setError] = useState<string | null>(initialData.error);
+  const [isFrameLoaded, setIsFrameLoaded] = useState(false);
+
+  const reconnectData = reconnectFetcher.data;
+  const isReconnecting = reconnectFetcher.state !== "idle";
+
+  useEffect(() => {
+    if (!reconnectData || reconnectData.kind !== "session") return;
+    if (reconnectData.session) {
+      setSession(reconnectData.session);
+      setError(null);
+      setIsFrameLoaded(false);
+      return;
+    }
+    setError(reconnectData.error || "Unable to refresh your Smart Home stream.");
+  }, [reconnectData]);
+
+  // The Vagon stream session persists after Unity redeems the one-time ticket
+  // at startup, so we intentionally do NOT refresh on ticket expiry (that would
+  // restart the whole stream). We only reconnect on an iframe load error.
+
+  const statusLabel = useMemo(() => {
+    if (isReconnecting) return "Connecting...";
+    if (!session) return "Connecting...";
+    if (!isFrameLoaded) return "Starting your house...";
+    return "";
+  }, [isFrameLoaded, isReconnecting, session]);
+
+  const reconnect = () => reconnectFetcher.submit({ intent: "reconnect" }, { method: "post" });
+
+  const deployData = deployFetcher.data;
+  const isDeploying = deployFetcher.state !== "idle";
+  const feedback: DeployFeedback = useMemo(() => {
+    if (isDeploying) return null;
+    if (!deployData || deployData.kind !== "deploy") return null;
+    if (deployData.result) {
+      const count = deployData.result.deployed_count;
+      return { ok: true, message: `Deployed ${count} change${count === 1 ? "" : "s"} — watch your house above.` };
+    }
+    return { ok: false, message: deployData.error || "Couldn't deploy to your Smart Home." };
+  }, [deployData, isDeploying]);
+
+  const handleDeploy = (blockIds: string[]) =>
+    deployFetcher.submit({ intent: "deploy", blocks: JSON.stringify(blockIds) }, { method: "post" });
+
+  return (
+    <div className={wattClasses.page}>
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section className={`${wattClasses.panelStrong} overflow-hidden p-0`}>
+          <div className="relative aspect-video w-full bg-black">
+            {session?.stream_url ? (
+              <iframe
+                key={session.stream_url}
+                title="Watt The Hack Smart Home stream"
+                src={session.stream_url}
+                className="absolute inset-0 h-full w-full border-0 bg-black"
+                allow="autoplay; fullscreen; clipboard-read; clipboard-write; encrypted-media; gamepad"
+                allowFullScreen
+                referrerPolicy="no-referrer"
+                onLoad={() => setIsFrameLoaded(true)}
+                onError={() => {
+                  setError("Unable to load your Smart Home stream.");
+                  reconnect();
+                }}
+              />
+            ) : null}
+
+            {(statusLabel || error) && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#121e16]">
+                <div className="mx-4 flex max-w-md flex-col items-center text-center">
+                  {error ? (
+                    <ExclamationTriangleIcon className="h-10 w-10 text-[#f0c742]" aria-hidden="true" />
+                  ) : (
+                    <div className="h-10 w-10 animate-spin rounded-full border-4 border-[#e6efd7] border-t-[#2f6f2c]" />
+                  )}
+                  <p className="mt-5 text-lg font-black text-[#fffefa]">{error || statusLabel}</p>
+                  {error && (
+                    <button
+                      type="button"
+                      className={`${wattClasses.buttonPrimary} mt-6 px-6 py-3`}
+                      onClick={reconnect}
+                    >
+                      Reconnect
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <SmartHomeController
+          catalog={initialData.catalog}
+          onDeploy={handleDeploy}
+          isDeploying={isDeploying}
+          feedback={feedback}
+        />
+      </div>
+    </div>
+  );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "mlai-au",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "@headlessui/react": "^2.2.9",
@@ -143,6 +144,12 @@
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, ""],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, ""],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.0", "", { "os": "darwin", "cpu": "arm64" }, ""],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "react-router typegen && tsc -b && bun run check:article-internal-links"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "@headlessui/react": "^2.2.9",


### PR DESCRIPTION
## What
Frontend for the Watt The Hack **Smart Home (Beginner)** challenge, on the page below the live Unity stream: a `@dnd-kit` palette of fixed energy blocks (appliances, battery, EV, climate & lights) the user drags into a "Smart Home Controller" and deploys; the streamed house reacts in real time.

## Changes
- `app/components/SmartHomeController.tsx` — dnd-kit palette + droppable canvas (drag or tap to add, remove/clear, DragOverlay) + Deploy button with feedback.
- `app/lib/generic-hackathon.ts` — Smart Home types + `getSmartHomeBlocks`/`deploySmartHome` (and the `createWattUnitySession` helper the page uses).
- `app/routes/watt-the-hack.smart-home-beginner.tsx` — loader also fetches the block catalog; action gains a deploy branch; `shouldRevalidate` avoids re-minting the Unity stream on deploy; renders the controller under the stream.
- `@dnd-kit/core` dependency.

## Verification
- `tsc -b` passes.
- The authenticated drag/deploy happy path needs a logged-in Watt team + live stream, so final visual QA should be done on a deployed/authed environment.

## Depends on
Backend PR (`MLAI-AUS-Inc/mlai-backend`) — the `watt/smart-home/*` endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
