### PR TITLE
Make MLAITemplateResourceCTA honest: promote the article library, not a fake download

### DIFF
--- a/app/components/articles/MLAITemplateResourceCTA.tsx
+++ b/app/components/articles/MLAITemplateResourceCTA.tsx
@@ -10,20 +10,20 @@ export function MLAITemplateResourceCTA({ className = '' }: MLAITemplateResource
       <div className="flex items-start space-x-4">
         <div className="flex-shrink-0">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#1028E0]">
-            <span className="text-sm font-semibold text-white">📝</span>
+            <span className="text-sm font-semibold text-white">📚</span>
           </div>
         </div>
         <div className="flex-1">
-          <h3 className="mb-2 text-lg font-semibold text-[#1028E0]">Free MLAI Template Resource</h3>
+          <h3 className="mb-2 text-lg font-semibold text-[#1028E0]">More from the MLAI article library</h3>
           <p className="mb-4 text-gray-700">
-            Download our comprehensive template and checklist to structure your approach systematically. 
-            Created by the MLAI community for Australian startups and teams.
+            Browse practical guides and explainers on AI, startups, and careers, written by the MLAI
+            community for Australian startups and teams.
           </p>
           <Link
             to="/articles"
             className="inline-block rounded-lg bg-[#1028E0] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#1020C2] focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            Access free templates
+            Browse all articles
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

`MLAITemplateResourceCTA` promised **"Download our comprehensive template and checklist"** with an **"Access free templates"** button — but the button links to `/articles` (a category index) and no template download exists anywhere on the site.

This rewrites the card to promote what the link actually delivers: browsing the MLAI article library. Heading is now "More from the MLAI article library", button is "Browse all articles", still pointing at `/articles`.

- Props (`className`) and both exports (named + default) are unchanged, so the ~37 published articles that import this component compile and render without modification — they just stop promising a download.
- Real downloadable resources are now handled by the manifest-gated `ArticleResourceCTA` in the content-factory pipeline ([content-factory#416](https://github.com/MLAI-AUS-Inc/content-factory/pull/416)), which also stops emitting this component in newly generated articles.

## Test plan
- `tsc -b` clean with this change applied (verified against the full repo including all importers).
- Visual: same blue-accent card styling, copy/icon/button text updated only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)