### PR TITLE
Make in-flight AI draft generation visible across the founder app

### DIFF
--- a/app/components/ActiveDraftRunStatus.tsx
+++ b/app/components/ActiveDraftRunStatus.tsx
@@ -1,0 +1,149 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import { Link, useLocation } from "react-router";
+import { ArrowRightIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import { getVibeRaisingStartupUpdateActiveRun } from "~/lib/vibe-raising";
+import type { VibeRaisingStartupUpdateStatusResponse } from "~/types/vibe-raising";
+import { VIBE_RAISING_MONTH_OPTIONS } from "~/components/VibeRaisingDateTabs";
+
+const ACTIVE_RUN_POLL_INTERVAL_MS = 25_000;
+
+type ActiveDraftRunContextValue = {
+    activeRun: VibeRaisingStartupUpdateStatusResponse | null;
+    refreshActiveRun: () => void;
+};
+
+const ActiveDraftRunContext = createContext<ActiveDraftRunContextValue>({
+    activeRun: null,
+    refreshActiveRun: () => {},
+});
+
+export function useActiveDraftRun(): ActiveDraftRunContextValue {
+    return useContext(ActiveDraftRunContext);
+}
+
+function isGeneratingRun(run: VibeRaisingStartupUpdateStatusResponse | null): run is VibeRaisingStartupUpdateStatusResponse {
+    return Boolean(run?.runId && (run.state === "queued" || run.state === "running"));
+}
+
+export function activeDraftRunMonthLabel(run: VibeRaisingStartupUpdateStatusResponse | null): string | null {
+    const match = /^(\d{4})-(\d{2})/.exec(String(run?.targetMonth || "").trim());
+    if (!match) return null;
+    const option = VIBE_RAISING_MONTH_OPTIONS[Number(match[2]) - 1];
+    if (!option) return null;
+    return `${option.name} ${match[1]}`;
+}
+
+function runProgressParts(run: VibeRaisingStartupUpdateStatusResponse) {
+    const completedSteps = run.completedSteps ?? run.progress?.completedSteps ?? 0;
+    const totalSteps = run.totalSteps ?? run.progress?.totalSteps ?? 0;
+    const displayStage = run.displayStage || run.progress?.displayStage || "Drafting in progress";
+    return { completedSteps, totalSteps, displayStage };
+}
+
+export function ActiveDraftRunProvider({
+    backendBaseUrl,
+    children,
+}: {
+    backendBaseUrl: string;
+    children: ReactNode;
+}) {
+    const [activeRun, setActiveRun] = useState<VibeRaisingStartupUpdateStatusResponse | null>(null);
+    const inFlightRef = useRef(false);
+
+    const refreshActiveRun = useCallback(() => {
+        if (inFlightRef.current) return;
+        inFlightRef.current = true;
+        getVibeRaisingStartupUpdateActiveRun(backendBaseUrl)
+            .then((run) => {
+                setActiveRun(isGeneratingRun(run) ? run : null);
+            })
+            .catch(() => {
+                // Transient failures keep the last known state; the next poll corrects it.
+            })
+            .finally(() => {
+                inFlightRef.current = false;
+            });
+    }, [backendBaseUrl]);
+
+    useEffect(() => {
+        refreshActiveRun();
+        const intervalId = window.setInterval(refreshActiveRun, ACTIVE_RUN_POLL_INTERVAL_MS);
+        window.addEventListener("focus", refreshActiveRun);
+        return () => {
+            window.clearInterval(intervalId);
+            window.removeEventListener("focus", refreshActiveRun);
+        };
+    }, [refreshActiveRun]);
+
+    return (
+        <ActiveDraftRunContext.Provider value={{ activeRun, refreshActiveRun }}>
+            {children}
+        </ActiveDraftRunContext.Provider>
+    );
+}
+
+export function ActiveDraftRunBanner() {
+    const { activeRun } = useActiveDraftRun();
+    const location = useLocation();
+
+    if (!isGeneratingRun(activeRun)) return null;
+    // The create-update wizard renders the full progress card; avoid doubling up.
+    if (location.pathname.startsWith("/founder-tools/updates/create")) return null;
+
+    const monthLabel = activeDraftRunMonthLabel(activeRun);
+    const { completedSteps, totalSteps, displayStage } = runProgressParts(activeRun);
+
+    return (
+        <div className="sticky top-2 z-30 mb-4 px-1">
+            <Link
+                to="/founder-tools/updates/create"
+                className="mx-auto flex max-w-6xl items-center justify-between gap-3 rounded-2xl border border-[rgba(0,128,128,0.22)] bg-[linear-gradient(135deg,rgba(0,255,215,0.16),rgba(255,255,255,0.96))] px-4 py-3 shadow-lg shadow-[rgba(0,128,128,0.10)] backdrop-blur transition hover:border-[var(--vr-color-primary)]"
+            >
+                <span className="flex min-w-0 items-center gap-3">
+                    <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.18)] text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.30)]">
+                        <SparklesIcon className="h-5 w-5 animate-pulse" />
+                    </span>
+                    <span className="min-w-0">
+                        <span className="block truncate text-sm font-black text-gray-950">
+                            Drafting {monthLabel ? `${monthLabel} ` : ""}update
+                        </span>
+                        <span className="block truncate text-xs font-semibold text-slate-500">
+                            {displayStage}
+                            {totalSteps > 0 ? ` · step ${Math.min(completedSteps + 1, totalSteps)} of ${totalSteps}` : ""}
+                        </span>
+                    </span>
+                </span>
+                <span className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-xl bg-[var(--vr-color-primary)] px-3 py-2 text-xs font-extrabold text-white">
+                    View progress
+                    <ArrowRightIcon className="h-3.5 w-3.5" />
+                </span>
+            </Link>
+        </div>
+    );
+}
+
+export function ActiveDraftRunChip({ className }: { className?: string }) {
+    const { activeRun } = useActiveDraftRun();
+
+    if (!isGeneratingRun(activeRun)) return null;
+
+    const monthLabel = activeDraftRunMonthLabel(activeRun);
+    const { completedSteps, totalSteps } = runProgressParts(activeRun);
+
+    return (
+        <Link
+            to="/founder-tools/updates/create"
+            className={[
+                "inline-flex items-center gap-1.5 rounded-lg bg-[rgba(0,255,215,0.14)] px-3 py-1.5 text-xs font-black text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.32)] transition hover:bg-[rgba(0,255,215,0.24)]",
+                className || "",
+            ].join(" ").trim()}
+        >
+            <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--vr-color-primary)] opacity-60" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-[var(--vr-color-primary)]" />
+            </span>
+            AI drafting{monthLabel ? ` ${monthLabel}` : ""}
+            {totalSteps > 0 ? ` · ${Math.min(completedSteps + 1, totalSteps)}/${totalSteps}` : ""}
+        </Link>
+    );
+}

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -37,6 +37,7 @@ import {
     InformationCircleIcon,
     DocumentArrowUpIcon,
 } from "@heroicons/react/24/outline";
