### PR TITLE
Watt smart-home: switchboard reflects live device state

### DIFF
--- a/app/components/SmartHomeSwitchboard.tsx
+++ b/app/components/SmartHomeSwitchboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   BatteryCharging,
   Car,
@@ -77,16 +77,47 @@ export function SmartHomeSwitchboard({
   isDeploying,
   feedback,
   upcoming,
+  liveStates,
 }: {
   onDeploy: (switches: Record<string, boolean>) => void;
   isDeploying: boolean;
   feedback: DeployFeedback;
   upcoming: Upcoming[];
+  // {device id: on} from the live game. Switches the player hasn't flipped track this, so the
+  // board opens matching the house's real state.
+  liveStates?: Record<string, boolean> | null;
 }) {
   // Each device starts at its natural default (lights tend to be left on; appliances idle).
   const initial = () => Object.fromEntries(SWITCH_DEVICES.map((d) => [d.id, d.defaultOn]));
   const [on, setOn] = useState<Record<string, boolean>>(initial);
-  const toggle = (id: string) => setOn((prev) => ({ ...prev, [id]: !prev[id] }));
+  // Switches flipped since the last deploy hold their position; everything else tracks the live
+  // house state as it streams in.
+  const touched = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!liveStates) return;
+    setOn((prev) => {
+      const next = { ...prev };
+      for (const d of SWITCH_DEVICES) {
+        const value = liveStates[d.id];
+        if (typeof value === "boolean" && !touched.current.has(d.id)) next[d.id] = value;
+      }
+      return next;
+    });
+  }, [liveStates]);
+
+  const toggle = (id: string) => {
+    touched.current.add(id);
+    setOn((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+  const deploy = () => {
+    onDeploy(on);
+    touched.current = new Set(); // the deployed state is the new baseline the live feed re-confirms
+  };
+  const reset = () => {
+    touched.current = new Set();
+    setOn(initial());
+  };
 
   return (
     <section className={`${wattClasses.panel} p-6`}>
@@ -122,7 +153,7 @@ export function SmartHomeSwitchboard({
       <div className="mt-5 flex flex-wrap items-center gap-3">
         <button
           type="button"
-          onClick={() => onDeploy(on)}
+          onClick={deploy}
           disabled={isDeploying}
           className={`${wattClasses.buttonPrimary} gap-2 px-6 py-2.5 disabled:cursor-not-allowed disabled:opacity-50`}
         >
@@ -135,7 +166,7 @@ export function SmartHomeSwitchboard({
         )}
         <button
           type="button"
-          onClick={() => setOn(initial())}
+          onClick={reset}
           className="ml-auto inline-flex items-center gap-1.5 rounded-[0.65rem] border border-[#e8dfcf] bg-[#fffefa] px-3 py-2 text-xs font-bold text-[#64705f] hover:bg-[#fbf6e9]"
         >
           <RotateCcw className="h-3.5 w-3.5" /> Reset

--- a/app/hooks/useWattRealtimeState.ts
+++ b/app/hooks/useWattRealtimeState.ts
@@ -29,6 +29,39 @@ function num(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+// Derive a {switchboard device id: on} map from the live observation so the Stage-1 switches can
+// reflect the house's real state. Mirrors the backend SWITCH_DEVICE_COMMANDS on/off semantics
+// (battery "hold" == off, appliance "running" == on, thermostat comfort setpoint == on). Lights
+// come from obs.lights (published per room by the streamed game; absent until that build ships,
+// so those keys are simply omitted and the switch keeps its default).
+function devicesFromObservation(obs: any): Record<string, boolean> {
+  const devices: Record<string, boolean> = {};
+  if (!obs || typeof obs !== "object") return devices;
+  if (Array.isArray(obs.lights)) {
+    for (const entry of obs.lights) {
+      if (entry && typeof entry.room === "string") devices[entry.room] = Boolean(entry.on);
+    }
+  }
+  const setpoint = num(obs.thermostat_setpoint_c);
+  if (setpoint != null) devices.thermostat = setpoint >= 20;
+  if (obs.hot_water && typeof obs.hot_water.mode === "string") {
+    devices.hot_water = obs.hot_water.mode.toLowerCase() !== "off";
+  }
+  if (obs.ev && typeof obs.ev.charging_enabled === "boolean") {
+    devices.ev = obs.ev.charging_enabled;
+  }
+  if (obs.battery && typeof obs.battery.mode === "string") {
+    devices.battery = obs.battery.mode.toLowerCase() !== "hold";
+  }
+  if (obs.appliances && typeof obs.appliances === "object") {
+    for (const name of ["dishwasher", "washer", "dryer"] as const) {
+      const st = obs.appliances[name];
+      if (typeof st === "string") devices[name] = st.toLowerCase() === "running";
+    }
+  }
+  return devices;
+}
+
 // Merge the two RTDB nodes the streamed game publishes into the SmartHomeState the HUD renders.
 function mergeState(score: any, obs: any): SmartHomeState {
   // No score node yet = never played = zeros.
@@ -52,6 +85,7 @@ function mergeState(score: any, obs: any): SmartHomeState {
     score: num(score.score) ?? 0,
     tariff_period: typeof obs?.tariff?.period === "string" ? obs.tariff.period : null,
     weather_condition: typeof obs?.weather?.condition === "string" ? obs.weather.condition : null,
+    devices: devicesFromObservation(obs),
     published_age_ms: ageMs,
   };
 }

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -306,6 +306,9 @@ export interface SmartHomeState {
   score?: number | null;
   tariff_period?: string | null;
   weather_condition?: string | null;
+  // {device_id: on} snapshot derived from the live observation (keys match the switchboard
+  // SWITCH_DEVICES ids), so the Stage-1 switches can reflect the house's real state.
+  devices?: Record<string, boolean> | null;
   // Why the house is/ isn't live (from the backend's observation_liveness):
   // "live" | "stale" | "no_observation" | "missing_timestamp".
   live_reason?: string | null;

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -406,6 +406,7 @@ export default function WattTheHackSmartHomeBeginnerTrack() {
             isDeploying={isDeploying}
             feedback={feedback}
             upcoming={progression.upcoming}
+            liveStates={homeState.live ? homeState.devices ?? null : null}
           />
         ) : (
           <SmartHomeControllerV2


### PR DESCRIPTION
## What
The Stage-1 switchboard now **opens matching the house's real state** instead of fixed defaults — closing the loop on the expanded switchboard (#951).

## How
- `useWattRealtimeState` already subscribes the browser to the RTDB observation. Derive a `{device_id: on}` map from it (`devicesFromObservation`) — battery mode, EV charging, hot-water mode, thermostat setpoint, appliance `running`, plus per-room lights from `obs.lights`. Surfaced as `SmartHomeState.devices`.
- `SmartHomeSwitchboard` takes `liveStates` and syncs each switch the player **hasn't** flipped since the last deploy (a `touched` set), so the board tracks reality without fighting in-progress edits.

## Notes
- No backend change (the observation is already streamed to the browser).
- The 7 systems reflect live immediately; the **6 room lights** require the paired Unity PR (publishes `obs.lights`) + a Vagon rebuild — until then those keys are simply absent and the switch keeps its default (graceful degradation).
- `react-router typegen && tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)