### PR TITLE
Fix Build button disabled when scan not hydrated in-session

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -982,12 +982,12 @@ export default function ArticleSystemConnectionPanel({
         </Form>
       ) : (
         <Form method="POST" className="w-full sm:w-auto">
-          <input type="hidden" name="scanRunId" value={effectiveScanRun?.runId ?? ""} />
+          <input type="hidden" name="scanRunId" value={effectiveScanRun?.runId ?? currentScanRunId} />
           <button
             type="submit"
             name="intent"
             value="build-article-system-preview"
-            disabled={isSubmitting || !effectiveScanRun?.runId}
+            disabled={isSubmitting || !currentScanRunId}
             className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50 sm:w-auto"
           >
             {scaffoldActionLabel}


### PR DESCRIPTION
## Problem

The **Build articles/blogs directory page** button was gated on \`effectiveScanRun?.runId\`, which is only populated when a scan run is actively loaded into the current page session. Returning to a saved setup state (after reset, a page reload, or navigating back) had no \`effectiveScanRun\`, leaving the button permanently disabled with no visible explanation.

## Fix (2 lines)

Use \`currentScanRunId\` as the fallback for both the hidden \`scanRunId\` input and the \`disabled\` guard.

\`currentScanRunId\` ([line 628](../app/components/ArticleSystemConnectionPanel.tsx)) already reads:
\`\`\`ts
requestedScanRunId || scanRun?.runId || articleSetupState?.scanRunId || ""
\`\`\`
So it covers the live-session case *and* the persisted-setup case where only \`articleSetupState.scanRunId\` is available.

## Pairs with

- mlai-backend [#394](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/394) — decouples scan-detected existing route from "setup complete", so step 4 actually reaches this Build button after reset.
- content-factory [#397](https://github.com/MLAI-AUS-Inc/content-factory/pull/397) — populates \`package.json\` scripts + detected article route in scan output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)