### PR TITLE
Watt smart-home: full live HUD panel on the web (energy/carbon/money/mood)

### DIFF
--- a/app/components/SmartHomeStatusBar.tsx
+++ b/app/components/SmartHomeStatusBar.tsx
@@ -10,13 +10,38 @@ function round(value: number, dp = 0) {
   return Math.round(value * f) / f;
 }
 
-function Stat({ label, value, hero = false }: { label: string; value: string; hero?: boolean }) {
+function Stat({
+  label,
+  value,
+  hero = false,
+  accent = "#121e16",
+  icon,
+}: {
+  label: string;
+  value: string;
+  hero?: boolean;
+  accent?: string;
+  icon?: string;
+}) {
   return (
     <div className="rounded-[0.8rem] border border-[#e8dfcf] bg-[#fffefa] px-3 py-2">
       <div className="text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a8477]">{label}</div>
-      <div className={`font-black text-[#121e16] ${hero ? "text-2xl" : "text-base"}`}>{value}</div>
+      <div
+        className={`flex items-baseline gap-1 font-black ${hero ? "text-2xl" : "text-base"}`}
+        style={{ color: accent }}
+      >
+        {icon ? <span aria-hidden="true">{icon}</span> : null}
+        <span>{value}</span>
+      </div>
     </div>
   );
+}
+
+// House mood -> a quick face, echoing the mood meter we removed from the in-house HUD.
+function moodFace(mood: number): string {
+  if (mood >= 67) return "🙂";
+  if (mood >= 34) return "😐";
+  return "🙁";
 }
 
 type Chip = { icon: string; label: string; cls: string };
@@ -55,10 +80,22 @@ function Pill({ chip }: { chip: Chip }) {
 
 export function SmartHomeStatusBar({ state }: { state?: SmartHomeState }) {
   const live = state?.live ?? false;
-  const day = typeof state?.day === "number" ? state.day : null;
-  // The unified Main Score is computed in the Unity sim (WattScoreFormula) and published through
-  // the backend. Money / energy / comfort detail now lives in the house stream's HUD, not here.
-  const score = typeof state?.score === "number" ? state.score : null;
+  const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+  // Live house telemetry, published by the Unity sim each tick (score/current in RTDB) and forwarded
+  // by the backend state endpoint. This panel is now the primary HUD: the wooden stat bar + day/night
+  // wheel were removed from the streamed game, so energy / carbon / money / mood are shown here.
+  const energy = num(state?.energy_kwh);
+  const carbon = num(state?.carbon);
+  const money = num(state?.wallet);
+  const mood = num(state?.comfort);
+  const day = num(state?.day);
+  const score = num(state?.score);
+  const dash = "—";
+
+  const time = live && state?.game_time ? state.game_time : null;
+  const timeChip: Chip | null = time
+    ? { icon: "◷", label: time, cls: "border-[#e8dfcf] bg-[#fffefa] text-[#354031]" }
+    : null;
   const weather = live ? weatherChip(state?.weather_condition) : null;
   const tariff = live ? tariffChip(state?.tariff_period) : null;
 
@@ -77,22 +114,35 @@ export function SmartHomeStatusBar({ state }: { state?: SmartHomeState }) {
         </div>
       </div>
 
-      <div className="mt-3 grid grid-cols-2 gap-2">
-        <Stat label="Day" value={day !== null ? `${day} / ${CAMPAIGN_DAYS}` : "—"} />
-        <Stat label="Score" value={score !== null ? `${round(score)}` : "—"} hero />
+      <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <Stat label="Energy" icon="⚡" accent="#5f7a1f" value={energy !== null ? `${round(energy, 1)} kWh` : dash} />
+        <Stat label="Carbon" icon="🌍" accent="#6b6f6a" value={carbon !== null ? `${round(carbon, 1)} kg` : dash} />
+        <Stat label="Money" accent="#9a7b1a" value={money !== null ? `$${round(money).toLocaleString()}` : dash} />
+        <Stat
+          label="Mood"
+          icon={mood !== null ? moodFace(mood) : undefined}
+          accent="#2f6f2c"
+          value={mood !== null ? `${round(mood)}%` : dash}
+        />
       </div>
 
-      {(weather || tariff) && (
+      <div className="mt-2 grid grid-cols-2 gap-2">
+        <Stat label="Day" value={day !== null ? `${day} / ${CAMPAIGN_DAYS}` : dash} />
+        <Stat label="Score" value={score !== null ? `${round(score)}` : dash} hero />
+      </div>
+
+      {(timeChip || weather || tariff) && (
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <span className="text-[10px] font-bold uppercase tracking-[0.08em] text-[#8a8477]">Today</span>
+          {timeChip && <Pill chip={timeChip} />}
           {weather && <Pill chip={weather} />}
           {tariff && <Pill chip={tariff} />}
         </div>
       )}
 
       <p className="mt-2 text-xs font-medium text-[#6f6a5d]">
-        Your score balances energy use, carbon, and home comfort — watch the house stream for the detail.
-        Money is managed in the house: let it run low and the family starts selling things off.
+        Energy, carbon and comfort drive your Score. Money is managed in the house — let it run low
+        and the family starts selling things off.
       </p>
     </section>
   );

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -301,6 +301,7 @@ export interface SmartHomeState {
   wallet?: number | null;
   cost?: number | null;
   energy_kwh?: number | null;
+  carbon?: number | null;
   comfort?: number | null;
   score?: number | null;
   tariff_period?: string | null;

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -222,7 +222,9 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
   useEffect(() => {
     const STATE_PATH = "/watt-the-hack/smart-home-beginner/state";
     stateFetcher.load(STATE_PATH);
-    const id = setInterval(() => stateFetcher.load(STATE_PATH), 6000);
+    // 3s so the live HUD (energy/money tick up each second in-sim) feels responsive; the score
+    // summary is a tiny payload and this is the only state poll. Shop stays at 6s.
+    const id = setInterval(() => stateFetcher.load(STATE_PATH), 3000);
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## What
Turns the `smart-home-beginner` status bar into the **primary HUD** for the streamed game. The in-game wooden HUD bar + day/night wheel are being removed from the Unity/Vagon stream (separate PR), so these live stats move to a crisp native panel above the video.

- `SmartHomeStatusBar` now shows **Energy · Carbon · Money · Mood** stat tiles (accent colours + a mood face) alongside the existing **Day** + **Score**, plus a **time · weather · tariff** "Today" chip row (game time added to the existing weather/tariff chips).
- Adds `carbon?: number | null` to `SmartHomeState` (the backend now forwards `carbon_kg` — see mlai-backend#412).
- Tightens the live **state poll 6s → 3s** so energy/money feel responsive; the shop poll stays at 6s.

All values are null-safe and render "—" when offline; the chip row hides when not live.

## Why
Rendering the HUD inside Unity bakes it into the video stream — low-res, un-styleable, and tied to the game engine. Money/energy/mood already flow to the web via the state endpoint; this surfaces them (plus carbon) as a real HUD.

## Dependencies
- **mlai-backend#412** (carbon passthrough) — without it `carbon` is `undefined` → shows "—".
- Carbon also needs the Vagon stream rebuilt from the Unity `origin/main` that publishes `carbon_kg`. Money/energy/mood already populate from the current stream. Degrades gracefully until then.

## Verification
- `react-router typegen && tsc -b` — clean.
- Rendered **live (healthy)**, **live (struggling: peak/heatwave/low-cash/low-mood)**, and **offline** states in a local preview (temporary throwaway route, not committed). No console errors; responsive 2-up → 4-up confirmed.

| Live (healthy) | Live (struggling) | Offline |
|---|---|---|
| ⚡22.8 kWh · 🌍3.1 kg · \$1,268 · 🙂74% — Day 4/33 · Score 612 — ◷2:45pm ☁Cloudy ▼Off-peak | ⚡41.6 kWh · 🌍12.4 kg · \$42 · 🙁28% — Day 19/33 · Score 318 — ◷6:10pm ☀Heatwave ▲Peak | all "—", chip row hidden |

🤖 Generated with [Claude Code](https://claude.com/claude-code)