### PR TITLE
Show real publish status on recent articles instead of hardcoded "Published"

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -25,6 +25,7 @@ import type {
   VibeMarketingStartupProfile,
   VibeMarketingWebsiteBaseline,
   VibeMarketingGoogleBaselineConnection,
+  VibeMarketingArticlePublishStatus,
   VibeMarketingTopicCandidate,
   VibeMarketingTopicFeedback,
   VibeMarketingTopicPillar,
@@ -680,7 +681,20 @@ function normalizeTopicFeedback(raw: unknown): VibeMarketingTopicFeedback | null
   };
 }
 
-function normalizeWrittenTopic(raw: unknown): VibeMarketingWrittenTopic | null {
+const ARTICLE_PUBLISH_STATUSES: ReadonlySet<string> = new Set([
+  "written",
+  "pr_open",
+  "pr_closed",
+  "merged",
+  "live",
+]);
+
+function asArticlePublishStatus(value: unknown): VibeMarketingArticlePublishStatus | null {
+  const text = asNullableString(value)?.toLowerCase() ?? null;
+  return text && ARTICLE_PUBLISH_STATUSES.has(text) ? (text as VibeMarketingArticlePublishStatus) : null;
+}
+
+export function normalizeWrittenTopic(raw: unknown): VibeMarketingWrittenTopic | null {
   const payload = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
   const title = asNullableString(payload.title);
   const keyword = asNullableString(payload.keyword) ?? asNullableString(payload.primary_keyword);
@@ -692,6 +706,9 @@ function normalizeWrittenTopic(raw: unknown): VibeMarketingWrittenTopic | null {
     keyword: keyword ?? title ?? "",
     articleUrl: asNullableString(payload.articleUrl) ?? asNullableString(payload.article_url),
     prUrl: asNullableString(payload.prUrl) ?? asNullableString(payload.pr_url),
+    prNumber: asNumber(payload.prNumber) ?? asNumber(payload.pr_number),
+    publishStatus: asArticlePublishStatus(payload.publishStatus ?? payload.publish_status),
+    liveUrl: asNullableString(payload.liveUrl) ?? asNullableString(payload.live_url),
     writtenAt: asNullableString(payload.writtenAt) ?? asNullableString(payload.written_at),
   };
 }

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -2507,14 +2507,72 @@ function TopicRow({
   );
 }
 
+function articlePublishStatusTone(article: VibeMarketingWrittenTopic) {
+  switch (article.publishStatus) {
+    case "live":
+      return {
+        label: "Live",
+        pill: "bg-emerald-50 text-emerald-600",
+        dot: "bg-emerald-500",
+        hint: "Verified on your website.",
+      };
+    case "merged":
+      return {
+        label: "Merged",
+        pill: "bg-sky-50 text-sky-700",
+        dot: "bg-sky-500",
+        hint: "The PR merged — waiting for the next site deploy.",
+      };
+    case "pr_open":
+      return {
+        label: "PR open",
+        pill: "bg-amber-50 text-amber-700",
+        dot: "bg-amber-500",
+        hint: "A pull request is waiting to be merged.",
+      };
+    case "pr_closed":
+      return {
+        label: "PR closed",
+        pill: "bg-red-50 text-red-700",
+        dot: "bg-red-500",
+        hint: "The pull request was closed without merging.",
+      };
+    default:
+      return {
+        label: "Not published",
+        pill: "bg-slate-100 text-slate-600",
+        dot: "bg-slate-400",
+        hint: "Written and packaged, but not on your website yet.",
+      };
+  }
+}
+
 function RecentArticleRow({ article }: { article: VibeMarketingWrittenTopic }) {
+  const tone = articlePublishStatusTone(article);
+  const href =
+    (article.publishStatus === "live" ? article.liveUrl : null) ?? article.prUrl ?? article.articleUrl ?? null;
+  const title = article.title || article.keyword;
   return (
-    <div className="grid grid-cols-[110px_minmax(0,1fr)_auto] items-center gap-4 border-t border-slate-100 py-4 first:border-t-0">
-      <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-black text-emerald-600">
-        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-        Published
+    <div className="grid grid-cols-[130px_minmax(0,1fr)_auto] items-center gap-4 border-t border-slate-100 py-4 first:border-t-0">
+      <span
+        title={tone.hint}
+        className={clsx("inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-black", tone.pill)}
+      >
+        <span className={clsx("h-1.5 w-1.5 rounded-full", tone.dot)} />
+        {tone.label}
       </span>
-      <p className="truncate text-sm font-black text-slate-950">{article.title || article.keyword}</p>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="truncate text-sm font-black text-slate-950 hover:underline"
+        >
+          {title}
+        </a>
+      ) : (
+        <p className="truncate text-sm font-black text-slate-950">{title}</p>
+      )}
       <p className="text-sm font-bold text-slate-500">{formatArticleDate(article.writtenAt)}</p>
     </div>
   );

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -352,6 +352,13 @@ export interface VibeMarketingTopicFeedback {
   restoredAt?: string | null;
 }
 
