### PR TITLE
[codex] Enable Watt The Hack login card

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -450,3 +450,5 @@
 - [x] Add a confirm step before template/reset/revert discards custom unsaved controller code
 - [x] Add Applied/Unsaved status, a Revert action, and per-scenario save messaging to the controller editor
 - [x] Cover controller-draft logic and store persistence with bun tests; run `bunx tsc -b`
+- [x] Enable the Watt The Hack card on `/hackathons` so it opens the login flow
+- [x] Run `bun run typecheck`

--- a/app/routes/hackathons.tsx
+++ b/app/routes/hackathons.tsx
@@ -16,23 +16,28 @@ export default function Hackathons() {
                 </div>
 
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-12 max-w-5xl mx-auto">
-                    {/* Watt The Hack Card — Disabled */}
-                    <div
-                        className="group relative aspect-video overflow-hidden rounded-2xl bg-white shadow-lg grayscale opacity-75 cursor-not-allowed"
+                    {/* Watt The Hack Card */}
+                    <a
+                        href="/platform/login?app=watt-the-hack&next=/watt-the-hack/dashboard"
+                        aria-label="Log in to Watt The Hack"
+                        className="group relative aspect-video overflow-hidden rounded-2xl bg-white shadow-lg transition duration-200 hover:-translate-y-1 hover:shadow-2xl focus:outline-none focus-visible:ring-4 focus-visible:ring-[var(--brutalist-yellow)]"
                     >
                         <img
                             src={WATT_THE_HACK_STATIC}
                             alt="Watt The Hack"
-                            className="absolute inset-0 h-full w-full object-cover object-center"
+                            className="absolute inset-0 h-full w-full object-cover object-center transition duration-300 group-hover:scale-105"
                         />
                         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                         <div className="absolute bottom-0 left-0 right-0 z-10 p-6 text-white">
-                            <h3 className="text-2xl font-bold">Watt The Hack (Coming Soon)</h3>
+                            <h3 className="text-2xl font-bold">Watt The Hack</h3>
                             <p className="mt-2 text-sm text-gray-200">
                                 Build practical AI and software projects for a cleaner, smarter energy future.
                             </p>
+                            <span className="mt-4 inline-flex rounded-full bg-white px-4 py-2 text-sm font-semibold text-[var(--brutalist-black)] transition group-hover:bg-[var(--brutalist-yellow)]">
+                                Log in
+                            </span>
                         </div>
-                    </div>
+                    </a>
 
                     {/* Medhack: Frontiers Card — Disabled */}
                     <div


### PR DESCRIPTION
## Summary

- Enables the Watt The Hack card on `/hackathons` as a clickable login entry point.
- Points the card at `/platform/login?app=watt-the-hack&next=/watt-the-hack/dashboard`.
- Leaves the Medhack and eSafety cards in their existing disabled states.

## Validation

- `bun run typecheck`