### PR TITLE
Vibe Raising: 'Run again' button on the AI draft step

### DIFF
--- a/app/components/VibeRaisingStickyStepBar.tsx
+++ b/app/components/VibeRaisingStickyStepBar.tsx
@@ -16,6 +16,10 @@ type VibeRaisingStickyStepBarProps = {
     mobileSecondaryLabel?: string;
     onSecondary?: () => void;
     secondaryDisabled?: boolean;
+    tertiaryLabel?: string;
+    mobileTertiaryLabel?: string;
+    onTertiary?: () => void;
+    tertiaryDisabled?: boolean;
     primaryLabel: string;
     mobilePrimaryLabel?: string;
     onPrimary?: () => void;
@@ -39,6 +43,10 @@ export default function VibeRaisingStickyStepBar({
     mobileSecondaryLabel,
     onSecondary,
     secondaryDisabled = false,
+    tertiaryLabel,
+    mobileTertiaryLabel,
+    onTertiary,
+    tertiaryDisabled = false,
     primaryLabel,
     mobilePrimaryLabel,
     onPrimary,
@@ -48,6 +56,7 @@ export default function VibeRaisingStickyStepBar({
 }: VibeRaisingStickyStepBarProps) {
     const resolvedBackLabel = mobileBackLabel ?? backLabel;
     const resolvedSecondaryLabel = mobileSecondaryLabel ?? secondaryLabel;
+    const resolvedTertiaryLabel = mobileTertiaryLabel ?? tertiaryLabel;
     const resolvedPrimaryLabel = mobilePrimaryLabel ?? primaryLabel;
 
     return (
@@ -105,6 +114,20 @@ export default function VibeRaisingStickyStepBar({
                         >
                             <span className="sm:hidden">{resolvedSecondaryLabel}</span>
                             <span className="hidden sm:inline">{secondaryLabel}</span>
+                        </button>
+                    ) : null}
+                    {tertiaryLabel && onTertiary ? (
+                        <button
+                            type="button"
+                            onClick={onTertiary}
+                            disabled={tertiaryDisabled}
+                            className={[
+                                "inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-extrabold text-slate-700 shadow-sm transition hover:bg-gray-50 hover:text-gray-950 disabled:cursor-not-allowed disabled:opacity-55",
+                                compactOnMobile ? "w-full sm:w-auto" : "w-full sm:w-auto",
+                            ].join(" ")}
+                        >
+                            <span className="sm:hidden">{resolvedTertiaryLabel}</span>
+                            <span className="hidden sm:inline">{tertiaryLabel}</span>
                         </button>
                     ) : null}
                     <button

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -3933,6 +3933,8 @@ export default function CreateUpdate() {
         };
     })();
 
+    const canRunAgainDraft = selectedDraftStage === "reporting" && hasDraftTemplate && !isManualOnlyDraftFlow && selectedInputSources.length > 0;
+
     const handleRetryEmailDraft = () => {
         requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true });
     };
@@ -5966,6 +5968,10 @@ export default function CreateUpdate() {
                 mobileSecondaryLabel={selectedDraftStage === "reporting" && hasDraftTemplate ? (saveDraftFetcher.state !== "idle" ? "Saving" : draftSaved ? "Saved" : "Save draft") : undefined}
                 onSecondary={selectedDraftStage === "reporting" && hasDraftTemplate ? handlePersistDraft : undefined}
                 secondaryDisabled={saveDraftFetcher.state !== "idle" || isEmailDraftBusy || isVideoUploadBlocking}
+                tertiaryLabel={canRunAgainDraft ? "Run again" : undefined}
+                mobileTertiaryLabel={canRunAgainDraft ? "Run again" : undefined}
+                onTertiary={canRunAgainDraft ? () => requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true }) : undefined}
+                tertiaryDisabled={emailDraftActionBusy}
                 primaryLabel={draftStickyBar.primaryLabel}
                 onPrimary={draftStickyBar.onPrimary}
                 primaryDisabled={draftStickyBar.primaryDisabled}
@@ -6073,9 +6079,9 @@ export default function CreateUpdate() {
                                     <ExclamationTriangleIcon className="h-6 w-6" />
                                 </div>
                                 <div>
-                                    <h2 className="text-lg font-black text-[var(--vr-color-text)]">Draft another update?</h2>
+                                    <h2 className="text-lg font-black text-[var(--vr-color-text)]">Replace this draft?</h2>
                                     <p className="mt-2 text-sm leading-6 text-gray-600">
-                                        You already have a monthly update for <strong className="font-bold text-gray-900">{selectedMonthLabel}</strong>. Creating a new draft from these inputs can take up to 20 minutes. Previous dot points will not be overwritten; matching points will be refreshed and new points will be added.
+                                        Running again rebuilds the <strong className="font-bold text-gray-900">{selectedMonthLabel}</strong> draft from scratch using your latest data, and can take up to 20 minutes. The current draft — including any manual edits — will be replaced. We keep a backup of the previous version.
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
## What
Adds a **Run again** button to the Vibe Raising monthly-update AI draft step, so founders can re-trigger AI drafting with the latest data once a draft already exists for the month.

Companion to the fresh-replace backend change already on main (#421) — together, regenerating now rebuilds the month's draft from current data instead of merging into the stale one.

## Changes
- `VibeRaisingStickyStepBar`: optional **tertiary** action (backward-compatible; existing usages unaffected).
- create-update: "Run again" tertiary on the draft review bar (alongside "Save as Draft"), shown only in the AI / source-assisted draft-ready state → `requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true })`.
- Regenerate dialog copy updated to reflect **replace** semantics (rebuilds from latest data; current draft incl. manual edits replaced; previous version backed up) — matching the backend behaviour now live on main.

## Verify
`tsc -b`: baseline-diffed — these changes introduce **no new type errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
