### PR TITLE
Watt: window-aware notice on the beginner stream page

### DIFF
--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -76,6 +76,10 @@ export interface WattUnitySession {
   stream_url: string;
   household_id: string;
   expires_at: string;
+  // Global campaign window (epoch ms), shared by every team and session. Present when the
+  // backend has WATT_CAMPAIGN_START configured; lets the page show pre-start / ended context.
+  campaign_start_ms?: number | null;
+  campaign_end_ms?: number | null;
 }
 
 function appPath(slug: string, path: string) {

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -39,6 +39,14 @@ function errorMessage(error: unknown, fallback: string) {
   return fallback;
 }
 
+function formatClockMs(ms: number) {
+  try {
+    return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
 async function loadSession(request: Request, context: Route.LoaderArgs["context"]): Promise<StreamData> {
   const env = getEnv(context);
   try {
@@ -194,6 +202,23 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
     return { dot: "bg-amber-400", label: "…" };
   }, [homeState]);
 
+  // The campaign runs on one fixed global clock shared by every team/session, so a session
+  // started before it opens (or after it ends) shows a hold/final state. Surface that context.
+  // Recomputed on each 6s state poll (homeState dep) so it flips as the window opens/closes.
+  const windowNotice = useMemo(() => {
+    if (!session) return null;
+    const now = Date.now();
+    const start = session.campaign_start_ms;
+    const end = session.campaign_end_ms;
+    if (typeof start === "number" && now < start) {
+      return `Your team's house opens at ${formatClockMs(start)} — it begins at day 1 then.`;
+    }
+    if (typeof end === "number" && now >= end) {
+      return "The campaign has ended — you're viewing the final state of your house.";
+    }
+    return null;
+  }, [session, homeState]);
+
   useEffect(() => {
     const STATE_PATH = "/watt-the-hack/smart-home-beginner/state";
     stateFetcher.load(STATE_PATH);
@@ -280,6 +305,11 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
             <button type="button" onClick={() => setRecap(null)} className="shrink-0 text-xs font-bold underline">
               Dismiss
             </button>
+          </div>
+        )}
+        {windowNotice && (
+          <div className="rounded-xl border border-[#3a5a3a] bg-[#1a2a1e] px-4 py-3 text-sm font-semibold text-[#e6efd7]">
+            {windowNotice}
           </div>
         )}
         <section className={`${wattClasses.panelStrong} overflow-hidden p-0`}>


### PR DESCRIPTION
## What
Adds a small **window-aware notice** to the beginner stream page using the global campaign window the backend now returns (`campaign_start_ms` / `campaign_end_ms`):

- Session started **before** the window opens → "Your team's house opens at HH:MM — it begins at day 1 then."
- Session started **after** it ends → "The campaign has ended — you're viewing the final state of your house."
- In-window → nothing extra (the live badge + status bar already cover it).

Recomputes on each 6 s state poll so it flips automatically as the window opens/closes.

## Why
The campaign runs on one fixed global clock shared by every team/session, so a house started outside the window renders a held (day-1) or final state. This explains that instead of looking broken.

## Scope
Frontend-only; the explicit "Start your house" CTA (no auto-mint on load, T7) already shipped on main. Pairs with backend #410 (emits the window) and Unity #15 (consumes it). Plan: `docs/watt-deterministic-resume-plan.md` (Watt-The-Hack repo).

## Verify
`react-router typegen && tsc -b` → 0 errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)