### PR TITLE
Add Schedule & Runsheet section to Watt The Hack dashboard

### DIFF
--- a/app/lib/watt-the-hack-schedule.ts
+++ b/app/lib/watt-the-hack-schedule.ts
@@ -1,0 +1,190 @@
+export type WattScheduleItem = {
+  time: string;
+  title: string;
+  detail?: string;
+  people?: string[];
+};
+
+export type WattScheduleDay = {
+  id: "friday" | "saturday";
+  weekday: string;
+  date: string;
+  shortLabel: string;
+  theme: string;
+  items: WattScheduleItem[];
+};
+
+export const wattTheHackSchedule: WattScheduleDay[] = [
+  {
+    id: "friday",
+    weekday: "Friday",
+    date: "5 Jun 2026",
+    shortLabel: "Fri · 5 Jun",
+    theme: "Welcome, trivia and networking",
+    items: [
+      {
+        time: "5:30 PM",
+        title: "Doors open & registration",
+        detail: "Check in and settle in.",
+      },
+      {
+        time: "6:00 PM",
+        title: "Welcome from MC and sponsor notes",
+        detail: "MC will call each sponsor/speaker up one by one.",
+        people: ["Doron Bahar (base44)", "Graham McCorkill (S&C)"],
+      },
+      {
+        time: "6:15 PM",
+        title: "Keynote & welcome",
+        detail: "Opening keynote for attendees.",
+        people: ["John Allsop (AIE, Webdirections)"],
+      },
+      {
+        time: "6:25 PM",
+        title: "Event overview from Dr Sam Donegan",
+        detail: "Format, expectations and what happens next.",
+      },
+      {
+        time: "6:40 PM",
+        title: "First round of trivia",
+        detail: "Directed by Dr Sam Donegan.",
+      },
+      {
+        time: "7:00 PM",
+        title: "Break for dinner & drinks",
+        detail: "Dinner and refreshments.",
+      },
+      {
+        time: "7:25 PM",
+        title: "Second round of trivia",
+        detail: "Directed by Dr Sam Donegan.",
+      },
+      {
+        time: "7:45 PM",
+        title: "Third round of trivia",
+        detail: "Directed by Dr Sam Donegan.",
+      },
+      {
+        time: "8:15 PM",
+        title: "Networking",
+        detail: "Meet sponsors, mentors and other builders.",
+      },
+      {
+        time: "9:30 PM",
+        title: "Event close",
+        detail: "Venue closes.",
+      },
+    ],
+  },
+  {
+    id: "saturday",
+    weekday: "Saturday",
+    date: "6 Jun 2026",
+    shortLabel: "Sat · 6 Jun",
+    theme: "Hack day, pitches and awards",
+    items: [
+      {
+        time: "9:00 AM",
+        title: "Bump in",
+        detail: "MLAI and Monash DeepNeuron only.",
+      },
+      {
+        time: "10:30 AM",
+        title: "Doors open & registration",
+        detail: "Check in and set up.",
+      },
+      {
+        time: "11:00 AM",
+        title: "Welcome from MC and sponsor notes",
+        detail: "MC will call each sponsor/speaker up one by one for a quick 2-3 minute talk.",
+        people: [
+          "Scott Falkner (OpenAI)",
+          "Doron Bahar (base44)",
+          "Graham McCorkill (S&C)",
+          "Mat Brennan (Amber Electric)",
+        ],
+      },
+      {
+        time: "11:25 AM",
+        title: "Keynote speakers",
+        detail: "Explaining some of the big challenges in the Australian energy sector and grid.",
+        people: ["Bill Lilley (RaceFor2030)", "Julian Featherston (HAL Systems)"],
+      },
+      {
+        time: "11:40 AM",
+        title: "Event overview from MC",
+        detail: "Track overview by MC and Monash DeepNeuron.",
+      },
+      {
+        time: "12:00 PM",
+        title: "Hacking begins",
+        detail: "Lunch arrives. Mentors to answer questions.",
+        people: ["All mentors"],
+      },
+      {
+        time: "1:00 PM",
+        title: "Speaker session",
+        detail: "Boardroom Lv1.",
+        people: ["Hao Wang (Monash)"],
+      },
+      {
+        time: "2:00 PM",
+        title: "Speaker session",
+        detail: "Boardroom Lv1.",
+        people: ["Mat Brennan (Amber Electric)"],
+      },
+      {
+        time: "3:00 PM",
+        title: "Speaker session",
+        detail: "Boardroom Lv1.",
+        people: ["David Gilmore (MLAI)"],
+      },
+      {
+        time: "4:30 PM",
+        title: "Snacks and coffee",
+        detail: "Recharge break.",
+      },
+      {
+        time: "5:00 PM",
+        title: "Submissions for pitching track",
+        detail: "Semifinals.",
+      },
+      {
+        time: "6:30 PM",
+        title: "Dinner",
+        detail: "Food served.",
+      },
+      {
+        time: "7:30 PM",
+        title: "Closing ceremony",
+        detail: "Led by Dr Sam Donegan.",
+      },
+      {
+        time: "7:45 PM",
+        title: "Finalist teams pitching to judges",
+        detail: "Directed by MC.",
+        people: [
+          "David Gilmore (MLAI)",
+          "Mat Brennan (Amber Electric)",
+          "Doron Bahar (Base44)",
+          "Julian Featherston (HAL Systems)",
+        ],
+      },
+      {
+        time: "8:20 PM",
+        title: "Final scores calculated",
+        detail: "For all streams.",
+      },
+      {
+        time: "8:30 PM",
+        title: "Winners announced",
+        detail: "Networking follows.",
+      },
+      {
+        time: "9:30 PM",
+        title: "Event closes",
+        detail: "Venue closes.",
+      },
+    ],
+  },
+];

