### PR TITLE
Cancel generation from the sticky bar + faithful run restore

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -855,6 +855,7 @@ function normalizeStartupUpdateRun(raw: unknown): VibeRaisingStartupUpdateRunSum
       asNullableString(payload.targetMonth) ??
       asNullableString(payload.target_month) ??
       null,
+    inputSources: normalizeInputSourceKeyList(payload.inputSources ?? payload.input_sources),
     stepOrder: Array.isArray(payload.stepOrder ?? payload.step_order)
       ? ((payload.stepOrder ?? payload.step_order) as unknown[]).map((item: unknown) => String(item))
       : [],
@@ -1191,6 +1192,16 @@ function normalizeInputSourceStatus(value: unknown): VibeRaisingInputSourceStatu
   if (["coming_soon", "coming-soon"].includes(normalized)) return "coming_soon";
   if (["unavailable", "not_available", "not-available", "not_configured", "not-configured"].includes(normalized)) return "unavailable";
   return "not_connected";
+}
+
+function normalizeInputSourceKeyList(value: unknown): VibeRaisingInputSourceKey[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<VibeRaisingInputSourceKey>();
+  for (const item of value) {
+    const key = normalizeInputSourceProvider(item);
+    if (key) seen.add(key);
+  }
+  return Array.from(seen);
 }
 
 function normalizeInputSourceProvider(value: unknown): VibeRaisingInputSourceKey | null {

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -2466,7 +2466,7 @@ export default function CreateUpdate() {
     const location = useLocation();
     const navigation = useNavigation();
     const isSubmitting = navigation.state === "submitting";
-    const { activeRun: sharedActiveDraftRun } = useActiveDraftRun();
+    const { activeRun: sharedActiveDraftRun, refreshActiveRun } = useActiveDraftRun();
     const initialSelectedInputSourcesKey = initialSelectedInputSources.join(",");
     const goToConnectDataStep = useCallback(() => {
         const returnPath = `${location.pathname}${location.search || ""}`;
@@ -3306,6 +3306,12 @@ export default function CreateUpdate() {
                     setSelectedMonth(parsedMonth.month);
                     setSelectedYear(parsedMonth.year);
                 }
+                const runInputSources = (statusResponse.run?.inputSources || []).filter(
+                    (key): key is VibeRaisingInputSourceKey => VALID_INPUT_SOURCE_KEYS.has(key as VibeRaisingInputSourceKey),
+                );
+                if (runInputSources.length > 0) {
+                    setSelectedDraftInputSources(new Set(runInputSources));
+                }
                 setMonthConfirmed(true);
                 setSelectedDraftStage("reporting");
                 setMetricsConfirmed(true);
@@ -4022,6 +4028,7 @@ export default function CreateUpdate() {
             if (cancelResponse.status === "completed" || cancelResponse.terminalState === "completed") {
                 emailDraftIgnoredRunIdRef.current = null;
                 await hydrateCompletedEmailDraft(cancelResponse.runId);
+                refreshActiveRun();
                 return;
             }
 
@@ -4029,6 +4036,9 @@ export default function CreateUpdate() {
                 clearPersistedEmailDraftRun();
                 setPendingEmailDraftForceRegenerate(emailDraftForceRegenerateKey);
                 resetEmailDraftUi();
+                // Clear the app-shell "drafting" banner right away instead of
+                // waiting for its next poll cycle.
+                refreshActiveRun();
                 return;
             }
 
@@ -4044,6 +4054,7 @@ export default function CreateUpdate() {
         backendBaseUrl,
         emailDraftForceRegenerateKey,
         emailDraftStatus?.runId,
+        refreshActiveRun,
     ]);
 
     const stopMediaStream = useCallback(() => {
@@ -6039,10 +6050,14 @@ export default function CreateUpdate() {
                 mobileSecondaryLabel={selectedDraftStage === "reporting" && hasDraftTemplate ? (saveDraftFetcher.state !== "idle" ? "Saving" : draftSaved ? "Saved" : "Save draft") : undefined}
                 onSecondary={selectedDraftStage === "reporting" && hasDraftTemplate ? handlePersistDraft : undefined}
                 secondaryDisabled={saveDraftFetcher.state !== "idle" || isEmailDraftBusy || isVideoUploadBlocking}
-                tertiaryLabel={canRunAgainDraft ? "Run again" : undefined}
-                mobileTertiaryLabel={canRunAgainDraft ? "Run again" : undefined}
-                onTertiary={canRunAgainDraft ? () => requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true }) : undefined}
-                tertiaryDisabled={emailDraftActionBusy}
+                tertiaryLabel={canRunAgainDraft ? "Run again" : isEmailDraftBusy ? (emailDraftCancelBusy ? "Cancelling..." : "Cancel draft") : undefined}
+                mobileTertiaryLabel={canRunAgainDraft ? "Run again" : isEmailDraftBusy ? (emailDraftCancelBusy ? "Cancelling" : "Cancel") : undefined}
+                onTertiary={canRunAgainDraft
+                    ? () => requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true })
+                    : isEmailDraftBusy
+                        ? () => { void handleCancelEmailDraft(); }
+                        : undefined}
+                tertiaryDisabled={canRunAgainDraft ? emailDraftActionBusy : emailDraftActionBusy || emailDraftCancelBusy}
                 primaryLabel={draftStickyBar.primaryLabel}
                 onPrimary={draftStickyBar.onPrimary}
                 primaryDisabled={draftStickyBar.primaryDisabled}

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -552,6 +552,7 @@ export interface VibeRaisingStartupUpdateRunSummary {
   status: string;
   currentStep?: string | null;
   targetMonth?: string | null;
+  inputSources?: VibeRaisingInputSourceKey[];
   stepOrder?: string[];
   stepStates?: Record<string, VibeRaisingStartupUpdateStepState>;
   createdAt?: string;


### PR DESCRIPTION
## What
1. **Cancel from the sticky bar** — while a draft is generating, the bar's spare slot becomes **"Cancel draft"** (the same slot shows "Run again" when a draft is ready). It drives the existing `handleCancelEmailDraft` flow: confirm → backend cancel (which restores backups and deletes run artifacts) → UI reset to the clean editable template with the persisted run cleared and a force-regenerate primed for the next attempt.
2. **Immediate banner cleanup** — cancelling calls `refreshActiveRun()` on the shared provider (#982), so the app-wide "Drafting…" banner and dashboard/drafts chips disappear instantly instead of after the next 25s poll. (Re-seeding of the cancelled run is already prevented by the ignored-run guard.)
3. **Faithful restore after refresh** — the recovery path now seeds the source selection from the run summary's new `inputSources` field (mlai-backend #433), fixing the "Drafting update from **Manual materials only**" mislabel visible after refreshing mid-run.

## Verify
- `tsc -b` clean on a frozen-lockfile install; production build green.
- "Cancel draft" present twice in the built create-update chunk (progress card + sticky bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
