### PR TITLE
Integrate MLAI Studio landing page into the global sidebar shell

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -462,3 +462,6 @@
 - [x] Add mlai-backend `mlai_studio` app: StudioApplication table, public upsert submit endpoint, Django admin registration
 - [x] Wire the MLAI Studio application form to the backend (lead capture after step 1, awaited final submit with inline error fallback)
 - [x] Verify MLAI Studio signups end-to-end locally (lead row → complete row, admin changelist) and run `bun run typecheck`
+- [x] Remove the MLAI Studio landing page top nav and integrate the page into the global sidebar + footer shell
+- [x] Replace the Sponsor sidebar tab with Studio and move the homepage Studio teaser after People to match
+- [x] Verify the integrated /mlai-studio layout and homepage tab order in the local browser, run `bun run typecheck`

--- a/app/components/SectionMarkers.tsx
+++ b/app/components/SectionMarkers.tsx
@@ -24,6 +24,11 @@ const sectionMarkers = [
         color: "#3537dc", // Blue
     },
     {
+        sectionId: "mlai-studio",
+        name: "Studio",
+        color: "#00ffd7", // Teal — MLAI Studio's signature accent
+    },
+    {
         sectionId: "articles",
         name: "Articles",
         color: "#fefc22", // Yellow

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -28,34 +28,27 @@ const navigation = [
   },
   {
     number: "4",
-    name: "MLAI Studio",
-    href: "/#mlai-studio",
-    sectionId: "mlai-studio", // MLAI Studio teaser section
-    color: "#00ffd7", // Teal — MLAI Studio's signature accent
-  },
-  {
-    number: "5",
     name: "People",
     href: "/#people",
     sectionId: "people", // Testimonials + Team section
     color: "#3537dc", // Blue
   },
   {
-    number: "6",
-    name: "Sponsor",
-    href: "/sponsors",
-    // No sectionId - navigates to /sponsors page
-    color: "#ff003d", // Crimson
+    number: "5",
+    name: "Studio",
+    href: "/#mlai-studio",
+    sectionId: "mlai-studio", // MLAI Studio teaser section
+    color: "#00ffd7", // Teal — MLAI Studio's signature accent
   },
   {
-    number: "7",
+    number: "6",
     name: "Articles",
     href: "/#articles",
     sectionId: "articles", // Substack "Monthly updates" section
     color: "#fefc22", // Yellow
   },
   {
-    number: "8",
+    number: "7",
     name: "Login",
     href: "/hackathons",
     color: "#00ffd7", // Mint (external route - no section)

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -93,17 +93,13 @@ export default function Layout() {
     location.pathname === "/valley" ||
     location.pathname.startsWith("/valley/");
   const isWattTheHackApp = location.pathname.startsWith("/watt-the-hack");
-  // MLAI Studio is a standalone landing page with its own top nav, so it
-  // opts out of the global left sidebar / footer chrome.
-  const isMlaiStudio = location.pathname === "/mlai-studio";
   const isAppRoute =
     isEsafetyApp ||
     isHospitalApp ||
     isVibeRaisingLegacyApp ||
     isFounderToolsApp ||
     isValleyApp ||
-    isWattTheHackApp ||
-    isMlaiStudio;
+    isWattTheHackApp;
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -218,16 +218,6 @@ export default function Home({ events, substackPosts }: { events: Promise<any>, 
         <FounderTools />
       </section>
 
-      {/* ===== MLAI STUDIO SECTION ===== */}
-      {/* Teaser intro that links through to the full /mlai-studio landing page */}
-      <section id="mlai-studio">
-        {/* MLAI Studio section divider - Teal */}
-        <SectionDivider color="#00ffd7" />
-
-        {/* MLAI Studio teaser */}
-        <MlaiStudioTeaser />
-      </section>
-
       {/* ===== VOLUNTEER SECTION ===== */}
       {/* Starts at "We are proud to have worked with amazing people", ends at Articles */}
       <section id="people">
@@ -246,6 +236,16 @@ export default function Home({ events, substackPosts }: { events: Promise<any>, 
 
         {/* Team section - moved here directly under testimonials */}
         <Team />
+      </section>
+
+      {/* ===== MLAI STUDIO SECTION ===== */}
+      {/* Teaser intro that links through to the full /mlai-studio landing page */}
+      <section id="mlai-studio">
+        {/* MLAI Studio section divider - Teal */}
+        <SectionDivider color="#00ffd7" />
+
+        {/* MLAI Studio teaser */}
+        <MlaiStudioTeaser />
       </section>
 
       {/* ===== ARTICLES SECTION ===== */}

--- a/app/routes/mlai-studio.tsx
+++ b/app/routes/mlai-studio.tsx
@@ -152,32 +152,6 @@ function Reveal({
   );
 }
 
-/* ---------- NAV ---------- */
-function Nav() {
-  return (
-    <nav className="nav">
-      <div className="wrap nav-inner">
-        <a href="#top" aria-label="MLAI Studio home" onClick={scrollToId("top")}>
-          <img className="nav-logo" src={asset("logo-wide-black.png")} alt="MLAI" />
-        </a>
-        <div className="nav-links">
-          <a className="nav-link" href="#why" onClick={scrollToId("why")}>Why join</a>
-          <a className="nav-link" href="#work" onClick={scrollToId("work")}>The work</a>
-          <a className="nav-link" href="#how" onClick={scrollToId("how")}>How it works</a>
-          <a className="nav-link" href="#fit" onClick={scrollToId("fit")}>Who fits</a>
-          <button
-            className="btn btn-orange"
-            style={{ fontSize: 14, padding: "11px 20px" }}
-            onClick={scrollToApply}
-          >
-            Apply to join
-          </button>
-        </div>
-      </div>
-    </nav>
-  );
-}
-
 /* ---------- HERO ---------- */
 function Hero() {
   return (
@@ -488,31 +462,10 @@ function FinalCTA() {
   );
 }
 
-/* ---------- FOOTER ---------- */
-function Footer() {
-  return (
-    <footer className="footer">
-      <div className="wrap footer-inner">
-        <div>
-          <img src={asset("logo-wide-teal.png")} alt="MLAI" style={{ height: 40, marginBottom: 18 }} />
-          <p className="footer-tag">Australia's AI community, from Melbourne outward.</p>
-        </div>
-        <div style={{ textAlign: "right" }}>
-          <a className="link" href="https://mlai.au" style={{ fontSize: 18 }}>mlai.au →</a>
-          <p className="footer-tag" style={{ marginLeft: "auto", marginTop: 10 }}>
-            Come for the AI.<br />Stay for the community.
-          </p>
-        </div>
-      </div>
-    </footer>
-  );
-}
-
 /* ---------- PAGE ---------- */
 export default function MlaiStudio() {
   return (
     <div className="ms-scope">
-      <Nav />
       <Hero />
       <WhyJoin />
       <WhatBuild />
@@ -522,7 +475,6 @@ export default function MlaiStudio() {
       <ApplySection />
       <SocialProof />
       <FinalCTA />
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #989, per Sam's feedback on the live page.

## Changes
1. **Top nav removed** — the landing page's own nav bar (Why join / The work / … / Apply to join) is gone; in-page CTAs still scroll to the apply form.
2. **Global sidebar layout** — `/mlai-studio` no longer opts out of the site shell in `root.tsx`: the original MLAI sidebar shows on the left and the landing page fills the content area to its right.
3. **Sidebar tabs** — the dedicated "4 · MLAI Studio" tab is removed; the Sponsor slot becomes **"Studio"** (teal, scrolls to the homepage teaser like the other numbered tabs) and everything renumbers to 1–7. The homepage teaser section moves from after Founder Tools to after People so scroll order matches the tabs, and the right-edge section markers get a matching Studio entry. The `/sponsors` page itself is untouched — it just loses its sidebar entry.
4. **Footer** — the landing page's own footer is removed; the shared MLAI footer now renders there like every other page.

## Verified locally
Sidebar + landing page render side by side at desktop width (content clears the 220px rail), single shared footer at the bottom, homepage tabs read 1 Hello → 7 Login with Studio at 5 scrolling to the repositioned teaser, no console errors, `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)