### PR TITLE
Watt The Hack dashboard: top-3 standings, How to submit, docs links

### DIFF
--- a/app/lib/watt-the-hack-leaderboard.ts
+++ b/app/lib/watt-the-hack-leaderboard.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types/helpers for the Watt The Hack "City of Melbourne" leaderboard.
+ *
+ * Both the full Current Standings page
+ * (`watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx`) and the dashboard's
+ * top-3 standings panel fetch the same same-origin proxy
+ * (`/watt-the-hack/city-of-melbourne-advanced-leaderboard-data`) and render the same
+ * entry shape, so the type + relative-time formatting live here to stay in sync.
+ */
+
+export interface LeaderboardEntry {
+  rank: number;
+  team_name: string;
+  final_score: number;
+  cost_score: number | null;
+  renewable_score: number | null;
+  stability_score: number | null;
+  reliability_score: number | null;
+  scored_at: string | null;
+}
+
+/** Format an ISO timestamp as a short "just now / 5m ago / 3h ago / 2d ago" string. */
+export function relativeTime(iso: string | null): string {
+  if (!iso) return "";
+  const t = Date.parse(iso.replace(" ", "T"));
+  if (Number.isNaN(t)) return "";
+  const secs = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard.tsx
@@ -10,6 +10,7 @@ import {
   TrophyIcon,
 } from "@heroicons/react/24/outline";
 import { wattClasses, wattImages } from "~/lib/watt-theme";
+import { relativeTime, type LeaderboardEntry } from "~/lib/watt-the-hack-leaderboard";
 
 const REFRESH_MS = 15000;
 
@@ -19,36 +20,11 @@ const CARD_H = 86;
 const GAP = 14;
 const STRIDE = CARD_H + GAP;
 
-interface LeaderboardEntry {
-  rank: number;
-  team_name: string;
-  final_score: number;
-  cost_score: number | null;
-  renewable_score: number | null;
-  stability_score: number | null;
-  reliability_score: number | null;
-  scored_at: string | null;
-}
-
 type Delta = number | "new" | "same";
 
 function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-}
-
-function relativeTime(iso: string | null): string {
-  if (!iso) return "";
-  const t = Date.parse(iso.replace(" ", "T"));
-  if (Number.isNaN(t)) return "";
-  const secs = Math.max(0, Math.floor((Date.now() - t) / 1000));
-  if (secs < 60) return "just now";
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
 }
 
 const MEDAL: Record<number, { ring: string; bar: string; label: string }> = {

--- a/app/routes/watt-the-hack.dashboard.tsx
+++ b/app/routes/watt-the-hack.dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Route } from "./+types/watt-the-hack.dashboard";
 import { Link, redirect, useLoaderData } from "react-router";
 import {
@@ -19,14 +19,11 @@ import {
   getGenericAnnouncements,
   getGenericCurrentTeam,
   getGenericHackathon,
-  getGenericResources,
-  getGenericSubmissions,
   WATT_THE_HACK_SLUG,
-  type GenericHackathonResource,
-  type GenericHackathonSubmission,
   type GenericHackathonTeam,
 } from "~/lib/generic-hackathon";
 import { wattClasses, wattImages } from "~/lib/watt-theme";
+import { relativeTime, type LeaderboardEntry } from "~/lib/watt-the-hack-leaderboard";
 import { wattTheHackSchedule } from "~/lib/watt-the-hack-schedule";
 import type { Hackathon } from "~/services/hackathon";
 
@@ -50,20 +47,16 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     throw redirect("/platform/login?app=watt-the-hack&next=/watt-the-hack/dashboard");
   }
 
-  const [hackathon, announcements, team, submissions, resources] = await Promise.all([
+  const [hackathon, announcements, team] = await Promise.all([
     getGenericHackathon(env, request).catch(() => FALLBACK_HACKATHON),
     getGenericAnnouncements(env, request).catch(() => []),
     getGenericCurrentTeam(env, request).catch(() => null),
-    getGenericSubmissions(env, request).catch(() => []),
-    getGenericResources(env, request).catch(() => []),
   ]);
 
   return {
     hackathon,
     announcements,
     team,
-    latestSubmission: submissions[0] ?? null,
-    resources: resources.slice(0, 2),
   };
 }
 
@@ -132,85 +125,180 @@ function TeamPanel({ team }: { team: GenericHackathonTeam | null }) {
   );
 }
 