+import { ActiveDraftRunChip } from "~/components/ActiveDraftRunStatus";
 import StartupRegionBadge from "~/components/StartupRegionBadge";
 import { parseVibeRaisingMonthYear, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
 
@@ -879,6 +880,7 @@ function VRPreviewUpdateCard({
                                     {statusLabel}
                                 </span>
                             ) : null}
+                            <ActiveDraftRunChip />
                             {formattedDate ? (
                                 <span className="rounded-lg bg-white px-3 py-1.5 text-xs font-bold text-gray-400 ring-1 ring-gray-200">
                                     {formattedDate}
@@ -893,6 +895,7 @@ function VRPreviewUpdateCard({
                                     {statusLabel}
                                 </span>
                             ) : null}
+                            <ActiveDraftRunChip />
                             <Link
                                 to={`/founder-tools/updates/create?edit=${encodeURIComponent(update.id)}`}
                                 className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-black text-gray-500 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-200 hover:text-gray-700"
@@ -1453,9 +1456,12 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                                 </div>
                             </div>
                         ) : (
-                            <p className="vr-text-body-small" style={{ color: "var(--vr-color-text-sub)" }}>
-                                No current update yet — create your first one above.
-                            </p>
+                            <div className="space-y-3">
+                                <ActiveDraftRunChip />
+                                <p className="vr-text-body-small" style={{ color: "var(--vr-color-text-sub)" }}>
+                                    No current update yet — create your first one above.
+                                </p>
+                            </div>
                         )
                     ) : (
                         <div className="flex flex-col gap-4 lg:flex-row lg:items-start">

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -47,6 +47,7 @@ import {
 import { useDropzone } from 'react-dropzone';
 import { motion, useInView } from "motion/react";
 import { clsx } from "clsx";
+import { useActiveDraftRun } from "~/components/ActiveDraftRunStatus";
 import DraftFromEmailWizard from "~/components/DraftFromEmailWizard";
 import EmailDraftInProgressCard from "~/components/EmailDraftInProgressCard";
 import MonthlyUpdateStepper, { type MonthlyUpdateStepKey } from "~/components/MonthlyUpdateStepper";
@@ -2465,6 +2466,7 @@ export default function CreateUpdate() {
     const location = useLocation();
     const navigation = useNavigation();
     const isSubmitting = navigation.state === "submitting";
+    const { activeRun: sharedActiveDraftRun } = useActiveDraftRun();
     const initialSelectedInputSourcesKey = initialSelectedInputSources.join(",");
     const goToConnectDataStep = useCallback(() => {
         const returnPath = `${location.pathname}${location.search || ""}`;
@@ -3361,6 +3363,18 @@ export default function CreateUpdate() {
             setEmailDraftPollDelayMs(EMAIL_DRAFT_POLL_INTERVAL_MS);
         });
     });
+
+    useEffect(() => {
+        // The app shell already polls the active run; seed the wizard from it
+        // so arriving here (banner/chip click or navigation) lands straight on
+        // the progress view without waiting for this page's own recovery fetch.
+        if (!isClientMounted) return;
+        if (emailDraftStatus?.runId) return;
+        if (!sharedActiveDraftRun?.runId) return;
+        if (sharedActiveDraftRun.state !== "queued" && sharedActiveDraftRun.state !== "running") return;
+        void processEmailDraftStatus(sharedActiveDraftRun);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isClientMounted, sharedActiveDraftRun?.runId, emailDraftStatus?.runId]);
 
     const startOrResumeEmailDraft = useCallback(async (options?: { forceRegenerate?: boolean; inputSources?: VibeRaisingInputSourceKey[] }) => {
         setEmailDraftActionBusy(true);

--- a/app/routes/vibe-raising-app.drafts.tsx
+++ b/app/routes/vibe-raising-app.drafts.tsx
@@ -1,6 +1,7 @@
 import { Link, redirect, useLoaderData } from "react-router";
 import { formatDistanceToNow } from "date-fns";
 import type { Route } from "./+types/vibe-raising-app.drafts";
+import { ActiveDraftRunChip } from "~/components/ActiveDraftRunStatus";
 import { getEnv } from "~/lib/env.server";
 import {
     getVibeRaisingDrafts,
@@ -86,6 +87,7 @@ export default function VibeRaisingDraftsPage() {
                     <div className="rounded-2xl border border-[var(--vr-color-border)] bg-[var(--vr-palette-paper)] px-4 py-4">
                         <p className="text-xs font-black uppercase tracking-[0.16em] text-slate-500">Still in progress</p>
                         <p className="mt-2 text-2xl font-black text-gray-950">{inProgressDrafts}</p>
+                        <ActiveDraftRunChip className="mt-3" />
                     </div>
                 </div>
             </section>

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -6,6 +6,10 @@ import {
   redirect,
   useLoaderData,
 } from "react-router";
+import {
+  ActiveDraftRunBanner,
+  ActiveDraftRunProvider,
+} from "~/components/ActiveDraftRunStatus";
 import AuthenticatedLayout from "~/components/AuthenticatedLayout";
 import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import { getEnv } from "~/lib/env.server";
@@ -87,11 +91,12 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     user: vibeContext.authUser,
     profile: vibeContext.profile,
     appUser: vibeContext.appUser,
+    backendBaseUrl: String(env.BACKEND_BASE_URL || "https://api.mlai.au"),
   };
 }
 
 export default function VibeRaisingApp() {
-  const { user } = useLoaderData<typeof loader>();
+  const { user, backendBaseUrl } = useLoaderData<typeof loader>();
   const [showAnnouncement, setShowAnnouncement] = useState(false);
   const [onCompleteCallback, setOnCompleteCallback] =
     useState<(() => void) | undefined>();
@@ -116,7 +121,10 @@ export default function VibeRaisingApp() {
       ) : null}
 
       <div className="vr-scope">
-        <Outlet context={{ triggerAnnouncement }} />
+        <ActiveDraftRunProvider backendBaseUrl={backendBaseUrl}>
+          <ActiveDraftRunBanner />
+          <Outlet context={{ triggerAnnouncement }} />
+        </ActiveDraftRunProvider>
       </div>
     </AuthenticatedLayout>
   );


### PR DESCRIPTION
## What
Follow-up to #980: in-flight AI draft generation is now visible everywhere in the founder app, not just on Step 1 of the wizard.

1. **App-shell banner** — `ActiveDraftRunProvider` in [vibe-raising-app.tsx] polls `GET /email-draft/active-run/` (the endpoint refresh-recovery already uses) every ~25s plus on window focus, and a sticky banner renders under the shell nav on every founder page: *"Drafting May 2026 update · Scanning recent Gmail messages · step 4 of 13 → View progress"*. Hidden on the create-update route (the wizard shows the full card there).
2. **Dashboard + drafts chips** — `ActiveDraftRunChip` ("AI drafting May 2026 · 4/13", pulsing dot, links to the wizard) on the Current Update card (mobile/desktop chip rows + empty state) and the My Drafts "Still in progress" stat.
3. **Wizard seeding** — create-update consumes the shared context: when a queued/running run is known and no local status exists yet, it feeds the run straight into `processEmailDraftStatus`, so clicking the banner/chip lands on the live progress view with no month-select flash and no extra fetch round-trip.

All three share one source of truth (the provider); SSR-safe (fetches only in effects, renders nothing until a run is found).

## Verify
- `tsc -b` fully clean on a frozen-lockfile install.
- Production build succeeds and the `ActiveDraftRunStatus` chunk with banner/chip strings is present in the output (lesson from #978 applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
