### PR TITLE
Watt smart-home: expand the Stage-1 switchboard UI to all home devices

### DIFF
--- a/app/components/SmartHomeSwitchboard.tsx
+++ b/app/components/SmartHomeSwitchboard.tsx
@@ -1,14 +1,77 @@
 import { useState } from "react";
-import { Lightbulb, RotateCcw, Rocket } from "lucide-react";
+import {
+  BatteryCharging,
+  Car,
+  Droplets,
+  Lightbulb,
+  RotateCcw,
+  Rocket,
+  Thermometer,
+  Utensils,
+  WashingMachine,
+  Wind,
+  type LucideIcon,
+} from "lucide-react";
 import { wattClasses } from "~/lib/watt-theme";
 import type { DeployFeedback } from "~/components/SmartHomeController";
-import { SWITCH_DEVICES, type Upcoming } from "~/lib/smart-home-progression";
+import { SWITCH_DEVICES, SWITCH_GROUPS, type SwitchDevice, type Upcoming } from "~/lib/smart-home-progression";
 
 /**
- * Stage 1 — the simplest possible controller: a few light switches. Flip and Deploy.
- * On Deploy the page posts { switches: {bathroom:false,...} } -> backend set_lights{room,on}.
- * This is the gentle on-ramp before the full SENSE->THINK->ACT pipeline unlocks.
+ * Stage 1 — the simplest controller: flip switches for the home's devices, then Deploy.
+ * On Deploy the page posts { switches: {bathroom:false, ev:true, ...} } -> backend
+ * SWITCH_DEVICE_COMMANDS -> the matching device command. This is the gentle on-ramp before
+ * the full SENSE->THINK->ACT pipeline unlocks.
  */
