### PR TITLE
Fix silent regenerate buttons: dialog was dead-code-eliminated from the build

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -6104,8 +6104,6 @@ export default function CreateUpdate() {
                 </div>
             ) : null}
 
-            {showLegacyDraftFlow ? (
-            <>
             {showRegenerateConfirm && (
                 <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-950/55 p-4 backdrop-blur-sm">
                     <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-[var(--vr-color-card)] shadow-2xl ring-1 ring-black/5">
@@ -6145,6 +6143,8 @@ export default function CreateUpdate() {
                 </div>
             )}
 
+            {showLegacyDraftFlow ? (
+            <>
             <Form method="POST" className="space-y-6">
                 <input type="hidden" name="intent" value="review" />
                 <input


### PR DESCRIPTION
## Problem
"Run again" / "Regenerate draft" did nothing in production — no dialog, no network request, no console error.

## Root cause
The regenerate confirmation dialog (`{showRegenerateConfirm && (...)}`) sits inside the `{showLegacyDraftFlow ? (...) : null}` wrapper, and `showLegacyDraftFlow` is `const ... = false` — a compile-time constant. The bundler dead-code-eliminates the whole subtree, so **the dialog is not in the shipped bundle at all** (confirmed: the live `create-update` chunk on mlai.au contains the buttons but zero dialog strings; a local build of main reproduces this byte-for-byte at 128,011 bytes). Every regenerate click sets state for UI that doesn't exist → perfect silent no-op.

This also explains why regeneration appeared broken before the recent regenerate work — the old "Draft another update?" dialog lived in the same dead block.

## Fix
Hoist the dialog out of the legacy wrapper to the live JSX level. Nothing else in the legacy block is resurrected.

## Verify
- Rebuilt: chunk grows 128,011 → 130,080 bytes and now contains "Replace this draft?".
- `tsc -b` clean (exit 0) with a full install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
