### PR TITLE
fix(wth): point leaderboard + submission proxies at eval.eliascorp.org

### DIFF
--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts
@@ -4,19 +4,22 @@ import { getEnv } from "~/lib/env.server";
 /**
  * Server-side leaderboard proxy (option B).
  *
- * The browser calls this SAME-ORIGIN endpoint; the Cloudflare worker fetches the
- * admin eval cluster and returns its JSON. Keeps the admin API off the public
- * internet (no browser CORS, no public API exposure) and reuses the mlai.au cert.
+ * The browser hits this SAME-ORIGIN endpoint; the Cloudflare worker fetches the
+ * admin eval cluster and returns its JSON, so the admin API stays private (no
+ * browser CORS / public exposure).
  *
- * Config via Cloudflare env (set these in the mlai-au worker):
- *   WTH_ADMIN_URL   origin to fetch.  RECOMMENDED: a subdomain of your own CF
- *                   zone pointed at the ingress LB, e.g. "https://eval.mlai.au"
- *                   (Cloudflare then terminates TLS for you). With this set and
- *                   WTH_ADMIN_HOST empty, this is just a plain fetch.
- *   WTH_ADMIN_HOST  ingress Host header, used only for the IP + resolveOverride
- *                   fallback. NOTE: cf.resolveOverride only applies to hostnames
- *                   inside your own Cloudflare zone, so the placeholder default
- *                   will NOT route until you point a real in-zone host at the LB.
+ * Config (Cloudflare worker vars; defaults baked in):
+ *   WTH_ADMIN_URL   admin origin to fetch (default "https://eval.eliascorp.org")
+ *   WTH_ADMIN_HOST  optional ingress Host for the IP-bypass fallback (see below)
+ *
+ * Normal path: a plain fetch of `${WTH_ADMIN_URL}/leaderboard`.
+ *
+ * Fallback: if a Worker -> Cloudflare-edge sub-request to the proxied host ever
+ * misbehaves (edge loop / Bot Fight / SSL mode), set WTH_ADMIN_URL to the GKE
+ * load-balancer IP (e.g. "http://34.129.156.145") and WTH_ADMIN_HOST to the
+ * ingress host ("eval.eliascorp.org"). We then connect straight to the IP and
+ * carry the Host via cf.resolveOverride (Host can't be set as a request header).
+ * resolveOverride is honored only for hostnames in a zone on your CF account.
  */
 interface AdminProxyEnv {
   WTH_ADMIN_URL?: string;
@@ -25,10 +28,7 @@ interface AdminProxyEnv {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context) as unknown as AdminProxyEnv;
-  // Default to the MLAI-owned Cloudflare-proxied subdomain (TLS handled by CF).
-  const base = env.WTH_ADMIN_URL || "https://eval.mlai.au";
-  // No Host override needed for a real public origin; only used for the
-  // legacy IP + resolveOverride fallback.
+  const base = env.WTH_ADMIN_URL || "https://eval.eliascorp.org";
   const host = env.WTH_ADMIN_HOST ?? "";
 
   const reqUrl = new URL(request.url);
@@ -43,21 +43,29 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   let target: string;
   if (host && host !== baseUrl.host) {
-    // Keep the ingress Host in the URL and connect to the LB IP at the edge.
-    // (`Host` cannot be set as a request header — it is stripped — so this is the
-    // supported technique. resolveOverride requires `host` to be in your CF zone.)
+    // IP-bypass fallback: connect to baseUrl's IP, carry the ingress Host in the URL.
     target = `${baseUrl.protocol}//${host}/leaderboard?limit=${limit}`;
     init.cf = { resolveOverride: baseUrl.hostname };
   } else {
-    // Clean path: WTH_ADMIN_URL is a real reachable origin (e.g. https://eval.mlai.au).
     target = `${baseUrl.origin}/leaderboard?limit=${limit}`;
   }
 
   try {
     const upstream = await fetch(target, init);
     const body = await upstream.text();
+    if (!upstream.ok) {
+      // Surface the REAL upstream status + a snippet instead of masking as 502.
+      return new Response(
+        JSON.stringify({
+          error: "upstream_error",
+          upstreamStatus: upstream.status,
+          detail: body.slice(0, 300),
+        }),
+        { status: 502, headers: { "Content-Type": "application/json; charset=utf-8" } },
+      );
+    }
     return new Response(body, {
-      status: upstream.ok ? 200 : 502,
+      status: 200,
       headers: {
         "Content-Type": "application/json; charset=utf-8",
         // Small shared cache so many viewers / rapid refreshes collapse to one
@@ -68,10 +76,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   } catch (err) {
     return new Response(
       JSON.stringify({ error: "upstream_unreachable", detail: String(err) }),
-      {
-        status: 502,
-        headers: { "Content-Type": "application/json; charset=utf-8" },
-      },
+      { status: 502, headers: { "Content-Type": "application/json; charset=utf-8" } },
     );
   }
 }

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx
@@ -153,7 +153,24 @@ export default function WattTheHackLeaderboard() {
       const res = await fetch("/watt-the-hack/city-of-melbourne-advanced-leaderboard-data", {
         headers: { Accept: "application/json" },
       });
-      if (!res.ok) throw new Error(`Leaderboard service responded ${res.status}`);
+      if (!res.ok) {
+        // The proxy returns { error, upstreamStatus?, detail? } — surface the
+        // real reason instead of a bare status code.
+        let message = `Leaderboard service responded ${res.status}`;
+        try {
+          const info = (await res.json()) as { error?: string; upstreamStatus?: number; detail?: string };
+          if (info?.upstreamStatus) {
+            message = `Upstream responded ${info.upstreamStatus}`;
+          } else if (info?.error === "upstream_unreachable") {
+            message = "Couldn't reach the evaluation server";
+          } else if (info?.error || info?.detail) {
+            message = String(info.detail || info.error);
+          }
+        } catch {
+          // non-JSON body — keep the generic message
+        }
+        throw new Error(message);
+      }
       const data = (await res.json()) as LeaderboardEntry[];
       if (!Array.isArray(data)) throw new Error("Unexpected response from leaderboard service");
 

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts
@@ -19,7 +19,7 @@ import { getEnv } from "~/lib/env.server";
  *
  * Config via Cloudflare env (shared with the leaderboard proxy):
  *   WTH_ADMIN_URL   origin to forward to. RECOMMENDED: an MLAI-owned subdomain
- *                   pointed at the eval ingress, e.g. "https://eval.mlai.au".
+ *                   pointed at the eval ingress, e.g. "https://eval.eliascorp.org".
  *   WTH_ADMIN_HOST  optional ingress Host header for the IP + resolveOverride
  *                   fallback (only used when it differs from the URL host).
  */
@@ -40,7 +40,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
   const env = getEnv(context) as unknown as AdminProxyEnv;
   // Default to the MLAI-owned Cloudflare-proxied subdomain (TLS handled by CF).
-  const base = env.WTH_ADMIN_URL || "https://eval.mlai.au";
+  const base = env.WTH_ADMIN_URL || "https://eval.eliascorp.org";
   // No Host override needed for a real public origin; only used for the
   // legacy IP + resolveOverride fallback.
   const host = env.WTH_ADMIN_HOST ?? "";
@@ -101,7 +101,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     target = `${baseUrl.protocol}//${host}/submissions`;
     init.cf = { resolveOverride: baseUrl.hostname };
   } else {
-    // Clean path: WTH_ADMIN_URL is a real reachable origin (e.g. https://eval.mlai.au).
+    // Clean path: WTH_ADMIN_URL is a real reachable origin (e.g. https://eval.eliascorp.org).
     target = `${baseUrl.origin}/submissions`;
   }
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -6,7 +6,7 @@ declare namespace Cloudflare {
 		mainModule: typeof import("./workers/app");
 	}
 	interface Env {
-		WTH_ADMIN_URL: "https://eval.mlai.au";
+		WTH_ADMIN_URL: "https://eval.eliascorp.org";
 		VALUE_FROM_CLOUDFLARE: string;
 		BACKEND_BASE_URL: string;
 		VITE_API_URL: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,7 +15,7 @@
     "BACKEND_BASE_URL": "https://api.mlai.au",
     "VITE_GOOGLE_CLIENT_ID": "",
     "VITE_ENABLE_FOUNDER_TOOLS_DISCOVER": "false",
-    "WTH_ADMIN_URL": "https://eval.mlai.au"
+    "WTH_ADMIN_URL": "https://eval.eliascorp.org"
   },
   "routes": [
     {


### PR DESCRIPTION
PR #909 repointed the WTH admin origin to https://eval.mlai.au, which doesn't resolve (NXDOMAIN) -> both same-origin proxies got no upstream and returned 502. Set WTH_ADMIN_URL to the real Cloudflare-proxied host eval.eliascorp.org (wrangler var + code defaults), and surface the real upstream status/detail in the leaderboard proxy and board UI instead of masking failures as a bare 502.