+const DEVICE_ICON: Record<string, LucideIcon> = {
+  bathroom: Lightbulb,
+  living: Lightbulb,
+  kitchen: Lightbulb,
+  bedroom: Lightbulb,
+  child_bedroom: Lightbulb,
+  office: Lightbulb,
+  thermostat: Thermometer,
+  hot_water: Droplets,
+  ev: Car,
+  battery: BatteryCharging,
+  dishwasher: Utensils,
+  washer: WashingMachine,
+  dryer: Wind,
+};
+
+function DeviceSwitch({ device, isOn, onToggle }: { device: SwitchDevice; isOn: boolean; onToggle: () => void }) {
+  const Icon = DEVICE_ICON[device.id] ?? Lightbulb;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      role="switch"
+      aria-checked={isOn}
+      aria-label={`${device.label} ${isOn ? "on" : "off"}`}
+      className={`flex items-center gap-3 rounded-[1rem] border-2 p-4 text-left transition ${
+        isOn ? "border-[#cfe0c2] bg-[#eef4e3]" : "border-[#e8dfcf] bg-[#fffefa]"
+      }`}
+    >
+      <span
+        className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full ${
+          isOn ? "bg-[#e6efd7] text-[#155420]" : "bg-[#f1ece0] text-[#8a8477]"
+        }`}
+      >
+        <Icon className="h-5 w-5" aria-hidden="true" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-black text-[#121e16]">{device.label}</span>
+        <span className="block truncate text-[11px] font-medium text-[#64705f]">{device.hint}</span>
+      </span>
+      <span className={`relative h-6 w-11 shrink-0 rounded-full transition ${isOn ? "bg-[#2f6f2c]" : "bg-[#d8cfbd]"}`}>
+        <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${isOn ? "left-[1.4rem]" : "left-0.5"}`} />
+      </span>
+      <span className="w-7 shrink-0 text-right text-[11px] font-black uppercase" style={{ color: isOn ? "#155420" : "#8a8477" }}>
+        {isOn ? "On" : "Off"}
+      </span>
+    </button>
+  );
+}
+
 export function SmartHomeSwitchboard({
   onDeploy,
   isDeploying,
@@ -20,9 +83,8 @@ export function SmartHomeSwitchboard({
   feedback: DeployFeedback;
   upcoming: Upcoming[];
 }) {
-  // Lights default ON — the house tends to start with some left on, so the natural first
-  // action is to spot one and turn it off.
-  const initial = () => Object.fromEntries(SWITCH_DEVICES.map((d) => [d.id, true]));
+  // Each device starts at its natural default (lights tend to be left on; appliances idle).
+  const initial = () => Object.fromEntries(SWITCH_DEVICES.map((d) => [d.id, d.defaultOn]));
   const [on, setOn] = useState<Record<string, boolean>>(initial);
   const toggle = (id: string) => setOn((prev) => ({ ...prev, [id]: !prev[id] }));
 
@@ -32,7 +94,7 @@ export function SmartHomeSwitchboard({
         <div>
           <h2 className="text-xl font-black text-[#121e16]">Your Smart Home</h2>
           <p className="mt-1 text-sm font-medium text-[#64705f]">
-            Flip a switch, then hit Deploy to control your house. Spotted a light left on? Turn it off.
+            Flip any switch, then hit Deploy to control your house. Spotted a light left on? Turn it off.
           </p>
         </div>
         <span className="rounded-full border border-[#e8dfcf] bg-[#fffefa] px-3 py-1 text-xs font-black text-[#155420]">
@@ -40,37 +102,19 @@ export function SmartHomeSwitchboard({
         </span>
       </div>
 
-      <div className="mt-5 grid gap-3 sm:grid-cols-2">
-        {SWITCH_DEVICES.map((d) => {
-          const isOn = on[d.id];
+      <div className="mt-5 space-y-5">
+        {SWITCH_GROUPS.map((group) => {
+          const devices = SWITCH_DEVICES.filter((d) => d.group === group);
+          if (devices.length === 0) return null;
           return (
-            <button
-              key={d.id}
-              type="button"
-              onClick={() => toggle(d.id)}
-              aria-pressed={isOn}
-              className={`flex items-center gap-3 rounded-[1rem] border-2 p-4 text-left transition ${
-                isOn ? "border-[#e7d3a3] bg-[#fdf6e3]" : "border-[#cfe0c2] bg-[#eef4e3]"
-              }`}
-            >
-              <span
-                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full ${
-                  isOn ? "bg-[#f4c84a] text-[#5c4a16]" : "bg-[#d6e3c6] text-[#64705f]"
-                }`}
-              >
-                <Lightbulb className="h-5 w-5" />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block text-sm font-black text-[#121e16]">{d.label}</span>
-                <span className="block truncate text-[11px] font-medium text-[#64705f]">{d.hint}</span>
-              </span>
-              <span className={`relative h-6 w-11 shrink-0 rounded-full transition ${isOn ? "bg-[#e0a93a]" : "bg-[#bcd0a8]"}`}>
-                <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${isOn ? "left-[1.4rem]" : "left-0.5"}`} />
-              </span>
-              <span className="w-7 shrink-0 text-right text-[11px] font-black uppercase" style={{ color: isOn ? "#9a6b00" : "#5b7a3a" }}>
-                {isOn ? "On" : "Off"}
-              </span>
-            </button>
+            <div key={group}>
+              <p className="mb-2 text-[11px] font-black uppercase tracking-[0.14em] text-[#64705f]">{group}</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {devices.map((d) => (
+                  <DeviceSwitch key={d.id} device={d} isOn={Boolean(on[d.id])} onToggle={() => toggle(d.id)} />
+                ))}
+              </div>
+            </div>
           );
         })}
       </div>

--- a/app/lib/smart-home-progression.ts
+++ b/app/lib/smart-home-progression.ts
@@ -18,16 +18,42 @@ export const STAGE2_DAY = 6; // pipeline introduced: Actions + Outputs
 export const STAGE3_DAY = 16; // + Schedule
 export const STAGE4_DAY = 26; // + Brain + Inputs (the full board)
 
+export type SwitchGroup = "Lights" | "Climate & energy" | "Appliances";
+
 export interface SwitchDevice {
   id: string;
   label: string;
   hint: string;
+  group: SwitchGroup;
+  defaultOn: boolean;
 }
 
-/** Stage-1 devices the player can switch on/off directly (-> backend set_lights{room,on}). */
+/** Group render order for the switchboard. */
+export const SWITCH_GROUPS: SwitchGroup[] = ["Lights", "Climate & energy", "Appliances"];
+
+/**
+ * Stage-1 devices the player can switch on/off directly. On Deploy the page posts
+ * `{ switches: {id: on} }` -> backend `SWITCH_DEVICE_COMMANDS` -> the matching device command
+ * (set_lights / set_thermostat_setpoint / set_ev_charging / run_appliance / ...). The ids here
+ * MUST mirror the backend map (generic_hackathons/smart_home_progression.py).
+ */
 export const SWITCH_DEVICES: SwitchDevice[] = [
-  { id: "bathroom", label: "Bathroom Light", hint: "The one that always gets left on." },
-  { id: "living", label: "Living Room Lights", hint: "Where everyone hangs out." },
+  // Lights — the house leaves some on; spotting one to switch off is the natural first move.
+  { id: "bathroom", label: "Bathroom Light", hint: "The one that always gets left on.", group: "Lights", defaultOn: true },
+  { id: "living", label: "Living Room Lights", hint: "Where everyone hangs out.", group: "Lights", defaultOn: true },
+  { id: "kitchen", label: "Kitchen Lights", hint: "Bright while someone's cooking.", group: "Lights", defaultOn: true },
+  { id: "bedroom", label: "Main Bedroom Light", hint: "Usually off through the day.", group: "Lights", defaultOn: false },
+  { id: "child_bedroom", label: "Child's Bedroom Light", hint: "On around bedtime.", group: "Lights", defaultOn: false },
+  { id: "office", label: "Office Light", hint: "On while working from home.", group: "Lights", defaultOn: false },
+  // Climate & energy.
+  { id: "thermostat", label: "Thermostat", hint: "Comfort (22°) vs eco setback (18°).", group: "Climate & energy", defaultOn: true },
+  { id: "hot_water", label: "Hot Water", hint: "Heat-pump water for showers & taps.", group: "Climate & energy", defaultOn: true },
+  { id: "ev", label: "EV Charger", hint: "Charge the electric car.", group: "Climate & energy", defaultOn: true },
+  { id: "battery", label: "Home Battery", hint: "Store & dispatch cheap / solar power.", group: "Climate & energy", defaultOn: true },
+  // Appliances — run a cycle now, or hold it for cheaper off-peak power.
+  { id: "dishwasher", label: "Dishwasher", hint: "Run a wash now, or hold for off-peak.", group: "Appliances", defaultOn: false },
+  { id: "washer", label: "Washing Machine", hint: "Run a load now, or hold for off-peak.", group: "Appliances", defaultOn: false },
+  { id: "dryer", label: "Dryer", hint: "Tumble dry now, or hold for off-peak.", group: "Appliances", defaultOn: false },
 ];
 
 const SLOTS_BY_STAGE: Record<number, SlotType[]> = {


### PR DESCRIPTION
## What
Grows the Stage-1 switchboard from the two starter lights to the **full home**, so players see and toggle every device they can control.

## Changes
- `app/lib/smart-home-progression.ts`: `SWITCH_DEVICES` now lists 6 room lights + climate & energy (thermostat, hot water, EV, battery) + the deferrable appliances, each with a group and a natural default. Adds `SwitchGroup` + `SWITCH_GROUPS`. Ids mirror the backend `SWITCH_DEVICE_COMMANDS`.
- `app/components/SmartHomeSwitchboard.tsx`: renders the devices grouped (Lights / Climate & energy / Appliances) with per-device icons and per-device default states.

## Notes
- Deploys over the existing `{switches}` path — no API change. Still Stage-1 only (replaced by the pipeline controller at day 6).
- `react-router typegen && tsc -b` clean. Pairs with the mlai-backend SWITCH_DEVICE_COMMANDS PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)