### PR TITLE
Activate Google Analytics as a connectable update source

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -18,6 +18,8 @@ import type {
   VibeRaisingGmailDisconnectResponse,
   VibeRaisingGmailMessagePreview,
   VibeRaisingGmailPreview,
+  VibeRaisingGoogleAnalyticsPropertiesResponse,
+  VibeRaisingGoogleAnalyticsProperty,
   VibeRaisingInputSourceKey,
   VibeRaisingInputSourceStatus,
   VibeRaisingInputSourceSummary,
@@ -94,6 +96,8 @@ const SLACK_PREVIEW_PATH = "/api/v1/integrations/slack/preview";
 const LINEAR_PROJECTS_PATH = "/api/v1/integrations/linear/projects";
 const LINEAR_PROJECT_SELECTIONS_PATH = "/api/v1/integrations/linear/project-selections";
 const LINEAR_PREVIEW_PATH = "/api/v1/integrations/linear/preview";
+const GOOGLE_ANALYTICS_PROPERTIES_PATH = "/api/v1/integrations/google-analytics/properties";
+const GOOGLE_ANALYTICS_PROPERTY_SELECTIONS_PATH = "/api/v1/integrations/google-analytics/property-selections";
 
 const INPUT_SOURCE_DEFINITIONS: Record<VibeRaisingInputSourceKey, Omit<VibeRaisingInputSourceSummary, "selected" | "status">> = {
   gmail: {
@@ -1430,6 +1434,10 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
       typeof connection.selectedProjectCount === "number" && Number.isFinite(connection.selectedProjectCount)
         ? connection.selectedProjectCount
         : Number(connection.selectedProjectCount ?? connection.selected_project_count ?? 0) || 0;
+    const selectedPropertyCount =
+      typeof connection.selectedPropertyCount === "number" && Number.isFinite(connection.selectedPropertyCount)
+        ? connection.selectedPropertyCount
+        : Number(connection.selectedPropertyCount ?? connection.selected_property_count ?? 0) || 0;
     const rawRequiredReportScopes = connection.requiredReportScopes ?? connection.required_report_scopes;
     const requiredReportScopes = Array.isArray(rawRequiredReportScopes)
       ? rawRequiredReportScopes.map((item) => String(item || "").trim()).filter(Boolean)
@@ -1448,6 +1456,7 @@ function normalizeInputSourceSummaries(raw: unknown): Partial<Record<VibeRaising
         asNullableString(connection.google_permissions_url),
       selectedChannelCount,
       selectedProjectCount,
+      selectedPropertyCount,
       hasReportScope: asBoolean(connection.hasReportScope ?? connection.has_report_scope),
       needsReportReconnect: asBoolean(connection.needsReportReconnect ?? connection.needs_report_reconnect),
       canRequestReportScopes: asBoolean(connection.canRequestReportScopes ?? connection.can_request_report_scopes),
@@ -2550,7 +2559,7 @@ export async function getVibeRaisingInputSourcesStatus(
     );
     const summaries = normalizeInputSourceSummaries(response);
     const sources = (Object.keys(INPUT_SOURCE_DEFINITIONS) as VibeRaisingInputSourceKey[]).map((key) => (
-      summaries[key] ?? createInputSourceSummary(key, key === "google_analytics" ? "coming_soon" : "not_connected")
+      summaries[key] ?? createInputSourceSummary(key, "not_connected")
     ));
     return {
       sources,
@@ -2626,7 +2635,7 @@ export async function getVibeRaisingInputSourcesStatus(
   return { sources, financeUnavailable };
 }
 
-type ConnectableVibeRaisingInputSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "google_analytics" | "manual_documents">;
+type ConnectableVibeRaisingInputSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "manual_documents">;
 
 const CONNECTOR_PROVIDER_SLUGS: Record<ConnectableVibeRaisingInputSourceKey, string> = {
   stripe: "stripe",
@@ -2636,6 +2645,7 @@ const CONNECTOR_PROVIDER_SLUGS: Record<ConnectableVibeRaisingInputSourceKey, str
   google_drive: "google-drive",
   slack: "slack",
   linear: "linear",
+  google_analytics: "google-analytics",
 };
 
 export function connectVibeRaisingInputSource(
@@ -3042,6 +3052,97 @@ export async function saveVibeRaisingSlackChannelSelections(
     channels: collectRawList(payload, ["selectedChannels", "selected_channels", "channels"])
       .map(normalizeSlackChannel)
       .filter((value): value is VibeRaisingSlackChannel => value !== null),
+    nextCursor: null,
+    warnings: Array.isArray(rawWarnings)
+      ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
+      : [],
+  };
+}
+
+function normalizeGoogleAnalyticsProperty(raw: unknown): VibeRaisingGoogleAnalyticsProperty | null {
+  if (!raw || typeof raw !== "object") return null;
+  const payload = raw as Record<string, unknown>;
+  const id = payload.id ?? payload.propertyId ?? payload.property_id;
+  const propertyId =
+    asNullableString(payload.propertyId) ??
+    asNullableString(payload.property_id) ??
+    asNullableString(payload.id);
+  if (!propertyId) return null;
+  const propertyDisplayName =
+    asNullableString(payload.propertyDisplayName) ??
+    asNullableString(payload.property_display_name) ??
+    asNullableString(payload.name) ??
+    propertyId;
+  return {
+    id: (typeof id === "number" || typeof id === "string") ? id : propertyId,
+    propertyId,
+    propertyDisplayName,
+    name: asNullableString(payload.name) ?? propertyDisplayName,
+    accountId:
+      asNullableString(payload.accountId) ??
+      asNullableString(payload.account_id),
+    accountDisplayName:
+      asNullableString(payload.accountDisplayName) ??
+      asNullableString(payload.account_display_name),
+    selected: asBoolean(payload.selected),
+    lastSyncedAt:
+      asNullableString(payload.lastSyncedAt) ??
+      asNullableString(payload.last_synced_at),
+  };
+}
+
+export async function getVibeRaisingGoogleAnalyticsProperties(
+  backendBaseUrl: string,
+  options: { cursor?: string | null; limit?: number } = {},
+): Promise<VibeRaisingGoogleAnalyticsPropertiesResponse> {
+  const searchParams = new URLSearchParams();
+  if (options.cursor) searchParams.set("cursor", options.cursor);
+  if (typeof options.limit === "number") searchParams.set("limit", String(options.limit));
+  const path = searchParams.toString()
+    ? `${GOOGLE_ANALYTICS_PROPERTIES_PATH}?${searchParams.toString()}`
+    : GOOGLE_ANALYTICS_PROPERTIES_PATH;
+  const payload = await requestBrowserJson<Record<string, unknown>>(
+    backendBaseUrl,
+    path,
+    { method: "GET" },
+  );
+  const rawWarnings = payload.warnings;
+  return {
+    accountLabel:
+      asNullableString(payload.accountLabel) ??
+      asNullableString(payload.account_label),
+    properties: collectRawList(payload, ["properties"])
+      .map(normalizeGoogleAnalyticsProperty)
+      .filter((value): value is VibeRaisingGoogleAnalyticsProperty => value !== null),
+    nextCursor:
+      asNullableString(payload.nextCursor) ??
+      asNullableString(payload.next_cursor),
+    warnings: Array.isArray(rawWarnings)
+      ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)
+      : [],
+  };
+}
+
+export async function saveVibeRaisingGoogleAnalyticsPropertySelections(
+  backendBaseUrl: string,
+  propertyIds: string[],
+): Promise<VibeRaisingGoogleAnalyticsPropertiesResponse> {
+  const payload = await requestBrowserJson<Record<string, unknown>>(
+    backendBaseUrl,
+    GOOGLE_ANALYTICS_PROPERTY_SELECTIONS_PATH,
+    {
+      method: "POST",
+      body: JSON.stringify({ propertyIds }),
+    },
+  );
+  const rawWarnings = payload.warnings;
+  return {
+    accountLabel:
+      asNullableString(payload.accountLabel) ??
+      asNullableString(payload.account_label),
+    properties: collectRawList(payload, ["selectedProperties", "selected_properties", "properties"])
+      .map(normalizeGoogleAnalyticsProperty)
+      .filter((value): value is VibeRaisingGoogleAnalyticsProperty => value !== null),
     nextCursor: null,
     warnings: Array.isArray(rawWarnings)
       ? rawWarnings.map((item) => String(item || "").trim()).filter(Boolean)

--- a/app/routes/vibe-raising-app.connect-data.tsx
+++ b/app/routes/vibe-raising-app.connect-data.tsx
@@ -28,6 +28,7 @@ import {
   disconnectVibeRaisingGmail,
   getVibeRaisingBankFeedPreview,
   getVibeRaisingGmailPreview,
+  getVibeRaisingGoogleAnalyticsProperties,
   getVibeRaisingInputSourcesStatus,
   getVibeRaisingLinearPreview,
   getVibeRaisingLinearProjects,
@@ -39,6 +40,7 @@ import {
   getVibeRaisingSlackPreview,
   getVibeRaisingXeroPreview,
   requireVibeRaisingFounder,
+  saveVibeRaisingGoogleAnalyticsPropertySelections,
   saveVibeRaisingLinearProjectSelections,
   saveVibeRaisingSlackChannelSelections,
   syncVibeRaisingFinancialSources,
@@ -47,6 +49,8 @@ import {
 import type {
   VibeRaisingBankFeedPreview,
   VibeRaisingGmailPreview,
+  VibeRaisingGoogleAnalyticsProperty,
+  VibeRaisingGoogleAnalyticsPropertiesResponse,
   VibeRaisingInputSourceKey,
   VibeRaisingInputSourceStatus,
   VibeRaisingInputSourceSummary,
@@ -65,12 +69,13 @@ import VibeRaisingStickyStepBar from "~/components/VibeRaisingStickyStepBar";
 const DEFAULT_NEXT = "/founder-tools/updates/create";
 const DEFAULT_BACKEND_BASE_URL = "https://api.mlai.au";
 const MANUAL_MATERIALS_STORAGE_KEY = "vibe_raising_manual_materials";
-const FUNCTIONAL_SOURCES = new Set<VibeRaisingInputSourceKey>(["gmail", "stripe", "xero", "bank_feed", "notion", "google_drive", "slack", "linear"]);
+const FUNCTIONAL_SOURCES = new Set<VibeRaisingInputSourceKey>(["gmail", "google_analytics", "stripe", "xero", "bank_feed", "notion", "google_drive", "slack", "linear"]);
 const OAUTH_CONNECTABLE_WHEN_STATUS_UNAVAILABLE = new Set<VibeRaisingInputSourceKey>(["stripe"]);
 const PRIORITY_SOURCE_KEYS: VibeRaisingInputSourceKey[] = ["google_analytics", "stripe", "linear", "notion"];
 const MORE_SOURCE_KEYS: VibeRaisingInputSourceKey[] = ["google_drive", "gmail", "slack", "bank_feed", "xero"];
 const SLACK_CHANNEL_PAGE_LIMIT = 100;
 const LINEAR_PROJECT_PAGE_LIMIT = 100;
+const GOOGLE_ANALYTICS_PROPERTY_PAGE_LIMIT = 200;
 const DATA_SOURCES_MOBILE_TOUR_STORAGE_KEY = "vibe_raising_data_sources_mobile_tour_seen_v1";
 const DATA_PRIVACY_POINTS = [
   "Only you can see connected source data in your workspace",
@@ -96,7 +101,7 @@ const EMPTY_SOURCES: VibeRaisingInputSourceSummary[] = [
     label: "Google Analytics",
     capabilities: ["metrics"],
     selected: false,
-    status: "coming_soon",
+    status: "not_connected",
   },
   {
     key: "stripe",
@@ -278,7 +283,7 @@ function MobileDataSourcesTour({
   );
 }
 
-type OAuthSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "google_analytics" | "manual_documents">;
+type OAuthSourceKey = Exclude<VibeRaisingInputSourceKey, "gmail" | "manual_documents">;
 
 function isOAuthSourceKey(key: VibeRaisingInputSourceKey): key is OAuthSourceKey {
   return key !== "gmail" && key !== "manual_documents";
@@ -1087,6 +1092,145 @@ function SlackPreview({
   );
 }
 
+function mergeGoogleAnalyticsPropertiesById(
+  previous: Record<string, VibeRaisingGoogleAnalyticsProperty>,
+  properties: VibeRaisingGoogleAnalyticsProperty[],
+) {
+  if (properties.length === 0) return previous;
+  const next = { ...previous };
+  properties.forEach((property) => {
+    next[property.propertyId] = { ...next[property.propertyId], ...property };
+  });
+  return next;
+}
+
+function getSelectedGoogleAnalyticsPropertyIds(properties: VibeRaisingGoogleAnalyticsProperty[]) {
+  return properties.filter((property) => property.selected).map((property) => property.propertyId);
+}
+
+function GoogleAnalyticsPreview({
+  properties,
+  accountLabel,
+  loading,
+  error,
+  saving,
+  selectedPropertyIds,
+  nextCursor,
+  loadingMore,
+  onToggleProperty,
+  onLoadMore,
+  onSave,
+}: {
+  properties: VibeRaisingGoogleAnalyticsProperty[];
+  accountLabel: string | null;
+  loading: boolean;
+  error: string | null;
+  saving: boolean;
+  selectedPropertyIds: Set<string>;
+  nextCursor: string | null;
+  loadingMore: boolean;
+  onToggleProperty: (propertyId: string) => void;
+  onLoadMore: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <section className="rounded-xl border border-[var(--vr-color-border)] bg-white p-6 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-black text-gray-950">Google Analytics properties</h2>
+          <p className="mt-2 text-sm text-slate-500">Choose which GA4 property feeds traffic and conversion metrics into this update.</p>
+        </div>
+        {loading ? (
+          <span className="inline-flex items-center gap-2 text-sm font-bold text-[var(--vr-color-primary)]">
+            <ArrowPathIcon className="h-4 w-4 animate-spin" />
+            Loading
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="mt-5 rounded-lg bg-[rgba(255,200,1,0.16)] px-4 py-3 text-sm font-semibold text-[var(--vr-color-text)]">{error}</div>
+      ) : null}
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        <div className="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-500">Google account</p>
+          <p className="mt-2 truncate text-sm font-black text-gray-950">{accountLabel || "Connected Google Analytics"}</p>
+        </div>
+        <div className="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-500">Selected properties</p>
+          <p className="mt-2 text-sm font-black text-gray-950">{selectedPropertyIds.size}</p>
+        </div>
+      </div>
+
+      {properties.length > 0 ? (
+        <div className="mt-5 rounded-lg border border-gray-100">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-100 bg-gray-50 px-4 py-3">
+            <div>
+              <p className="text-sm font-black text-gray-950">Properties</p>
+              <p className="mt-1 text-xs font-bold text-slate-500">{selectedPropertyIds.size} selected</p>
+            </div>
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={saving}
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--vr-color-primary)] px-3 py-2 text-xs font-extrabold text-white transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving ? "Saving" : "Save selection"}
+            </button>
+          </div>
+          <ul className="divide-y divide-gray-100 px-2 py-2">
+            {properties.map((property) => {
+              const selected = selectedPropertyIds.has(property.propertyId);
+              return (
+                <li key={property.propertyId}>
+                  <button
+                    type="button"
+                    onClick={() => onToggleProperty(property.propertyId)}
+                    className="flex w-full cursor-pointer items-center gap-3 rounded-lg px-2 py-3 text-left font-semibold text-gray-800 transition hover:bg-[rgba(0,255,215,0.08)]"
+                  >
+                    <span
+                      className={clsx(
+                        "flex h-5 w-5 shrink-0 items-center justify-center rounded border",
+                        selected ? "border-[var(--vr-color-primary)] bg-[var(--vr-color-primary)] text-white" : "border-gray-300 bg-white text-transparent",
+                      )}
+                    >
+                      <CheckIcon className="h-3.5 w-3.5" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-black text-gray-950">{property.propertyDisplayName}</span>
+                      <span className="mt-0.5 block truncate text-xs font-bold text-slate-500">
+                        {[property.accountDisplayName, `Property ${property.propertyId}`].filter(Boolean).join(" · ")}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          {nextCursor ? (
+            <div className="border-t border-gray-100 p-2">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={loadingMore}
+                className="flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-extrabold text-[var(--vr-color-primary)] transition hover:bg-[rgba(0,255,215,0.12)] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <ArrowPathIcon className={clsx("h-4 w-4", loadingMore && "animate-spin")} />
+                {loadingMore ? "Loading properties" : "Load more properties"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : !loading ? (
+        <div className="mt-5 rounded-lg bg-gray-50 px-4 py-4 text-sm font-semibold text-slate-500">
+          Google Analytics is connected, but no GA4 properties were found for this Google account.
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function mergeLinearProjectsById(
   previous: Record<string, VibeRaisingLinearProject>,
   projects: VibeRaisingLinearProject[],
@@ -1604,62 +1748,6 @@ function ConnectorCard({
   );
 }
 
-function GoogleAnalyticsPlaceholderCard({ isMobileView = false }: { isMobileView?: boolean }) {
-  return (
-    <div
-      className="relative flex min-h-[112px] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white p-3 shadow-sm outline-none sm:min-h-[220px] sm:rounded-2xl sm:p-4"
-      aria-label="Google Analytics source coming soon"
-    >
-      <div className="pointer-events-none flex flex-col gap-3">
-        <div className={clsx("flex gap-3", isMobileView ? "justify-center" : "items-start justify-between")}>
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-gray-200 sm:h-16 sm:w-16 sm:rounded-2xl">
-            <img src="/vibe-raising/logos/google-analytics.svg" alt="" className="h-8 w-8 object-contain sm:h-10 sm:w-10" />
-          </div>
-        </div>
-        <h3 className={clsx("break-words text-base font-black leading-tight text-gray-950 sm:text-left sm:text-lg", isMobileView && "text-center")}>
-          Google Analytics
-        </h3>
-      </div>
-
-      <div className={clsx("flex flex-1 flex-col", isMobileView ? "pt-2" : "pt-4 sm:pt-5")}>
-        {!isMobileView ? (
-          <p className="mt-1 line-clamp-3 min-h-0 text-[11px] leading-4 text-slate-500 sm:mt-2 sm:min-h-10 sm:text-xs sm:leading-5 sm:line-clamp-4">
-            Pull website traffic, acquisition, and top-page performance into your monthly update workflow.
-          </p>
-        ) : null}
-
-        {!isMobileView ? (
-          <div className="mt-2 flex flex-wrap gap-1 sm:mt-3">
-            {["Traffic", "Attribution"].map((capability) => (
-              <span
-                key={capability}
-                className="rounded-full bg-gray-50 px-1.5 py-0.5 text-[9px] font-bold text-slate-500 sm:text-[10px]"
-              >
-                {capability}
-              </span>
-            ))}
-          </div>
-        ) : null}
-
-        <div className={clsx("mt-auto", isMobileView ? "pt-2" : "pt-3 sm:pt-4")}>
-          <button
-            type="button"
-            disabled
-            className="block w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-center text-xs font-extrabold text-gray-400"
-          >
-            Coming soon
-          </button>
-          {!isMobileView ? (
-            <p className="mt-2 min-h-8 line-clamp-2 text-[10px] leading-4 text-slate-500 sm:min-h-[2.75rem] sm:text-[11px] sm:line-clamp-none">
-              Website traffic support is coming soon for founder updates.
-            </p>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function ManualMaterialsCard({
   expanded,
   hasManualMaterials,
@@ -1920,6 +2008,14 @@ export default function ConnectData() {
   const [slackError, setSlackError] = useState<string | null>(null);
   const [savingSlackChannels, setSavingSlackChannels] = useState(false);
   const [selectedSlackChannelIds, setSelectedSlackChannelIds] = useState<Set<string>>(new Set());
+  const [googleAnalyticsPropertiesById, setGoogleAnalyticsPropertiesById] = useState<Record<string, VibeRaisingGoogleAnalyticsProperty>>({});
+  const [googleAnalyticsNextCursor, setGoogleAnalyticsNextCursor] = useState<string | null>(null);
+  const [loadingGoogleAnalyticsProperties, setLoadingGoogleAnalyticsProperties] = useState(false);
+  const [loadingMoreGoogleAnalyticsProperties, setLoadingMoreGoogleAnalyticsProperties] = useState(false);
+  const [googleAnalyticsAccountLabel, setGoogleAnalyticsAccountLabel] = useState<string | null>(null);
+  const [googleAnalyticsError, setGoogleAnalyticsError] = useState<string | null>(null);
+  const [savingGoogleAnalyticsProperties, setSavingGoogleAnalyticsProperties] = useState(false);
+  const [selectedGoogleAnalyticsPropertyIds, setSelectedGoogleAnalyticsPropertyIds] = useState<Set<string>>(new Set());
   const [syncingLinear, setSyncingLinear] = useState(false);
   const [linearProjectsById, setLinearProjectsById] = useState<Record<string, VibeRaisingLinearProject>>({});
   const [linearProjectsNextCursor, setLinearProjectsNextCursor] = useState<string | null>(null);
@@ -1943,6 +2039,7 @@ export default function ConnectData() {
   const defaultSelectionAppliedRef = useRef(false);
   const slackSelectionTouchedRef = useRef(false);
   const linearSelectionTouchedRef = useRef(false);
+  const googleAnalyticsSelectionTouchedRef = useRef(false);
   const [isMobileTourViewport, setIsMobileTourViewport] = useState(false);
   const [showStickyBarOnMobile, setShowStickyBarOnMobile] = useState(false);
   const [mobileTourOpen, setMobileTourOpen] = useState(false);
@@ -1985,6 +2082,7 @@ export default function ConnectData() {
   );
   const slackChannels = useMemo(() => Object.values(slackChannelsById), [slackChannelsById]);
   const linearProjects = useMemo(() => Object.values(linearProjectsById), [linearProjectsById]);
+  const googleAnalyticsProperties = useMemo(() => Object.values(googleAnalyticsPropertiesById), [googleAnalyticsPropertiesById]);
   const selectedManualDocumentIds = useMemo(() => new Set(manualMaterials.manualDocumentIds), [manualMaterials.manualDocumentIds]);
   const hasManualMaterials = Boolean(manualMaterials.manualDocumentIds.length > 0 || manualMaterials.summary.trim());
   const manualMaterialsSummary = hasManualMaterials
@@ -2003,6 +2101,9 @@ export default function ConnectData() {
   const shouldShowSlackPreview = slackSource?.status === "connected" || slackSource?.status === "syncing" || slackSource?.status === "error";
   const linearSource = sourceByKey.get("linear");
   const shouldShowLinearPreview = linearSource?.status === "connected" || linearSource?.status === "syncing" || linearSource?.status === "error";
+  const googleAnalyticsSource = sourceByKey.get("google_analytics");
+  const shouldShowGoogleAnalyticsPreview =
+    googleAnalyticsSource?.status === "connected" || googleAnalyticsSource?.status === "syncing" || googleAnalyticsSource?.status === "error";
 
   const refreshStatuses = async () => {
     setLoadingStatus(true);
@@ -2408,6 +2509,55 @@ export default function ConnectData() {
     };
   }, [backendBaseUrl, shouldShowLinearPreview, linearSource?.lastSyncedAt, linearSource?.status]);
 
+  useEffect(() => {
+    if (!shouldShowGoogleAnalyticsPreview) {
+      setGoogleAnalyticsPropertiesById({});
+      setGoogleAnalyticsNextCursor(null);
+      setGoogleAnalyticsAccountLabel(null);
+      setGoogleAnalyticsError(null);
+      setLoadingGoogleAnalyticsProperties(false);
+      setLoadingMoreGoogleAnalyticsProperties(false);
+      setSelectedGoogleAnalyticsPropertyIds(new Set());
+      googleAnalyticsSelectionTouchedRef.current = false;
+      return;
+    }
+
+    let cancelled = false;
+    googleAnalyticsSelectionTouchedRef.current = false;
+    setGoogleAnalyticsPropertiesById({});
+    setGoogleAnalyticsNextCursor(null);
+    setSelectedGoogleAnalyticsPropertyIds(new Set());
+    setLoadingGoogleAnalyticsProperties(true);
+    setGoogleAnalyticsError(null);
+    getVibeRaisingGoogleAnalyticsProperties(backendBaseUrl, { limit: GOOGLE_ANALYTICS_PROPERTY_PAGE_LIMIT })
+      .then((payload: VibeRaisingGoogleAnalyticsPropertiesResponse) => {
+        if (cancelled) return;
+        setGoogleAnalyticsPropertiesById((previous) => mergeGoogleAnalyticsPropertiesById(previous, payload.properties));
+        setGoogleAnalyticsNextCursor(payload.nextCursor ?? null);
+        setGoogleAnalyticsAccountLabel(payload.accountLabel ?? null);
+        const selectedPropertyIds = getSelectedGoogleAnalyticsPropertyIds(payload.properties);
+        if (!googleAnalyticsSelectionTouchedRef.current && selectedPropertyIds.length > 0) {
+          setSelectedGoogleAnalyticsPropertyIds((previous) => {
+            const nextSelected = new Set(previous);
+            selectedPropertyIds.forEach((propertyId) => nextSelected.add(propertyId));
+            return nextSelected;
+          });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setGoogleAnalyticsError(error instanceof Error ? error.message : "We couldn't load Google Analytics properties.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingGoogleAnalyticsProperties(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [backendBaseUrl, shouldShowGoogleAnalyticsPreview, googleAnalyticsSource?.status]);
+
   const currentReturnPath = `${location.pathname}${location.search || ""}`;
 
   const requestConnectSource = (source: VibeRaisingInputSourceSummary) => {
@@ -2460,6 +2610,10 @@ export default function ConnectData() {
     }
     if (source.key === "linear" && selectedLinearProjectIds.size === 0 && !selectedSources.has("linear")) {
       setStatusMessage("Select at least one Linear project before using Linear in this update.");
+      return;
+    }
+    if (source.key === "google_analytics" && selectedGoogleAnalyticsPropertyIds.size === 0 && !selectedSources.has("google_analytics")) {
+      setStatusMessage("Select at least one Google Analytics property before using Google Analytics in this update.");
       return;
     }
 
@@ -2635,6 +2789,71 @@ export default function ConnectData() {
       setStatusMessage(error instanceof Error ? error.message : "We couldn't sync Slack.");
     } finally {
       setSyncingSlack(false);
+    }
+  };
+
+  const handleToggleGoogleAnalyticsProperty = (propertyId: string) => {
+    googleAnalyticsSelectionTouchedRef.current = true;
+    setSelectedGoogleAnalyticsPropertyIds((previous) => {
+      const nextSelected = new Set(previous);
+      if (nextSelected.has(propertyId)) {
+        nextSelected.delete(propertyId);
+      } else {
+        nextSelected.add(propertyId);
+      }
+      return nextSelected;
+    });
+  };
+
+  const handleLoadMoreGoogleAnalyticsProperties = async () => {
+    if (!googleAnalyticsNextCursor || loadingMoreGoogleAnalyticsProperties) return;
+    setLoadingMoreGoogleAnalyticsProperties(true);
+    setGoogleAnalyticsError(null);
+    try {
+      const payload = await getVibeRaisingGoogleAnalyticsProperties(backendBaseUrl, {
+        cursor: googleAnalyticsNextCursor,
+        limit: GOOGLE_ANALYTICS_PROPERTY_PAGE_LIMIT,
+      });
+      setGoogleAnalyticsPropertiesById((previous) => mergeGoogleAnalyticsPropertiesById(previous, payload.properties));
+      setGoogleAnalyticsNextCursor(payload.nextCursor ?? null);
+      const selectedPropertyIds = getSelectedGoogleAnalyticsPropertyIds(payload.properties);
+      if (!googleAnalyticsSelectionTouchedRef.current && selectedPropertyIds.length > 0) {
+        setSelectedGoogleAnalyticsPropertyIds((previous) => {
+          const nextSelected = new Set(previous);
+          selectedPropertyIds.forEach((propertyId) => nextSelected.add(propertyId));
+          return nextSelected;
+        });
+      }
+    } catch (error) {
+      setGoogleAnalyticsError(error instanceof Error ? error.message : "We couldn't load more Google Analytics properties.");
+    } finally {
+      setLoadingMoreGoogleAnalyticsProperties(false);
+    }
+  };
+
+  const handleSaveGoogleAnalyticsProperties = async () => {
+    setSavingGoogleAnalyticsProperties(true);
+    setStatusMessage(null);
+    try {
+      const selectionResponse = await saveVibeRaisingGoogleAnalyticsPropertySelections(
+        backendBaseUrl,
+        Array.from(selectedGoogleAnalyticsPropertyIds),
+      );
+      setGoogleAnalyticsPropertiesById((previous) => mergeGoogleAnalyticsPropertiesById(previous, selectionResponse.properties));
+      setSelectedSources((previous) => {
+        const nextSelected = new Set(previous);
+        if (selectedGoogleAnalyticsPropertyIds.size > 0) {
+          nextSelected.add("google_analytics");
+        } else {
+          nextSelected.delete("google_analytics");
+        }
+        return nextSelected;
+      });
+      await refreshStatuses();
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : "We couldn't save Google Analytics property selection.");
+    } finally {
+      setSavingGoogleAnalyticsProperties(false);
     }
   };
 
@@ -3165,6 +3384,22 @@ export default function ConnectData() {
           ) : null}
         </div>
       </section>
+
+      {shouldShowGoogleAnalyticsPreview ? (
+        <GoogleAnalyticsPreview
+          properties={googleAnalyticsProperties}
+          accountLabel={googleAnalyticsAccountLabel ?? googleAnalyticsSource?.accountLabel ?? null}
+          loading={loadingGoogleAnalyticsProperties}
+          error={googleAnalyticsError}
+          saving={savingGoogleAnalyticsProperties}
+          selectedPropertyIds={selectedGoogleAnalyticsPropertyIds}
+          nextCursor={googleAnalyticsNextCursor}
+          loadingMore={loadingMoreGoogleAnalyticsProperties}
+          onToggleProperty={handleToggleGoogleAnalyticsProperty}
+          onLoadMore={() => void handleLoadMoreGoogleAnalyticsProperties()}
+          onSave={() => void handleSaveGoogleAnalyticsProperties()}
+        />
+      ) : null}
 
       {shouldShowSlackPreview ? (
         <SlackPreview

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -266,6 +266,7 @@ export interface VibeRaisingInputSourceSummary {
   googlePermissionsUrl?: string | null;
   selectedChannelCount?: number;
   selectedProjectCount?: number;
+  selectedPropertyCount?: number;
   hasReportScope?: boolean;
   needsReportReconnect?: boolean;
   canRequestReportScopes?: boolean;
@@ -383,6 +384,24 @@ export interface VibeRaisingSlackChannel {
   isPrivate: boolean;
   selected: boolean;
   lastSyncedAt?: string | null;
+}
+
+export interface VibeRaisingGoogleAnalyticsProperty {
+  id?: number | string;
+  propertyId: string;
+  propertyDisplayName: string;
+  name?: string | null;
+  accountId?: string | null;
+  accountDisplayName?: string | null;
+  selected: boolean;
+  lastSyncedAt?: string | null;
+}
+
+export interface VibeRaisingGoogleAnalyticsPropertiesResponse {
+  accountLabel?: string | null;
+  properties: VibeRaisingGoogleAnalyticsProperty[];
+  nextCursor?: string | null;
+  warnings: string[];
 }
 
 export interface VibeRaisingSlackChannelsResponse {


### PR DESCRIPTION
Turns the scaffolded **"coming soon"** Google Analytics source into a real connectable source and adds a GA4 property picker. Companion to mlai-backend#440 (which adds the GA OAuth + `/google-analytics/*` endpoints this calls).

## What's included
- **Activation** — GA removed from the `Connectable…`/`OAuthSourceKey` exclusions and added to `FUNCTIONAL_SOURCES`; the `coming_soon` hardcode dropped so real backend status flows through; `google-analytics` connect slug added; dead `GoogleAnalyticsPlaceholderCard` deleted.
- **GA4 property picker** (mirrors the Slack channel pattern) — `getVibeRaisingGoogleAnalyticsProperties` / `saveVibeRaisingGoogleAnalyticsPropertySelections`, a `GoogleAnalyticsPreview` panel (checkbox list, save, load-more) shown once GA is connected, and "Use in this update" gated on ≥1 selected property.
- **Types** — `VibeRaisingGoogleAnalyticsProperty` + response type, `selectedPropertyCount` on the source summary.

The create-update tile/label/logo were already scaffolded, so no changes needed there. `bun run typecheck` clean.

> Deploy note: the GA connect/property endpoints land with mlai-backend#440 — merge/deploy that first (or together) so connecting GA doesn't 404 in the transient window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)