### PR TITLE
Watt smart-home pipeline controller — v2 drag-and-drop UI

### DIFF
--- a/app/components/SmartHomeControllerV2.tsx
+++ b/app/components/SmartHomeControllerV2.tsx
@@ -1,0 +1,333 @@
+import { type CSSProperties, useMemo, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { wattClasses } from "~/lib/watt-theme";
+import type { DeployFeedback } from "~/components/SmartHomeController";
+import {
+  PIPELINE,
+  PIPELINE_BY_TYPE,
+  PALETTE,
+  compilePipeline,
+  emptyPipeline,
+  isComplete,
+  type BlockDef,
+  type PlacedPipeline,
+  type SlotDef,
+  type SlotShape,
+  type SlotType,
+} from "~/lib/smart-home-pipeline";
+
+/**
+ * v2 prototype — the "sense -> think -> act" pipeline builder from the draft.
+ * Typed + shaped slots (only matching shapes snap in), single-capacity slots SWAP, and
+ * Deploy compiles the filled pipeline -> backend block_ids (Path A). Shapes are approximate
+ * clip-paths for the prototype; precise jigsaw silhouettes are a polish pass.
+ */
+
+const SHAPE_STYLE: Record<SlotShape, CSSProperties> = {
+  plug: { clipPath: "polygon(0% 24%, 7% 24%, 7% 0%, 100% 0%, 100% 100%, 7% 100%, 7% 76%, 0% 76%)" },
+  gem: { clipPath: "polygon(9% 0%, 100% 0%, 91% 100%, 0% 100%)" },
+  square: { borderRadius: "0.4rem" },
+  bolt: { clipPath: "polygon(0% 0%, 89% 0%, 100% 50%, 89% 100%, 0% 100%)" },
+  node: { borderRadius: "1.5rem" },
+  shield: { clipPath: "polygon(0% 0%, 100% 0%, 100% 70%, 50% 100%, 0% 70%)" },
+};
+
+const GLYPH: Record<SlotType, string> = {
+  input: "▷",
+  schedule: "◈",
+  brain: "▣",
+  action: "⚡",
+  output: "⦿",
+  safety: "🛡",
+};
+
+type PlacedCells = Record<SlotType, Array<BlockDef | null>>;
+
+function makeEmptyCells(): PlacedCells {
+  return Object.fromEntries(PIPELINE.map((slot) => [slot.type, Array(slot.max).fill(null)])) as PlacedCells;
+}
+
+function shapePadding(shape: SlotShape): string {
+  // Give clipped shapes extra side padding so labels aren't cut.
+  if (shape === "plug") return "py-2 pl-4 pr-3";
+  if (shape === "bolt") return "py-2 pl-3 pr-5";
+  if (shape === "gem") return "py-2 px-4";
+  if (shape === "shield") return "pt-2 pb-4 px-3";
+  return "py-2 px-3";
+}
+
+function BlockChip({ block, withBlurb = false }: { block: BlockDef; withBlurb?: boolean }) {
+  const slot = PIPELINE_BY_TYPE[block.type];
+  return (
+    <div
+      style={{ ...SHAPE_STYLE[slot.shape], borderColor: slot.accent, background: `${slot.accent}12` }}
+      className={`w-full border-2 bg-[#fffefa] text-left shadow-sm ${shapePadding(slot.shape)}`}
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden style={{ color: slot.accent }} className="text-sm leading-none">{GLYPH[block.type]}</span>
+        <span className="text-sm font-black text-[#121e16]">{block.label}</span>
+      </div>
+      {withBlurb && <p className="mt-1 text-[11px] font-medium leading-tight text-[#64705f]">{block.blurb}</p>}
+    </div>
+  );
+}
+
+function PaletteBlock({ block }: { block: BlockDef }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: `pal#${block.id}`, data: { block } });
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      style={{ opacity: isDragging ? 0.35 : 1 }}
+      className="w-full cursor-grab touch-none focus:outline-none active:cursor-grabbing"
+      {...listeners}
+      {...attributes}
+    >
+      <BlockChip block={block} withBlurb />
+    </button>
+  );
+}
+
+function SlotCell({
+  slot,
+  index,
+  block,
+  activeType,
+  onRemove,
+}: {
+  slot: SlotDef;
+  index: number;
+  block: BlockDef | null;
+  activeType: SlotType | null;
+  onRemove: () => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `${slot.type}#${index}`, data: { slotType: slot.type } });
+  const isTarget = activeType === slot.type; // a matching piece is being dragged
+  const dimmed = activeType !== null && activeType !== slot.type;
+
+  let ring = "border-[#d8cfbd]";
+  if (isOver && isTarget) ring = "border-[#2f6f2c] ring-4 ring-[#2f6f2c]/20";
+  else if (isTarget) ring = "border-[var(--accent)] ring-2 ring-[var(--accent)]/25 animate-pulse";
+
+  if (block) {
+    return (
+      <div className="relative">
+        <div ref={setNodeRef}>
+          <BlockChip block={block} />
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${block.label}`}
+          className="absolute -right-2 -top-2 inline-flex h-6 w-6 items-center justify-center rounded-full border border-[#e8dfcf] bg-[#fffefa] text-xs text-[#9f2f28] shadow-sm hover:bg-[#fff1ef]"
+        >
+          &times;
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ ...SHAPE_STYLE[slot.shape], ["--accent" as string]: slot.accent } as CSSProperties}
+      className={`flex min-h-[3.25rem] items-center justify-center border-2 border-dashed bg-[#fbf6e9] text-center transition ${shapePadding(slot.shape)} ${ring} ${dimmed ? "opacity-40" : ""}`}
+    >
+      <span className="flex items-center gap-1.5 text-xs font-bold text-[#8a8477]">
+        <span aria-hidden style={{ color: slot.accent }}>{GLYPH[slot.type]}</span>
+        {slot.type}
+      </span>
+    </div>
+  );
+}
+
+function SlotColumn({
+  slot,
+  cells,
+  activeType,
+  onRemove,
+}: {
+  slot: SlotDef;
+  cells: Array<BlockDef | null>;
+  activeType: SlotType | null;
+  onRemove: (index: number) => void;
+}) {
+  const filled = cells.filter(Boolean).length;
+  return (
+    <div className="min-w-[8.5rem] flex-1">
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <span className="text-[11px] font-black uppercase tracking-[0.14em]" style={{ color: slot.accent }}>
+          {slot.label}
+        </span>
+        <span className="text-[10px] font-bold text-[#8a8477]">
+          {slot.min === 0 ? "optional" : `${filled}/${slot.max}`}
+        </span>
+      </div>
+      <div className="space-y-2">
+        {cells.map((block, index) => (
+          <SlotCell
+            key={index}
+            slot={slot}
+            index={index}
+            block={block}
+            activeType={activeType}
+            onRemove={() => onRemove(index)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SmartHomeControllerV2({
+  onDeploy,
+  isDeploying,
+  feedback,
+}: {
+  onDeploy: (blockIds: string[]) => void;
+  isDeploying: boolean;
+  feedback: DeployFeedback;
+}) {
+  const [cells, setCells] = useState<PlacedCells>(makeEmptyCells);
+  const [activeBlock, setActiveBlock] = useState<BlockDef | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  const flow = PIPELINE.filter((slot) => slot.type !== "safety");
+  const safety = PIPELINE_BY_TYPE.safety;
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveBlock((event.active.data.current?.block as BlockDef | undefined) ?? null);
+  }
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveBlock(null);
+    const block = event.active.data.current?.block as BlockDef | undefined;
+    const overData = event.over?.data.current as { slotType?: SlotType } | undefined;
+    const slotType = overData?.slotType;
+    const index = Number(String(event.over?.id ?? "").split("#")[1]);
+    if (!block || !slotType || slotType !== block.type || Number.isNaN(index)) return; // shape/type gate
+    setCells((prev) => {
+      const next: PlacedCells = { ...prev, [slotType]: [...prev[slotType]] };
+      next[slotType][index] = block; // single-capacity slots have one cell => natural swap
+      return next;
+    });
+  }
+  function removeAt(type: SlotType, index: number) {
+    setCells((prev) => {
+      const next: PlacedCells = { ...prev, [type]: [...prev[type]] };
+      next[type][index] = null;
+      return next;
+    });
+  }
+  const reset = () => setCells(makeEmptyCells());
+
+  const pipeline: PlacedPipeline = useMemo(() => {
+    const placed = emptyPipeline();
+    for (const slot of PIPELINE) placed[slot.type] = cells[slot.type].filter(Boolean) as BlockDef[];
+    return placed;
+  }, [cells]);
+
+  const complete = isComplete(pipeline);
+  const { blockIds, incompatible } = useMemo(() => compilePipeline(pipeline), [pipeline]);
+  const activeType = activeBlock?.type ?? null;
+  const canDeploy = complete && blockIds.length > 0 && !isDeploying;
+
+  const byType = (type: SlotType) => PALETTE.filter((block) => block.type === type);
+
+  return (
+    <section className={`${wattClasses.panel} p-6`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className={wattClasses.eyebrow}>Build your Smart Home Controller</p>
+          <p className="mt-1 text-sm font-medium text-[#64705f]">
+            Drag blocks into the controller. Each slot only accepts its own shape — there's room for one Brain
+            and one Schedule. Deploy compiles your pipeline and the house above reacts.
+          </p>
+        </div>
+        <button type="button" onClick={reset} className="shrink-0 text-xs font-bold text-[#9f2f28] hover:underline">
+          ↺ Reset
+        </button>
+      </div>
+
+      <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+        <div className="mt-5 grid gap-6 lg:grid-cols-[minmax(0,1fr)_17rem]">
+          {/* Controller */}
+          <div>
+            <div className="flex items-stretch gap-2 overflow-x-auto rounded-[1rem] border border-[#e8dfcf] bg-[#fffefa]/60 p-3">
+              {flow.map((slot, i) => (
+                <div key={slot.type} className="flex items-stretch gap-2">
+                  <SlotColumn slot={slot} cells={cells[slot.type]} activeType={activeType} onRemove={(idx) => removeAt(slot.type, idx)} />
+                  {i < flow.length - 1 && <div className="flex items-center text-[#c9b98f]">▷</div>}
+                </div>
+              ))}
+            </div>
+
+            {/* Safety hangs below */}
+            <div className="mt-3 max-w-[16rem]">
+              <SlotColumn slot={safety} cells={cells.safety} activeType={activeType} onRemove={(idx) => removeAt("safety", idx)} />
+            </div>
+
+            {/* Deploy bar */}
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={() => onDeploy(blockIds)}
+                disabled={!canDeploy}
+                className={`${wattClasses.buttonPrimary} px-6 py-2.5 disabled:cursor-not-allowed disabled:opacity-50`}
+              >
+                {isDeploying ? "Deploying…" : "🚀 Deploy Controller"}
+              </button>
+              <span className="text-xs font-semibold text-[#64705f]">
+                {complete
+                  ? `${blockIds.length} device command${blockIds.length === 1 ? "" : "s"} ready`
+                  : "Fix all required slots to deploy"}
+              </span>
+              {feedback && (
+                <span className={`text-sm font-semibold ${feedback.ok ? "text-[#155420]" : "text-[#9f2f28]"}`}>
+                  {feedback.message}
+                </span>
+              )}
+            </div>
+            {incompatible.length > 0 && (
+              <p className="mt-2 text-xs font-medium text-[#9f6a08]">
+                Ignored {incompatible.length} incompatible pairing
+                {incompatible.length === 1 ? "" : "s"} (e.g. {incompatible[0].action} → {incompatible[0].device}).
+              </p>
+            )}
+          </div>
+
+          {/* Palette */}
+          <div className="rounded-[1rem] border border-[#e8dfcf] bg-[#fbf6e9] p-3">
+            <p className="text-[11px] font-black uppercase tracking-[0.16em] text-[#64705f]">Draggable blocks</p>
+            <div className="mt-3 space-y-4">
+              {PIPELINE.map((slot) => (
+                <div key={slot.type}>
+                  <div className="mb-2 flex items-center gap-1.5">
+                    <span aria-hidden style={{ color: slot.accent }}>{GLYPH[slot.type]}</span>
+                    <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-[#354031]">{slot.label}</span>
+                  </div>
+                  <div className="space-y-2">
+                    {byType(slot.type).map((block) => (
+                      <PaletteBlock key={block.id} block={block} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <DragOverlay>{activeBlock ? <div className="w-56"><BlockChip block={activeBlock} /></div> : null}</DragOverlay>
+      </DndContext>
+    </section>
+  );
+}

--- a/app/lib/smart-home-pipeline.ts
+++ b/app/lib/smart-home-pipeline.ts
@@ -1,0 +1,147 @@
+/**
+ * Watt Smart Home — "pipeline" spec (Path A).
+ *
+ * The drag-and-drop controller is a SENSE -> THINK -> ACT pipeline (Inputs -> Schedule ->
+ * Brain -> Actions -> Outputs, + optional Safety). It's a presentation layer: on Deploy the
+ * frontend COMPILES the filled slots into the existing backend device `block_id` list and
+ * posts to /api/v1/hackathons/watt/smart-home/deploy. No backend change required.
+ *
+ * In v1 the Brain / Inputs / Safety are required *scaffolding* (they gate Deploy and teach the
+ * loop) — only Outputs x Actions x Schedule produce device commands. This data model is
+ * forward-compatible with "Path B", where the Brain becomes a real server-side policy that
+ * consumes the Inputs live.
+ */
+
+export type SlotType = "input" | "schedule" | "brain" | "action" | "output" | "safety";
+export type SlotShape = "plug" | "gem" | "square" | "bolt" | "node" | "shield";
+
+export interface SlotDef {
+  type: SlotType;
+  label: string;
+  hint: string;
+  min: number; // required minimum to deploy (0 => optional)
+  max: number; // capacity (single-capacity slots SWAP on a new drop)
+  shape: SlotShape;
+  accent: string; // hex accent for the slot/blocks
+}
+
+/** The controller skeleton, left-to-right, matching the draft. */
+export const PIPELINE: SlotDef[] = [
+  { type: "input", label: "Inputs", hint: "Add one or more", min: 1, max: 3, shape: "plug", accent: "#2f6f2c" },
+  { type: "schedule", label: "Schedule", hint: "Add one", min: 1, max: 1, shape: "gem", accent: "#2f6fae" },
+  { type: "brain", label: "Brain", hint: "Add one", min: 1, max: 1, shape: "square", accent: "#7c5cd6" },
+  { type: "action", label: "Actions", hint: "Add one or more", min: 1, max: 3, shape: "bolt", accent: "#caa207" },
+  { type: "output", label: "Outputs", hint: "Add one or more", min: 1, max: 3, shape: "node", accent: "#0e8f99" },
+  { type: "safety", label: "Safety & Override", hint: "Optional", min: 0, max: 1, shape: "shield", accent: "#64705f" },
+];
+
+export const PIPELINE_BY_TYPE: Record<SlotType, SlotDef> = Object.fromEntries(
+  PIPELINE.map((slot) => [slot.type, slot]),
+) as Record<SlotType, SlotDef>;
+
+export type DeviceKey = "smart_plugs" | "battery" | "ev";
+export type ActionIntent = "shift_load" | "reduce_usage" | "charge_battery";
+export type TimingKey = "time_of_day" | "day_of_week" | "price_signal";
+
+export interface BlockDef {
+  id: string;
+  type: SlotType;
+  label: string;
+  blurb: string;
+  device?: DeviceKey; // outputs only
+  intent?: ActionIntent; // actions only
+  timing?: TimingKey; // schedule only
+}
+
+/** Palette blocks, mirroring the draft UI. (Catalog will move server-side later.) */
+export const PALETTE: BlockDef[] = [
+  // Inputs (sensors the controller reads)
+  { id: "in_smart_meter", type: "input", label: "Smart Meter", blurb: "Live household power draw." },
+  { id: "in_temp", type: "input", label: "Temperature Sensor", blurb: "Indoor & outdoor temperature." },
+  { id: "in_weather", type: "input", label: "Weather Forecast", blurb: "Sun & temperature outlook." },
+  // Schedule (the trigger / timing)
+  { id: "sc_time", type: "schedule", label: "Time of Day", blurb: "Act against the clock (off-peak).", timing: "time_of_day" },
+  { id: "sc_day", type: "schedule", label: "Day of Week", blurb: "Weekday vs weekend patterns.", timing: "day_of_week" },
+  { id: "sc_price", type: "schedule", label: "Price Signal", blurb: "React to cheap/expensive power.", timing: "price_signal" },
+  // Brain (the policy engine — one only)
+  { id: "br_chatgpt", type: "brain", label: "ChatGPT", blurb: "OpenAI policy brain." },
+  { id: "br_claude", type: "brain", label: "Claude", blurb: "Anthropic policy brain." },
+  { id: "br_gemini", type: "brain", label: "Gemini", blurb: "Google policy brain." },
+  // Actions (strategy verbs)
+  { id: "ac_shift", type: "action", label: "Shift Load", blurb: "Move usage to cheaper/greener times.", intent: "shift_load" },
+  { id: "ac_reduce", type: "action", label: "Reduce Usage", blurb: "Cut consumption where comfort allows.", intent: "reduce_usage" },
+  { id: "ac_charge", type: "action", label: "Charge Battery", blurb: "Store cheap / solar energy.", intent: "charge_battery" },
+  // Outputs (target devices)
+  { id: "ou_plugs", type: "output", label: "Smart Plugs", blurb: "Appliances & lights.", device: "smart_plugs" },
+  { id: "ou_battery", type: "output", label: "Battery System", blurb: "Home battery dispatch.", device: "battery" },
+  { id: "ou_ev", type: "output", label: "EV Charger", blurb: "Electric-vehicle charging.", device: "ev" },
+  // Safety (guardrails)
+  { id: "sa_manual", type: "safety", label: "Manual Override", blurb: "You can always take control." },
+  { id: "sa_budget", type: "safety", label: "Max Budget Guard", blurb: "Never exceed a daily spend." },
+];
+
+export const PALETTE_BY_ID: Record<string, BlockDef> = Object.fromEntries(
+  PALETTE.map((block) => [block.id, block]),
+);
+
+/**
+ * The core Path A mapping: (output device x action intent) -> backend block_id(s).
+ * Schedule refines below. Missing cells are intentionally incompatible (puzzle feedback).
+ * Backend block_ids are the 11 already live on main (#391).
+ */
+const COMMAND_MAP: Record<DeviceKey, Partial<Record<ActionIntent, string[]>>> = {
+  smart_plugs: {
+    shift_load: ["dishwasher_offpeak", "washer_offpeak"],
+    reduce_usage: ["lights_auto_off", "thermostat_eco", "dryer_hang_dry"],
+    // charge_battery: incompatible with plugs
+  },
+  battery: {
+    shift_load: ["battery_store_solar"],
+    charge_battery: ["battery_store_solar"],
+    reduce_usage: ["battery_discharge_peak"],
+  },
+  ev: {
+    shift_load: ["ev_overnight_80"],
+    charge_battery: ["ev_overnight_80"],
+    reduce_usage: ["ev_pause"],
+  },
+};
+
+export type PlacedPipeline = Record<SlotType, BlockDef[]>;
+
+export interface CompileResult {
+  blockIds: string[];
+  incompatible: Array<{ device: string; action: string }>;
+}
+
+/** Compile the placed pipeline into the flat backend block_id list. Pure. */
+export function compilePipeline(placed: PlacedPipeline): CompileResult {
+  const priceAware = placed.schedule.some((b) => b.timing === "price_signal");
+  const blockIds = new Set<string>();
+  const incompatible: Array<{ device: string; action: string }> = [];
+
+  for (const output of placed.output) {
+    if (!output.device) continue;
+    for (const action of placed.action) {
+      if (!action.intent) continue;
+      let ids = COMMAND_MAP[output.device][action.intent];
+      if (!ids || ids.length === 0) {
+        incompatible.push({ device: output.label, action: action.label });
+        continue;
+      }
+      // Schedule refinement: a price-aware battery becomes smart auto peak-shaving.
+      if (output.device === "battery" && priceAware) ids = ["battery_smart"];
+      ids.forEach((id) => blockIds.add(id));
+    }
+  }
+  return { blockIds: [...blockIds], incompatible };
+}
+
+/** Deploy is allowed only when every required slot meets its minimum. */
+export function isComplete(placed: PlacedPipeline): boolean {
+  return PIPELINE.every((slot) => placed[slot.type].length >= slot.min);
+}
+
+export function emptyPipeline(): PlacedPipeline {
+  return Object.fromEntries(PIPELINE.map((slot) => [slot.type, [] as BlockDef[]])) as PlacedPipeline;
+}

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -11,7 +11,8 @@ import {
 } from "~/lib/generic-hackathon";
 import { getEnv } from "~/lib/env.server";
 import { wattClasses } from "~/lib/watt-theme";
-import { SmartHomeController, type DeployFeedback } from "~/components/SmartHomeController";
+import { SmartHomeControllerV2 } from "~/components/SmartHomeControllerV2";
+import type { DeployFeedback } from "~/components/SmartHomeController";
 
 type StreamData = {
   session: WattUnitySession | null;
@@ -189,8 +190,7 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
           </div>
         </section>
 
-        <SmartHomeController
-          catalog={initialData.catalog}
+        <SmartHomeControllerV2
           onDeploy={handleDeploy}
           isDeploying={isDeploying}
           feedback={feedback}


### PR DESCRIPTION
## What
Redesigns the **Smart Home (Beginner)** controller from a flat block palette into the drafted **sense → think → act pipeline**: typed, shaped slots **Inputs → Schedule → Brain → Actions → Outputs** (+ optional **Safety**), under the live Unity stream.

## How it works (Path A — no backend change)
The pipeline is a presentation layer. On **Deploy** the frontend compiles the filled slots into the existing device `block_id` list and posts to the live `…/smart-home/deploy` endpoint. `compilePipeline()` maps **(output device × action intent × schedule timing) → block_id(s)**:

| Output \ Action | Shift Load | Reduce Usage | Charge Battery |
|---|---|---|---|
| Smart Plugs | dishwasher/washer_offpeak | lights_auto_off, thermostat_eco, dryer_hang_dry | — |
| Battery System | battery_store_solar | battery_discharge_peak | battery_store_solar |
| EV Charger | ev_overnight_80 | ev_pause | ev_overnight_80 |

A *Price Signal* schedule upgrades Battery to `battery_smart` (auto peak-shaving). Incompatible pairings are surfaced, not silently dropped.

## UX
- Distinct **shapes** per slot type (plug/gem/square/bolt/node/shield); only matching shapes drop in (type-gated).
- **One Brain, one Schedule** — single-capacity slots **swap** when a new piece is dropped.
- Magnetic target highlighting; **Deploy** locked until required slots are filled.

## Notes
- Brain / Inputs / Safety are **required scaffolding** in v1 (gate Deploy + teach the loop); the Brain becomes a real policy in a later pass.
- v1 `SmartHomeController` is kept for its shared `DeployFeedback` type.
- `tsc -b` passes; final interactive QA needs an authenticated Watt-team session.

## Files
`app/lib/smart-home-pipeline.ts` (spec + compiler), `app/components/SmartHomeControllerV2.tsx`, and the page swapped to render v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
