### PR TITLE
Watt teams: header notification bell (Phase 4)

### DIFF
--- a/app/components/GenericHackathonAppLayout.tsx
+++ b/app/components/GenericHackathonAppLayout.tsx
@@ -28,13 +28,14 @@ interface GenericHackathonAppLayoutProps {
     accentClass?: string;
     theme?: "default" | "watt";
   };
+  headerAccessory?: React.ReactNode;
 }
 
 function classNames(...classes: (string | false | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
 
-export default function GenericHackathonAppLayout({ children, user, config }: GenericHackathonAppLayoutProps) {
+export default function GenericHackathonAppLayout({ children, user, config, headerAccessory }: GenericHackathonAppLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const location = useLocation();
@@ -414,7 +415,9 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
               </p>
               <h1 className={isWattTheme ? "mt-1 text-lg font-black text-[#121e16]" : "text-base font-semibold text-gray-950"}>{config.name}</h1>
             </div>
-            <Menu as="div" className="relative">
+            <div className="flex items-center gap-2 sm:gap-3">
+              {headerAccessory}
+              <Menu as="div" className="relative">
               <Menu.Button
                 className={classNames(
                   isWattTheme
@@ -491,7 +494,8 @@ export default function GenericHackathonAppLayout({ children, user, config }: Ge
                   </Menu.Item>
                 </Menu.Items>
               </Transition>
-            </Menu>
+              </Menu>
+            </div>
           </div>
         </header>
         <main>{children}</main>

--- a/app/components/WattNotificationBell.tsx
+++ b/app/components/WattNotificationBell.tsx
@@ -1,0 +1,81 @@
+import { Fragment, useEffect } from "react";
+import { Menu, Transition } from "@headlessui/react";
+import { BellIcon } from "@heroicons/react/24/outline";
+import { Link, useFetcher } from "react-router";
+import { generateAvatarUrl, getInitials } from "~/lib/avatar";
+import type { GenericHackathonRequests } from "~/lib/generic-hackathon";
+
+/**
+ * Header bell for Watt team leaders: polls incoming join-requests and shows a count badge.
+ * Acting on a request happens on the Profile & Team page (linked from the dropdown).
+ */
+export default function WattNotificationBell({ basePath }: { basePath: string }) {
+  const fetcher = useFetcher<GenericHackathonRequests>();
+  const path = `${basePath}/notifications`;
+
+  useEffect(() => {
+    fetcher.load(path);
+    const id = setInterval(() => fetcher.load(path), 45000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const incoming = fetcher.data?.incoming ?? [];
+  const count = incoming.length;
+
+  return (
+    <Menu as="div" className="relative">
+      <Menu.Button className="relative -m-1.5 inline-flex h-10 w-10 items-center justify-center rounded-full p-1.5 text-[#155420] transition hover:bg-[#e6efd7]">
+        <span className="sr-only">Join requests</span>
+        <BellIcon className="h-5 w-5" aria-hidden="true" />
+        {count > 0 && (
+          <span className="absolute right-1 top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-[#df5047] px-1 text-[10px] font-black text-white ring-2 ring-[#fffefa]">
+            {count > 9 ? "9+" : count}
+          </span>
+        )}
+      </Menu.Button>
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items className="absolute right-0 z-20 mt-2.5 w-72 origin-top-right rounded-2xl border border-[#e8dfcf] bg-[#fffefa] p-2 shadow-[0_18px_42px_rgba(82,67,39,0.14)] focus:outline-none">
+          <p className="px-2 py-1.5 text-[11px] font-black uppercase tracking-[0.14em] text-[#64705f]">Join requests</p>
+          {count === 0 ? (
+            <p className="px-2 py-3 text-sm text-[#64705f]">You&rsquo;re all caught up.</p>
+          ) : (
+            <ul className="max-h-72 space-y-0.5 overflow-auto">
+              {incoming.map((req) => (
+                <li key={req.id} className="flex items-center gap-2 rounded-xl px-2 py-2">
+                  <img
+                    src={req.user.avatar_url || generateAvatarUrl(getInitials(req.user.full_name || req.user.email))}
+                    alt=""
+                    className="h-8 w-8 shrink-0 rounded-full object-cover ring-1 ring-[#c9dbb8]"
+                  />
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-bold text-[#121e16]">{req.user.full_name || req.user.email}</p>
+                    <p className="truncate text-xs text-[#64705f]">wants to join {req.team_name}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Menu.Item>
+            {({ focus }) => (
+              <Link
+                to={`${basePath}/profile`}
+                className={`mt-1 block rounded-xl px-2 py-2 text-center text-sm font-bold text-[#155420] ${focus ? "bg-[#e6efd7]" : ""}`}
+              >
+                Review in Profile &amp; Team
+              </Link>
+            )}
+          </Menu.Item>
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -58,6 +58,7 @@ export default [
     index("routes/watt-the-hack._index.tsx"),
     route("dashboard", "routes/watt-the-hack.dashboard.tsx"),
     route("profile", "routes/watt-the-hack.profile.tsx"),
+    route("notifications", "routes/watt-the-hack.notifications.tsx"),
     route("team", "routes/watt-the-hack.team.tsx"),
     route("submissions", "routes/watt-the-hack.submissions.tsx"),
     route("resources", "routes/watt-the-hack.resources.tsx"),

--- a/app/routes/watt-the-hack.notifications.tsx
+++ b/app/routes/watt-the-hack.notifications.tsx
@@ -1,0 +1,13 @@
+import type { Route } from "./+types/watt-the-hack.notifications";
+import { getEnv } from "~/lib/env.server";
+import { getJoinRequests, type GenericHackathonRequests } from "~/lib/generic-hackathon";
+
+// Resource route (no default export) — polled by the header notification bell for join requests.
+export async function loader({ request, context }: Route.LoaderArgs): Promise<GenericHackathonRequests> {
+  const env = getEnv(context);
+  try {
+    return await getJoinRequests(env, request);
+  } catch {
+    return { incoming: [], outgoing: [] };
+  }
+}

--- a/app/routes/watt-the-hack.tsx
+++ b/app/routes/watt-the-hack.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/watt-the-hack";
 import { Outlet, redirect, useLoaderData } from "react-router";
 import GenericHackathonAppLayout from "~/components/GenericHackathonAppLayout";
+import WattNotificationBell from "~/components/WattNotificationBell";
 import { getCurrentUser } from "~/lib/auth";
 import { getEnv } from "~/lib/env.server";
 import { WATT_THE_HACK_SLUG } from "~/lib/generic-hackathon";
@@ -36,6 +37,7 @@ export default function WattTheHackApp() {
         basePath: BASE_PATH,
         theme: "watt",
       }}
+      headerAccessory={<WattNotificationBell basePath={BASE_PATH} />}
     >
       <Outlet />
     </GenericHackathonAppLayout>


### PR DESCRIPTION
## What (Phase 4 — the header bell)

The final piece: a team leader now gets a **notification bell in the app header** with a badge counting incoming join requests.

- New `WattNotificationBell` component — a bell with an unread-count badge, polling every 45s. The dropdown lists the requesters ("X wants to join <team>") and links to **Profile & Team** to accept/reject (the Phase 3 UI).
- New `watt-the-hack/notifications` resource route that returns `getJoinRequests().incoming`.
- `GenericHackathonAppLayout` gains an optional `headerAccessory` slot; the Watt layout passes the bell, so the generic layout stays generic and other hackathons are unaffected.

**No backend change** — reuses the existing `team/requests/` endpoint from Phase 3.

This completes the team-gating feature: valid-team stream gate (Phase 1) → leader role + safe exits (Phase 2) → approval-based join requests (Phase 3) → header bell (Phase 4).

`tsc -b` clean against `origin/main`; no new deps. Not browser-verified (local backend down) — the bell renders client-side and degrades to empty if the poll fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)