### PR TITLE
Fix stuck busy state that disabled cancel during a recovered run

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -3565,6 +3565,58 @@ export default function CreateUpdate() {
         }
     });
 
+    // useEffectEvent so the recovery cannot be cancelled mid-flight by state
+    // churn (restoring the run re-renders, which previously re-fired this
+    // effect via callback identities and left emailDraftActionBusy stuck true,
+    // disabling every draft action including cancel).
+    const runEmailDraftRecovery = useEffectEvent(async () => {
+        setEmailDraftActionBusy(true);
+        try {
+            const activeRun = await getVibeRaisingStartupUpdateActiveRun(backendBaseUrl);
+            if (activeRun) {
+                await processEmailDraftStatus(activeRun);
+                return;
+            }
+
+            const persistedRun = readPersistedEmailDraftRun(emailDraftStorageKey);
+            if (persistedRun?.runId) {
+                try {
+                    const storedStatus = await getVibeRaisingStartupUpdateStatus(
+                        backendBaseUrl,
+                        persistedRun.runId,
+                    );
+                    await processEmailDraftStatus(storedStatus);
+                    return;
+                } catch {
+                    clearPersistedEmailDraftRun();
+                }
+            }
+
+            if (resumeEmailDrafting) {
+                await startOrResumeEmailDraft();
+                return;
+            }
+
+            try {
+                await hydrateCompletedEmailDraft();
+                return;
+            } catch (error) {
+                if ((error as { status?: number })?.status !== 404) {
+                    throw error;
+                }
+            }
+        } catch (error) {
+            startTransition(() => {
+                setEmailDraftUiError(getEmailDraftErrorMessage(error));
+            });
+        } finally {
+            setEmailDraftActionBusy(false);
+            if (resumeEmailDrafting) {
+                clearEmailDraftingParams();
+            }
+        }
+    });
+
     useEffect(() => {
         if (!isClientMounted) return;
 
@@ -3573,72 +3625,12 @@ export default function CreateUpdate() {
             return;
         }
         emailDraftRecoveryKeyRef.current = recoveryKey;
-
-        let cancelled = false;
-        void (async () => {
-            setEmailDraftActionBusy(true);
-            try {
-                const activeRun = await getVibeRaisingStartupUpdateActiveRun(backendBaseUrl);
-                if (cancelled) return;
-                if (activeRun) {
-                    await processEmailDraftStatus(activeRun);
-                    return;
-                }
-
-                const persistedRun = readPersistedEmailDraftRun(emailDraftStorageKey);
-                if (persistedRun?.runId) {
-                    try {
-                        const storedStatus = await getVibeRaisingStartupUpdateStatus(
-                            backendBaseUrl,
-                            persistedRun.runId,
-                        );
-                        if (cancelled) return;
-                        await processEmailDraftStatus(storedStatus);
-                        return;
-                    } catch {
-                        clearPersistedEmailDraftRun();
-                    }
-                }
-
-                if (resumeEmailDrafting) {
-                    await startOrResumeEmailDraft();
-                    return;
-                }
-
-                try {
-                    await hydrateCompletedEmailDraft();
-                    return;
-                } catch (error) {
-                    if ((error as { status?: number })?.status !== 404) {
-                        throw error;
-                    }
-                }
-            } catch (error) {
-                if (!cancelled) {
-                    startTransition(() => {
-                        setEmailDraftUiError(getEmailDraftErrorMessage(error));
-                    });
-                }
-            } finally {
-                if (!cancelled) {
-                    setEmailDraftActionBusy(false);
-                    if (resumeEmailDrafting) {
-                        clearEmailDraftingParams();
-                    }
-                }
-            }
-        })();
-
-        return () => {
-            cancelled = true;
-        };
+        void runEmailDraftRecovery();
     }, [
         backendBaseUrl,
-        clearEmailDraftingParams,
         emailDraftStorageKey,
         isClientMounted,
         resumeEmailDrafting,
-        startOrResumeEmailDraft,
     ]);
 
     useEffect(() => {
@@ -5762,7 +5754,7 @@ export default function CreateUpdate() {
                                     onCancel={isEmailDraftBusy ? () => {
                                         void handleCancelEmailDraft();
                                     } : undefined}
-                                    cancelDisabled={emailDraftActionBusy || emailDraftCancelBusy}
+                                    cancelDisabled={emailDraftCancelBusy}
                                     isCancelling={emailDraftCancelBusy}
                                     manualFallbackMessage={canContinueDraftManually ? "You can keep editing the update below while the backend draft connection is unavailable." : null}
                                 />
@@ -6057,7 +6049,7 @@ export default function CreateUpdate() {
                     : isEmailDraftBusy
                         ? () => { void handleCancelEmailDraft(); }
                         : undefined}
-                tertiaryDisabled={canRunAgainDraft ? emailDraftActionBusy : emailDraftActionBusy || emailDraftCancelBusy}
+                tertiaryDisabled={canRunAgainDraft ? emailDraftActionBusy : emailDraftCancelBusy}
                 primaryLabel={draftStickyBar.primaryLabel}
                 onPrimary={draftStickyBar.onPrimary}
                 primaryDisabled={draftStickyBar.primaryDisabled}
@@ -6295,7 +6287,7 @@ export default function CreateUpdate() {
                                 onCancel={isEmailDraftBusy ? () => {
                                     void handleCancelEmailDraft();
                                 } : undefined}
-                                cancelDisabled={emailDraftActionBusy || emailDraftCancelBusy}
+                                cancelDisabled={emailDraftCancelBusy}
                                 isCancelling={emailDraftCancelBusy}
                             />
                         ) : (


### PR DESCRIPTION
## Problem
On https://mlai.au/founder-tools/updates/create, refreshing during generation left **every action except Back disabled** — both "Cancel draft" buttons and the rest of the bar — so a mid-run draft couldn't be cancelled.

## Root cause
A self-cancellation race in the refresh-recovery effect:

1. Effect fires → `setEmailDraftActionBusy(true)` → awaits the active-run fetch.
2. The restore path (#980/#982/#983) sets month/stage/source state, which changes `targetMonthIso`/`selectedInputSources` → `startOrResumeEmailDraft` gets a new identity → it's in the effect's dependency array → React re-runs the effect.
3. The cleanup sets `cancelled = true` for the still-in-flight attempt; its `finally` is guarded by `if (!cancelled)` and **skips `setEmailDraftActionBusy(false)`**; the re-run early-returns on the recovery-key guard.
4. `emailDraftActionBusy` is stuck `true` → `cancelDisabled`/`tertiaryDisabled` forever.

## Fix
- Recovery body moved into a `useEffectEvent` (repo-standard pattern in this file): the effect now depends only on the recovery-key inputs (`backendBaseUrl`, `emailDraftStorageKey`, `isClientMounted`, `resumeEmailDrafting`), so restore-triggered re-renders can't cancel it and `finally` always clears busy.
- Cancel buttons (progress card ×2 + sticky bar) now disabled only by `emailDraftCancelBusy` — cancelling is the escape hatch and stays clickable while a run is generating or other actions are busy.

## Verify
`tsc -b` clean; production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
