### PR TITLE
Watt smart-home: Path B-lite controller wiring + web status bar

### DIFF
--- a/app/components/SmartHomeController.tsx
+++ b/app/components/SmartHomeController.tsx
@@ -13,7 +13,7 @@ import {
 import { wattClasses } from "~/lib/watt-theme";
 import type { SmartHomeBlock, SmartHomeCatalog } from "~/lib/generic-hackathon";
 
-export type DeployFeedback = { ok: boolean; message: string } | null;
+export type DeployFeedback = { ok: boolean; message: string; decisions?: string[] } | null;
 
 type PlacedBlock = { instanceId: string; block: SmartHomeBlock };
 

--- a/app/components/SmartHomeControllerV2.tsx
+++ b/app/components/SmartHomeControllerV2.tsx
@@ -38,11 +38,11 @@ import {
 } from "lucide-react";
 import { wattClasses } from "~/lib/watt-theme";
 import type { DeployFeedback } from "~/components/SmartHomeController";
+import type { SmartHomePipeline } from "~/lib/generic-hackathon";
 import {
   PIPELINE,
   PIPELINE_BY_TYPE,
   PALETTE,
-  compilePipeline,
   emptyPipeline,
   isComplete,
   type BlockDef,
@@ -276,7 +276,7 @@ export function SmartHomeControllerV2({
   isDeploying,
   feedback,
 }: {
-  onDeploy: (blockIds: string[]) => void;
+  onDeploy: (pipeline: SmartHomePipeline) => void;
   isDeploying: boolean;
   feedback: DeployFeedback;
 }) {
@@ -325,9 +325,19 @@ export function SmartHomeControllerV2({
   }, [cells]);
 
   const complete = isComplete(pipeline);
-  const { blockIds, incompatible } = useMemo(() => compilePipeline(pipeline), [pipeline]);
+  const pipelinePayload = useMemo<SmartHomePipeline>(
+    () => ({
+      inputs: pipeline.input.map((b) => b.id),
+      schedule: pipeline.schedule.map((b) => b.id),
+      brain: pipeline.brain.map((b) => b.id),
+      actions: pipeline.action.map((b) => b.id),
+      outputs: pipeline.output.map((b) => b.id),
+      safety: pipeline.safety.map((b) => b.id),
+    }),
+    [pipeline],
+  );
   const activeType = activeBlock?.type ?? null;
-  const canDeploy = complete && blockIds.length > 0 && !isDeploying;
+  const canDeploy = complete && !isDeploying;
   const countOf = (type: SlotType) => cells[type].filter(Boolean).length;
 
   return (
@@ -351,7 +361,7 @@ export function SmartHomeControllerV2({
         </div>
       </div>
 
-      <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <DndContext id="watt-smart-home-controller" sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_18rem]">
           {/* Controller board */}
           <div>
@@ -386,7 +396,7 @@ export function SmartHomeControllerV2({
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <button
                 type="button"
-                onClick={() => onDeploy(blockIds)}
+                onClick={() => onDeploy(pipelinePayload)}
                 disabled={!canDeploy}
                 className={`${wattClasses.buttonPrimary} gap-2 px-6 py-2.5 disabled:cursor-not-allowed disabled:opacity-50`}
               >
@@ -394,7 +404,7 @@ export function SmartHomeControllerV2({
                 {isDeploying ? "Deploying…" : "Deploy Controller"}
               </button>
               <span className="text-xs font-semibold text-[#64705f]">
-                {complete ? `${blockIds.length} device command${blockIds.length === 1 ? "" : "s"} ready` : "Fix all required slots to deploy"}
+                {complete ? "Ready to deploy" : "Fix all required slots to deploy"}
               </span>
               {feedback && (
                 <span className={`text-sm font-semibold ${feedback.ok ? "text-[#155420]" : "text-[#9f2f28]"}`}>{feedback.message}</span>
@@ -403,10 +413,16 @@ export function SmartHomeControllerV2({
                 <RotateCcw className="h-3.5 w-3.5" /> Reset
               </button>
             </div>
-            {incompatible.length > 0 && (
-              <p className="mt-2 text-xs font-medium text-[#9f6a08]">
-                Ignored {incompatible.length} incompatible pairing{incompatible.length === 1 ? "" : "s"} (e.g. {incompatible[0].action} → {incompatible[0].device}).
-              </p>
+            {feedback?.decisions && feedback.decisions.length > 0 && (
+              <ul className="mt-3 space-y-1.5 rounded-[0.9rem] border border-[#e8dfcf] bg-[#fbf6e9] p-3">
+                <li className="text-[11px] font-black uppercase tracking-[0.12em] text-[#7c5cd6]">Your brain decided</li>
+                {feedback.decisions.map((line, i) => (
+                  <li key={i} className="flex items-start gap-2 text-xs font-medium text-[#354031]">
+                    <Brain className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[#7c5cd6]" />
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
 

--- a/app/components/SmartHomeStatusBar.tsx
+++ b/app/components/SmartHomeStatusBar.tsx
@@ -1,0 +1,63 @@
+import type { SmartHomeState } from "~/lib/generic-hackathon";
+import { wattClasses } from "~/lib/watt-theme";
+
+// Display target only; the real campaign length is a Unity constant (CAMPAIGN_LENGTH_DAYS).
+// ~6.5h event (12:00–18:30) at the default ~11.7 min/day ≈ 33 days.
+const CAMPAIGN_DAYS = 33;
+
+const LOW_CASH = 45;
+
+function round(value: number, dp = 0) {
+  const f = 10 ** dp;
+  return Math.round(value * f) / f;
+}
+
+function Stat({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div className="rounded-[0.8rem] border border-[#e8dfcf] bg-[#fffefa] px-3 py-2">
+      <div className="text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a8477]">{label}</div>
+      <div className={`text-base font-black ${warn ? "text-[#9f2f28]" : "text-[#121e16]"}`}>{value}</div>
+    </div>
+  );
+}
+
+export function SmartHomeStatusBar({ state }: { state?: SmartHomeState }) {
+  const live = state?.live ?? false;
+  const day = typeof state?.day === "number" ? state.day : null;
+  const wallet = typeof state?.wallet === "number" ? state.wallet : null;
+  const cost = typeof state?.cost === "number" ? state.cost : null;
+  const comfort = typeof state?.comfort === "number" ? state.comfort : null;
+  const energy = typeof state?.energy_kwh === "number" ? state.energy_kwh : null;
+  const lowCash = wallet !== null && wallet < LOW_CASH;
+
+  return (
+    <section className={`${wattClasses.panel} p-4`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className={wattClasses.eyebrow}>Smart Home · Beginner</p>
+          <p className="mt-0.5 text-sm font-bold text-[#354031]">
+            Goal: run the smartest, cheapest, happiest home — survive the campaign, then beat your record.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 rounded-full border border-[#e8dfcf] bg-[#fffefa] px-2.5 py-1 text-xs font-bold">
+          <span className={`h-2.5 w-2.5 rounded-full ${live ? "bg-[#2f6f2c]" : "bg-[#c9b98f]"}`} />
+          <span className={live ? "text-[#155420]" : "text-[#8a8477]"}>{live ? "Live" : "Offline"}</span>
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
+        <Stat label="Day" value={day !== null ? `${day} / ${CAMPAIGN_DAYS}` : "—"} />
+        <Stat label="Wallet" value={wallet !== null ? `$${round(wallet, 2)}` : "—"} warn={lowCash} />
+        <Stat label="Cost / day" value={cost !== null ? `$${round(cost, 2)}` : "—"} />
+        <Stat label="Comfort" value={comfort !== null ? `${round(comfort)}%` : "—"} />
+        <Stat label="Energy" value={energy !== null ? `${round(energy, 1)} kWh` : "—"} />
+      </div>
+
+      {lowCash && (
+        <p className="mt-2 text-xs font-bold text-[#9f2f28]">
+          ⚠ Wallet low — cut peak-time grid use (shift load, store solar) or you'll fall behind.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -178,7 +178,7 @@ export interface SmartHomeCatalog {
 
 export interface SmartHomeDeployCommand {
   command_id: string;
-  block_id: string;
+  block_id: string | null;
   action: string;
   target_id: string;
 }
@@ -188,6 +188,32 @@ export interface SmartHomeDeployResult {
   tick_seen: number;
   deployed_count: number;
   commands: SmartHomeDeployCommand[];
+  decisions: string[];
+  brain?: string | null;
+}
+
+export interface SmartHomePipeline {
+  inputs: string[];
+  schedule: string[];
+  brain: string[];
+  actions: string[];
+  outputs: string[];
+  safety: string[];
+}
+
+export interface SmartHomeState {
+  live: boolean;
+  household_id?: string;
+  day?: number | null;
+  tick?: number | null;
+  game_time?: string | null;
+  wallet?: number | null;
+  cost?: number | null;
+  energy_kwh?: number | null;
+  comfort?: number | null;
+  score?: number | null;
+  tariff_period?: string | null;
+  weather_condition?: string | null;
 }
 
 export async function getSmartHomeBlocks(env: Env, request: Request): Promise<SmartHomeCatalog> {
@@ -203,9 +229,16 @@ export async function getSmartHomeBlocks(env: Env, request: Request): Promise<Sm
 export async function deploySmartHome(
   env: Env,
   request: Request,
-  blockIds: string[],
+  pipeline: SmartHomePipeline,
 ): Promise<SmartHomeDeployResult> {
   const client = createApiClient(env, request);
-  const response = await client.post("/api/v1/hackathons/watt/smart-home/deploy/", { blocks: blockIds });
+  const response = await client.post("/api/v1/hackathons/watt/smart-home/deploy/", { pipeline });
   return response.data as SmartHomeDeployResult;
+}
+
+export async function getSmartHomeState(env: Env, request: Request): Promise<SmartHomeState> {
+  const client = createApiClient(env, request);
+  const response = await client.get("/api/v1/hackathons/watt/smart-home/state/");
+  const data = (response.data ?? {}) as Partial<SmartHomeState>;
+  return { ...data, live: Boolean(data.live) } as SmartHomeState;
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -68,6 +68,7 @@ export default [
     route("city-of-melbourne-advanced-leaderboard", "routes/watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx"),
     route("city-of-melbourne-advanced-leaderboard-data", "routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts"),
     route("smart-home-beginner", "routes/watt-the-hack.smart-home-beginner.tsx"),
+    route("smart-home-beginner/state", "routes/watt-the-hack.smart-home-beginner.state.tsx"),
   ]),
 
   // Hackathon pages

--- a/app/routes/watt-the-hack.smart-home-beginner.state.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.state.tsx
@@ -1,0 +1,13 @@
+import type { Route } from "./+types/watt-the-hack.smart-home-beginner.state";
+import { getEnv } from "~/lib/env.server";
+import { getSmartHomeState, type SmartHomeState } from "~/lib/generic-hackathon";
+
+// Resource route (no default export) — polled by the smart-home page for the live status bar.
+export async function loader({ request, context }: Route.LoaderArgs): Promise<SmartHomeState> {
+  const env = getEnv(context);
+  try {
+    return await getSmartHomeState(env, request);
+  } catch {
+    return { live: false };
+  }
+}

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/watt-the-hack.smart-home-beginner";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher, useLoaderData, type ShouldRevalidateFunctionArgs } from "react-router";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import {
@@ -7,11 +7,14 @@ import {
   deploySmartHome,
   getSmartHomeBlocks,
   type SmartHomeCatalog,
+  type SmartHomePipeline,
+  type SmartHomeState,
   type WattUnitySession,
 } from "~/lib/generic-hackathon";
 import { getEnv } from "~/lib/env.server";
 import { wattClasses } from "~/lib/watt-theme";
 import { SmartHomeControllerV2 } from "~/components/SmartHomeControllerV2";
+import { SmartHomeStatusBar } from "~/components/SmartHomeStatusBar";
 import type { DeployFeedback } from "~/components/SmartHomeController";
 
 type StreamData = {
@@ -64,15 +67,15 @@ export async function action({ request, context }: Route.ActionArgs) {
   const intent = String(formData.get("intent") || "reconnect");
 
   if (intent === "deploy") {
-    let blockIds: string[] = [];
+    let pipeline: SmartHomePipeline = { inputs: [], schedule: [], brain: [], actions: [], outputs: [], safety: [] };
     try {
-      const parsed = JSON.parse(String(formData.get("blocks") || "[]"));
-      if (Array.isArray(parsed)) blockIds = parsed.map((value) => String(value));
+      const parsed = JSON.parse(String(formData.get("pipeline") || "{}"));
+      if (parsed && typeof parsed === "object") pipeline = { ...pipeline, ...parsed };
     } catch {
-      blockIds = [];
+      /* keep empty pipeline */
     }
     try {
-      const result = await deploySmartHome(env, request, blockIds);
+      const result = await deploySmartHome(env, request, pipeline);
       return { kind: "deploy" as const, result, error: null as string | null };
     } catch (error) {
       return {
@@ -136,17 +139,61 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
     if (!deployData || deployData.kind !== "deploy") return null;
     if (deployData.result) {
       const count = deployData.result.deployed_count;
-      return { ok: true, message: `Deployed ${count} change${count === 1 ? "" : "s"} — watch your house above.` };
+      return {
+        ok: true,
+        message: `Deployed ${count} change${count === 1 ? "" : "s"} — watch your house above.`,
+        decisions: deployData.result.decisions ?? [],
+      };
     }
     return { ok: false, message: deployData.error || "Couldn't deploy to your Smart Home." };
   }, [deployData, isDeploying]);
 
-  const handleDeploy = (blockIds: string[]) =>
-    deployFetcher.submit({ intent: "deploy", blocks: JSON.stringify(blockIds) }, { method: "post" });
+  const handleDeploy = (pipeline: SmartHomePipeline) =>
+    deployFetcher.submit({ intent: "deploy", pipeline: JSON.stringify(pipeline) }, { method: "post" });
+
+  // Poll the live game state for the goal/day/wallet status bar.
+  const stateFetcher = useFetcher();
+  const homeState = stateFetcher.data as SmartHomeState | undefined;
+  useEffect(() => {
+    const STATE_PATH = "/watt-the-hack/smart-home-beginner/state";
+    stateFetcher.load(STATE_PATH);
+    const id = setInterval(() => stateFetcher.load(STATE_PATH), 6000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Lightweight recap: snapshot the deltas when the game day advances.
+  const lastDayRef = useRef<{ day: number; wallet: number; comfort: number } | null>(null);
+  const [recap, setRecap] = useState<string | null>(null);
+  useEffect(() => {
+    if (!homeState || typeof homeState.day !== "number") return;
+    const snap = {
+      day: homeState.day,
+      wallet: typeof homeState.wallet === "number" ? homeState.wallet : 0,
+      comfort: typeof homeState.comfort === "number" ? homeState.comfort : 0,
+    };
+    const prev = lastDayRef.current;
+    if (prev && snap.day > prev.day) {
+      const dWallet = Math.round((snap.wallet - prev.wallet) * 100) / 100;
+      setRecap(
+        `Day ${prev.day} done — wallet ${dWallet >= 0 ? "+" : ""}$${dWallet}, comfort ${Math.round(snap.comfort)}%. Tune your controller for day ${snap.day}.`,
+      );
+    }
+    lastDayRef.current = snap;
+  }, [homeState]);
 
   return (
     <div className={wattClasses.page}>
       <div className="mx-auto max-w-7xl space-y-6">
+        <SmartHomeStatusBar state={homeState} />
+        {recap && (
+          <div className={`${wattClasses.successAlert} flex items-center justify-between gap-3`}>
+            <span>{recap}</span>
+            <button type="button" onClick={() => setRecap(null)} className="shrink-0 text-xs font-bold underline">
+              Dismiss
+            </button>
+          </div>
+        )}
         <section className={`${wattClasses.panelStrong} overflow-hidden p-0`}>
           <div className="relative aspect-video w-full bg-black">
             {session?.stream_url ? (


### PR DESCRIPTION
Wires the controller to the new Path B-lite backend (#395) and adds the web meta-layer (goal/day/wallet/recap).

## What
- **Deploy sends the structured pipeline** (Inputs/Schedule/Brain/Actions/Outputs/Safety); the controller renders the backend's **"Your brain decided …"** decisions — the legibility payoff.
- **`SmartHomeStatusBar`** above the stream: the goal, **Day X/33**, Wallet, Cost/day, Comfort, Energy, a Live/Offline indicator, and a low-cash warning — polled from `GET …/smart-home/state/` every 6s via a resource route.
- A lightweight **day-change recap** banner.
- `generic-hackathon.ts`: `deploySmartHome({pipeline})` → returns `decisions`; `getSmartHomeState`; new types.
- Fixed an SSR hydration warning via a stable `DndContext id` (latent since v2).

## Verification
- `tsc -b` clean.
- SSR returns 200 and renders the status bar + controller; browser render confirmed.
- Note: requires backend #395 (merged) for live data; in local dev (backend down) the bar shows Offline.

Depends on backend #395 (merged to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