+export type VibeMarketingArticlePublishStatus =
+  | "written"
+  | "pr_open"
+  | "pr_closed"
+  | "merged"
+  | "live";
+
 export interface VibeMarketingWrittenTopic {
   id?: string;
   title: string;
@@ -359,6 +366,9 @@ export interface VibeMarketingWrittenTopic {
   keyword: string;
   articleUrl?: string | null;
   prUrl?: string | null;
+  prNumber?: number | null;
+  publishStatus?: VibeMarketingArticlePublishStatus | null;
+  liveUrl?: string | null;
   writtenAt?: string | null;
 }
 

--- a/tests/vibe-marketing-written-topic-status.test.ts
+++ b/tests/vibe-marketing-written-topic-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeWrittenTopic } from "../app/lib/vibe-marketing";
+
+describe("normalizeWrittenTopic publish status", () => {
+  test("parses camelCase publish status and live url", () => {
+    const topic = normalizeWrittenTopic({
+      title: "How to Start Fundraising for Your AI Startup",
+      keyword: "ai startup fundraising",
+      publishStatus: "live",
+      liveUrl: "https://mlai.au/articles/featured/how-to-start-fundraising-for-your-ai-startup",
+      prNumber: 990,
+    });
+    expect(topic?.publishStatus).toBe("live");
+    expect(topic?.liveUrl).toBe(
+      "https://mlai.au/articles/featured/how-to-start-fundraising-for-your-ai-startup",
+    );
+    expect(topic?.prNumber).toBe(990);
+  });
+
+  test("parses snake_case publish status from older payloads", () => {
+    const topic = normalizeWrittenTopic({
+      title: "Article",
+      keyword: "article",
+      publish_status: "pr_open",
+      pr_url: "https://github.com/MLAI-AUS-Inc/mlai-au/pull/990",
+    });
+    expect(topic?.publishStatus).toBe("pr_open");
+    expect(topic?.prUrl).toBe("https://github.com/MLAI-AUS-Inc/mlai-au/pull/990");
+  });
+
+  test("unknown status values fall back to null instead of leaking through", () => {
+    const topic = normalizeWrittenTopic({
+      title: "Article",
+      keyword: "article",
+      publishStatus: "shipped",
+    });
+    expect(topic?.publishStatus).toBeNull();
+  });
+
+  test("missing status stays null for legacy rows", () => {
+    const topic = normalizeWrittenTopic({ title: "Article", keyword: "article" });
+    expect(topic?.publishStatus).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`RecentArticleRow` rendered an **unconditional green "Published" pill** for every written article. Combined with the backend stamping `published_at` at writing-run completion, the dashboard claimed articles were published even when no PR was opened and nothing reached the customer's site.

## Change

Surface the real lifecycle the backend now tracks (companion PR: `mlai-backend#424`):

- `VibeMarketingWrittenTopic` carries `publishStatus`, `prNumber`, `liveUrl`, parsed in `normalizeWrittenTopic` (accepts camelCase + snake_case; unknown status values coerce to `null` rather than leaking through).
- `RecentArticleRow` renders a tone per status, each with a hover hint:
  - **Live** (emerald) — links to the production URL
  - **Merged** (sky) — "waiting for the next site deploy"
  - **PR open** (amber) — links to the PR
  - **PR closed** (red)
  - **Not published** (slate) — written/packaged but not on the site

Legacy rows with no `publishStatus` fall back to **Not published** — the honest state.

## Tests

`tests/vibe-marketing-written-topic-status.test.ts` (4 cases: camel/snake parsing, unknown→null, missing→null). Full `bun test` (79) and `bun run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)