### PR TITLE
Vibe Raising: 'Regenerate draft' button on the review step

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -4697,6 +4697,11 @@ export default function CreateUpdate() {
         const reviewDraftId = String(reviewData?.draftId || actionData?.update?.id || "").trim();
         const reviewMonth = String(reviewData?.month || selectedMonth);
         const reviewYear = Number(reviewData?.year || selectedYear);
+        const canRegenerateDraftFromReview = !isManualOnlyDraftFlow && selectedInputSources.length > 0;
+        const handleRegenerateDraftFromReview = () => {
+            setDismissedFeedback(true);
+            requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true });
+        };
         const reviewSummary = String(reviewData?.summary || "").trim();
         const reviewSourceUrl = String(reviewData?.sourceUrl || "").trim();
         const reviewPitchDeckUrl = String(reviewData?.pitchDeckUrl || "").trim();
@@ -5514,6 +5519,10 @@ export default function CreateUpdate() {
                     mobileSecondaryLabel={draftSaved ? "Draft saved" : "Save draft"}
                     onSecondary={handlePersistDraft}
                     secondaryDisabled={saveDraftFetcher.state !== "idle"}
+                    tertiaryLabel={canRegenerateDraftFromReview ? "Regenerate draft" : undefined}
+                    mobileTertiaryLabel={canRegenerateDraftFromReview ? "Regenerate" : undefined}
+                    onTertiary={canRegenerateDraftFromReview ? handleRegenerateDraftFromReview : undefined}
+                    tertiaryDisabled={emailDraftActionBusy || saveDraftFetcher.state !== "idle"}
                     primaryLabel="Publish update"
                     mobilePrimaryLabel="Publish"
                     onPrimary={() => setShowConfirmPopup(true)}


### PR DESCRIPTION
## What
Adds a **Regenerate draft** button to the monthly-update **Review** step (the "Review … update / Publish update" sticky bar), so founders can re-run AI drafting with the latest data without hunting for the draft-step button.

Completes the regenerate surface: draft step has "Run again" (#966); review step now has "Regenerate draft". Both go through the same confirm dialog and the fresh-replace backend behaviour already live on main (mlai-backend #421).

## Behaviour
- Click → returns to the draft view (same as Back) and triggers `requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true })` — confirm dialog appears when an update already exists for the month, then progress card + polling as usual.
- Hidden for manual-only drafts / no selected input sources; disabled while a draft action is busy.

## Verify
`tsc -b` baseline-diffed — no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
