### PR TITLE
Smart Home: progressive controller — switchboard first, pipeline unlocks over the campaign

### DIFF
--- a/app/components/SmartHomeControllerV2.tsx
+++ b/app/components/SmartHomeControllerV2.tsx
@@ -47,12 +47,12 @@ import {
   PALETTE,
   compilePipeline,
   emptyPipeline,
-  isComplete,
   type BlockDef,
   type PlacedPipeline,
   type SlotDef,
   type SlotType,
 } from "~/lib/smart-home-pipeline";
+import { SLOT_UNLOCK_DAY, type Progression } from "~/lib/smart-home-progression";
 
 /**
  * v2.1 — game-board styling to match the draft.
@@ -376,10 +376,12 @@ export function SmartHomeControllerV2({
   onDeploy,
   isDeploying,
   feedback,
+  progression,
 }: {
   onDeploy: (pipeline: SmartHomePipeline) => void;
   isDeploying: boolean;
   feedback: DeployFeedback;
+  progression?: Progression;
 }) {
   const [cells, setCells] = useState<PlacedCells>(makeEmptyCells);
   const [activeBlock, setActiveBlock] = useState<BlockDef | null>(null);
@@ -389,7 +391,14 @@ export function SmartHomeControllerV2({
   // palette; false => it landed in a slot, so kill the animation and let it snap into place.
   const returnToPaletteRef = useRef(false);
 
-  const flow = PIPELINE.filter((slot) => slot.type !== "safety");
+  // Stage gating: only render the slots/blocks the team has unlocked (default: everything, so the
+  // component is unchanged when no progression is passed). Redefining `flow` cascades to the
+  // header counts, the board columns, the connectors and the living-pipeline animation.
+  const unlockedSlots = progression?.unlockedSlots ?? new Set<SlotType>(PIPELINE.map((s) => s.type));
+  const isSlotUnlocked = (t: SlotType) => unlockedSlots.has(t);
+  const safetyUnlocked = isSlotUnlocked("safety");
+
+  const flow = PIPELINE.filter((slot) => slot.type !== "safety" && isSlotUnlocked(slot.type));
   const safety = PIPELINE_BY_TYPE.safety;
 
   function handleDragStart(event: DragStartEvent) {
@@ -430,7 +439,8 @@ export function SmartHomeControllerV2({
     return placed;
   }, [cells]);
 
-  const complete = isComplete(pipeline);
+  // Only the unlocked required slots gate Deploy; locked slots are auto-defaulted server-side.
+  const complete = flow.every((slot) => pipeline[slot.type].length >= slot.min);
   const pipelinePayload = useMemo<SmartHomePipeline>(
     () => ({
       inputs: pipeline.input.map((b) => b.id),
@@ -532,21 +542,23 @@ export function SmartHomeControllerV2({
                 ))}
               </div>
 
-              {/* Safety & override */}
-              <div className="mt-4 rounded-[1rem] border border-dashed border-[#d8cfbd] bg-[#fbf6e9] p-4">
-                <div className="flex items-center gap-3">
-                  <ShieldCheck className="h-6 w-6 shrink-0 text-[#64705f]" />
-                  <div className="flex-1">
-                    <div className="text-[12px] font-black uppercase tracking-[0.1em] text-[#64705f]">Safety &amp; Override (Optional)</div>
-                    <div className="text-xs font-medium text-[#8a8477]">Overrides can stop or limit actions.</div>
-                  </div>
-                  <div className="w-44">
-                    <div className="min-h-[3.5rem]">
-                      <SlotCell slot={safety} index={0} block={cells.safety[0]} activeType={activeType} onRemove={() => removeAt("safety", 0)} />
+              {/* Safety & override (unlocks with the full board) */}
+              {safetyUnlocked && (
+                <div className="mt-4 rounded-[1rem] border border-dashed border-[#d8cfbd] bg-[#fbf6e9] p-4">
+                  <div className="flex items-center gap-3">
+                    <ShieldCheck className="h-6 w-6 shrink-0 text-[#64705f]" />
+                    <div className="flex-1">
+                      <div className="text-[12px] font-black uppercase tracking-[0.1em] text-[#64705f]">Safety &amp; Override (Optional)</div>
+                      <div className="text-xs font-medium text-[#8a8477]">Overrides can stop or limit actions.</div>
+                    </div>
+                    <div className="w-44">
+                      <div className="min-h-[3.5rem]">
+                        <SlotCell slot={safety} index={0} block={cells.safety[0]} activeType={activeType} onRemove={() => removeAt("safety", 0)} />
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              )}
             </div>
 
             {/* Deploy bar */}