-function SubmissionPanel({ submission }: { submission: GenericHackathonSubmission | null }) {
+function HowToSubmitCard() {
+  return (
+    <Link
+      to="/watt-the-hack/docs"
+      className={`${wattClasses.panel} group relative block min-h-[112px] overflow-hidden px-6 py-5 transition hover:border-[#c9dbb8]`}
+    >
+      <img
+        src={wattImages.bottomScene}
+        alt=""
+        className="pointer-events-none absolute -bottom-7 -right-9 w-36 opacity-90"
+      />
+      <div className="relative flex items-center gap-5">
+        <span className={wattClasses.iconTile}>
+          <PaperAirplaneIcon className="h-7 w-7 stroke-[1.8]" aria-hidden="true" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[#485244]">Submission</p>
+          <p className="mt-0.5 flex items-center gap-1.5 text-xl font-black leading-tight text-[#121e16]">
+            How to submit
+            <ArrowRightIcon
+              className="h-4 w-4 stroke-[2.4] text-[#155420] transition-transform group-hover:translate-x-0.5"
+              aria-hidden="true"
+            />
+          </p>
+          <p className="mt-1 text-sm font-medium text-[#354031]">Steps for all three tracks</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+const STANDINGS_LIMIT = 3;
+
+function StandingsPanel() {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/watt-the-hack/city-of-melbourne-advanced-leaderboard-data?limit=${STANDINGS_LIMIT}`,
+          { headers: { Accept: "application/json" } },
+        );
+        if (!res.ok) throw new Error(`Leaderboard service responded ${res.status}`);
+        const data = (await res.json()) as LeaderboardEntry[];
+        if (!Array.isArray(data)) throw new Error("Unexpected leaderboard response");
+        const top = [...data].sort((a, b) => a.rank - b.rank).slice(0, STANDINGS_LIMIT);
+        if (!cancelled) {
+          setEntries(top);
+          setPhase("ready");
+        }
+      } catch {
+        if (!cancelled) setPhase("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <div className={`${wattClasses.panel} px-6 py-5`}>
       <div className="flex items-center justify-between gap-4">
-        <div className="flex min-w-0 items-center gap-5">
-          <span className="flex h-12 w-12 items-center justify-center rounded-full text-[#155420]">
-            <TrophyIcon className="h-9 w-9 fill-[#f0c742]/45 stroke-[1.8]" aria-hidden="true" />
-          </span>
-          <div className="min-w-0">
-            <h2 className="text-xl font-black leading-tight text-[#121e16]">Latest Submission</h2>
-            <p className="mt-1 truncate text-sm font-medium text-[#354031]">
-              {submission ? submission.title : "No project submitted yet."}
-            </p>
-          </div>
+        <div className="flex items-center gap-3">
+          <TrophyIcon className="h-7 w-7 text-[#155420]" aria-hidden="true" />
+          <h2 className="text-xl font-black leading-tight text-[#121e16]">Current Standings</h2>
         </div>
-        <Link to="/watt-the-hack/submissions" className={`${wattClasses.buttonPrimary} shrink-0 px-6`}>
-          Submit
+        <Link
+          to="/watt-the-hack/city-of-melbourne-advanced-leaderboard"
+          className="inline-flex shrink-0 items-center gap-2 text-sm font-black text-[#155420] hover:text-[#2f6f2c]"
+        >
+          View all
+          <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
         </Link>
       </div>
-      {submission && (
-        <p className="mt-4 line-clamp-3 text-sm leading-6 text-[#64705f]">{submission.summary}</p>
+
+      {phase === "loading" ? (
+        <ul className="mt-4 space-y-2.5">
+          {Array.from({ length: STANDINGS_LIMIT }).map((_, i) => (
+            <li
+              key={i}
+              className="h-[58px] animate-pulse rounded-xl border border-[#e8dfcf] bg-[#efe6d4]/60"
+            />
+          ))}
+        </ul>
+      ) : phase === "error" ? (
+        <p className="mt-4 text-sm font-medium text-[#64705f]">
+          Couldn&apos;t load standings just now —{" "}
+          <Link
+            to="/watt-the-hack/city-of-melbourne-advanced-leaderboard"
+            className="font-black text-[#155420] hover:text-[#2f6f2c]"
+          >
+            open the leaderboard
+          </Link>
+          .
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="mt-4 text-sm font-medium text-[#64705f]">
+          No standings yet — they&apos;ll appear once teams are scored.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2.5">
+          {entries.map((entry) => {
+            const score = Number.isFinite(entry.final_score) ? entry.final_score : 0;
+            return (
+              <li
+                key={entry.team_name}
+                className="flex items-center gap-4 rounded-xl border border-[#e8dfcf] bg-[rgba(255,254,250,0.88)] px-4 py-3"
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#e6efd7] text-sm font-black tabular-nums text-[#155420]">
+                  {entry.rank}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-black text-[#121e16]">{entry.team_name}</p>
+                  <p className="mt-0.5 truncate text-xs font-medium text-[#64705f]">
+                    {entry.scored_at ? `best run ${relativeTime(entry.scored_at)}` : "awaiting first score"}
+                  </p>
+                </div>
+                <div className="shrink-0 text-right">
+                  <p className="text-base font-black tabular-nums text-[#121e16]">{score.toFixed(2)}</p>
+                  <p className="text-[0.6rem] font-bold uppercase tracking-[0.18em] text-[#64705f]">pts</p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
       )}
     </div>
   );
 }
 
-function ResourcesPanel({ resources }: { resources: GenericHackathonResource[] }) {
+const DOC_LINKS: { title: string; summary: string; to: string }[] = [
+  { title: "Overview & Submission Guide", summary: "Event overview and how to submit", to: "/watt-the-hack/docs" },
+  { title: "Pitching Track", summary: "Base44 pitching guide and judging", to: "/watt-the-hack/docs/base44-pitching" },
+  { title: "Advanced Track", summary: "City of Melbourne — Grid Guardian", to: "/watt-the-hack/docs/grid-guardian" },
+  { title: "Beginner Track", summary: "Amber Electric — Smart Home", to: "/watt-the-hack/docs/smart-home" },
+];
+
+function ResourcesPanel() {
   return (
-    <div className={`${wattClasses.panel} relative overflow-hidden px-6 py-5 sm:px-7`}>
-      <img
-        src={wattImages.bottomScene}
-        alt=""
-        className="pointer-events-none absolute -bottom-4 right-0 hidden w-[310px] opacity-95 sm:block"
-      />
-      <div className="relative flex items-center justify-between gap-4">
+    <div className={`${wattClasses.panel} px-6 py-5 sm:px-7`}>
+      <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <BookOpenIcon className="h-8 w-8 text-[#155420]" aria-hidden="true" />
           <h2 className="text-xl font-black text-[#121e16]">Resources</h2>
         </div>
-        <Link to="/watt-the-hack/resources" className="inline-flex items-center gap-2 text-sm font-black text-[#155420] hover:text-[#2f6f2c]">
+        <Link to="/watt-the-hack/docs" className="inline-flex items-center gap-2 text-sm font-black text-[#155420] hover:text-[#2f6f2c]">
           View all
           <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
         </Link>
       </div>
-      <div className="relative mt-5 grid gap-4 lg:grid-cols-2 lg:pr-44">
-
-        <Link to="/watt-the-hack/docs" className="block rounded-xl border border-[#e8dfcf] bg-[rgba(255,254,250,0.88)] p-4 transition hover:border-[#c9dbb8] hover:bg-[#fffefa]">
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex min-w-0 items-center gap-4">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#e6efd7] text-[#155420]">
-                <DocumentTextIcon className="h-6 w-6 stroke-[1.8]" aria-hidden="true" />
-              </span>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-black text-[#121e16]">API Documentation</p>
-                <p className="mt-1 truncate text-xs font-medium text-[#354031]">Read the official python controller guide</p>
-              </div>
-            </div>
-            <ArrowTopRightOnSquareIcon className="h-5 w-5 shrink-0 text-[#64705f]" aria-hidden="true" />
-          </div>
-        </Link>
-
-        {resources.length > 0 ? resources.map((resource) => (
-          <Link key={resource.id} to="/watt-the-hack/resources" className="block rounded-xl border border-[#e8dfcf] bg-[rgba(255,254,250,0.88)] p-4 transition hover:border-[#c9dbb8] hover:bg-[#fffefa]">
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {DOC_LINKS.map((doc) => (
+          <Link
+            key={doc.to}
+            to={doc.to}
+            className="block rounded-xl border border-[#e8dfcf] bg-[rgba(255,254,250,0.88)] p-4 transition hover:border-[#c9dbb8] hover:bg-[#fffefa]"
+          >
             <div className="flex items-center justify-between gap-4">
               <div className="flex min-w-0 items-center gap-4">
                 <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#e6efd7] text-[#155420]">
                   <DocumentTextIcon className="h-6 w-6 stroke-[1.8]" aria-hidden="true" />
                 </span>
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-black text-[#121e16]">{resource.title}</p>
-                  <p className="mt-1 truncate text-xs font-medium text-[#354031]">{resource.summary}</p>
+                  <p className="truncate text-sm font-black text-[#121e16]">{doc.title}</p>
+                  <p className="mt-1 truncate text-xs font-medium text-[#354031]">{doc.summary}</p>
                 </div>
               </div>
               <ArrowTopRightOnSquareIcon className="h-5 w-5 shrink-0 text-[#64705f]" aria-hidden="true" />
             </div>
           </Link>
-        )) : (
-          <p className="text-sm font-medium text-[#64705f]">Resources will appear here when they are published.</p>
-        )}
+        ))}
       </div>
     </div>
   );
@@ -294,7 +382,7 @@ function ScheduleSection() {
 }
 
 export default function WattTheHackDashboard() {
-  const { hackathon, announcements, team, latestSubmission, resources } = useLoaderData<typeof loader>();
+  const { hackathon, announcements, team } = useLoaderData<typeof loader>();
 
   return (
     <div className={wattClasses.page}>
@@ -342,23 +430,18 @@ export default function WattTheHackDashboard() {
             description={team ? "Your team is ready to build." : "You don't have any teammates yet."}
             icon={UserGroupIcon}
           />
-          <StatCard
-            label="Submission"
-            value={latestSubmission ? "Submitted" : "Not submitted"}
-            description={latestSubmission ? "Your prototype is in the queue." : "Submit your project prototype."}
-            icon={DocumentTextIcon}
-          />
+          <HowToSubmitCard />
         </div>
 
         <div className="grid gap-5 lg:grid-cols-[1fr_1.08fr]">
           <Announcements announcements={announcements} variant="watt" />
           <div className="space-y-5">
             <TeamPanel team={team} />
-            <SubmissionPanel submission={latestSubmission} />
+            <StandingsPanel />
           </div>
         </div>
 
-        <ResourcesPanel resources={resources} />
+        <ResourcesPanel />
 
         <ScheduleSection />
       </div>

--- a/app/routes/watt-the-hack.docs._index.tsx
+++ b/app/routes/watt-the-hack.docs._index.tsx
@@ -39,6 +39,42 @@ const TRACKS = [
   },
 ];
 
+const SUBMIT_STEPS = [
+  {
+    eyebrow: "Pitching track",
+    title: "Base44 Pitching",
+    body: "Pitch in person from 5:00pm at the semi-finals. The top 5 teams are then selected to pitch in the finals at 7:30pm.",
+    to: "/watt-the-hack/docs/base44-pitching",
+    linkLabel: "Pitching track docs",
+    Icon: PresentationChartBarIcon,
+    iconBg: "bg-emerald-100 text-emerald-700",
+    border: "hover:border-emerald-400",
+    eyebrowColor: "text-emerald-700",
+  },
+  {
+    eyebrow: "Advanced · coding",
+    title: "City of Melbourne — Grid Guardian",
+    body: "Register your team by talking to Monash DeepNeuron first, then submit through the online Submission Portal.",
+    to: "/watt-the-hack/city-of-melbourne-advanced-submit",
+    linkLabel: "Open the Submission Portal",
+    Icon: BoltIcon,
+    iconBg: "bg-sky-100 text-sky-700",
+    border: "hover:border-sky-400",
+    eyebrowColor: "text-sky-700",
+  },
+  {
+    eyebrow: "Beginner · coding",
+    title: "Amber Electric — Smart Home",
+    body: "Auto-submitted as long as your team has clicked to start the stream at least once from the beginner track page.",
+    to: "/watt-the-hack/smart-home-beginner",
+    linkLabel: "Open the Smart Home track",
+    Icon: HomeModernIcon,
+    iconBg: "bg-amber-100 text-amber-700",
+    border: "hover:border-amber-400",
+    eyebrowColor: "text-amber-700",
+  },
+];
+
 export default function DocsIndex() {
   return (
     <div className="space-y-8 pb-12">
@@ -72,6 +108,39 @@ export default function DocsIndex() {
           </Link>
         ))}
       </div>
+
+      <section className="space-y-5">
+        <div>
+          <h2 className="text-2xl font-extrabold tracking-tight text-slate-900 sm:text-3xl">How to submit</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted">
+            Each track submits a different way. Find yours below.
+          </p>
+        </div>
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {SUBMIT_STEPS.map((step) => (
+            <div
+              key={step.to}
+              className={`flex flex-col rounded-2xl border border-line bg-surface p-6 shadow-sm transition-all hover:shadow-md ${step.border}`}
+            >
+              <div className={`flex h-11 w-11 items-center justify-center rounded-xl ${step.iconBg}`}>
+                <step.Icon className="h-6 w-6" />
+              </div>
+              <p className={`mt-4 text-[11px] font-bold uppercase tracking-[0.14em] ${step.eyebrowColor}`}>
+                {step.eyebrow}
+              </p>
+              <h3 className="mt-1 text-lg font-bold tracking-tight text-ink">{step.title}</h3>
+              <p className="mt-2 flex-1 text-sm leading-relaxed text-muted">{step.body}</p>
+              <Link
+                to={step.to}
+                className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-ink hover:underline"
+              >
+                {step.linkLabel}
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## What

Repurposes three sections of the Watt The Hack participant dashboard and adds per-track submission guidance to the Docs overview.

1. **Latest Submission → Top 3 standings.** New `StandingsPanel` client-fetches `/watt-the-hack/city-of-melbourne-advanced-leaderboard-data?limit=3`, sorts by rank, and renders the top 3 in plain dashboard style with a **View all** link to the full Current Standings page. Loading / empty / error states handled.
2. **"Submission" stat card → "How to submit"** card linking to `/watt-the-hack/docs`.
3. **Resources → the four track docs**: Overview & Submission Guide, Pitching, Advanced, Beginner.

Also adds a **How to submit** section to the Docs overview (`watt-the-hack.docs._index.tsx`):
- **Pitching:** in-person from 5pm at the semi-finals; top 5 selected to pitch in the finals at 7:30pm.
- **Advanced:** register your team with Monash DeepNeuron first, then submit via the online Submission Portal.
- **Beginner:** auto-submitted once the team has started the stream at least once.

The leaderboard entry type + `relativeTime` helper are extracted into `app/lib/watt-the-hack-leaderboard.ts`, shared by the standings page and the dashboard (no behaviour change to the standings page).

## Verification
- `bun run typecheck` — clean
- `bun run build` — clean (benign IndexNow 403 tail only)
- The dashboard/docs sit behind the `/watt-the-hack` auth gate and the standings panel reads the live eval cluster, so they are verified in an authenticated env rather than a fresh local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)