--- a/app/routes/watt-the-hack.dashboard.tsx
+++ b/app/routes/watt-the-hack.dashboard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRightIcon,
   ArrowTopRightOnSquareIcon,
   BookOpenIcon,
+  CalendarDaysIcon,
   DocumentTextIcon,
   MegaphoneIcon,
   PaperAirplaneIcon,
@@ -26,6 +27,7 @@ import {
   type GenericHackathonTeam,
 } from "~/lib/generic-hackathon";
 import { wattClasses, wattImages } from "~/lib/watt-theme";
+import { wattTheHackSchedule } from "~/lib/watt-the-hack-schedule";
 import type { Hackathon } from "~/services/hackathon";
 
 const FALLBACK_HACKATHON: Hackathon = {
@@ -360,6 +362,83 @@ function ResourcesPanel({ resources }: { resources: GenericHackathonResource[] }
   );
 }
 
+function ScheduleSection() {
+  const [activeDayId, setActiveDayId] = useState(wattTheHackSchedule[0].id);
+  const activeDay =
+    wattTheHackSchedule.find((day) => day.id === activeDayId) ?? wattTheHackSchedule[0];
+
+  return (
+    <section className={`${wattClasses.panel} px-6 py-5 sm:px-7`}>
+      <div className="flex items-center gap-3">
+        <CalendarDaysIcon className="h-8 w-8 text-[#155420]" aria-hidden="true" />
+        <div>
+          <h2 className="text-xl font-black text-[#121e16]">Schedule &amp; Runsheet</h2>
+          <p className="mt-0.5 text-sm font-medium text-[#354031]">
+            Two days of building, talks and pitches.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-5 inline-flex rounded-full border border-[#e8dfcf] bg-[#fbf6e9] p-1">
+        {wattTheHackSchedule.map((day) => {
+          const isActive = day.id === activeDayId;
+          return (
+            <button
+              key={day.id}
+              type="button"
+              onClick={() => setActiveDayId(day.id)}
+              aria-pressed={isActive}
+              className={`rounded-full px-4 py-1.5 text-sm transition ${
+                isActive
+                  ? "bg-[#2f6f2c] font-black text-white shadow-[0_8px_16px_rgba(21,84,32,0.18)]"
+                  : "font-bold text-[#485244] hover:text-[#155420]"
+              }`}
+            >
+              {day.shortLabel}
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="mt-3 text-sm font-semibold text-[#485244]">
+        {activeDay.weekday} · {activeDay.date} — {activeDay.theme}
+      </p>
+
+      <ol className="mt-5">
+        {activeDay.items.map((item, index) => {
+          const isLast = index === activeDay.items.length - 1;
+          return (
+            <li key={`${item.time}-${item.title}`} className="flex gap-3 sm:gap-5">
+              <div className="w-16 shrink-0 pt-0.5 text-right sm:w-20">
+                <span className="text-sm font-black text-[#155420]">{item.time}</span>
+              </div>
+              <div className="flex w-3 shrink-0 flex-col items-center">
+                <span className="mt-0.5 h-3 w-3 shrink-0 rounded-full border-2 border-[#2f6f2c] bg-[#fffefa]" />
+                {!isLast && <span className="mt-1 w-px flex-1 bg-[#e8dfcf]" />}
+              </div>
+              <div className={`min-w-0 flex-1 ${isLast ? "pb-0" : "pb-6"}`}>
+                <p className="font-black leading-snug text-[#121e16]">{item.title}</p>
+                {item.detail && (
+                  <p className="mt-0.5 text-sm leading-6 text-[#64705f]">{item.detail}</p>
+                )}
+                {item.people && item.people.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {item.people.map((person) => (
+                      <span key={person} className={wattClasses.chip}>
+                        {person}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
 export default function WattTheHackDashboard() {
   const { hackathon, announcements, team, latestSubmission, resources } = useLoaderData<typeof loader>();
 
@@ -426,6 +505,8 @@ export default function WattTheHackDashboard() {
         </div>
 
         <ResourcesPanel resources={resources} />
+
+        <ScheduleSection />
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Adds a **Schedule & Runsheet** section to the Watt The Hack participant dashboard, below the Resources panel.

- Compact **Fri · 5 Jun / Sat · 6 Jun** day-tab toggle (defaults to Friday).
- Vertical timeline per day: green times, connected dots, session title, detail, and speaker/sponsor chips.
- Friday (10 items, 5:30 PM → 9:30 PM) and Saturday (17 items, 9:00 AM → 9:30 PM) transcribed from the official runsheet.

## Files

- `app/lib/watt-the-hack-schedule.ts` (new) — typed, static two-day schedule data.
- `app/routes/watt-the-hack.dashboard.tsx` — new inline `ScheduleSection` component + render.

## Verification

- `tsc -b`: no type errors introduced (error set identical to base `main`; none reference the changed files).
- Verified in a local browser at desktop and mobile (390px): tab switching works, chips wrap, no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)