### PR TITLE
Remove Submissions and Resources tabs from the Watt sidebar

### DIFF
--- a/app/components/GenericHackathonAppLayout.tsx
+++ b/app/components/GenericHackathonAppLayout.tsx
@@ -6,7 +6,6 @@ import {
   BookOpenIcon,
   BuildingOffice2Icon,
   ChevronDownIcon,
-  DocumentTextIcon,
   HomeIcon,
   HomeModernIcon,
   PresentationChartBarIcon,
@@ -52,8 +51,6 @@ export default function GenericHackathonAppLayout({ children, user, config, head
   }> = [
     { name: "Dashboard", href: `${config.basePath}/dashboard`, icon: HomeIcon },
     { name: "Profile & Team", href: `${config.basePath}/profile`, icon: UserGroupIcon },
-    { name: "Submissions", href: `${config.basePath}/submissions`, icon: DocumentTextIcon },
-    { name: "Resources", href: `${config.basePath}/resources`, icon: BookOpenIcon },
     ...(isWattTheme
       ? [
           { name: "Docs", href: `${config.basePath}/docs`, icon: BookOpenIcon, highlighted: true },


### PR DESCRIPTION
## What
Removes the **Submissions** and **Resources** nav entries from the Watt The Hack sidebar (`GenericHackathonAppLayout`), plus the now-unused `DocumentTextIcon` import.

Sidebar is now: Dashboard · Profile & Team · Docs · Base44 (Pitching) Track · City of Melbourne (Advanced) Track · Smart Home (Beginner) Track.

## Why
We no longer use the standalone Submissions and Resources pages.

## Scope
Frontend-only. Sidebar nav only — the `/submissions` and `/resources` routes themselves are left in place, as are the dashboard's own panels.

## Test plan
- `react-router typegen && tsc -b` → 0 errors
- `BookOpenIcon` retained (still used by Docs); no dangling references
- Net diff: 3 deletions, 1 file

🤖 Generated with [Claude Code](https://claude.com/claude-code)