### PR TITLE
Watt smart-home: upgrades shop UI (2C)

### DIFF
--- a/app/components/SmartHomeShop.tsx
+++ b/app/components/SmartHomeShop.tsx
@@ -1,0 +1,156 @@
+import { useMemo } from "react";
+import { Check, Loader2, Lock, ShoppingCart } from "lucide-react";
+import { wattClasses } from "~/lib/watt-theme";
+import type { SmartHomeShopItem, SmartHomeShopState } from "~/lib/generic-hackathon";
+
+export interface ShopFeedback {
+  ok: boolean;
+  message: string;
+}
+
+interface SmartHomeShopProps {
+  shop: SmartHomeShopState | undefined;
+  onBuy: (itemId: string) => void;
+  buyingId: string | null;
+  feedback: ShopFeedback | null;
+}
+
+function prettyCategory(category: string): string {
+  const cleaned = String(category || "Upgrades").replace(/[_-]+/g, " ").trim();
+  if (!cleaned) return "Upgrades";
+  return cleaned.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatMoney(value: number | null | undefined): string {
+  if (typeof value !== "number" || Number.isNaN(value)) return "—";
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function groupByCategory(items: SmartHomeShopItem[]): Array<[string, SmartHomeShopItem[]]> {
+  const order: string[] = [];
+  const map = new Map<string, SmartHomeShopItem[]>();
+  for (const item of items) {
+    const key = item.category || "Upgrades";
+    if (!map.has(key)) {
+      map.set(key, []);
+      order.push(key);
+    }
+    map.get(key)!.push(item);
+  }
+  return order.map((key) => [key, map.get(key)!]);
+}
+
+function ShopCard({
+  item,
+  wallet,
+  onBuy,
+  isBuying,
+}: {
+  item: SmartHomeShopItem;
+  wallet: number | null | undefined;
+  onBuy: (itemId: string) => void;
+  isBuying: boolean;
+}) {
+  const tooDear = typeof wallet === "number" && item.cost > wallet;
+  return (
+    <div
+      className={`${wattClasses.panel} flex flex-col gap-3 p-4 transition ${
+        item.owned ? "opacity-70" : ""
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className={`${wattClasses.title} text-sm`}>{item.name}</p>
+          <p className={`${wattClasses.muted} mt-1 text-xs leading-relaxed`}>{item.summary}</p>
+        </div>
+        <span className={`${wattClasses.smallChip} shrink-0`}>{formatMoney(item.cost)}</span>
+      </div>
+
+      <div className="mt-auto">
+        {item.owned ? (
+          <span className="inline-flex items-center gap-1.5 rounded-[0.65rem] bg-[#e6efd7] px-3 py-2 text-sm font-black text-[#155420]">
+            <Check className="h-4 w-4" aria-hidden="true" /> Owned
+          </span>
+        ) : isBuying ? (
+          <button type="button" disabled className={`${wattClasses.buttonPrimary} w-full opacity-70`}>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> Buying…
+          </button>
+        ) : item.can_buy ? (
+          <button
+            type="button"
+            onClick={() => onBuy(item.item_id)}
+            className={`${wattClasses.buttonPrimary} w-full`}
+          >
+            Buy {formatMoney(item.cost)}
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled
+            title={tooDear ? "Not enough savings yet" : "Locked"}
+            className={`${wattClasses.buttonOutline} w-full cursor-not-allowed opacity-60`}
+          >
+            <Lock className="mr-2 h-4 w-4" aria-hidden="true" />
+            {tooDear ? `Need ${formatMoney(item.cost)}` : "Locked"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SmartHomeShop({ shop, onBuy, buyingId, feedback }: SmartHomeShopProps) {
+  const groups = useMemo(() => groupByCategory(shop?.items ?? []), [shop?.items]);
+  const hasItems = (shop?.items?.length ?? 0) > 0;
+
+  return (
+    <section className={`${wattClasses.panelStrong} p-5 sm:p-6`}>
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className={wattClasses.iconTile}>
+            <ShoppingCart className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <p className={wattClasses.eyebrow}>Upgrade Shop</p>
+            <h2 className={`${wattClasses.title} text-lg`}>Spend your savings on permanent upgrades</h2>
+          </div>
+        </div>
+        <span className={wattClasses.chip}>{formatMoney(shop?.wallet)} to spend</span>
+      </header>
+
+      {feedback && (
+        <div className={`mt-4 ${feedback.ok ? wattClasses.successAlert : wattClasses.errorAlert}`}>
+          {feedback.message}
+        </div>
+      )}
+
+      {!hasItems ? (
+        <div className={`${wattClasses.panelSoft} mt-4 p-5 text-center`}>
+          <p className={`${wattClasses.title} text-sm`}>The shop opens as your campaign rolls on.</p>
+          <p className={`${wattClasses.muted} mt-1 text-xs`}>
+            Keep your house running and bank some savings — new upgrades unlock day by day. Check back soon.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-5 space-y-6">
+          {groups.map(([category, items]) => (
+            <div key={category}>
+              <p className={`${wattClasses.smallChip} mb-3`}>{prettyCategory(category)}</p>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {items.map((item) => (
+                  <ShopCard
+                    key={item.item_id}
+                    item={item}
+                    wallet={shop?.wallet}
+                    onBuy={onBuy}
+                    isBuying={buyingId === item.item_id}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -242,3 +242,52 @@ export async function getSmartHomeState(env: Env, request: Request): Promise<Sma
   const data = (response.data ?? {}) as Partial<SmartHomeState>;
   return { ...data, live: Boolean(data.live) } as SmartHomeState;
 }
+
+export interface SmartHomeShopItem {
+  item_id: string;
+  name: string;
+  summary: string;
+  category: string;
+  cost: number;
+  visible_from_day: number;
+  owned: boolean;
+  can_buy: boolean;
+}
+
+export interface SmartHomeShopState {
+  available: boolean;
+  day?: number | null;
+  wallet?: number | null;
+  items: SmartHomeShopItem[];
+}
+
+export interface SmartHomeBuyResult {
+  ok: boolean;
+  item_id: string;
+  reason?: string | null;
+  message?: string | null;
+  pending?: boolean;
+  command_id?: string;
+}
+
+export async function getSmartHomeShop(env: Env, request: Request): Promise<SmartHomeShopState> {
+  const client = createApiClient(env, request);
+  const response = await client.get("/api/v1/hackathons/watt/smart-home/shop/");
+  const data = (response.data ?? {}) as Partial<SmartHomeShopState>;
+  return {
+    available: Boolean(data.available),
+    day: data.day ?? null,
+    wallet: data.wallet ?? null,
+    items: Array.isArray(data.items) ? (data.items as SmartHomeShopItem[]) : [],
+  };
+}
+
+export async function buySmartHomeUpgrade(
+  env: Env,
+  request: Request,
+  itemId: string,
+): Promise<SmartHomeBuyResult> {
+  const client = createApiClient(env, request);
+  const response = await client.post("/api/v1/hackathons/watt/smart-home/buy/", { item_id: itemId });
+  return response.data as SmartHomeBuyResult;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -69,6 +69,7 @@ export default [
     route("city-of-melbourne-advanced-leaderboard-data", "routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts"),
     route("smart-home-beginner", "routes/watt-the-hack.smart-home-beginner.tsx"),
     route("smart-home-beginner/state", "routes/watt-the-hack.smart-home-beginner.state.tsx"),
+    route("smart-home-beginner/shop", "routes/watt-the-hack.smart-home-beginner.shop.tsx"),
   ]),
 
   // Hackathon pages

--- a/app/routes/watt-the-hack.smart-home-beginner.shop.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.shop.tsx
@@ -1,0 +1,13 @@
+import type { Route } from "./+types/watt-the-hack.smart-home-beginner.shop";
+import { getEnv } from "~/lib/env.server";
+import { getSmartHomeShop, type SmartHomeShopState } from "~/lib/generic-hackathon";
+
+// Resource route (no default export) — polled by the smart-home page for the upgrades shop.
+export async function loader({ request, context }: Route.LoaderArgs): Promise<SmartHomeShopState> {
+  const env = getEnv(context);
+  try {
+    return await getSmartHomeShop(env, request);
+  } catch {
+    return { available: false, items: [] };
+  }
+}

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -3,17 +3,20 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher, useLoaderData, type ShouldRevalidateFunctionArgs } from "react-router";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import {
+  buySmartHomeUpgrade,
   createWattUnitySession,
   deploySmartHome,
   getSmartHomeBlocks,
   type SmartHomeCatalog,
   type SmartHomePipeline,
+  type SmartHomeShopState,
   type SmartHomeState,
   type WattUnitySession,
 } from "~/lib/generic-hackathon";
 import { getEnv } from "~/lib/env.server";
 import { wattClasses } from "~/lib/watt-theme";
 import { SmartHomeControllerV2 } from "~/components/SmartHomeControllerV2";
+import { SmartHomeShop, type ShopFeedback } from "~/components/SmartHomeShop";
 import { SmartHomeStatusBar } from "~/components/SmartHomeStatusBar";
 import type { DeployFeedback } from "~/components/SmartHomeController";
 
@@ -82,6 +85,23 @@ export async function action({ request, context }: Route.ActionArgs) {
         kind: "deploy" as const,
         result: null,
         error: errorMessage(error, "Couldn't deploy to your Smart Home."),
+      };
+    }
+  }
+
+  if (intent === "buy") {
+    const itemId = String(formData.get("item_id") || "").trim();
+    if (!itemId) {
+      return { kind: "buy" as const, result: null, error: "Pick an upgrade to buy." as string | null };
+    }
+    try {
+      const result = await buySmartHomeUpgrade(env, request, itemId);
+      return { kind: "buy" as const, result, error: null as string | null };
+    } catch (error) {
+      return {
+        kind: "buy" as const,
+        result: null,
+        error: errorMessage(error, "Couldn't complete your purchase."),
       };
     }
   }
@@ -182,6 +202,44 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
     lastDayRef.current = snap;
   }, [homeState]);
 
+  // Poll the upgrades shop (the game publishes it on day-change + after a purchase).
+  const shopFetcher = useFetcher<SmartHomeShopState>();
+  const shop = shopFetcher.data;
+  const SHOP_PATH = "/watt-the-hack/smart-home-beginner/shop";
+  useEffect(() => {
+    shopFetcher.load(SHOP_PATH);
+    const id = setInterval(() => shopFetcher.load(SHOP_PATH), 6000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const buyFetcher = useFetcher<typeof action>();
+  const buyData = buyFetcher.data;
+  const isBuying = buyFetcher.state !== "idle";
+  const rawBuyingId = buyFetcher.formData?.get("item_id");
+  const buyingId = isBuying && typeof rawBuyingId === "string" ? rawBuyingId : null;
+
+  const buyFeedback: ShopFeedback | null = useMemo(() => {
+    if (isBuying) return null;
+    if (!buyData || buyData.kind !== "buy") return null;
+    if (buyData.result) {
+      const r = buyData.result;
+      if (r.pending) return { ok: true, message: "Purchase sent — your house is applying it…" };
+      if (r.ok) return { ok: true, message: r.message || "Upgrade purchased — it's installed in your house." };
+      return { ok: false, message: r.reason || r.message || "Couldn't buy that upgrade." };
+    }
+    return { ok: false, message: buyData.error || "Couldn't complete your purchase." };
+  }, [buyData, isBuying]);
+
+  // Refresh the shop as soon as a purchase resolves (owned + wallet update).
+  useEffect(() => {
+    if (!isBuying && buyData && buyData.kind === "buy") shopFetcher.load(SHOP_PATH);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buyData, isBuying]);
+
+  const handleBuy = (itemId: string) =>
+    buyFetcher.submit({ intent: "buy", item_id: itemId }, { method: "post" });
+
   return (
     <div className={wattClasses.page}>
       <div className="mx-auto max-w-7xl space-y-6">
@@ -242,6 +300,8 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
           isDeploying={isDeploying}
           feedback={feedback}
         />
+
+        <SmartHomeShop shop={shop} onBuy={handleBuy} buyingId={buyingId} feedback={buyFeedback} />
       </div>
     </div>
   );


### PR DESCRIPTION
Frontend layer of the 2C upgrades shop. Pairs with backend MLAI-AUS-Inc/mlai-backend#396 and Unity drsamdonegan/Watt-The-Hack#6 (playtest).

## What's new
A `SmartHomeShop` panel renders below the controller on `/watt-the-hack/smart-home-beginner`:
- Items grouped by category, with a wallet **"$X to spend"** chip in the header.
- Each item card: name, summary, cost, and a state-aware action — **Buy $X** (affordable), **Owned ✓** (purchased), or a disabled **Need $X / Locked** when it can't be bought yet.
- Friendly placeholder ("The shop opens as your campaign rolls on…") until the game publishes a shop — so it degrades gracefully offline / pre-campaign.

## Wiring
- `generic-hackathon.ts`: `SmartHomeShopItem` / `SmartHomeShopState` / `SmartHomeBuyResult` types + `getSmartHomeShop` (GET `shop/`) + `buySmartHomeUpgrade` (POST `buy/`).
- New resource route `smart-home-beginner/shop` polled every 6s, and re-fetched the moment a purchase resolves (so Owned + wallet update live).
- Page `action` gains an `intent="buy"` branch; the buy verdict surfaces as success/error feedback and handles the `pending` case (command sent, game still applying). `shouldRevalidate` already returns false on form POSTs, so buying never re-mints the stream.

## Verification
- `react-router typegen && tsc -b` — **0 errors** (full build on a clean `origin/main` install).
- Page + shop render in-browser with **no console errors**; the `/shop` resource route returns `{available:false,items:[]}` when offline.
- Only 5 files touched; `routes.ts` carries a single added line (no unrelated churn).

## Integration note
Fully wired but the shop only populates once a **2C-enabled Unity build** (PR #6) is deployed and publishes `shop/current` on day-change. Safe to merge now — it shows the placeholder until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)