### PR TITLE
Beginner track: intentional stream start, live badge, explained team-gate

### DIFF
--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -135,7 +135,9 @@ export function isValidWattTeam(team: GenericHackathonTeam | null): boolean {
 export async function requireValidWattTeam(env: Env, request: Request): Promise<GenericHackathonTeam> {
   const team = await getGenericCurrentTeam(env, request);
   if (!isValidWattTeam(team)) {
-    throw redirect("/watt-the-hack/profile");
+    // Carry a reason so the profile page can explain why they landed there
+    // instead of dumping them on the team page with no context.
+    throw redirect("/watt-the-hack/profile?reason=team-size");
   }
   return team as GenericHackathonTeam;
 }
@@ -295,6 +297,10 @@ export interface SmartHomeState {
   score?: number | null;
   tariff_period?: string | null;
   weather_condition?: string | null;
+  // Why the house is/ isn't live (from the backend's observation_liveness):
+  // "live" | "stale" | "no_observation" | "missing_timestamp".
+  live_reason?: string | null;
+  published_age_ms?: number | null;
 }
 
 export async function getSmartHomeBlocks(env: Env, request: Request): Promise<SmartHomeCatalog> {

--- a/app/routes/watt-the-hack.profile.tsx
+++ b/app/routes/watt-the-hack.profile.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/watt-the-hack.profile";
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import { Form, redirect, useActionData, useFetcher, useLoaderData } from "react-router";
+import { Form, redirect, useActionData, useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { InformationCircleIcon, PencilIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import AvatarModal from "~/components/AvatarModal";
 import { getCurrentUser, updateUser } from "~/lib/auth";
@@ -144,6 +144,9 @@ function personaClass(persona: string) {
 
 export default function WattTheHackProfile() {
   const { user: initialUser, currentTeam, teams, requests } = useLoaderData<typeof loader>();
+  // T6: surface *why* the Smart Home track bounced them here (requireValidWattTeam redirect).
+  const [searchParams] = useSearchParams();
+  const needsValidTeam = searchParams.get("reason") === "team-size";
   const actionData = useActionData<typeof action>() as ActionResult | undefined;
   const fetcher = useFetcher<ActionResult>();
 
@@ -303,6 +306,13 @@ export default function WattTheHackProfile() {
             </div>
           </div>
         </div>
+
+        {needsValidTeam && (
+          <div className={`mt-6 ${wattClasses.warningAlert}`}>
+            You need a team of 2–6 members to enter the Smart Home Beginner track. Create or join
+            one below, then head back to the game.
+          </div>
+        )}
 
         <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-flow-col-dense lg:grid-cols-3">
           <div className="space-y-6 lg:col-span-2 lg:col-start-1">

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -61,11 +61,10 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   // Gate the whole page (stream + controller + shop) behind a valid 2..6 member team.
   // Redirects to the profile/team page before any Unity stream session is minted.
   await requireValidWattTeam(getEnv(context), request);
-  const [stream, catalog] = await Promise.all([
-    loadSession(request, context),
-    loadCatalog(request, context),
-  ]);
-  return { ...stream, catalog };
+  // T7: do NOT mint a Vagon session on page load -- that allocates a GPU instance just for
+  // visiting the page. The player clicks "Start your house" (the reconnect action) to begin.
+  const catalog = await loadCatalog(request, context);
+  return { session: null as WattUnitySession | null, error: null as string | null, catalog };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -147,12 +146,16 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
   // at startup, so we intentionally do NOT refresh on ticket expiry (that would
   // restart the whole stream). We only reconnect on an iframe load error.
 
+  const hasStream = Boolean(session?.stream_url);
+  // T7: before the first "Start your house" click there is no session, so the panel shows a
+  // Start CTA (not a perpetual spinner) and no GPU session is allocated for a passive visit.
+  const notStarted = !hasStream && !isReconnecting && !error;
+
   const statusLabel = useMemo(() => {
-    if (isReconnecting) return "Connecting...";
-    if (!session) return "Connecting...";
-    if (!isFrameLoaded) return "Starting your house...";
+    if (isReconnecting) return "Starting your house...";
+    if (hasStream && !isFrameLoaded) return "Starting your house...";
     return "";
-  }, [isFrameLoaded, isReconnecting, session]);
+  }, [hasStream, isFrameLoaded, isReconnecting]);
 
   const reconnect = () => reconnectFetcher.submit({ intent: "reconnect" }, { method: "post" });
 
@@ -178,6 +181,19 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
   // Poll the live game state for the goal/day/wallet status bar.
   const stateFetcher = useFetcher();
   const homeState = stateFetcher.data as SmartHomeState | undefined;
+
+  // T5: live/offline badge driven by the published-observation freshness the backend reports
+  // (live / stale / no_observation / missing_timestamp from observation_liveness).
+  const liveBadge = useMemo(() => {
+    if (homeState?.live) return { dot: "bg-emerald-400", label: "Live" };
+    const reason = homeState?.live_reason;
+    if (reason === "stale") return { dot: "bg-amber-400", label: "Reconnecting…" };
+    if (reason === "no_observation" || reason === "missing_timestamp")
+      return { dot: "bg-amber-400", label: "Starting…" };
+    if (homeState && homeState.live === false) return { dot: "bg-rose-400", label: "Offline" };
+    return { dot: "bg-amber-400", label: "…" };
+  }, [homeState]);
+
   useEffect(() => {
     const STATE_PATH = "/watt-the-hack/smart-home-beginner/state";
     stateFetcher.load(STATE_PATH);
@@ -274,6 +290,31 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
                 }}
               />
             ) : null}
+
+            {hasStream && (
+              <div className="absolute left-3 top-3 z-10 flex items-center gap-2 rounded-full bg-black/55 px-3 py-1.5 text-xs font-black text-white backdrop-blur-sm">
+                <span className={`h-2 w-2 rounded-full ${liveBadge.dot}`} aria-hidden="true" />
+                {liveBadge.label}
+              </div>
+            )}
+
+            {notStarted && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#121e16]">
+                <div className="mx-4 flex max-w-md flex-col items-center text-center">
+                  <p className="text-lg font-black text-[#fffefa]">Your team's house isn't running yet.</p>
+                  <p className="mt-2 text-sm text-[#cfe0c2]">
+                    Start it to watch your smart home live and deploy your controller.
+                  </p>
+                  <button
+                    type="button"
+                    className={`${wattClasses.buttonPrimary} mt-6 px-6 py-3`}
+                    onClick={reconnect}
+                  >
+                    Start your house
+                  </button>
+                </div>
+              </div>
+            )}
 
             {(statusLabel || error) && (
               <div className="absolute inset-0 flex items-center justify-center bg-[#121e16]">


### PR DESCRIPTION
Three small, self-contained Beginner-track hardening items (T5/T6/T7 from the streaming backlog). They share the same page surface, so they're bundled to avoid artificial merge conflicts.

## T7 — "Start your house" CTA (don't auto-spin a GPU)
The loader minted a Vagon session on page load, so merely visiting allocated a GPU instance. Now the loader only gates + loads the catalog; the panel shows a **Start your house** button that mints the session on click (reusing the existing `reconnect` action). No passive-visit GPU cost.

## T5 — Live/offline badge
A small badge on the stream driven by the polled `state/` fields (`live`, `live_reason`, `published_age_ms` — shipped in backend #401): 🟢 Live / 🟡 Starting…/Reconnecting… / 🔴 Offline. Players can now distinguish a live house from a stale or black frame. Added `live_reason`/`published_age_ms` to the `SmartHomeState` type.

## T6 — Explain the team-gate redirect
`requireValidWattTeam` already redirected invalid teams to `/watt-the-hack/profile`, but with no context. It now redirects with `?reason=team-size`, and the profile page shows an amber banner explaining the 2–6 member requirement.

## Verification
`bun install` + `bunx react-router typegen` + `bunx tsc -b` → **0 errors**. Only 3 source files changed.

⚠️ **Not browser-verified** — these routes require an authenticated session + the backend up (the loaders call `requireValidWattTeam`/state), so local render redirects without it. Logic is low-risk (presentational + reuse of the existing reconnect path); final visual QA wants an authed load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)