@@ -616,6 +628,18 @@ export function SmartHomeControllerV2({
               {PIPELINE.map((slot) => {
                 const isCollapsed = collapsed.has(slot.type);
                 const blocks = PALETTE.filter((b) => b.type === slot.type);
+                if (!isSlotUnlocked(slot.type)) {
+                  // Locked group: a greyed teaser so the player sees what's coming + when.
+                  return (
+                    <div key={slot.type} className="rounded-[0.8rem] border border-dashed border-[#d8cfbd] bg-[#f3eddc] px-3 py-2 opacity-80">
+                      <div className="flex items-center gap-1.5">
+                        <span className="h-2 w-2 rounded-full bg-[#c9b98f]" />
+                        <span className="text-[11px] font-black uppercase tracking-[0.1em] text-[#8a8477]">{slot.label}</span>
+                        <span className="ml-auto text-[10px] font-bold text-[#a89a78]">🔒 day {SLOT_UNLOCK_DAY[slot.type] ?? "?"}</span>
+                      </div>
+                    </div>
+                  );
+                }
                 return (
                   <div key={slot.type}>
                     <button type="button" onClick={() => toggleGroup(slot.type)} className="flex w-full items-center gap-1.5">

--- a/app/components/SmartHomeStatusBar.tsx
+++ b/app/components/SmartHomeStatusBar.tsx
@@ -1,9 +1,8 @@
 import type { SmartHomeState } from "~/lib/generic-hackathon";
 import { wattClasses } from "~/lib/watt-theme";
-
-// Display target only; the real campaign length is a Unity constant (CAMPAIGN_LENGTH_DAYS).
-// ~6.5h event (12:00–18:30) at the default ~11.7 min/day ≈ 33 days.
-const CAMPAIGN_DAYS = 33;
+// Shared with the controller's progression so "Day x / N" never drifts from Unity's
+// CAMPAIGN_LENGTH_DAYS (currently 46).
+import { CAMPAIGN_DAYS } from "~/lib/smart-home-progression";
 
 function round(value: number, dp = 0) {
   const f = 10 ** dp;

--- a/app/components/SmartHomeSwitchboard.tsx
+++ b/app/components/SmartHomeSwitchboard.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { Lightbulb, RotateCcw, Rocket } from "lucide-react";
+import { wattClasses } from "~/lib/watt-theme";
+import type { DeployFeedback } from "~/components/SmartHomeController";
+import { SWITCH_DEVICES, type Upcoming } from "~/lib/smart-home-progression";
+
+/**
+ * Stage 1 — the simplest possible controller: a few light switches. Flip and Deploy.
+ * On Deploy the page posts { switches: {bathroom:false,...} } -> backend set_lights{room,on}.
+ * This is the gentle on-ramp before the full SENSE->THINK->ACT pipeline unlocks.
+ */
+export function SmartHomeSwitchboard({
+  onDeploy,
+  isDeploying,
+  feedback,
+  upcoming,
+}: {
+  onDeploy: (switches: Record<string, boolean>) => void;
+  isDeploying: boolean;
+  feedback: DeployFeedback;
+  upcoming: Upcoming[];
+}) {
+  // Lights default ON — the house tends to start with some left on, so the natural first
+  // action is to spot one and turn it off.
+  const initial = () => Object.fromEntries(SWITCH_DEVICES.map((d) => [d.id, true]));
+  const [on, setOn] = useState<Record<string, boolean>>(initial);
+  const toggle = (id: string) => setOn((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <section className={`${wattClasses.panel} p-6`}>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-black text-[#121e16]">Your Smart Home</h2>
+          <p className="mt-1 text-sm font-medium text-[#64705f]">
+            Flip a switch, then hit Deploy to control your house. Spotted a light left on? Turn it off.
+          </p>
+        </div>
+        <span className="rounded-full border border-[#e8dfcf] bg-[#fffefa] px-3 py-1 text-xs font-black text-[#155420]">
+          Getting started
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        {SWITCH_DEVICES.map((d) => {
+          const isOn = on[d.id];
+          return (
+            <button
+              key={d.id}
+              type="button"
+              onClick={() => toggle(d.id)}
+              aria-pressed={isOn}
+              className={`flex items-center gap-3 rounded-[1rem] border-2 p-4 text-left transition ${
+                isOn ? "border-[#e7d3a3] bg-[#fdf6e3]" : "border-[#cfe0c2] bg-[#eef4e3]"
+              }`}
+            >
+              <span
+                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full ${
+                  isOn ? "bg-[#f4c84a] text-[#5c4a16]" : "bg-[#d6e3c6] text-[#64705f]"
+                }`}
+              >
+                <Lightbulb className="h-5 w-5" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-black text-[#121e16]">{d.label}</span>
+                <span className="block truncate text-[11px] font-medium text-[#64705f]">{d.hint}</span>
+              </span>
+              <span className={`relative h-6 w-11 shrink-0 rounded-full transition ${isOn ? "bg-[#e0a93a]" : "bg-[#bcd0a8]"}`}>
+                <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${isOn ? "left-[1.4rem]" : "left-0.5"}`} />
+              </span>
+              <span className="w-7 shrink-0 text-right text-[11px] font-black uppercase" style={{ color: isOn ? "#9a6b00" : "#5b7a3a" }}>
+                {isOn ? "On" : "Off"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => onDeploy(on)}
+          disabled={isDeploying}
+          className={`${wattClasses.buttonPrimary} gap-2 px-6 py-2.5 disabled:cursor-not-allowed disabled:opacity-50`}
+        >
+          <Rocket className="h-4 w-4" />
+          {isDeploying ? "Deploying…" : "Deploy"}
+        </button>
+        <span className="text-xs font-semibold text-[#64705f]">Set your switches, then deploy them to the house.</span>
+        {feedback && (
+          <span className={`text-sm font-semibold ${feedback.ok ? "text-[#155420]" : "text-[#9f2f28]"}`}>{feedback.message}</span>
+        )}
+        <button
+          type="button"
+          onClick={() => setOn(initial())}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-[0.65rem] border border-[#e8dfcf] bg-[#fffefa] px-3 py-2 text-xs font-bold text-[#64705f] hover:bg-[#fbf6e9]"
+        >
+          <RotateCcw className="h-3.5 w-3.5" /> Reset
+        </button>
+      </div>
+
+      {upcoming.length > 0 && (
+        <div className="mt-5 rounded-[1.25rem] border border-dashed border-[#d8cfbd] bg-[#fbf6e9] p-4">
+          <p className="text-[11px] font-black uppercase tracking-[0.14em] text-[#64705f]">Unlocks ahead</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {upcoming.map((u) => (
+              <span
+                key={u.label}
+                className="inline-flex items-center gap-1.5 rounded-full border border-[#e8dfcf] bg-[#fffefa] px-3 py-1 text-xs font-bold text-[#8a8477]"
+              >
+                🔒 {u.label} · day {u.day}
+              </span>
+            ))}
+          </div>
+          <p className="mt-2 text-[11px] font-medium text-[#8a8477]">
+            As the campaign rolls on you'll unlock a full automation pipeline — schedules, more devices, and an AI brain
+            that runs the house for you.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -332,6 +332,17 @@ export async function deploySmartHome(
   return response.data as SmartHomeDeployResult;
 }
 
+/** Stage-1 switchboard deploy: a {deviceId: on} map -> direct set_lights commands. */
+export async function deploySmartHomeSwitches(
+  env: Env,
+  request: Request,
+  switches: Record<string, boolean>,
+): Promise<SmartHomeDeployResult> {
+  const client = createApiClient(env, request);
+  const response = await client.post("/api/v1/hackathons/watt/smart-home/deploy/", { switches });
+  return response.data as SmartHomeDeployResult;
+}
+
 export async function getSmartHomeState(env: Env, request: Request): Promise<SmartHomeState> {
   const client = createApiClient(env, request);
   const response = await client.get("/api/v1/hackathons/watt/smart-home/state/");

--- a/app/lib/smart-home-progression.ts
+++ b/app/lib/smart-home-progression.ts
@@ -1,0 +1,79 @@
+/**
+ * Day-gated capability progression for the Smart Home controller.
+ *
+ * The controller starts as a simple light switch (stage 1) and reveals the SENSE->THINK->ACT
+ * pipeline as the campaign progresses: Actions+Outputs (stage 2) -> Schedule (stage 3) ->
+ * Brain+Inputs, the full board (stage 4). The in-game day is a deterministic function of
+ * wall-clock time (Unity CampaignClock), so the unlocked stage is shared + resume-safe.
+ *
+ * Mirror of generic_hackathons/smart_home_progression.py on the backend — keep in sync.
+ */
+import { PALETTE, type SlotType } from "~/lib/smart-home-pipeline";
+
+/** Total in-game days (mirrors Unity ScoreConstants.CAMPAIGN_LENGTH_DAYS = 46). */
+export const CAMPAIGN_DAYS = 46;
+
+// Stage thresholds (in-game day). The main pacing lever; mirror the backend constants.
+export const STAGE2_DAY = 6; // pipeline introduced: Actions + Outputs
+export const STAGE3_DAY = 16; // + Schedule
+export const STAGE4_DAY = 26; // + Brain + Inputs (the full board)
+
+export interface SwitchDevice {
+  id: string;
+  label: string;
+  hint: string;
+}
+
+/** Stage-1 devices the player can switch on/off directly (-> backend set_lights{room,on}). */
+export const SWITCH_DEVICES: SwitchDevice[] = [
+  { id: "bathroom", label: "Bathroom Light", hint: "The one that always gets left on." },
+  { id: "living", label: "Living Room Lights", hint: "Where everyone hangs out." },
+];
+
+const SLOTS_BY_STAGE: Record<number, SlotType[]> = {
+  1: [],
+  2: ["action", "output"],
+  3: ["action", "output", "schedule"],
+  4: ["input", "schedule", "brain", "action", "output", "safety"],
+};
+
+/** The day each slot first unlocks (for "🔒 unlocks day N" teasers). */
+export const SLOT_UNLOCK_DAY: Partial<Record<SlotType, number>> = {
+  action: STAGE2_DAY,
+  output: STAGE2_DAY,
+  schedule: STAGE3_DAY,
+  input: STAGE4_DAY,
+  brain: STAGE4_DAY,
+  safety: STAGE4_DAY,
+};
+
+export interface Upcoming {
+  label: string;
+  day: number;
+}
+
+export interface Progression {
+  stage: number; // 1..4
+  switchboard: boolean; // stage 1 = the simple light switch
+  unlockedSlots: Set<SlotType>; // pipeline slots active at this stage (stage >= 2)
+  unlockedBlockIds: Set<string>; // palette blocks that are draggable
+  upcoming: Upcoming[]; // locked capabilities + the day they unlock
+}
+
+export function stageForDay(day: number | null | undefined): number {
+  const d = typeof day === "number" && Number.isFinite(day) ? Math.floor(day) : 1;
+  if (d >= STAGE4_DAY) return 4;
+  if (d >= STAGE3_DAY) return 3;
+  if (d >= STAGE2_DAY) return 2;
+  return 1;
+}
+
+export function progressionForDay(day: number | null | undefined): Progression {
+  const stage = stageForDay(day);
+  const unlockedSlots = new Set<SlotType>(SLOTS_BY_STAGE[stage] ?? []);
+  const unlockedBlockIds = new Set(PALETTE.filter((b) => unlockedSlots.has(b.type)).map((b) => b.id));
+  const upcoming: Upcoming[] = [];
+  if (stage < 3) upcoming.push({ label: "Schedule", day: STAGE3_DAY });
+  if (stage < 4) upcoming.push({ label: "AI Brain + Sensors", day: STAGE4_DAY });
+  return { stage, switchboard: stage === 1, unlockedSlots, unlockedBlockIds, upcoming };
+}

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -6,6 +6,7 @@ import {
   buySmartHomeUpgrade,
   createWattUnitySession,
   deploySmartHome,
+  deploySmartHomeSwitches,
   getSmartHomeBlocks,
   requireValidWattTeam,
   type SmartHomeCatalog,
@@ -17,8 +18,10 @@ import {
 import { getEnv } from "~/lib/env.server";
 import { wattClasses } from "~/lib/watt-theme";
 import { SmartHomeControllerV2 } from "~/components/SmartHomeControllerV2";
+import { SmartHomeSwitchboard } from "~/components/SmartHomeSwitchboard";
 import { SmartHomeShop, type ShopFeedback } from "~/components/SmartHomeShop";
 import { SmartHomeStatusBar } from "~/components/SmartHomeStatusBar";
+import { progressionForDay } from "~/lib/smart-home-progression";
 import type { DeployFeedback } from "~/components/SmartHomeController";
 
 type StreamData = {
@@ -81,6 +84,24 @@ export async function action({ request, context }: Route.ActionArgs) {
   const intent = String(formData.get("intent") || "reconnect");
 
   if (intent === "deploy") {
+    // Stage-1 switchboard sends a {deviceId: on} map; later stages send a structured pipeline.
+    const switchesRaw = formData.get("switches");
+    if (typeof switchesRaw === "string" && switchesRaw) {
+      let switches: Record<string, boolean> = {};
+      try {
+        const parsed = JSON.parse(switchesRaw);
+        if (parsed && typeof parsed === "object") switches = parsed as Record<string, boolean>;
+      } catch {
+        /* keep empty */
+      }
+      try {
+        const result = await deploySmartHomeSwitches(env, request, switches);
+        return { kind: "deploy" as const, result, error: null as string | null };
+      } catch (error) {
+        return { kind: "deploy" as const, result: null, error: errorMessage(error, "Couldn't deploy to your Smart Home.") };
+      }
+    }
+
     let pipeline: SmartHomePipeline = { inputs: [], schedule: [], brain: [], actions: [], outputs: [], safety: [] };
     try {
       const parsed = JSON.parse(String(formData.get("pipeline") || "{}"));
@@ -185,10 +206,14 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
 
   const handleDeploy = (pipeline: SmartHomePipeline) =>
     deployFetcher.submit({ intent: "deploy", pipeline: JSON.stringify(pipeline) }, { method: "post" });
+  const handleSwitchDeploy = (switches: Record<string, boolean>) =>
+    deployFetcher.submit({ intent: "deploy", switches: JSON.stringify(switches) }, { method: "post" });
 
   // Poll the live game state for the goal/day/wallet status bar.
   const stateFetcher = useFetcher();
   const homeState = stateFetcher.data as SmartHomeState | undefined;
+  // Day-gated capability progression: a simple switchboard early, the full pipeline later.
+  const progression = useMemo(() => progressionForDay(homeState?.day ?? null), [homeState?.day]);
 
   // T5: live/offline badge driven by the published-observation freshness the backend reports
   // (live / stale / no_observation / missing_timestamp from observation_liveness).
@@ -382,11 +407,21 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
           </div>
         </section>
 
-        <SmartHomeControllerV2
-          onDeploy={handleDeploy}
-          isDeploying={isDeploying}
-          feedback={feedback}
-        />
+        {progression.switchboard ? (
+          <SmartHomeSwitchboard
+            onDeploy={handleSwitchDeploy}
+            isDeploying={isDeploying}
+            feedback={feedback}
+            upcoming={progression.upcoming}
+          />
+        ) : (
+          <SmartHomeControllerV2
+            onDeploy={handleDeploy}
+            isDeploying={isDeploying}
+            feedback={feedback}
+            progression={progression}
+          />
+        )}
 
         <SmartHomeShop shop={shop} onBuy={handleBuy} buyingId={buyingId} feedback={buyFeedback} />
       </div>


### PR DESCRIPTION
Replaces the overwhelming first-load (five required slots + 16 blocks) with a gentle ramp that reveals the controller as the campaign progresses (pairs with mlai-backend #413).

## What
- **New `smart-home-progression.ts`** (mirrors the backend): in-game `day` -> stage, the unlocked slots/blocks, and `CAMPAIGN_DAYS = 46` (single source of truth).
- **Stage 1** renders a new **`SmartHomeSwitchboard`** — Bathroom / Living-Room lights as on/off toggles + Deploy -> `set_lights`. Lights default ON so the natural first move is to spot one and turn it off.
- **Stages 2–4** render the existing `SmartHomeControllerV2`, now **stage-aware**: only the unlocked slots show (Actions+Outputs @ day 6 -> +Schedule @ 16 -> +Brain+Inputs @ 26), locked palette groups become greyed "🔒 day N" teasers, and the Deploy gate only requires the unlocked slots. Backward-compatible (no `progression` prop = full board).
- The page computes the stage from the polled `state.day` and routes switchboard-vs-controller; the deploy action handles a `{switches}` payload alongside the pipeline.
- Fixes the stale `33`-day status-bar constant (now the shared `46`).

## Verification
`react-router typegen && tsc -b` clean. The live switchboard render needs the backend up + an authed Watt team (the page loader gates on a valid team), so it wasn't browser-verified offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)