### PR TITLE
Restore in-flight draft progress on page refresh

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -288,6 +288,15 @@ function getMonthlyUpdateIsoMonth(month: string, year: number | string) {
     return key ? `${key}-01` : "";
 }
 
+function monthYearFromIso(value?: string | null): { month: string; year: number } | null {
+    const match = /^(\d{4})-(\d{2})/.exec(String(value || "").trim());
+    if (!match) return null;
+    const year = Number(match[1]);
+    const option = VIBE_RAISING_MONTH_OPTIONS[Number(match[2]) - 1];
+    if (!option || !Number.isFinite(year)) return null;
+    return { month: option.name, year };
+}
+
 function isFutureMonthlyUpdate(month: string, year: number | string) {
     const monthIndex = VIBE_RAISING_MONTH_OPTIONS.findIndex((option) => option.name === month);
     const parsedYear = Number(year);
@@ -3286,6 +3295,18 @@ export default function CreateUpdate() {
 
         if (statusResponse.state === "queued" || statusResponse.state === "running") {
             startTransition(() => {
+                // Restore the drafting stage from the run status itself so the
+                // progress card renders even on a fresh page load (refresh
+                // recovery), where monthConfirmed / selectedDraftStage would
+                // otherwise still be at their defaults and hide it.
+                const parsedMonth = monthYearFromIso(statusResponse.targetMonth);
+                if (parsedMonth) {
+                    setSelectedMonth(parsedMonth.month);
+                    setSelectedYear(parsedMonth.year);
+                }
+                setMonthConfirmed(true);
+                setSelectedDraftStage("reporting");
+                setMetricsConfirmed(true);
                 setEmailDraftStatus(statusResponse);
                 setEmailDraftUiError(null);
             });


### PR DESCRIPTION
## Problem
While an AI monthly-update draft is generating, refreshing the page loses the progress UI — the card disappears and the only action left is "regenerate again", even though the run is still happily processing on the backend.

## Cause
The `EmailDraftInProgressCard` is rendered behind a JSX gate that requires `monthConfirmed === true` **and** `selectedDraftStage === "reporting"`. Both are `useState` defaults (`false` / `null`) that reset on every page load. The refresh-recovery effect already does the right data work — it calls the `active-run` endpoint (and the localStorage persisted run) and feeds the result through `processEmailDraftStatus`, which restores `emailDraftStatus` — but the `queued`/`running` branch never restored the **stage flags**. So `emailDraftStatus` says "running" while the gate stays closed.

In a normal session this never shows because `handleGenerateSelectedMonthUpdate` sets the stage before the run starts; only the refresh path hits it.

## Fix
In `processEmailDraftStatus`'s queued/running branch, re-enter the drafting stage (`monthConfirmed` / `selectedDraftStage = "reporting"` / `metricsConfirmed`) and restore the month from `statusResponse.targetMonth` (new `monthYearFromIso` helper). Idempotent during live polling; correct on cold refresh.

## Verify
`tsc -b` baseline-diffed — no new type errors. (Companion suggestions for a more global "generating" indicator discussed separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
