### PR TITLE
Vibe Raising: metric trend charts + TLDR snippet / full article split

### DIFF
--- a/app/components/vibe-raising/MetricSparkline.tsx
+++ b/app/components/vibe-raising/MetricSparkline.tsx
@@ -1,0 +1,31 @@
+import { Line, LineChart, ResponsiveContainer } from "recharts";
+import type { VibeRaisingMetricHistoryPoint } from "~/types/vibe-raising";
+
+// Subtle trend line for snippet metric tiles: no axes, no tooltip, just the
+// shape of the series. Renders nothing when there is no trend to show.
+export default function MetricSparkline({
+    points,
+    height = 28,
+}: {
+    points: VibeRaisingMetricHistoryPoint[];
+    height?: number;
+}) {
+    if (points.length < 2) return null;
+
+    return (
+        <div style={{ height }} className="w-full" aria-hidden="true">
+            <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={points} margin={{ top: 4, right: 2, bottom: 2, left: 2 }}>
+                    <Line
+                        type="monotone"
+                        dataKey="value"
+                        stroke="var(--vr-color-primary)"
+                        strokeWidth={1.5}
+                        dot={false}
+                        isAnimationActive={false}
+                    />
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}

--- a/app/components/vibe-raising/MetricTrendChart.tsx
+++ b/app/components/vibe-raising/MetricTrendChart.tsx
@@ -1,0 +1,102 @@
+import {
+    CartesianGrid,
+    Line,
+    LineChart,
+    ReferenceDot,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+import type { VibeRaisingMetricHistorySeries } from "~/types/vibe-raising";
+import {
+    formatCompactNumber,
+    formatMonthLabel,
+    monthKey,
+} from "~/lib/vibe-raising-metric-history";
+
+function TrendTooltip({ active, payload }: { active?: boolean; payload?: any[] }) {
+    if (!active || !payload?.length) return null;
+    const point = payload[0]?.payload as { month?: string; valueText?: string } | undefined;
+    if (!point?.month) return null;
+
+    return (
+        <div className="rounded-lg border border-[var(--vr-color-border)] bg-white px-3 py-2 shadow-md">
+            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-gray-400">
+                {formatMonthLabel(point.month)}
+            </p>
+            {/* The founder's original string, so currency/percent/duration read correctly. */}
+            <p className="mt-0.5 text-sm font-black text-gray-900">{point.valueText}</p>
+        </div>
+    );
+}
+
+// One metric's trend over the trailing months, themed with the vr-* tokens.
+export default function MetricTrendChart({
+    series,
+    label,
+    highlightMonth,
+}: {
+    series: VibeRaisingMetricHistorySeries;
+    label?: string;
+    highlightMonth?: string | null;
+}) {
+    const points = series.points;
+    if (points.length < 2) return null;
+
+    const highlightKey = monthKey(highlightMonth);
+    const highlightPoint = highlightKey
+        ? points.find((point) => monthKey(point.month) === highlightKey)
+        : undefined;
+
+    return (
+        <div className="rounded-xl border border-[var(--vr-color-border)] bg-white p-4 shadow-sm">
+            <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-gray-600">
+                {label || series.label}
+            </p>
+            <div className="mt-3 h-40 w-full">
+                <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={points} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="var(--vr-color-border)" vertical={false} />
+                        <XAxis
+                            dataKey="month"
+                            tickFormatter={formatMonthLabel}
+                            tick={{ fontSize: 10, fill: "#9ca3af" }}
+                            tickLine={false}
+                            axisLine={{ stroke: "var(--vr-color-border)" }}
+                            interval="preserveStartEnd"
+                            minTickGap={24}
+                        />
+                        <YAxis
+                            tickFormatter={formatCompactNumber}
+                            tick={{ fontSize: 10, fill: "#9ca3af" }}
+                            tickLine={false}
+                            axisLine={false}
+                            width={42}
+                        />
+                        <Tooltip content={<TrendTooltip />} cursor={{ stroke: "var(--vr-color-border)" }} />
+                        <Line
+                            type="monotone"
+                            dataKey="value"
+                            stroke="var(--vr-color-primary)"
+                            strokeWidth={2}
+                            dot={{ r: 2.5, strokeWidth: 0, fill: "var(--vr-color-primary)" }}
+                            activeDot={{ r: 4 }}
+                            isAnimationActive={false}
+                        />
+                        {highlightPoint ? (
+                            <ReferenceDot
+                                x={highlightPoint.month}
+                                y={highlightPoint.value}
+                                r={5}
+                                fill="var(--vr-color-primary)"
+                                stroke="white"
+                                strokeWidth={2}
+                            />
+                        ) : null}
+                    </LineChart>
+                </ResponsiveContainer>
+            </div>
+        </div>
+    );
+}

--- a/app/components/vibe-raising/TrendsSection.tsx
+++ b/app/components/vibe-raising/TrendsSection.tsx
@@ -1,0 +1,62 @@
+import { ArrowTrendingUpIcon } from "@heroicons/react/24/outline";
+import type {
+    VibeRaisingMetricDisplayConfig,
+    VibeRaisingMetricHistory,
+} from "~/types/vibe-raising";
+import { VIBE_METRIC_KEYS, VIBE_METRIC_OPTION_MAP, metricCardLabel } from "~/lib/vibe-raising-metrics";
+import { windowPointsToMonth } from "~/lib/vibe-raising-metric-history";
+import MetricTrendChart from "./MetricTrendChart";
+
+// Trend charts for the metrics shown on the full update, windowed to the
+// update's own month so a past article never charts data from its future.
+export default function TrendsSection({
+    metricHistory,
+    displayConfig,
+    currentIsoMonth,
+    monthsBack = 12,
+}: {
+    metricHistory: VibeRaisingMetricHistory;
+    displayConfig?: VibeRaisingMetricDisplayConfig | null;
+    currentIsoMonth?: string | null;
+    monthsBack?: number;
+}) {
+    const metricKeys = displayConfig
+        ? displayConfig.fullMetricKeys
+        : VIBE_METRIC_KEYS.filter((key) => metricHistory[key]);
+
+    const chartableSeries = metricKeys
+        .map((key) => {
+            const series = metricHistory[key];
+            if (!series) return null;
+            const points = windowPointsToMonth(series.points, currentIsoMonth, monthsBack);
+            if (points.length < 2) return null;
+            const option = VIBE_METRIC_OPTION_MAP.get(key);
+            return {
+                key,
+                label: option ? metricCardLabel(option) : series.label,
+                series: { ...series, points },
+            };
+        })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+    if (!chartableSeries.length) return null;
+
+    return (
+        <div>
+            <h4 className="mb-3 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-gray-900">
+                <ArrowTrendingUpIcon className="h-3.5 w-3.5 text-[var(--vr-color-primary)]" />
+                Trends
+            </h4>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {chartableSeries.map(({ key, label, series }) => (
+                    <MetricTrendChart
+                        key={key}
+                        series={series}
+                        label={label}
+                        highlightMonth={currentIsoMonth}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/app/components/vibe-raising/VRPreviewUpdateCard.tsx
+++ b/app/components/vibe-raising/VRPreviewUpdateCard.tsx
@@ -1,0 +1,429 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { format } from "date-fns";
+import { clsx } from "clsx";
+import {
+    ArrowRightIcon,
+    ArrowTopRightOnSquareIcon,
+    DocumentArrowUpIcon,
+    ExclamationCircleIcon,
+    LightBulbIcon,
+    LinkIcon,
+    PencilSquareIcon,
+    QuestionMarkCircleIcon,
+    SparklesIcon,
+} from "@heroicons/react/24/outline";
+import StartupRegionBadge from "~/components/StartupRegionBadge";
+import { ActiveDraftRunChip } from "~/components/ActiveDraftRunStatus";
+import { parseVibeRaisingMonthYear, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
+import {
+    VIBE_METRIC_OPTIONS,
+    VIBE_METRIC_OPTION_MAP,
+    hasDisplayableMetricValue,
+    metricCardLabel,
+    type MetricOption,
+} from "~/lib/vibe-raising-metrics";
+
+export function MetricCard({ label, value, icon: _Icon, active = true }: { label: string, value: string, icon: any, colorClass?: string, active?: boolean }) {
+    return (
+        <div className={clsx(
+            "flex flex-col items-center justify-center rounded-xl border px-3 py-4 text-center",
+            active
+                ? "border-[var(--vr-color-border-md)] bg-white shadow-sm"
+                : "border-gray-200 bg-gray-50/80 opacity-45"
+        )}>
+            <p className={clsx(
+                "text-base font-black leading-tight sm:text-[1.75rem]",
+                active ? "text-gray-900" : "text-gray-300"
+            )}>{active ? value : "—"}</p>
+            <p className={clsx(
+                "mt-2 text-[11px] font-bold uppercase tracking-[0.12em]",
+                active ? "text-gray-600" : "text-gray-400"
+            )}>{label}</p>
+        </div>
+    );
+}
+
+// Split a text blob into bullet items on newlines or sentence boundaries.
+export function splitItems(text: string): string[] {
+    if (!text) return [];
+    return text.includes("\n")
+        ? text.split(/\n+/).filter(s => s.trim())
+        : text.split(/(?<=\.)\s+/).filter(s => s.trim());
+}
+
+function VRPreviewUpdateSection({
+    icon: Icon,
+    iconClassName,
+    label,
+    text,
+}: {
+    icon: any;
+    iconClassName: string;
+    label: string;
+    text?: string | null;
+}) {
+    const normalizedText = String(text || "").trim();
+    const items = splitItems(normalizedText);
+    const [mobileExpanded, setMobileExpanded] = useState(false);
+    const shouldClampOnMobile = items.length > 1;
+    const visibleItems = mobileExpanded ? items : items.slice(0, 1);
+
+    if (!normalizedText) return null;
+
+    return (
+        <div>
+            <h4 className="mb-1.5 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-gray-900">
+                <Icon className={clsx("h-3.5 w-3.5", iconClassName)} />
+                {label}
+            </h4>
+            <ul className="space-y-1 list-disc list-inside text-sm text-gray-600">
+                {visibleItems.map((item, index) => (
+                    <li key={`${label}-${index}`}>{item.trim()}</li>
+                ))}
+            </ul>
+            {shouldClampOnMobile ? (
+                <button
+                    type="button"
+                    onClick={() => setMobileExpanded((current) => !current)}
+                    className="mt-2 inline-flex text-xs font-bold text-[var(--vr-color-primary)] sm:hidden"
+                >
+                    {mobileExpanded ? "Show less" : `Show all ${items.length}`}
+                </button>
+            ) : null}
+        </div>
+    );
+}
+
+function getUpdateFileExtension(fileName?: string | null) {
+    const clean = String(fileName || "").split("?")[0]?.split("#")[0] || "";
+    const lastDot = clean.lastIndexOf(".");
+    return lastDot >= 0 ? clean.slice(lastDot).toLowerCase() : "";
+}
+
+export function formatUpdateFileSize(bytes?: number | null) {
+    if (!bytes || !Number.isFinite(bytes)) return "";
+    if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+function isUpdatePdfPitchDeck(contentType?: string | null, fileName?: string | null, src?: string | null) {
+    return (
+        String(contentType || "").split(";")[0].trim().toLowerCase() === "application/pdf" ||
+        getUpdateFileExtension(fileName || src || "") === ".pdf"
+    );
+}
+
+function VRPitchDeckPreview({
+    src,
+    contentType,
+    fileName,
+    fileSizeBytes,
+}: {
+    src: string;
+    contentType?: string | null;
+    fileName?: string | null;
+    fileSizeBytes?: number | null;
+}) {
+    const isPdf = isUpdatePdfPitchDeck(contentType, fileName, src);
+    const previewSrc = isPdf ? `${src}#page=1&toolbar=0&navpanes=0&scrollbar=0` : src;
+    const fileSize = formatUpdateFileSize(fileSizeBytes);
+
+    return (
+        <div className="overflow-hidden rounded-2xl border border-[var(--vr-color-border)] bg-[var(--vr-palette-paper)] text-left">
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--vr-color-border)] px-4 py-3">
+                <div className="min-w-0">
+                    <p className="truncate text-sm font-black text-gray-950">
+                        {fileName || (isPdf ? "Pitch deck PDF" : "Pitch deck")}
+                    </p>
+                    <p className="mt-0.5 text-xs font-semibold text-slate-500">
+                        {isPdf ? "First page preview" : "Pitch deck attached"}
+                        {fileSize ? ` · ${fileSize}` : ""}
+                    </p>
+                </div>
+                <a
+                    href={src}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(event) => event.stopPropagation()}
+                    className="flex-shrink-0 rounded-lg bg-white px-3 py-2 text-xs font-bold text-gray-950 ring-1 ring-[var(--vr-color-border)] transition hover:text-[var(--vr-color-primary)]"
+                >
+                    Open
+                </a>
+            </div>
+            {isPdf ? (
+                <iframe
+                    src={previewSrc}
+                    title="Pitch deck first page preview"
+                    className="h-80 w-full bg-white"
+                />
+            ) : (
+                <div className="flex min-h-48 flex-col items-center justify-center px-6 py-8 text-center">
+                    <DocumentArrowUpIcon className="h-10 w-10 text-slate-300" />
+                    <p className="mt-3 text-sm font-black text-gray-950">Deck uploaded</p>
+                    <p className="mt-2 max-w-sm text-sm leading-6 text-slate-500">
+                        The file is attached and ready for investors to open.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function VRPreviewUpdateCard({
+    update,
+    user,
+    statusLabel,
+    trendsSlot,
+}: {
+    update: any;
+    user: any;
+    statusLabel?: string;
+    trendsSlot?: React.ReactNode;
+}) {
+    const updatePeriod = update.year
+        ? { month: update.monthName || parseVibeRaisingMonthYear(update.month).month, year: update.year }
+        : parseVibeRaisingMonthYear(update.month);
+    const updateSummary = update.summary || "";
+    const updateSourceUrl = update.sourceUrl || "";
+    const updateDate = new Date(update.date);
+    const formattedDate = Number.isNaN(updateDate.getTime())
+        ? ""
+        : format(updateDate, "MMMM d, yyyy");
+    const valuedMetricOptions = VIBE_METRIC_OPTIONS.filter((option) =>
+        hasDisplayableMetricValue(update.metrics?.[option.key]),
+    );
+    // The founder's per-update choice of metrics for the full view; without
+    // a config (older data, dev stubs) every valued metric renders.
+    const fullMetricKeys: string[] | null = update.displayConfig?.fullMetricKeys ?? null;
+    const metrics = fullMetricKeys
+        ? fullMetricKeys
+            .map((key) => VIBE_METRIC_OPTION_MAP.get(key))
+            .filter((option): option is MetricOption => Boolean(option))
+            .filter((option) => hasDisplayableMetricValue(update.metrics?.[option.key]))
+        : valuedMetricOptions;
+    const companyName = user.companyName || "Company";
+    const pitchDeckUrl = String(update.pitchDeckUrl || "").trim();
+    const pitchDeckSummary = String(update.pitchDeckSummary || "").trim();
+    const pitchDeckFileName = String(update.pitchDeckOriginalFilename || "").trim();
+    const pitchDeckFileSize = formatUpdateFileSize(update.pitchDeckFileSizeBytes);
+    const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
+    const canExpandSummary = updateSummary.length > 180;
+
+    return (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+            <div className="relative h-24 w-full overflow-hidden sm:h-32">
+                <div className="absolute inset-0 bg-[linear-gradient(135deg,var(--vr-palette-teal)_0%,var(--vr-palette-mint)_100%)]" />
+                <svg className="absolute inset-0 h-full w-full opacity-[0.12]" viewBox="0 0 800 200">
+                    <circle cx="120" cy="80" r="100" fill="white" />
+                    <circle cx="650" cy="140" r="70" fill="white" />
+                    <circle cx="400" cy="30" r="50" fill="white" />
+                    <rect x="250" y="100" width="180" height="180" rx="40" fill="white" transform="rotate(-15 340 190)" />
+                </svg>
+                <div className="absolute inset-0 flex items-end px-4 pb-3 sm:px-6 sm:pb-4">
+                    <div className="flex items-center gap-3">
+                        {user.domain ? (
+                            <img
+                                src={`https://www.google.com/s2/favicons?domain=${user.domain}&sz=64`}
+                                alt=""
+                                className="h-10 w-10 rounded-lg border border-white/30 bg-white/20 object-cover shadow-sm backdrop-blur-sm"
+                            />
+                        ) : (
+                            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/30 bg-white/20 backdrop-blur-sm">
+                                <span className="text-sm font-bold text-white">{companyName.charAt(0)}</span>
+                            </div>
+                        )}
+                        <div>
+                            <p className="text-sm font-bold text-white drop-shadow-sm">{companyName}</p>
+                            <p className="text-xs text-white/70">Investor Update</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="border-b border-gray-100 px-4 pb-4 pt-5 sm:px-6 sm:pt-6">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                        <div className="flex items-start justify-between gap-3 sm:block">
+                            <h3 className="text-lg font-bold text-gray-900">
+                                {updatePeriod.month} {updatePeriod.year} Update
+                            </h3>
+                            <Link
+                                to={`/founder-tools/updates/create?edit=${encodeURIComponent(update.id)}`}
+                                className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-black text-gray-500 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-200 hover:text-gray-700 sm:hidden"
+                            >
+                                Edit
+                                <PencilSquareIcon className="h-3.5 w-3.5" />
+                            </Link>
+                        </div>
+                        <div className="mt-2 flex flex-wrap items-center gap-2 sm:hidden">
+                            <StartupRegionBadge location={user.location} />
+                            {statusLabel ? (
+                                <span className="rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-black text-gray-500 ring-1 ring-gray-200">
+                                    {statusLabel}
+                                </span>
+                            ) : null}
+                            <ActiveDraftRunChip />
+                            {formattedDate ? (
+                                <span className="rounded-lg bg-white px-3 py-1.5 text-xs font-bold text-gray-400 ring-1 ring-gray-200">
+                                    {formattedDate}
+                                </span>
+                            ) : null}
+                        </div>
+                        <div className="mt-2 hidden flex-wrap items-center gap-2 sm:flex">
+                            <VibeRaisingDateTabs month={updatePeriod.month} year={updatePeriod.year} size="compact" />
+                            <StartupRegionBadge location={user.location} />
+                            {statusLabel ? (
+                                <span className="rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-black text-gray-500 ring-1 ring-gray-200">
+                                    {statusLabel}
+                                </span>
+                            ) : null}
+                            <ActiveDraftRunChip />
+                            <Link
+                                to={`/founder-tools/updates/create?edit=${encodeURIComponent(update.id)}`}
+                                className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-black text-gray-500 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-200 hover:text-gray-700"
+                            >
+                                Edit
+                                <PencilSquareIcon className="h-3.5 w-3.5" />
+                            </Link>
+                        </div>
+                    </div>
+                    {formattedDate ? (
+                        <span className="hidden text-xs text-gray-400 sm:block">{formattedDate}</span>
+                    ) : null}
+                </div>
+            </div>
+
+            {metrics.length > 0 ? (
+                <div className="border-b border-gray-100 bg-gray-50/50 px-4 py-4 sm:px-6">
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+                        {metrics.map((metric) => (
+                            <MetricCard
+                                key={metric.key}
+                                label={metricCardLabel(metric)}
+                                value={update.metrics[metric.key]}
+                                icon={metric.icon}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ) : null}
+
+            {trendsSlot ? (
+                <div className="border-b border-gray-100 px-4 py-4 sm:px-6 sm:py-5">
+                    {trendsSlot}
+                </div>
+            ) : null}
+
+            {pitchDeckUrl ? (
+                <div className="border-b border-gray-100 bg-gray-50/50 px-4 py-4 sm:px-6 sm:py-5">
+                    <div className="space-y-4">
+                        <div>
+                            <p className="text-xs font-black uppercase tracking-[0.18em] text-[var(--vr-color-primary)]">
+                                Pitch deck
+                            </p>
+                            {pitchDeckSummary ? (
+                                <p className="mt-2 text-sm leading-6 text-slate-500">{pitchDeckSummary}</p>
+                            ) : null}
+                        </div>
+                        <div className="rounded-2xl border border-[var(--vr-color-border)] bg-white px-4 py-4 sm:hidden">
+                            <div className="flex items-start gap-3">
+                                <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.12)] text-[var(--vr-color-primary)]">
+                                    <DocumentArrowUpIcon className="h-5 w-5" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-sm font-black text-gray-950">Deck attached</p>
+                                    <p className="mt-1 text-sm leading-6 text-slate-500">
+                                        {pitchDeckFileName || "Pitch deck file"}{pitchDeckFileSize ? ` · ${pitchDeckFileSize}` : ""}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="hidden sm:block">
+                            <VRPitchDeckPreview
+                                src={pitchDeckUrl}
+                                contentType={update.pitchDeckContentType}
+                                fileName={update.pitchDeckOriginalFilename}
+                                fileSizeBytes={update.pitchDeckFileSizeBytes}
+                            />
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+
+            <div className="space-y-4 px-4 py-4 sm:space-y-5 sm:px-6 sm:py-5">
+                {(updateSummary || updateSourceUrl) ? (
+                    <div className="space-y-3 rounded-xl border border-gray-100 bg-gray-50/70 px-4 py-3 sm:p-4">
+                        {updateSummary ? (
+                            <div className="space-y-2">
+                                <p
+                                    className={clsx(
+                                        "text-sm font-medium leading-6 text-gray-700",
+                                        !isSummaryExpanded && "line-clamp-4 sm:line-clamp-none",
+                                    )}
+                                >
+                                    {updateSummary}
+                                </p>
+                                {canExpandSummary ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => setIsSummaryExpanded((current) => !current)}
+                                        className="inline-flex text-xs font-black uppercase tracking-[0.14em] text-[var(--vr-color-primary)] transition hover:text-[var(--vr-palette-black)] sm:hidden"
+                                        aria-expanded={isSummaryExpanded}
+                                    >
+                                        {isSummaryExpanded ? "Show less" : "Show more"}
+                                    </button>
+                                ) : null}
+                            </div>
+                        ) : null}
+                        {updateSourceUrl ? (
+                            <a
+                                href={updateSourceUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-2 text-xs font-bold text-[var(--vr-color-primary)] hover:text-[var(--vr-palette-black)]"
+                            >
+                                <LinkIcon className="h-3.5 w-3.5" />
+                                Source materials
+                                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                            </a>
+                        ) : null}
+                    </div>
+                ) : null}
+
+                <VRPreviewUpdateSection
+                    icon={SparklesIcon}
+                    iconClassName="text-[var(--vr-palette-purple)]"
+                    label="Key Highlights"
+                    text={update.highlights}
+                />
+                <VRPreviewUpdateSection
+                    icon={ExclamationCircleIcon}
+                    iconClassName="text-[var(--vr-palette-orange)]"
+                    label="Challenges"
+                    text={update.challenges}
+                />
+                <VRPreviewUpdateSection
+                    icon={LightBulbIcon}
+                    iconClassName="text-[var(--vr-palette-yellow)]"
+                    label="Learnings"
+                    text={update.learnings}
+                />
+                <VRPreviewUpdateSection
+                    icon={ArrowRightIcon}
+                    iconClassName="text-[var(--vr-palette-blue)]"
+                    label="Next 30 Days"
+                    text={update.next30Days}
+                />
+                <VRPreviewUpdateSection
+                    icon={QuestionMarkCircleIcon}
+                    iconClassName="text-[var(--vr-palette-lavender)]"
+                    label="Ask from Investors"
+                    text={update.asks}
+                />
+            </div>
+        </div>
+    );
+}
+
+export default VRPreviewUpdateCard;

--- a/app/components/vibe-raising/VRUpdateSnippetCard.tsx
+++ b/app/components/vibe-raising/VRUpdateSnippetCard.tsx
@@ -1,0 +1,129 @@
+import { Link } from "react-router";
+import { format } from "date-fns";
+import { ArrowRightIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
+import StartupRegionBadge from "~/components/StartupRegionBadge";
+import { parseVibeRaisingMonthYear, VibeRaisingDateTabs } from "~/components/VibeRaisingDateTabs";
+import type { VibeRaisingMetricHistory } from "~/types/vibe-raising";
+import {
+    VIBE_METRIC_OPTIONS,
+    VIBE_METRIC_OPTION_MAP,
+    hasDisplayableMetricValue,
+    metricCardLabel,
+    type MetricOption,
+} from "~/lib/vibe-raising-metrics";
+import { windowPointsToMonth } from "~/lib/vibe-raising-metric-history";
+import MetricSparkline from "./MetricSparkline";
+import { splitItems } from "./VRPreviewUpdateCard";
+
+const MAX_SNIPPET_METRICS = 4;
+
+// Compact TLDR card for the Past Updates list: headline metrics (with
+// sparklines), the summary, and a link through to the full article.
+export default function VRUpdateSnippetCard({
+    update,
+    user,
+    metricHistory,
+    statusLabel = "Sent",
+}: {
+    update: any;
+    user: any;
+    metricHistory: VibeRaisingMetricHistory;
+    statusLabel?: string;
+}) {
+    const updatePeriod = update.year
+        ? { month: update.monthName || parseVibeRaisingMonthYear(update.month).month, year: update.year }
+        : parseVibeRaisingMonthYear(update.month);
+    const updateDate = new Date(update.date);
+    const formattedDate = Number.isNaN(updateDate.getTime())
+        ? ""
+        : format(updateDate, "MMMM d, yyyy");
+
+    const summaryText = String(update.summary || "").trim();
+    const fallbackExcerpt = splitItems(String(update.highlights || ""))[0] || "";
+    const excerpt = summaryText || fallbackExcerpt;
+
+    // The founder's per-update snippet selection; older data without a
+    // config falls back to the first few valued metrics.
+    const snippetKeys: string[] | null = update.displayConfig?.snippetMetricKeys ?? null;
+    const valuedOptions = VIBE_METRIC_OPTIONS.filter((option) =>
+        hasDisplayableMetricValue(update.metrics?.[option.key]),
+    );
+    const metrics = (snippetKeys
+        ? snippetKeys
+            .map((key) => VIBE_METRIC_OPTION_MAP.get(key))
+            .filter((option): option is MetricOption => Boolean(option))
+            .filter((option) => hasDisplayableMetricValue(update.metrics?.[option.key]))
+        : valuedOptions
+    ).slice(0, MAX_SNIPPET_METRICS);
+
+    return (
+        <div className="flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+            <div className="flex flex-wrap items-center justify-between gap-2 px-4 pt-4 sm:px-5">
+                <h3 className="text-base font-bold text-gray-900">
+                    {updatePeriod.month} {updatePeriod.year} Update
+                </h3>
+                <Link
+                    to={`/founder-tools/updates/create?edit=${encodeURIComponent(update.id)}`}
+                    className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-2.5 py-1 text-xs font-black text-gray-500 ring-1 ring-gray-200 transition hover:bg-gray-200 hover:text-gray-700"
+                >
+                    Edit
+                    <PencilSquareIcon className="h-3.5 w-3.5" />
+                </Link>
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-2 px-4 sm:px-5">
+                <VibeRaisingDateTabs month={updatePeriod.month} year={updatePeriod.year} size="compact" />
+                <StartupRegionBadge location={user.location} />
+                {statusLabel ? (
+                    <span className="rounded-lg bg-gray-100 px-2.5 py-1 text-xs font-black text-gray-500 ring-1 ring-gray-200">
+                        {statusLabel}
+                    </span>
+                ) : null}
+                {formattedDate ? (
+                    <span className="text-xs text-gray-400">{formattedDate}</span>
+                ) : null}
+            </div>
+
+            {excerpt ? (
+                <p className="mt-3 px-4 text-sm font-medium leading-6 text-gray-700 line-clamp-3 sm:px-5">
+                    {excerpt}
+                </p>
+            ) : null}
+
+            {metrics.length > 0 ? (
+                <div className={`mt-4 grid gap-2 px-4 sm:px-5 ${metrics.length > 2 ? "grid-cols-2 sm:grid-cols-4" : "grid-cols-2"}`}>
+                    {metrics.map((metric) => {
+                        const series = metricHistory[metric.key];
+                        const points = series
+                            ? windowPointsToMonth(series.points, update.isoMonth)
+                            : [];
+                        return (
+                            <div
+                                key={metric.key}
+                                className="rounded-xl border border-[var(--vr-color-border)] bg-gray-50/60 px-3 py-2.5"
+                            >
+                                <p className="truncate text-sm font-black leading-tight text-gray-900">
+                                    {update.metrics[metric.key]}
+                                </p>
+                                <p className="mt-1 truncate text-[10px] font-bold uppercase tracking-[0.12em] text-gray-500">
+                                    {metricCardLabel(metric)}
+                                </p>
+                                <MetricSparkline points={points} />
+                            </div>
+                        );
+                    })}
+                </div>
+            ) : null}
+
+            <div className="mt-4 border-t border-gray-100 px-4 py-3 sm:px-5">
+                <Link
+                    to={`/founder-tools/updates/${encodeURIComponent(update.id)}`}
+                    className="inline-flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.14em] text-[var(--vr-color-primary)] transition hover:text-[var(--vr-palette-black)]"
+                >
+                    Read full update
+                    <ArrowRightIcon className="h-3.5 w-3.5" />
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/app/lib/vibe-raising-metric-history.ts
+++ b/app/lib/vibe-raising-metric-history.ts
@@ -1,0 +1,46 @@
+import type { VibeRaisingMetricHistoryPoint } from "~/types/vibe-raising";
+
+// History points use "YYYY-MM-DD" (first of month) while updates carry
+// isoMonth as either "YYYY-MM" or "YYYY-MM-DD"; compare on the year-month
+// prefix so both formats line up.
+export function monthKey(month?: string | null): string {
+    return String(month || "").slice(0, 7);
+}
+
+// Points up to (and including) the update's own month, most recent
+// `monthsBack` of them. Without a current month, just the trailing window.
+export function windowPointsToMonth(
+    points: VibeRaisingMetricHistoryPoint[],
+    currentIsoMonth?: string | null,
+    monthsBack = 12,
+): VibeRaisingMetricHistoryPoint[] {
+    const currentKey = monthKey(currentIsoMonth);
+    const windowed = currentKey
+        ? points.filter((point) => monthKey(point.month) <= currentKey)
+        : points;
+    return monthsBack > 0 ? windowed.slice(-monthsBack) : windowed;
+}
+
+export function formatMonthLabel(month: string): string {
+    const [year, monthNumber] = month.split("-");
+    const monthIndex = Number(monthNumber) - 1;
+    const yearNumber = Number(year);
+    if (!Number.isFinite(yearNumber) || monthIndex < 0 || monthIndex > 11) {
+        return month;
+    }
+    const date = new Date(yearNumber, monthIndex, 1);
+    return date.toLocaleDateString("en-AU", { month: "short", year: "2-digit" });
+}
+
+export function formatCompactNumber(value: number): string {
+    const formatScaled = (scaled: number, suffix: string) => {
+        const rounded = Math.round(scaled * 10) / 10;
+        const text = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+        return `${text}${suffix}`;
+    };
+    const abs = Math.abs(value);
+    if (abs >= 1_000_000_000) return formatScaled(value / 1_000_000_000, "b");
+    if (abs >= 1_000_000) return formatScaled(value / 1_000_000, "m");
+    if (abs >= 1_000) return formatScaled(value / 1_000, "k");
+    return formatScaled(value, "");
+}

--- a/app/lib/vibe-raising-metrics.tsx
+++ b/app/lib/vibe-raising-metrics.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import {
+    ArrowPathIcon,
+    ArrowRightIcon,
+    BanknotesIcon,
+    ChartBarIcon,
+    CurrencyDollarIcon,
+    FireIcon,
+    LightBulbIcon,
+    SparklesIcon,
+    UsersIcon,
+} from "@heroicons/react/24/outline";
+
+// Single source of truth for the vibe-raising metric catalog. Keys mirror
+// the backend catalog in mlai-backend startup_updates/metric_catalog.py.
+export interface MetricOption {
+    key: string;
+    label: string;
+    placeholder: string;
+    prefix?: string;
+    icon: React.ReactNode;
+    info?: string;
+}
+
+export const VIBE_METRIC_OPTIONS: MetricOption[] = [
+    { key: "revenue", label: "Revenue (AUD)", placeholder: "50,000", prefix: "$", icon: <CurrencyDollarIcon className="w-4 h-4 text-gray-400" />, info: "Your total income this month." },
+    { key: "activeUsers", label: "Active Users", placeholder: "1,500", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Unique users who engaged with your product this month." },
+    { key: "mrr", label: "MRR (AUD)", placeholder: "10,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Monthly recurring revenue from active subscriptions." },
+    { key: "burnRate", label: "Burn Rate (AUD)", placeholder: "20,000", prefix: "$", icon: <FireIcon className="w-4 h-4 text-gray-400" />, info: "How much capital the company is spending per month." },
+    { key: "runway", label: "Runway", placeholder: "18 months", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Estimated time before the company needs more funding." },
+    { key: "monthlyCosts", label: "Costs (AUD)", placeholder: "25,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Total monthly costs from Xero Profit and Loss expense rows." },
+    { key: "invoiceRevenue", label: "Invoice Revenue", placeholder: "45,000", prefix: "$", icon: <CurrencyDollarIcon className="w-4 h-4 text-gray-400" />, info: "Sales invoice revenue from accounting data." },
+    { key: "cashCollected", label: "Cash Collected", placeholder: "42,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Cash received from accounting payments." },
+    { key: "revenueGrowthRate", label: "Revenue Growth", placeholder: "12%", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Month-on-month revenue or MRR growth when source data supports it." },
+    { key: "customerCount", label: "Customers", placeholder: "24", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Number of active or paying customers when source data supports it." },
+    { key: "churn", label: "Churn", placeholder: "2%", icon: <ArrowPathIcon className="w-4 h-4 text-gray-400" />, info: "Customer or revenue churn when source data supports it." },
+    { key: "invoiceCount", label: "Invoices", placeholder: "12", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Sales invoice count or invoices sent this month." },
+    { key: "recurringInvoiceCount", label: "Recurring Invoices", placeholder: "6", icon: <ArrowPathIcon className="w-4 h-4 text-gray-400" />, info: "Active recurring invoice count from accounting data." },
+    { key: "websiteVisitors", label: "Website Visitors", placeholder: "1,200", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Visitors to the company website this month." },
+    { key: "waitlistSignups", label: "Waitlist Signups", placeholder: "85", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "People who joined the waitlist this month." },
+    { key: "demoRequests", label: "Demo Requests", placeholder: "14", icon: <ArrowRightIcon className="w-4 h-4 text-gray-400" />, info: "Inbound requests to see or try the product." },
+    { key: "customerInterviews", label: "Customer Interviews", placeholder: "10", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Potential or current customers interviewed this month." },
+    { key: "experimentsRun", label: "Experiments Run", placeholder: "4", icon: <LightBulbIcon className="w-4 h-4 text-gray-400" />, info: "Validation, growth, product, or pricing experiments completed." },
+    { key: "pilotCount", label: "Pilots", placeholder: "3", icon: <SparklesIcon className="w-4 h-4 text-gray-400" />, info: "Active pilots, design partners, or trials." },
+    { key: "qualifiedPipeline", label: "Qualified Pipeline", placeholder: "250,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Qualified sales pipeline with customer intent." },
+];
+
+export const VIBE_METRIC_OPTION_MAP = new Map(
+    VIBE_METRIC_OPTIONS.map((option) => [option.key, option]),
+);
+
+export const VIBE_METRIC_KEYS = VIBE_METRIC_OPTIONS.map((option) => option.key);
+
+// Compact label for metric cards ("Revenue (AUD)" -> "Revenue").
+export function metricCardLabel(option: MetricOption): string {
+    return option.label.replace(/\s*\(AUD\)\s*$/i, "");
+}
+
+export function hasDisplayableMetricValue(value: unknown): boolean {
+    if (value === null || value === undefined) return false;
+
+    const rawValue = String(value).trim();
+    if (!rawValue) return false;
+
+    const lowerValue = rawValue.toLowerCase();
+    return !["null", "undefined", "-", "—"].includes(lowerValue);
+}

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -32,6 +32,10 @@ import type {
   VibeRaisingManualDocumentDownloadResponse,
   VibeRaisingManualDocumentUploadResponse,
   VibeRaisingManualDocumentUploadSessionResponse,
+  VibeRaisingMetricDisplayConfig,
+  VibeRaisingMetricHistory,
+  VibeRaisingMetricHistoryPoint,
+  VibeRaisingMetricHistorySeries,
   VibeRaisingMetricSuggestion,
   VibeRaisingMonthlyUpdate,
   VibeRaisingProfile,
@@ -726,6 +730,80 @@ function normalizeEmailDraftMonth(raw: unknown): VibeRaisingEmailDraftMonth | nu
   };
 }
 
+function normalizeMetricKeyList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const keys: string[] = [];
+  for (const item of raw) {
+    const key = typeof item === "string" ? item.trim() : "";
+    if (key && !keys.includes(key)) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+export function normalizeDisplayConfig(raw: unknown): VibeRaisingMetricDisplayConfig | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const payload = raw as Record<string, unknown>;
+  const snippetMetricKeys = normalizeMetricKeyList(
+    payload.snippetMetricKeys ?? payload.snippet_metric_keys,
+  );
+  const fullMetricKeys = normalizeMetricKeyList(
+    payload.fullMetricKeys ?? payload.full_metric_keys,
+  );
+  for (const key of snippetMetricKeys) {
+    if (!fullMetricKeys.includes(key)) {
+      fullMetricKeys.push(key);
+    }
+  }
+  return { snippetMetricKeys, fullMetricKeys };
+}
+
+export function normalizeMetricHistory(raw: unknown): VibeRaisingMetricHistory {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+
+  const history: VibeRaisingMetricHistory = {};
+  for (const [rawKey, rawSeries] of Object.entries(raw as Record<string, unknown>)) {
+    if (!rawSeries || typeof rawSeries !== "object") continue;
+    const seriesPayload = rawSeries as Record<string, unknown>;
+    const metricKey =
+      asNullableString(seriesPayload.metricKey) ??
+      asNullableString(seriesPayload.metric_key) ??
+      rawKey;
+    if (!metricKey) continue;
+
+    const points: VibeRaisingMetricHistoryPoint[] = [];
+    const rawPoints = Array.isArray(seriesPayload.points) ? seriesPayload.points : [];
+    for (const rawPoint of rawPoints) {
+      if (!rawPoint || typeof rawPoint !== "object") continue;
+      const pointPayload = rawPoint as Record<string, unknown>;
+      const month = asNullableString(pointPayload.month);
+      const value = Number(pointPayload.value);
+      if (!month || !Number.isFinite(value)) continue;
+      points.push({
+        month,
+        value,
+        valueText:
+          asNullableString(pointPayload.valueText) ??
+          asNullableString(pointPayload.value_text) ??
+          String(pointPayload.value),
+      });
+    }
+    if (!points.length) continue;
+    points.sort((a, b) => a.month.localeCompare(b.month));
+
+    const series: VibeRaisingMetricHistorySeries = {
+      metricKey,
+      label: asNullableString(seriesPayload.label) ?? metricKey,
+      unit: asNullableString(seriesPayload.unit),
+      points,
+    };
+    history[metricKey] = series;
+  }
+  return history;
+}
+
 function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
   if (!raw || typeof raw !== "object") return null;
 
@@ -819,6 +897,7 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
     metricSuggestions: normalizeMetricSuggestions(
       payload.metricSuggestions ?? payload.metric_suggestions,
     ),
+    displayConfig: normalizeDisplayConfig(payload.displayConfig ?? payload.display_config),
     highlights: asNullableString(payload.highlights) ?? "",
     challenges: asNullableString(payload.challenges) ?? "",
     asks: asNullableString(payload.asks) ?? "",
@@ -1809,9 +1888,13 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     sourceUrl: "https://mlai.au/founder-tools/updates",
     metrics: {
       revenue: "250+ matches",
-      users: "10k+ professionals",
+      activeUsers: "10k+ professionals",
       mrr: "12 paying pilots",
       runway: "MAP cohort",
+    },
+    displayConfig: {
+      snippetMetricKeys: ["revenue", "activeUsers"],
+      fullMetricKeys: ["revenue", "activeUsers", "mrr", "runway"],
     },
     highlights:
       "Accepted into the Melbourne Accelerator Program (MAP), giving us a five-month runway of mentoring, ecosystem access, and Demo Day preparation.\nRolled out a simpler pricing model across Free, Solo, and Micro tiers, with early-bird discounts live until January 30.\nPilots are active with 3 support coordinators and 10 allied-health clinics, helping us pressure-test matching quality and workflow fit.",
@@ -1841,9 +1924,13 @@ const DEV_MONTHLY_DRAFTS_STUB: VibeRaisingMonthlyUpdate[] = [
     sourceUrl: "https://mlai.au/founder-tools/drafts",
     metrics: {
       revenue: "300+ matches",
-      users: "11k+ professionals",
+      activeUsers: "11k+ professionals",
       mrr: "14 paying pilots",
       runway: "MAP cohort",
+    },
+    displayConfig: {
+      snippetMetricKeys: ["revenue", "activeUsers"],
+      fullMetricKeys: ["revenue", "activeUsers", "mrr", "runway"],
     },
     highlights: "Drafted the May topline around MAP progress, pilot expansion, and marketplace match quality.",
     challenges: "Still refining the conversion benchmark story before publishing.",
@@ -1853,43 +1940,94 @@ const DEV_MONTHLY_DRAFTS_STUB: VibeRaisingMonthlyUpdate[] = [
   },
 ];
 
-export async function getVibeRaisingMonthlyUpdates(
+const DEV_METRIC_HISTORY_STUB: VibeRaisingMetricHistory = {
+  revenue: {
+    metricKey: "revenue",
+    label: "Revenue",
+    unit: "",
+    points: [
+      { month: "2025-08-01", value: 60, valueText: "60 matches" },
+      { month: "2025-09-01", value: 95, valueText: "95 matches" },
+      { month: "2025-10-01", value: 120, valueText: "120+ matches" },
+      { month: "2025-11-01", value: 150, valueText: "150+ matches" },
+      { month: "2025-12-01", value: 210, valueText: "210+ matches" },
+      { month: "2026-01-01", value: 250, valueText: "250+ matches" },
+    ],
+  },
+  activeUsers: {
+    metricKey: "activeUsers",
+    label: "Active Users",
+    unit: "",
+    points: [
+      { month: "2025-08-01", value: 4200, valueText: "4.2k professionals" },
+      { month: "2025-09-01", value: 5600, valueText: "5.6k professionals" },
+      { month: "2025-10-01", value: 7100, valueText: "7.1k professionals" },
+      { month: "2025-11-01", value: 8400, valueText: "8.4k professionals" },
+      { month: "2025-12-01", value: 9300, valueText: "9.3k professionals" },
+      { month: "2026-01-01", value: 10000, valueText: "10k+ professionals" },
+    ],
+  },
+};
+
+export interface VibeRaisingMonthlyUpdatesBundle {
+  updates: VibeRaisingMonthlyUpdate[];
+  metricHistory: VibeRaisingMetricHistory;
+}
+
+const DEV_MONTHLY_UPDATES_BUNDLE_STUB: VibeRaisingMonthlyUpdatesBundle = {
+  updates: DEV_MONTHLY_UPDATES_STUB,
+  metricHistory: DEV_METRIC_HISTORY_STUB,
+};
+
+export async function getVibeRaisingMonthlyUpdatesBundle(
   env: Env,
   request: Request,
-): Promise<VibeRaisingMonthlyUpdate[]> {
+): Promise<VibeRaisingMonthlyUpdatesBundle> {
   if (shouldUseDevBackendStub()) {
-    return DEV_MONTHLY_UPDATES_STUB;
+    return DEV_MONTHLY_UPDATES_BUNDLE_STUB;
   }
   const client = createApiClient(env, request);
 
   try {
     const response = await client.get(UPDATES_PATH);
     const updates: unknown[] = Array.isArray(response.data?.updates) ? response.data.updates : [];
-    return updates
-      .map(normalizeMonthlyUpdate)
-      .filter((value): value is VibeRaisingMonthlyUpdate => value !== null);
+    return {
+      updates: updates
+        .map(normalizeMonthlyUpdate)
+        .filter((value): value is VibeRaisingMonthlyUpdate => value !== null),
+      metricHistory: normalizeMetricHistory(
+        response.data?.metricHistory ?? response.data?.metric_history,
+      ),
+    };
   } catch (error: any) {
     if (error.response?.status === 404) {
-      return [];
+      return { updates: [], metricHistory: {} };
     }
 
     if (error.response?.status === 401 && shouldUseDevAuthBypass()) {
       console.warn("No backend monthly update session in local dev; using update stubs.");
-      return DEV_MONTHLY_UPDATES_STUB;
+      return DEV_MONTHLY_UPDATES_BUNDLE_STUB;
     }
 
     if (shouldUseDevAuthBypass() && !error.response) {
       console.warn("Backend monthly update lookup failed before returning a response in local dev; using update stubs.");
-      return DEV_MONTHLY_UPDATES_STUB;
+      return DEV_MONTHLY_UPDATES_BUNDLE_STUB;
     }
 
     if (shouldUseDevBackendFallback(error)) {
       console.warn("Backend unavailable in local dev; using Vibe Raising monthly update stubs for preview.");
-      return DEV_MONTHLY_UPDATES_STUB;
+      return DEV_MONTHLY_UPDATES_BUNDLE_STUB;
     }
 
     throw error;
   }
+}
+
+export async function getVibeRaisingMonthlyUpdates(
+  env: Env,
+  request: Request,
+): Promise<VibeRaisingMonthlyUpdate[]> {
+  return (await getVibeRaisingMonthlyUpdatesBundle(env, request)).updates;
 }
 
 export async function getVibeRaisingDrafts(
@@ -1968,6 +2106,7 @@ export async function saveVibeRaisingMonthlyUpdate(
     next30Days: string;
     metrics: Record<string, string>;
     metricSuggestions?: VibeRaisingMetricSuggestion[];
+    displayConfig?: VibeRaisingMetricDisplayConfig | null;
     summary?: string | null;
     sourceUrl?: string | null;
     pitchDeckUrl?: string | null;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -118,6 +118,7 @@ export default [
     route("company-setup", "routes/vibe-raising-app.company-setup.tsx"),
     route("data-sources", "routes/vibe-raising-app.connect-data.tsx"),
     route("updates/create", "routes/vibe-raising-app.create-update.tsx"),
+    route("updates/:id", "routes/vibe-raising-app.update-detail.tsx"),
     route("discover", "routes/vibe-raising-app.investors.tsx"),
     route("companies", "routes/vibe-raising-app.companies.tsx"),
     route("marketing", "routes/founder-tools.marketing.tsx"),

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -3,11 +3,13 @@ import { format } from "date-fns";
 import { useState, useRef, useEffect } from "react";
 import type { Route } from "./+types/vibe-raising-app._index";
 import {
-    getVibeRaisingMonthlyUpdates,
+    getVibeRaisingMonthlyUpdatesBundle,
     getOptionalVibeRaisingContext,
     getVibeRaisingLoginHref,
 } from "~/lib/vibe-raising";
+import type { VibeRaisingMetricHistory } from "~/types/vibe-raising";
 import { isFounderToolsDiscoverEnabled } from "~/lib/founder-tools-preview";
+import VRUpdateSnippetCard from "~/components/vibe-raising/VRUpdateSnippetCard";
 import { clsx } from "clsx";
 import { getEnv } from "~/lib/env.server";
 import {
@@ -56,17 +58,19 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     }
 
     const user = vibeContext.appUser;
-    const updates = user.role === "founder"
-        ? (await getVibeRaisingMonthlyUpdates(env, request)).map((update, index) => ({
-            ...update,
-            isCurrent: index === 0,
-            score: null,
-            likes: 0,
-            comments: 0,
-            investorsSentTo: 0,
-            investorsViewed: 0,
-        }))
-        : [];
+    const updatesBundle = user.role === "founder"
+        ? await getVibeRaisingMonthlyUpdatesBundle(env, request)
+        : { updates: [], metricHistory: {} };
+    const metricHistory = updatesBundle.metricHistory;
+    const updates = updatesBundle.updates.map((update, index) => ({
+        ...update,
+        isCurrent: index === 0,
+        score: null,
+        likes: 0,
+        comments: 0,
+        investorsSentTo: 0,
+        investorsViewed: 0,
+    }));
 
     // Investor Mock Data
     const portfolioUpdates = [
@@ -86,7 +90,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         }
     ];
 
-    return { user, updates, portfolioUpdates };
+    return { user, updates, metricHistory, portfolioUpdates };
 }
 
 // ─── Auto-resize textarea hook ──────────────────────────────────
@@ -1280,7 +1284,7 @@ function VRPastUpdateRow({
 }
 
 // 1. Founder Dashboard View
-function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
+function FounderDashboard({ user, updates, metricHistory }: { user: any, updates: any[], metricHistory: VibeRaisingMetricHistory }) {
     const { triggerAnnouncement } = useOutletContext<{ triggerAnnouncement: (cb?: () => void) => void }>();
     const navigate = useNavigate();
     const showDiscover = isFounderToolsDiscoverEnabled();
@@ -1632,6 +1636,15 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                         currentUpdate ? (
                             <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
                                 <div className="min-w-0 flex-1">
+                                    <div className="mb-3 flex justify-end">
+                                        <Link
+                                            to={`/founder-tools/updates/${encodeURIComponent(currentUpdate.id)}`}
+                                            className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-black text-gray-500 ring-1 ring-gray-200 transition hover:bg-gray-200 hover:text-gray-700"
+                                        >
+                                            View full update
+                                            <ArrowRightIcon className="h-3.5 w-3.5" />
+                                        </Link>
+                                    </div>
                                     <VRCurrentUpdateCard update={currentUpdate} user={user} />
                                 </div>
                             </div>
@@ -1646,12 +1659,13 @@ function FounderDashboard({ user, updates }: { user: any, updates: any[] }) {
                     ) : (
                         <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
                             {pastUpdates.length > 0 ? (
-                                <div className="min-w-0 flex-1 space-y-4">
+                                <div className="grid min-w-0 flex-1 grid-cols-1 gap-4 md:grid-cols-2">
                                     {pastUpdates.map((u) => (
-                                        <VRPreviewUpdateCard
+                                        <VRUpdateSnippetCard
                                             key={`${user.activeCompanyId || "default"}-${u.id}`}
                                             update={u}
                                             user={user}
+                                            metricHistory={metricHistory}
                                             statusLabel="Sent"
                                         />
                                     ))}
@@ -1796,13 +1810,13 @@ export default function VibeRaisingHome() {
         return null;
     }
 
-    const { user, updates, portfolioUpdates } = data;
+    const { user, updates, metricHistory, portfolioUpdates } = data;
     if (!user) return null;
 
     if (user.role === 'investor') {
         return <InvestorDashboard portfolioUpdates={portfolioUpdates} />;
     }
 
-    return <FounderDashboard user={user} updates={updates} />;
+    return <FounderDashboard user={user} updates={updates} metricHistory={metricHistory} />;
 }
 

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -22,6 +22,13 @@ import {
 } from "~/lib/vibe-raising";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import {
+    VIBE_METRIC_KEYS,
+    VIBE_METRIC_OPTIONS,
+    VIBE_METRIC_OPTION_MAP,
+    hasDisplayableMetricValue,
+    type MetricOption,
+} from "~/lib/vibe-raising-metrics";
+import {
     XMarkIcon,
     SparklesIcon,
     ArrowPathIcon,
@@ -60,7 +67,9 @@ import type {
     VibeRaisingFounderProfile,
     VibeRaisingInputSourceSummary,
     VibeRaisingManualDocument,
+    VibeRaisingMetricDisplayConfig,
     VibeRaisingMetricSuggestion,
+    VibeRaisingMetricVisibility,
     VibeRaisingMonthlyUpdate,
     VibeRaisingStartupUpdateStatusResponse,
     VibeRaisingVideoCompressionMetadata,
@@ -342,6 +351,29 @@ function getMonthlyUpdateStorageKey(update: VibeRaisingMonthlyUpdate) {
     return getMonthlyUpdateKey(parsed.month, parsed.year);
 }
 
+// Accepts either the object shape (loader data) or the JSON string echoed
+// back through the hidden form input on the feedback step.
+function parseDisplayConfigValue(raw: unknown): VibeRaisingMetricDisplayConfig | null {
+    if (!raw) return null;
+    if (typeof raw === "string") {
+        const text = raw.trim();
+        if (!text) return null;
+        try {
+            return parseDisplayConfigValue(JSON.parse(text));
+        } catch {
+            return null;
+        }
+    }
+    if (typeof raw !== "object" || Array.isArray(raw)) return null;
+    const candidate = raw as Record<string, unknown>;
+    const toKeys = (value: unknown) =>
+        Array.isArray(value) ? value.map(String).filter(Boolean) : [];
+    return {
+        snippetMetricKeys: toKeys(candidate.snippetMetricKeys),
+        fullMetricKeys: toKeys(candidate.fullMetricKeys),
+    };
+}
+
 function buildExistingUpdateFormData(update: VibeRaisingMonthlyUpdate) {
     const parsedPeriod = parseVibeRaisingMonthYear(update.month);
     const metrics = update.metrics || {};
@@ -369,6 +401,7 @@ function buildExistingUpdateFormData(update: VibeRaisingMonthlyUpdate) {
         next30Days: update.next30Days || "",
         metrics,
         metricSuggestions: update.metricSuggestions || [],
+        displayConfig: update.displayConfig || null,
         metricKeys: Object.keys(metrics).join(","),
         ...metrics,
     };
@@ -429,6 +462,7 @@ function buildMonthlyUpdateSavePayload(formData: FormData) {
             .filter(([, value]) => value.length > 0),
     );
     const metricSuggestions = metricSuggestionsFromKeys(selectedMetricKeys, metrics);
+    const displayConfig = parseDisplayConfigValue(formData.get("displayConfig"));
     const rawPitchDeckFileSizeBytes = Number(formData.get("pitchDeckFileSizeBytes") || 0);
     const rawVideoUrl = String(formData.get("videoUrl") || "").trim();
     const rawVideoFileSizeBytes = Number(formData.get("videoFileSizeBytes") || 0);
@@ -462,6 +496,7 @@ function buildMonthlyUpdateSavePayload(formData: FormData) {
         next30Days: String(formData.get("next30Days") || ""),
         metrics,
         metricSuggestions,
+        displayConfig,
     };
 }
 
@@ -653,50 +688,11 @@ export async function action({ request, context }: Route.ActionArgs) {
 }
 
 // ─── Metric Options ──────────────────────────────────────────────
-interface MetricOption {
-    key: string;
-    label: string;
-    placeholder: string;
-    prefix?: string;
-    icon: React.ReactNode;
-    info?: string;
-}
-
-const METRIC_OPTIONS: MetricOption[] = [
-    { key: "revenue", label: "Revenue (AUD)", placeholder: "50,000", prefix: "$", icon: <CurrencyDollarIcon className="w-4 h-4 text-gray-400" />, info: "Your total income this month." },
-    { key: "activeUsers", label: "Active Users", placeholder: "1,500", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Unique users who engaged with your product this month." },
-    { key: "mrr", label: "MRR (AUD)", placeholder: "10,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Monthly recurring revenue from active subscriptions." },
-    { key: "burnRate", label: "Burn Rate (AUD)", placeholder: "20,000", prefix: "$", icon: <FireIcon className="w-4 h-4 text-gray-400" />, info: "How much capital the company is spending per month." },
-    { key: "runway", label: "Runway", placeholder: "18 months", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Estimated time before the company needs more funding." },
-    { key: "monthlyCosts", label: "Costs (AUD)", placeholder: "25,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Total monthly costs from Xero Profit and Loss expense rows." },
-    { key: "invoiceRevenue", label: "Invoice Revenue", placeholder: "45,000", prefix: "$", icon: <CurrencyDollarIcon className="w-4 h-4 text-gray-400" />, info: "Sales invoice revenue from accounting data." },
-    { key: "cashCollected", label: "Cash Collected", placeholder: "42,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Cash received from accounting payments." },
-    { key: "revenueGrowthRate", label: "Revenue Growth", placeholder: "12%", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Month-on-month revenue or MRR growth when source data supports it." },
-    { key: "customerCount", label: "Customers", placeholder: "24", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Number of active or paying customers when source data supports it." },
-    { key: "churn", label: "Churn", placeholder: "2%", icon: <ArrowPathIcon className="w-4 h-4 text-gray-400" />, info: "Customer or revenue churn when source data supports it." },
-    { key: "invoiceCount", label: "Invoices", placeholder: "12", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Sales invoice count or invoices sent this month." },
-    { key: "recurringInvoiceCount", label: "Recurring Invoices", placeholder: "6", icon: <ArrowPathIcon className="w-4 h-4 text-gray-400" />, info: "Active recurring invoice count from accounting data." },
-    { key: "websiteVisitors", label: "Website Visitors", placeholder: "1,200", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Visitors to the company website this month." },
-    { key: "waitlistSignups", label: "Waitlist Signups", placeholder: "85", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "People who joined the waitlist this month." },
-    { key: "demoRequests", label: "Demo Requests", placeholder: "14", icon: <ArrowRightIcon className="w-4 h-4 text-gray-400" />, info: "Inbound requests to see or try the product." },
-    { key: "customerInterviews", label: "Customer Interviews", placeholder: "10", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Potential or current customers interviewed this month." },
-    { key: "experimentsRun", label: "Experiments Run", placeholder: "4", icon: <LightBulbIcon className="w-4 h-4 text-gray-400" />, info: "Validation, growth, product, or pricing experiments completed." },
-    { key: "pilotCount", label: "Pilots", placeholder: "3", icon: <SparklesIcon className="w-4 h-4 text-gray-400" />, info: "Active pilots, design partners, or trials." },
-    { key: "qualifiedPipeline", label: "Qualified Pipeline", placeholder: "250,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Qualified sales pipeline with customer intent." },
-];
-
-const METRIC_OPTION_MAP = new Map(METRIC_OPTIONS.map((option) => [option.key, option]));
-const METRIC_FORM_KEYS = METRIC_OPTIONS.map((option) => option.key);
-
-function hasDisplayableMetricValue(value: unknown) {
-    if (value === null || value === undefined) return false;
-
-    const rawValue = String(value).trim();
-    if (!rawValue) return false;
-
-    const lowerValue = rawValue.toLowerCase();
-    return !["null", "undefined", "-", "—"].includes(lowerValue);
-}
+// Catalog lives in ~/lib/vibe-raising-metrics so the dashboard, article
+// page, and editor all share one source of truth.
+const METRIC_OPTIONS = VIBE_METRIC_OPTIONS;
+const METRIC_OPTION_MAP = VIBE_METRIC_OPTION_MAP;
+const METRIC_FORM_KEYS = VIBE_METRIC_KEYS;
 
 function getMetricOptionsForMetrics(metrics?: Record<string, string>) {
     const keys = Object.keys(metrics || {}).filter((key) => hasDisplayableMetricValue(metrics?.[key]));
@@ -736,6 +732,53 @@ function metricSuggestionsFromKeys(keys: string[], metrics: Record<string, strin
 function metricOptionsFromKeys(keys: string[]) {
     const selected = new Set(keys.filter((key) => METRIC_OPTION_MAP.has(key)));
     return METRIC_OPTIONS.filter((option) => selected.has(option.key));
+}
+
+const METRIC_VISIBILITY_OPTIONS: { key: VibeRaisingMetricVisibility; label: string; title: string }[] = [
+    { key: "hidden", label: "Hide", title: "Not shown on the published update" },
+    { key: "full", label: "Full", title: "Shown on the full update only" },
+    { key: "snippet", label: "TLDR", title: "Shown on the TLDR snippet and the full update" },
+];
+
+// Three-way visibility control for a metric with a value: hidden, full
+// update only, or TLDR snippet + full update.
+function MetricVisibilityToggle({
+    value,
+    onChange,
+}: {
+    value: VibeRaisingMetricVisibility;
+    onChange: (value: VibeRaisingMetricVisibility) => void;
+}) {
+    return (
+        <div
+            className="mt-3 inline-flex rounded-lg border border-gray-200 bg-white p-0.5"
+            onClick={(event) => event.stopPropagation()}
+        >
+            {METRIC_VISIBILITY_OPTIONS.map((option) => (
+                <button
+                    key={option.key}
+                    type="button"
+                    title={option.title}
+                    aria-pressed={value === option.key}
+                    onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onChange(option.key);
+                    }}
+                    className={clsx(
+                        "rounded-md px-2 py-0.5 text-[10px] font-black uppercase tracking-wide transition",
+                        value === option.key
+                            ? option.key === "hidden"
+                                ? "bg-gray-200 text-gray-600"
+                                : "bg-[rgba(0,255,215,0.16)] text-[var(--vr-color-primary)]"
+                            : "text-gray-400 hover:text-gray-600",
+                    )}
+                >
+                    {option.label}
+                </button>
+            ))}
+        </div>
+    );
 }
 
 function MetricInfoBadge({ info }: { info?: string }) {
@@ -2667,6 +2710,23 @@ export default function CreateUpdate() {
         });
         return initial;
     });
+
+    // Per-metric snippet/full visibility. Seeded from the update being
+    // edited, else carried forward from the most recent prior update.
+    const [metricDisplayStates, setMetricDisplayStates] = useState<Record<string, VibeRaisingMetricVisibility>>(() => {
+        const seeded =
+            parseDisplayConfigValue(defaultData?.displayConfig) ||
+            existingMonthlyUpdates.find((update) => update.displayConfig)?.displayConfig ||
+            null;
+        if (!seeded) return {};
+        const states: Record<string, VibeRaisingMetricVisibility> = {};
+        seeded.fullMetricKeys.forEach((key) => { states[key] = "full"; });
+        seeded.snippetMetricKeys.forEach((key) => { states[key] = "snippet"; });
+        return states;
+    });
+    const setMetricDisplayState = useCallback((key: string, next: VibeRaisingMetricVisibility) => {
+        setMetricDisplayStates((previous) => ({ ...previous, [key]: next }));
+    }, []);
     const [compactSources, setCompactSources] = useState<VibeRaisingInputSourceSummary[]>([]);
     const [compactSourcesLoading, setCompactSourcesLoading] = useState(false);
     const [compactSourcesError, setCompactSourcesError] = useState<string | null>(null);
@@ -4297,6 +4357,21 @@ export default function CreateUpdate() {
         ...Array.from(selectedMetrics),
         ...Object.keys(metricValues),
     ])).filter((key) => METRIC_OPTION_MAP.has(key));
+    // Snippet/full selection for the update being saved, restricted to
+    // valued metrics in catalog order (snippet keys are a subset of full).
+    const displayConfigFormValue = useMemo(() => {
+        const valuedKeys = VIBE_METRIC_KEYS.filter(
+            (key) => String(metricValues[key] || "").trim().length > 0,
+        );
+        const hasExplicitStates = Object.keys(metricDisplayStates).length > 0;
+        const fullMetricKeys = valuedKeys.filter(
+            (key) => (metricDisplayStates[key] ?? "full") !== "hidden",
+        );
+        const snippetMetricKeys = hasExplicitStates
+            ? valuedKeys.filter((key) => metricDisplayStates[key] === "snippet")
+            : fullMetricKeys.slice(0, 4);
+        return JSON.stringify({ snippetMetricKeys, fullMetricKeys });
+    }, [metricValues, metricDisplayStates]);
     const activeHighlights = isViewingCurrentUpdate ? highlights : activePastCard?.highlights || "";
     const activeChallenges = isViewingCurrentUpdate ? challenges : activePastCard?.challenges || "";
     const activeAsks = isViewingCurrentUpdate ? asks : activePastCard?.asks || "";
@@ -5997,6 +6072,7 @@ export default function CreateUpdate() {
                                 <Form id={DRAFT_REVIEW_FORM_ID} method="POST" className="space-y-6">
                                     <input type="hidden" name="intent" value="review" />
                                     <input type="hidden" name="metricKeys" value={formMetricKeys.join(",")} />
+                                    <input type="hidden" name="displayConfig" value={displayConfigFormValue} />
                                     <input type="hidden" name="summary" value={summary} />
                                     <input type="hidden" name="sourceUrl" value={sourceUrl} />
                                     <input type="hidden" name="pitchDeckUrl" value={pitchDeckUrl} />
@@ -6104,6 +6180,12 @@ export default function CreateUpdate() {
                                                                 : "border-gray-200 text-gray-300 opacity-45 saturate-0 placeholder:text-gray-300 focus:border-[var(--vr-color-primary)] focus:opacity-100 focus:saturate-100",
                                                         )}
                                                     />
+                                                    {hasMetricValue ? (
+                                                        <MetricVisibilityToggle
+                                                            value={metricDisplayStates[metric.key] ?? "full"}
+                                                            onChange={(next) => setMetricDisplayState(metric.key, next)}
+                                                        />
+                                                    ) : null}
                                                 </label>
                                                     );
                                                 })()
@@ -6376,6 +6458,7 @@ export default function CreateUpdate() {
                     name="metricKeys"
                     value={formMetricKeys.join(",")}
                 />
+                <input type="hidden" name="displayConfig" value={displayConfigFormValue} />
                 <input type="hidden" name="summary" value={summary} />
                 <input type="hidden" name="sourceUrl" value={sourceUrl} />
                 <input type="hidden" name="pitchDeckUrl" value={pitchDeckUrl} />
@@ -6765,6 +6848,12 @@ export default function CreateUpdate() {
                                                     "mt-1 max-w-full break-words text-[10px] font-semibold uppercase leading-tight tracking-wide",
                                                     active ? "text-gray-600" : "text-gray-400"
                                                 )}>{m.label}</p>
+                                                {isViewingCurrentUpdate && active && String(activeMetricValues[m.key] || "").trim() ? (
+                                                    <MetricVisibilityToggle
+                                                        value={metricDisplayStates[m.key] ?? "full"}
+                                                        onChange={(next) => setMetricDisplayState(m.key, next)}
+                                                    />
+                                                ) : null}
                                             </div>
                                         );
                                     })}

--- a/app/routes/vibe-raising-app.update-detail.tsx
+++ b/app/routes/vibe-raising-app.update-detail.tsx
@@ -1,0 +1,90 @@
+import { Link, redirect, useLoaderData } from "react-router";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import type { Route } from "./+types/vibe-raising-app.update-detail";
+import { getEnv } from "~/lib/env.server";
+import {
+    getOptionalVibeRaisingContext,
+    getVibeRaisingLoginHref,
+    getVibeRaisingMonthlyUpdatesBundle,
+} from "~/lib/vibe-raising";
+import VRPreviewUpdateCard from "~/components/vibe-raising/VRPreviewUpdateCard";
+import TrendsSection from "~/components/vibe-raising/TrendsSection";
+
+export async function loader({ request, context, params }: Route.LoaderArgs) {
+    const env = getEnv(context);
+    const vibeContext = await getOptionalVibeRaisingContext(env, request);
+
+    if (!vibeContext.authUser) {
+        throw redirect(getVibeRaisingLoginHref(request));
+    }
+
+    if (!vibeContext.appUser || vibeContext.appUser.role !== "founder") {
+        throw redirect("/founder-tools/updates");
+    }
+
+    const { updates, metricHistory } = await getVibeRaisingMonthlyUpdatesBundle(env, request);
+    const update = updates.find((item) => String(item.id) === String(params.id));
+    if (!update) {
+        throw new Response("Update not found", { status: 404 });
+    }
+
+    return { user: vibeContext.appUser, update, metricHistory };
+}
+
+function isCurrentMonthUpdate(update: { date?: string | null }): boolean {
+    const updateDate = new Date(update.date || "");
+    if (Number.isNaN(updateDate.getTime())) return false;
+    const now = new Date();
+    return (
+        updateDate.getMonth() === now.getMonth() &&
+        updateDate.getFullYear() === now.getFullYear()
+    );
+}
+
+export default function UpdateDetailPage() {
+    const { user, update, metricHistory } = useLoaderData<typeof loader>();
+
+    return (
+        <div className="vr-scope mx-auto max-w-4xl space-y-4 pb-12">
+            <Link
+                to="/founder-tools/updates"
+                className="inline-flex items-center gap-1.5 text-xs font-black uppercase tracking-[0.14em] text-gray-500 transition hover:text-[var(--vr-color-primary)]"
+            >
+                <ArrowLeftIcon className="h-3.5 w-3.5" />
+                All updates
+            </Link>
+            <VRPreviewUpdateCard
+                update={update}
+                user={user}
+                statusLabel={isCurrentMonthUpdate(update) ? "Current" : "Sent"}
+                trendsSlot={
+                    <TrendsSection
+                        metricHistory={metricHistory}
+                        displayConfig={update.displayConfig}
+                        currentIsoMonth={update.isoMonth}
+                    />
+                }
+            />
+        </div>
+    );
+}
+
+export function ErrorBoundary() {
+    return (
+        <div className="vr-scope mx-auto max-w-4xl pb-12">
+            <div className="rounded-xl border border-gray-200 bg-white px-6 py-10 text-center shadow-sm">
+                <h1 className="text-lg font-bold text-gray-900">Update not found</h1>
+                <p className="mt-2 text-sm text-gray-500">
+                    This update may have been removed, or the link is out of date.
+                </p>
+                <Link
+                    to="/founder-tools/updates"
+                    className="mt-5 inline-flex items-center gap-1.5 rounded-lg bg-[var(--vr-color-primary)] px-4 py-2 text-xs font-black uppercase tracking-[0.14em] text-white transition hover:bg-[var(--vr-palette-black)]"
+                >
+                    <ArrowLeftIcon className="h-3.5 w-3.5" />
+                    Back to updates
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -64,6 +64,28 @@ export interface VibeRaisingMetricSuggestion {
   reason?: string;
 }
 
+export type VibeRaisingMetricVisibility = "hidden" | "full" | "snippet";
+
+export interface VibeRaisingMetricDisplayConfig {
+  snippetMetricKeys: string[];
+  fullMetricKeys: string[];
+}
+
+export interface VibeRaisingMetricHistoryPoint {
+  month: string;
+  value: number;
+  valueText: string;
+}
+
+export interface VibeRaisingMetricHistorySeries {
+  metricKey: string;
+  label: string;
+  unit?: string | null;
+  points: VibeRaisingMetricHistoryPoint[];
+}
+
+export type VibeRaisingMetricHistory = Record<string, VibeRaisingMetricHistorySeries>;
+
 export interface VibeRaisingDraftedContent {
   month?: string;
   year?: number;
@@ -117,6 +139,7 @@ export interface VibeRaisingMonthlyUpdate {
   videoOriginalFilename?: string | null;
   metrics: Record<string, string>;
   metricSuggestions?: VibeRaisingMetricSuggestion[];
+  displayConfig?: VibeRaisingMetricDisplayConfig | null;
   highlights: string;
   challenges: string;
   asks: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ const sharedOptimizeDepsInclude = [
   "gsap",
   "gsap/ScrollTrigger",
   "react-dropzone",
+  "recharts",
   "tailwind-merge",
 ];
 


### PR DESCRIPTION
Frontend half of the Vibe Raising metric-trends feature (backend merged in mlai-backend#437).

## What
- **Full-article route** `/founder-tools/updates/:id` with a **Trends** section — per-metric line charts (recharts) over the trailing 12 months, tooltips showing the founder's original metric string, the update's own month highlighted. 404 + back-link.
- **Past Updates** tab now renders compact **TLDR snippet cards** (summary + up to 4 chosen metrics with sparklines) that link to the full article; Current tab gains a "View full update" link.
- **Per-update display config** in the editor: each metric toggles Hide / Full / Snippet+Full, seeded from the previous update, round-tripped via `displayConfig`. Cards honor the saved snippet/full selection.
- **Shared metric catalog** (`app/lib/vibe-raising-metrics`) so all 20 backend metric keys render — fixes the stale 6-key dashboard list that used `users` instead of `activeUsers`.
- Charts read `metricHistory` from `GET /vibe-raising/updates/` via the new `getVibeRaisingMonthlyUpdatesBundle` (old `getVibeRaisingMonthlyUpdates` kept as a thin wrapper).
- `recharts` added to the shared `optimizeDeps.include` (already a dependency) so it pre-bundles for these lazy routes.

## Scope / rebase note
Rebuilt cleanly on current `main` (post #988 dashboard redesign): `_index.tsx` changes are minimal/additive (loader → bundle, past-tab → snippet grid, current-tab link), inline components left untouched; the extracted `VRPreviewUpdateCard` keeps #988's `ActiveDraftRunChip`. `package.json` untouched (recharts already present).

## Verification
`bun run typecheck` ✓, `bun run build` ✓, and a stub-backend runtime pass: snippet sparklines, detail Trends, editor toggles, and 404 all render with a clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)