### PR TITLE
Watt: gate smart-home page behind a valid (2-6) team

### DIFF
--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -1,3 +1,4 @@
+import { redirect } from "react-router";
 import { createApiClient, getBaseUrl } from "~/lib/api";
 import type { Announcement } from "~/components/Announcements";
 import type { Hackathon } from "~/services/hackathon";
@@ -101,6 +102,28 @@ export async function getGenericCurrentTeam(env: Env, request: Request, slug = W
   const client = createApiClient(env, request);
   const response = await client.get(appPath(slug, "team/"));
   return asGenericTeam(response.data);
+}
+
+/** A Watt team may enter the streamed game only with 2..6 members (matches the backend gate). */
+export const WATT_MIN_TEAM_MEMBERS = 2;
+export const WATT_MAX_TEAM_MEMBERS = 6;
+
+export function isValidWattTeam(team: GenericHackathonTeam | null): boolean {
+  if (!team) return false;
+  const count = team.member_count ?? team.members?.length ?? 0;
+  return count >= WATT_MIN_TEAM_MEMBERS && count <= WATT_MAX_TEAM_MEMBERS;
+}
+
+/**
+ * Loader guard: the smart-home game (stream + controller + shop) is only reachable by a team of
+ * 2..6 members. Redirects to the profile/team page otherwise, and returns the team when valid.
+ */
+export async function requireValidWattTeam(env: Env, request: Request): Promise<GenericHackathonTeam> {
+  const team = await getGenericCurrentTeam(env, request);
+  if (!isValidWattTeam(team)) {
+    throw redirect("/watt-the-hack/profile");
+  }
+  return team as GenericHackathonTeam;
 }
 
 export async function getGenericTeams(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<GenericHackathonTeam[]> {

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -7,6 +7,7 @@ import {
   createWattUnitySession,
   deploySmartHome,
   getSmartHomeBlocks,
+  requireValidWattTeam,
   type SmartHomeCatalog,
   type SmartHomePipeline,
   type SmartHomeShopState,
@@ -57,6 +58,9 @@ async function loadCatalog(request: Request, context: Route.LoaderArgs["context"
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  // Gate the whole page (stream + controller + shop) behind a valid 2..6 member team.
+  // Redirects to the profile/team page before any Unity stream session is minted.
+  await requireValidWattTeam(getEnv(context), request);
   const [stream, catalog] = await Promise.all([
     loadSession(request, context),
     loadCatalog(request, context),


### PR DESCRIPTION
## What

Phase 1 (frontend half): the **Smart Home (Beginner)** page no longer loads unless the user is in a valid **2–6 member** team.

- New `requireValidWattTeam(env, request)` in `generic-hackathon.ts` (+ `isValidWattTeam` / `WATT_MIN|MAX_TEAM_MEMBERS`).
- Called at the top of the `smart-home-beginner` loader, **before** `createWattUnitySession`, so an invalid team redirects to `/watt-the-hack/profile` and **no stream session is ever minted**.

The whole page (Vagon stream + controller + shop + status bar) is gated by the single loader guard. The polled `state`/`shop` resource routes are covered at the source by the backend gate (they already fall back to empty on error), so no per-poll team fetch is added here.

Pairs with the backend PR (`mlai-backend#397`) which returns **403** from the stream/token and smart-home endpoints for invalid teams — the redirect is UX, the 403 is enforcement.

`tsc -b` clean against `origin/main`. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)