### PR TITLE
[codex] Disable Watt The Hack access

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -452,3 +452,6 @@
 - [x] Cover controller-draft logic and store persistence with bun tests; run `bunx tsc -b`
 - [x] Enable the Watt The Hack card on `/hackathons` so it opens the login flow
 - [x] Run `bun run typecheck`
+- [x] Disable the Watt The Hack card on `/hackathons`
+- [x] Block Watt The Hack login, route, and endpoint access from the website
+- [x] Run `bun run typecheck`

--- a/app/lib/auth-return.ts
+++ b/app/lib/auth-return.ts
@@ -1,3 +1,5 @@
+import { isWattTheHackAuthRequest, isWattTheHackRoutePath } from "~/lib/watt-the-hack-access";
+
 export type AuthReturnAppName =
   | "esafety"
   | "hospital"
@@ -26,7 +28,7 @@ function pathWithSearchAndHash(url: URL) {
 export function getDefaultAuthNext(app: AuthReturnAppName | string | null | undefined, fallback = "/hackathons"): string {
   if (app === "hospital") return "/hospital/app";
   if (app === "esafety") return "/esafety/dashboard";
-  if (app === "watt-the-hack") return "/watt-the-hack/dashboard";
+  if (app === "watt-the-hack") return fallback;
   if (isFounderToolsApp(app)) return "/founder-tools";
   return fallback;
 }
@@ -39,6 +41,7 @@ export function normalizeAuthNextForApp(
   const fallback = options.fallback ?? getDefaultAuthNext(app);
   const next = nextValue?.trim() || fallback;
 
+  if (isWattTheHackAuthRequest(app, next) || isWattTheHackRoutePath(next)) return fallback;
   if (!next.startsWith("/") || next.startsWith("//")) return fallback;
 
   if (!isFounderToolsApp(app)) return next;

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -1,5 +1,6 @@
 import { axiosInstance, API_URL, shouldUseDevAuthBypass, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "./api";
 import axios from "axios";
+import { assertWattTheHackAuthEnabled } from "~/lib/watt-the-hack-access";
 
 export type AuthAppName = "esafety" | "hospital" | "founder-tools" | "vibe-raising" | "watt-the-hack";
 type GetCurrentUserOptions = {
@@ -10,6 +11,8 @@ function resolveAuthApp(body: {
     app?: AuthAppName;
     next?: string;
 }): AuthAppName {
+    assertWattTheHackAuthEnabled(body.app, body.next);
+
     if (body.app === "vibe-raising") {
         return "founder-tools";
     }
@@ -92,6 +95,7 @@ export async function verifyMagicLink(
     token: string,
     options?: { app?: string | null; next?: string | null },
 ) {
+    assertWattTheHackAuthEnabled(options?.app, options?.next);
     const client = getAxios(env);
     const response = await client.get(`/api/v1/auth/verify-magic-link/?${buildVerifyMagicLinkQuery(token, options)}`);
     return response.data;
@@ -102,6 +106,7 @@ export async function verifyMagicLinkWithCookies(
     token: string,
     options?: { app?: string | null; next?: string | null },
 ) {
+    assertWattTheHackAuthEnabled(options?.app, options?.next);
     const client = getAxios(env);
     const response = await client.get(`/api/v1/auth/verify-magic-link/?${buildVerifyMagicLinkQuery(token, options)}`);
     const setCookieHeaders = response.headers["set-cookie"] || [];

--- a/app/lib/generic-hackathon.ts
+++ b/app/lib/generic-hackathon.ts
@@ -2,8 +2,13 @@ import { redirect } from "react-router";
 import { createApiClient, getBaseUrl } from "~/lib/api";
 import type { Announcement } from "~/components/Announcements";
 import type { Hackathon } from "~/services/hackathon";
+import {
+  assertWattTheHackPublicAccessEnabled,
+  assertWattTheHackSlugEnabled,
+  WATT_THE_HACK_SLUG,
+} from "~/lib/watt-the-hack-access";
 
-export const WATT_THE_HACK_SLUG = "watt-the-hack";
+export { WATT_THE_HACK_SLUG };
 
 export interface GenericHackathonMember {
   id: number;
@@ -83,6 +88,7 @@ export interface WattUnitySession {
 }
 
 function appPath(slug: string, path: string) {
+  assertWattTheHackSlugEnabled(slug);
   return `/api/v1/hackathons/${slug}/app/${path}`;
 }
 
@@ -110,6 +116,7 @@ function asGenericTeam(data: unknown): GenericHackathonTeam | null {
 }
 
 export async function getGenericHackathon(env: Env, request: Request, slug = WATT_THE_HACK_SLUG): Promise<Hackathon> {
+  assertWattTheHackSlugEnabled(slug);
   const client = createApiClient(env, request);
   const response = await client.get(`/api/v1/hackathons/${slug}/`);
   if (!response.data || Array.isArray(response.data) || typeof response.data.name !== "string") {
@@ -242,6 +249,7 @@ export async function getGenericResources(env: Env, request: Request, slug = WAT
 }
 
 export async function createWattUnitySession(env: Env, request: Request): Promise<WattUnitySession> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.post("/api/v1/hackathons/watt/unity-sessions/current/", {});
   const data = response.data as Partial<WattUnitySession>;
@@ -324,12 +332,14 @@ export interface WattParticipantAuth {
 }
 
 export async function getWattParticipantToken(env: Env, request: Request): Promise<WattParticipantAuth> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.post("/api/v1/hackathons/watt/firebase-token/", {});
   return response.data as WattParticipantAuth;
 }
 
 export async function getSmartHomeBlocks(env: Env, request: Request): Promise<SmartHomeCatalog> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.get("/api/v1/hackathons/watt/smart-home/blocks/");
   const data = (response.data ?? {}) as Partial<SmartHomeCatalog>;
@@ -344,6 +354,7 @@ export async function deploySmartHome(
   request: Request,
   pipeline: SmartHomePipeline,
 ): Promise<SmartHomeDeployResult> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.post("/api/v1/hackathons/watt/smart-home/deploy/", { pipeline });
   return response.data as SmartHomeDeployResult;
@@ -355,12 +366,14 @@ export async function deploySmartHomeSwitches(
   request: Request,
   switches: Record<string, boolean>,
 ): Promise<SmartHomeDeployResult> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.post("/api/v1/hackathons/watt/smart-home/deploy/", { switches });
   return response.data as SmartHomeDeployResult;
 }
 
 export async function getSmartHomeState(env: Env, request: Request): Promise<SmartHomeState> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.get("/api/v1/hackathons/watt/smart-home/state/");
   const data = (response.data ?? {}) as Partial<SmartHomeState>;
@@ -395,6 +408,7 @@ export interface SmartHomeBuyResult {
 }
 
 export async function getSmartHomeShop(env: Env, request: Request): Promise<SmartHomeShopState> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.get("/api/v1/hackathons/watt/smart-home/shop/");
   const data = (response.data ?? {}) as Partial<SmartHomeShopState>;
@@ -411,6 +425,7 @@ export async function buySmartHomeUpgrade(
   request: Request,
   itemId: string,
 ): Promise<SmartHomeBuyResult> {
+  assertWattTheHackPublicAccessEnabled();
   const client = createApiClient(env, request);
   const response = await client.post("/api/v1/hackathons/watt/smart-home/buy/", { item_id: itemId });
   return response.data as SmartHomeBuyResult;

--- a/app/lib/watt-the-hack-access.ts
+++ b/app/lib/watt-the-hack-access.ts
@@ -1,0 +1,60 @@
+export const WATT_THE_HACK_SLUG = "watt-the-hack";
+export const WATT_THE_HACK_API_SLUG = "watt";
+export const WATT_THE_HACK_PUBLIC_ACCESS_ENABLED = false;
+
+const WATT_ROUTE_PREFIX = `/${WATT_THE_HACK_SLUG}`;
+const WATT_API_PATH_PATTERN = /^\/api\/v1\/hackathons\/(?:watt|watt-the-hack)(?:\/|$)/;
+
+function pathFromValue(value: string | null | undefined): string {
+  if (!value) return "";
+
+  try {
+    return new URL(value, "https://mlai.local").pathname;
+  } catch {
+    return "";
+  }
+}
+
+export function isWattTheHackRoutePath(value: string | null | undefined): boolean {
+  const pathname = pathFromValue(value);
+  return pathname === WATT_ROUTE_PREFIX || pathname.startsWith(`${WATT_ROUTE_PREFIX}/`);
+}
+
+export function isWattTheHackEndpointPath(pathname: string): boolean {
+  return WATT_API_PATH_PATTERN.test(pathname);
+}
+
+export function isWattTheHackSlug(slug: string | null | undefined): boolean {
+  return slug === WATT_THE_HACK_SLUG || slug === WATT_THE_HACK_API_SLUG;
+}
+
+export function isWattTheHackAuthRequest(app: string | null | undefined, next: string | null | undefined): boolean {
+  return app === WATT_THE_HACK_SLUG || isWattTheHackRoutePath(next);
+}
+
+export function wattTheHackUnavailableResponse() {
+  return new Response("Not Found", {
+    status: 404,
+    headers: {
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
+}
+
+export function assertWattTheHackPublicAccessEnabled(): void {
+  if (!WATT_THE_HACK_PUBLIC_ACCESS_ENABLED) {
+    throw wattTheHackUnavailableResponse();
+  }
+}
+
+export function assertWattTheHackSlugEnabled(slug: string | null | undefined): void {
+  if (!WATT_THE_HACK_PUBLIC_ACCESS_ENABLED && isWattTheHackSlug(slug)) {
+    throw wattTheHackUnavailableResponse();
+  }
+}
+
+export function assertWattTheHackAuthEnabled(app: string | null | undefined, next: string | null | undefined): void {
+  if (!WATT_THE_HACK_PUBLIC_ACCESS_ENABLED && isWattTheHackAuthRequest(app, next)) {
+    throw wattTheHackUnavailableResponse();
+  }
+}

--- a/app/lib/watt-the-hack-sandbox/api.ts
+++ b/app/lib/watt-the-hack-sandbox/api.ts
@@ -6,6 +6,7 @@ import type {
   SimulationState,
   StepResponse,
 } from "./types";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:8000";
 
@@ -14,6 +15,8 @@ const DEFAULT_BASE_URL = "http://127.0.0.1:8000";
 // - On mlai.au production, the sandbox proxies through the Vercel-hosted
 //   WTH frontend which has the FastAPI backend behind it.
 const baseUrl = (): string => {
+  assertWattTheHackPublicAccessEnabled();
+
   // Explicit override always wins (set in .dev.vars or Cloudflare dashboard)
   const configured = (typeof import.meta !== "undefined" && import.meta.env?.VITE_WTH_SANDBOX_API_URL) || "";
   if (configured) return configured;

--- a/app/routes/hackathons.tsx
+++ b/app/routes/hackathons.tsx
@@ -16,28 +16,23 @@ export default function Hackathons() {
                 </div>
 
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-12 max-w-5xl mx-auto">
-                    {/* Watt The Hack Card */}
-                    <a
-                        href="/platform/login?app=watt-the-hack&next=/watt-the-hack/dashboard"
-                        aria-label="Log in to Watt The Hack"
-                        className="group relative aspect-video overflow-hidden rounded-2xl bg-white shadow-lg transition duration-200 hover:-translate-y-1 hover:shadow-2xl focus:outline-none focus-visible:ring-4 focus-visible:ring-[var(--brutalist-yellow)]"
+                    {/* Watt The Hack Card — Disabled */}
+                    <div
+                        className="group relative aspect-video overflow-hidden rounded-2xl bg-white shadow-lg grayscale opacity-75 cursor-not-allowed"
                     >
                         <img
                             src={WATT_THE_HACK_STATIC}
                             alt="Watt The Hack"
-                            className="absolute inset-0 h-full w-full object-cover object-center transition duration-300 group-hover:scale-105"
+                            className="absolute inset-0 h-full w-full object-cover object-center"
                         />
                         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                         <div className="absolute bottom-0 left-0 right-0 z-10 p-6 text-white">
-                            <h3 className="text-2xl font-bold">Watt The Hack</h3>
+                            <h3 className="text-2xl font-bold">Watt The Hack (Coming Soon)</h3>
                             <p className="mt-2 text-sm text-gray-200">
                                 Build practical AI and software projects for a cleaner, smarter energy future.
                             </p>
-                            <span className="mt-4 inline-flex rounded-full bg-white px-4 py-2 text-sm font-semibold text-[var(--brutalist-black)] transition group-hover:bg-[var(--brutalist-yellow)]">
-                                Log in
-                            </span>
                         </div>
-                    </a>
+                    </div>
 
                     {/* Medhack: Frontiers Card — Disabled */}
                     <div

--- a/app/routes/platform.login.tsx
+++ b/app/routes/platform.login.tsx
@@ -7,6 +7,7 @@ import { Field, Input, Label } from "@headlessui/react";
 import { clsx } from "clsx";
 import { getEnv } from "~/lib/env.server";
 import { normalizeAuthNextForApp } from "~/lib/auth-return";
+import { assertWattTheHackAuthEnabled } from "~/lib/watt-the-hack-access";
 
 export const meta: Route.MetaFunction = () => [
     { title: "Sign In to the MLAI Platform | MLAI" },
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => [
 
 function parseAuthApp(value: string | null): AuthAppName | null {
     if (value === "vibe-raising") return "founder-tools";
-    return value === "esafety" || value === "hospital" || value === "founder-tools" || value === "watt-the-hack"
+    return value === "esafety" || value === "hospital" || value === "founder-tools"
         ? value
         : null;
 }
@@ -91,6 +92,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
     const url = new URL(request.url);
     const appParam = url.searchParams.get("app");
+    assertWattTheHackAuthEnabled(appParam, url.searchParams.get("next"));
     const app = parseAuthApp(appParam);
     if (appParam && !app) {
         throw new Response("Not Found", { status: 404 });
@@ -116,6 +118,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     const formData = await request.formData();
     const intent = formData.get("intent")?.toString() ?? "check";
     const appParam = formData.get("app")?.toString() ?? null;
+    assertWattTheHackAuthEnabled(appParam, formData.get("next")?.toString());
     const app = parseAuthApp(appParam) ?? undefined;
     if (appParam && !app) {
         return { error: "Unsupported app." };

--- a/app/routes/verify-email.tsx
+++ b/app/routes/verify-email.tsx
@@ -3,6 +3,7 @@ import { useLoaderData } from "react-router";
 import { normalizeAuthNextForApp } from "~/lib/auth-return";
 import { getEnv } from "~/lib/env.server";
 import { verifyMagicLinkWithCookies } from "~/lib/auth";
+import { assertWattTheHackAuthEnabled } from "~/lib/watt-the-hack-access";
 
 function getLoginHref(app: string | null, next: string): string {
     const params = new URLSearchParams();
@@ -20,6 +21,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     const url = new URL(request.url);
     const token = url.searchParams.get("token");
     const app = url.searchParams.get("app");
+    assertWattTheHackAuthEnabled(app, url.searchParams.get("next"));
     const next = normalizeAuthNextForApp(app, url.searchParams.get("next"), { fallback: "/esafety/dashboard" });
     const loginHref = getLoginHref(app, next);
 

--- a/app/routes/watt-the-hack._index.tsx
+++ b/app/routes/watt-the-hack._index.tsx
@@ -1,8 +1,10 @@
 import type { Route } from "./+types/watt-the-hack._index";
 import { redirect } from "react-router";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 
 export function loader({}: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   return redirect("/watt-the-hack/dashboard");
 }
 

--- a/app/routes/watt-the-hack.base44-pitching.tsx
+++ b/app/routes/watt-the-hack.base44-pitching.tsx
@@ -1,8 +1,10 @@
 import { redirect } from "react-router";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 // The Base44 Pitching "track" lives in the docs hub now — keep this URL working by
 // sending it to the single source of truth.
 export function loader() {
+  assertWattTheHackPublicAccessEnabled();
   return redirect("/watt-the-hack/docs/base44-pitching");
 }
 

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-leaderboard-data.ts
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/watt-the-hack.city-of-melbourne-advanced-leaderboard-data";
 import { FINAL_LEADERBOARD } from "~/lib/watt-the-hack-leaderboard-final";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 /**
  * Final-standings endpoint (frozen snapshot).
@@ -15,6 +16,7 @@ import { FINAL_LEADERBOARD } from "~/lib/watt-the-hack-leaderboard-final";
  * resolveOverride IP-bypass fallback) and redeploy.
  */
 export async function loader({ request }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const reqUrl = new URL(request.url);
   const rawLimit = Number.parseInt(reqUrl.searchParams.get("limit") || "50", 10);
   const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 100) : 50;

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-recent-submissions-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-recent-submissions-data.ts
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/watt-the-hack.city-of-melbourne-advanced-recent-submissions-data";
 import { getEnv } from "~/lib/env.server";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 /**
  * Same-origin proxy for the gateway's `/teams/{id}/submissions` endpoint.
@@ -49,6 +50,7 @@ function buildAdminRequest(
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const url = new URL(request.url);
   const teamId = url.searchParams.get("team_id") ?? "";
   // Refuse to forward arbitrary path components into the upstream URL.

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-submit-data.ts
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/watt-the-hack.city-of-melbourne-advanced-submit-data";
 import { getEnv } from "~/lib/env.server";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 /**
  * Server-side submission proxy (mirrors the leaderboard proxy).
@@ -63,6 +64,7 @@ function buildAdminRequest(
  * POST half below.
  */
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const url = new URL(request.url);
   const id = url.searchParams.get("id") ?? "";
   // `part` selects which sub-endpoint to proxy. New addition: `source` exposes
@@ -123,6 +125,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
+  assertWattTheHackPublicAccessEnabled();
   if (request.method !== "POST") {
     return new Response(JSON.stringify({ detail: "Method not allowed" }), {
       status: 405,

--- a/app/routes/watt-the-hack.city-of-melbourne-advanced-submit.tsx
+++ b/app/routes/watt-the-hack.city-of-melbourne-advanced-submit.tsx
@@ -21,6 +21,7 @@ import type { Route } from "./+types/watt-the-hack.city-of-melbourne-advanced-su
 import { getEnv } from "~/lib/env.server";
 import { getGenericCurrentTeam } from "~/lib/generic-hackathon";
 import { wattClasses, wattImages } from "~/lib/watt-theme";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 import {
   LLM_SCENARIO_IDS,
   getTemplatesForScenario,
@@ -34,6 +35,7 @@ import {
 // Empty creds ⇒ the team isn't provisioned yet ⇒ the form shows an
 // "ask staff to enable the advanced track" notice instead of inputs.
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   const team = await getGenericCurrentTeam(env, request).catch(() => null);
   return {

--- a/app/routes/watt-the-hack.dashboard.tsx
+++ b/app/routes/watt-the-hack.dashboard.tsx
@@ -25,6 +25,7 @@ import {
 import { wattClasses, wattImages } from "~/lib/watt-theme";
 import { relativeTime, type LeaderboardEntry } from "~/lib/watt-the-hack-leaderboard";
 import { wattTheHackSchedule } from "~/lib/watt-the-hack-schedule";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 import type { Hackathon } from "~/services/hackathon";
 
 const FALLBACK_HACKATHON: Hackathon = {
@@ -36,6 +37,7 @@ const FALLBACK_HACKATHON: Hackathon = {
 };
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   let user = null;
   try {

--- a/app/routes/watt-the-hack.notifications.tsx
+++ b/app/routes/watt-the-hack.notifications.tsx
@@ -1,9 +1,11 @@
 import type { Route } from "./+types/watt-the-hack.notifications";
 import { getEnv } from "~/lib/env.server";
 import { getJoinRequests, type GenericHackathonRequests } from "~/lib/generic-hackathon";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 // Resource route (no default export) — polled by the header notification bell for join requests.
 export async function loader({ request, context }: Route.LoaderArgs): Promise<GenericHackathonRequests> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   try {
     return await getJoinRequests(env, request);

--- a/app/routes/watt-the-hack.profile.tsx
+++ b/app/routes/watt-the-hack.profile.tsx
@@ -23,6 +23,7 @@ import {
   type GenericHackathonTeam,
 } from "~/lib/generic-hackathon";
 import { wattClasses } from "~/lib/watt-theme";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 import type { User } from "~/types/user";
 
 interface WattUser extends User {
@@ -54,6 +55,7 @@ const PERSONA_CONFIG: Record<string, { label: string; color: string }> = {
 };
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   let user = null;
   try {
@@ -75,6 +77,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, context }: Route.ActionArgs): Promise<ActionResult | null> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   const formData = await request.formData();
   const intent = formData.get("intent")?.toString();

--- a/app/routes/watt-the-hack.resources.tsx
+++ b/app/routes/watt-the-hack.resources.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { getCurrentUser } from "~/lib/auth";
 import { getEnv } from "~/lib/env.server";
 import { wattClasses } from "~/lib/watt-theme";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 const TOC = [
   { id: "brief", label: "Brief" },
@@ -344,6 +345,7 @@ const POLICIES = [
 ] as const;
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   let user = null;
   try {
@@ -851,5 +853,4 @@ function RubricRow({ label, text, tone }: { label: string; text: string; tone: "
     </div>
   );
 }
-
 

--- a/app/routes/watt-the-hack.smart-home-beginner.firebase-token.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.firebase-token.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/watt-the-hack.smart-home-beginner.firebase-token";
 import { getEnv } from "~/lib/env.server";
 import { getWattParticipantToken } from "~/lib/generic-hackathon";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 export interface WattRealtimeAuth {
   token: string | null;
@@ -13,6 +14,7 @@ export interface WattRealtimeAuth {
 // The smart-home page fetches this once on mount (raw `fetch`) to bootstrap a direct Firebase RTDB
 // subscription — so it returns an explicit JSON Response rather than a bare value.
 export async function loader({ request, context }: Route.LoaderArgs): Promise<Response> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   let payload: WattRealtimeAuth = { token: null, classId: null, householdId: null };
   try {

--- a/app/routes/watt-the-hack.smart-home-beginner.shop.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.shop.tsx
@@ -1,9 +1,11 @@
 import type { Route } from "./+types/watt-the-hack.smart-home-beginner.shop";
 import { getEnv } from "~/lib/env.server";
 import { getSmartHomeShop, type SmartHomeShopState } from "~/lib/generic-hackathon";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 // Resource route (no default export) — polled by the smart-home page for the upgrades shop.
 export async function loader({ request, context }: Route.LoaderArgs): Promise<SmartHomeShopState> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   try {
     return await getSmartHomeShop(env, request);

--- a/app/routes/watt-the-hack.smart-home-beginner.state.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.state.tsx
@@ -1,9 +1,11 @@
 import type { Route } from "./+types/watt-the-hack.smart-home-beginner.state";
 import { getEnv } from "~/lib/env.server";
 import { getSmartHomeState, type SmartHomeState } from "~/lib/generic-hackathon";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 // Resource route (no default export) — polled by the smart-home page for the live status bar.
 export async function loader({ request, context }: Route.LoaderArgs): Promise<SmartHomeState> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   try {
     return await getSmartHomeState(env, request);

--- a/app/routes/watt-the-hack.smart-home-beginner.tsx
+++ b/app/routes/watt-the-hack.smart-home-beginner.tsx
@@ -23,6 +23,7 @@ import { SmartHomeStatusBar } from "~/components/SmartHomeStatusBar";
 import { useWattRealtimeState } from "~/hooks/useWattRealtimeState";
 import { progressionForDay } from "~/lib/smart-home-progression";
 import type { DeployFeedback } from "~/components/SmartHomeController";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 type StreamData = {
   session: WattUnitySession | null;
@@ -51,6 +52,7 @@ function formatClockMs(ms: number) {
 }
 
 async function loadSession(request: Request, context: Route.LoaderArgs["context"]): Promise<StreamData> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   try {
     return { session: await createWattUnitySession(env, request), error: null };
@@ -60,6 +62,7 @@ async function loadSession(request: Request, context: Route.LoaderArgs["context"
 }
 
 async function loadCatalog(request: Request, context: Route.LoaderArgs["context"]): Promise<SmartHomeCatalog> {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   try {
     return await getSmartHomeBlocks(env, request);
@@ -69,6 +72,7 @@ async function loadCatalog(request: Request, context: Route.LoaderArgs["context"
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   // Gate the whole page (stream + controller + shop) behind a valid 2..6 member team.
   // Redirects to the profile/team page before any Unity stream session is minted.
   await requireValidWattTeam(getEnv(context), request);
@@ -79,6 +83,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   const formData = await request.formData();
   const intent = String(formData.get("intent") || "reconnect");

--- a/app/routes/watt-the-hack.submissions.tsx
+++ b/app/routes/watt-the-hack.submissions.tsx
@@ -14,8 +14,10 @@ import {
   WATT_THE_HACK_SLUG,
 } from "~/lib/generic-hackathon";
 import { wattClasses } from "~/lib/watt-theme";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   let user = null;
   try {
@@ -36,6 +38,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   const formData = await request.formData();
   formData.delete("intent");

--- a/app/routes/watt-the-hack.team.tsx
+++ b/app/routes/watt-the-hack.team.tsx
@@ -1,8 +1,10 @@
 import type { Route } from "./+types/watt-the-hack.team";
 import { redirect } from "react-router";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 
 
 export function loader({}: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   return redirect("/watt-the-hack/profile");
 }
 

--- a/app/routes/watt-the-hack.tsx
+++ b/app/routes/watt-the-hack.tsx
@@ -5,11 +5,13 @@ import WattNotificationBell from "~/components/WattNotificationBell";
 import { getCurrentUser } from "~/lib/auth";
 import { getEnv } from "~/lib/env.server";
 import { WATT_THE_HACK_SLUG } from "~/lib/generic-hackathon";
+import { assertWattTheHackPublicAccessEnabled } from "~/lib/watt-the-hack-access";
 import type { User } from "~/types/user";
 
 const BASE_PATH = "/watt-the-hack";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
+  assertWattTheHackPublicAccessEnabled();
   const env = getEnv(context);
   let user = null;
   try {

--- a/app/services/hackathon.ts
+++ b/app/services/hackathon.ts
@@ -1,5 +1,6 @@
 import { createApiClient } from "~/lib/api";
 import type { Announcement } from "~/components/Announcements";
+import { assertWattTheHackSlugEnabled } from "~/lib/watt-the-hack-access";
 
 export interface Hackathon {
     name: string;
@@ -43,12 +44,14 @@ export interface ThreadResponse {
 }
 
 export async function getHackathon(env: Env, request: Request, slug: string): Promise<Hackathon> {
+    assertWattTheHackSlugEnabled(slug);
     const client = createApiClient(env, request);
     const response = await client.get(`/api/v1/hackathons/${slug}/`);
     return response.data;
 }
 
 export async function getAnnouncements(env: Env, request: Request, slug: string): Promise<Announcement[]> {
+    assertWattTheHackSlugEnabled(slug);
     const client = createApiClient(env, request);
     const response = await client.get(`/api/v1/hackathons/${slug}/announcements/`);
     return response.data;
@@ -61,6 +64,7 @@ export async function getChannelMessages(
     limit?: number,
     cursor?: string,
 ): Promise<ChannelResponse> {
+    assertWattTheHackSlugEnabled(slug);
     const client = createApiClient(env, request);
     const params: Record<string, string | number> = {};
     if (limit) params.limit = limit;
@@ -75,6 +79,7 @@ export async function getThreadMessages(
     slug: string,
     threadTs: string,
 ): Promise<ThreadResponse> {
+    assertWattTheHackSlugEnabled(slug);
     const client = createApiClient(env, request);
     const response = await client.get(`/api/v1/hackathons/${slug}/channel/thread/${threadTs}/`);
     return response.data;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,7 @@ const livePreviewDisableHmr = ["1", "true", "yes", "on"].includes(
 );
 const inspectorPort =
   livePreviewDisableHmr || process.env.CLOUDFLARE_INSPECTOR_PORT === "false" ? false : undefined;
+const wattTheHackApiPathPattern = /^\/api\/v1\/hackathons\/(?:watt|watt-the-hack)(?:\/|$)/;
 const sharedOptimizeDepsInclude = [
   "@heroicons/react/20/solid",
   "@heroicons/react/24/solid",
@@ -67,6 +68,10 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
         ws: true,
+        bypass(req) {
+          const pathname = new URL(req.url || "/", "http://localhost").pathname;
+          return wattTheHackApiPathPattern.test(pathname) ? req.url : undefined;
+        },
       },
     },
   },

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,4 +1,5 @@
 import { createRequestHandler } from "react-router";
+import { isWattTheHackEndpointPath } from "~/lib/watt-the-hack-access";
 
 declare module "react-router" {
   export interface AppLoadContext {
@@ -57,7 +58,17 @@ export default {
       return Response.redirect(url.toString(), 301);
     }
 
-    // 2. Redirect legacy paths (301)
+    // 2. Block disabled Watt The Hack API paths on the website domain.
+    if (isWattTheHackEndpointPath(url.pathname)) {
+      return new Response("Not Found", {
+        status: 404,
+        headers: {
+          "X-Robots-Tag": "noindex, nofollow",
+        },
+      });
+    }
+
+    // 3. Redirect legacy paths (301)
     const legacyTarget = LEGACY_REDIRECTS[url.pathname];
     if (legacyTarget) {
       url.pathname = legacyTarget;
@@ -65,7 +76,7 @@ export default {
       return Response.redirect(url.toString(), 301);
     }
 
-    // 3. Strip tracking query parameters (301)
+    // 4. Strip tracking query parameters (301)
     let hasTrackingParams = false;
     for (const param of TRACKING_PARAMS) {
       if (url.searchParams.has(param)) {
@@ -77,7 +88,7 @@ export default {
       return Response.redirect(url.toString(), 301);
     }
 
-    // 4. Let React Router handle /__manifest (needed for client-side navigation)
+    // 5. Let React Router handle /__manifest (needed for client-side navigation)
     //    but add noindex header to keep it out of search engines
     if (url.pathname === "/__manifest") {
       const response = await renderWithReactRouter(request, env, ctx);


### PR DESCRIPTION
## Summary

- Disables the Watt The Hack card on `/hackathons` so it no longer links into login.
- Blocks Watt The Hack as an auth target, including `app=watt-the-hack`, `next=/watt-the-hack/...`, and old magic-link verification paths.
- Adds route, API helper, Worker, and local dev proxy guards so Watt app routes and Watt endpoint paths return 404 instead of logging in or forwarding backend/API requests.

## Validation

- `bun run typecheck`
- Local smoke checks:
  - `/hackathons` returns 200 with 0 Watt login links
  - Watt login and magic-link URLs return 404
  - `/watt-the-hack/dashboard` returns 404
  - Watt API paths return 404
  - Advanced-track data route returns 404
- Browser check confirms `/hackathons` shows `Watt The Hack (Coming Soon)` with no Watt links.