### PR TITLE
Show the content-only banner over degraded article previews

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -842,6 +842,8 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
     renderMode: asNullableString(payload.renderMode) ?? asNullableString(payload.render_mode),
     renderConfidence: asNullableString(payload.renderConfidence) ?? asNullableString(payload.render_confidence),
     fallbackReason: asNullableString(payload.fallbackReason) ?? asNullableString(payload.fallback_reason),
+    previewQuality: asNullableString(payload.previewQuality) ?? asNullableString(payload.preview_quality),
+    previewBanner: asNullableString(payload.previewBanner) ?? asNullableString(payload.preview_banner),
     previewUnavailableReason:
       asNullableString(payload.previewUnavailableReason) ??
       asNullableString(payload.preview_unavailable_reason) ??

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1867,6 +1867,13 @@ function LivePreviewCommentInspectorPanel({
     } as NonNullable<VibeMarketingRunSummary["livePreview"]>;
   }, [previewUrlFallback, requiresExactPreview, run.livePreview]);
   const canRenderPreview = Boolean(preview?.available && preview.previewUrl);
+  const contentOnlyPreviewActive =
+    canRenderPreview &&
+    (String(preview?.previewQuality ?? "").trim().toLowerCase() === "content_only" ||
+      String(preview?.previewMode ?? "").trim().toLowerCase() === "content_only");
+  const contentOnlyPreviewBanner =
+    String(preview?.previewBanner ?? "").trim() ||
+    "Exact preview unavailable — showing a content-only preview of the article.";
   const [componentMeasurements, setComponentMeasurements] = useState<Record<string, InspectorComponentMeasurement>>({});
   const [pendingPin, setPendingPin] = useState<PendingCommentPin | null>(null);
   const [openCommentId, setOpenCommentId] = useState<string | null>(null);
@@ -2083,6 +2090,19 @@ function LivePreviewCommentInspectorPanel({
                   </span>
                 </div>
               </div>
+              {contentOnlyPreviewActive ? (
+                <div
+                  role="status"
+                  className="flex items-start gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm font-bold text-amber-900"
+                >
+                  <ExclamationTriangleIcon className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                  <span>
+                    {contentOnlyPreviewBanner}
+                    {" "}
+                    You can still review and pin comments on the article content.
+                  </span>
+                </div>
+              ) : null}
               <div className="relative">
                 {legacyInspectorWarning ? (
                   <div className="absolute left-4 right-4 top-4 z-30 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900 shadow-sm">

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -450,6 +450,8 @@ export interface VibeMarketingLivePreview {
   renderMode?: string | null;
   renderConfidence?: string | null;
   fallbackReason?: string | null;
+  previewQuality?: string | null;
+  previewBanner?: string | null;
   previewUnavailableReason?: string | null;
   proof?: Record<string, unknown>;
   nativePreviewFailure?: Record<string, unknown>;


### PR DESCRIPTION
## Problem

When content-factory cannot prove an exact article preview it degrades to a **content-only fallback** instead of blocking the run, stamping the payload with `previewQuality: "content_only"` and a human-readable `previewBanner`. Its contract (content-factory `docs/hosted-review-previews.md`) says: *"The iframe should display the banner while letting reviewers inspect and comment on the article content."*

The frontend never consumed either field — they weren't in the `VibeMarketingLivePreview` type or the parser, and no component rendered them — so reviewers saw degraded content-only previews presented exactly like exact previews, with no indication anything was different.

Part of robustness fix #4 (content-only fallback end-to-end). Pairs with [mlai-backend#431](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/431), which passes the two fields through `_live_preview_from_run` (they were previously dropped by its field whitelist).

## Changes

- `app/types/vibe-marketing.ts`: add `previewQuality` / `previewBanner` to `VibeMarketingLivePreview`.
- `app/lib/vibe-marketing.ts`: parse both fields (camelCase + snake_case).
- `app/routes/founder-tools.marketing.run.tsx` (`LivePreviewCommentInspectorPanel`): when the rendered preview is content-only (`previewQuality`/`previewMode` === `content_only`), show a persistent amber `role="status"` banner between the preview URL bar and the iframe — backend-provided banner text with a local fallback — plus a note that pinning comments still works. Exact previews are unchanged; the existing collapsible "Preview warnings" list is untouched.

## Verification

`tsc -b` reports no errors in the three touched files (the build has pre-existing unrelated errors in `watt-the-hack`/`vibe-raising-app` sandbox files on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
