### PR TITLE
Give the homepage Founder Tools cards the MLAI Studio deck animation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -467,3 +467,6 @@
 - [x] Verify the integrated /mlai-studio layout and homepage tab order in the local browser, run `bun run typecheck`
 - [x] Recolor the Studio sidebar tab, section marker, and homepage divider from teal back to crimson (#ff003d)
 - [x] Recolor the MLAI Studio teaser main accents (eyebrow, rotating word box, stats, CTA) from mint to crimson, leaving the sliding pill marquee untouched
+- [x] Replace the homepage FounderTools card deck with the MLAI Studio "Why join" fanned-deck animation (self-contained, ported under ft- classes)
+- [x] Repopulate the deck with the four Founder Tools tracks (Vibe Coding/Marketing/Raising/Coworking), matching the studio card style (flat colour + emoji + hover-reveal, no images/links)
+- [x] Verify the homepage deck (4 cards, studio fan/hover, descriptions fit) and that the studio page deck is unaffected; run `bun run typecheck`

--- a/app/components/FounderTools.tsx
+++ b/app/components/FounderTools.tsx
@@ -1,214 +1,104 @@
-import { useState, useRef, useEffect } from "react";
+/* ============================================================
+   FOUNDER TOOLS — homepage section
+   Ported from the MLAI Studio "Why join" fanned deck
+   (app/routes/mlai-studio.tsx + the `.deck` rules in
+   app/styles/mlai-studio.css). The homepage isn't under
+   `.ms-scope`, so the deck CSS is recreated self-contained here
+   with concrete colours under `ft-` classes and embedded in a
+   <style> block (same pattern as MlaiStudioTeaser).
 
-interface ToolCard {
-  id: string;
-  title: string;
-  bgColor: string;
-  icon: string;
-  explanation: string;
-  image?: string;
-  href?: string;
-  rotation: string;
-  zIndex: number;
-}
+   Interaction (pure CSS, no JS): the four cards fan out; hovering
+   the deck dims them; hovering a card straightens + lifts it,
+   pops its badge, and cross-fades "See what's inside →" into the
+   blurb. On narrow screens the fan collapses to a plain stack
+   with the blurbs always shown.
+   ============================================================ */
 
-const tools: ToolCard[] = [
+// Four founder tracks. Colours match the studio deck (orange / teal /
+// purple / yellow) and the sidebar palette.
+const TOOLS = [
   {
-    id: "coding",
-    title: "Vibe Coding",
-    bgColor: "#ff3d00", // Orange - from sidebar
+    c: "orange",
     icon: "💻",
-    explanation:
-      "Turn a shower idea into a real product. Join a hands-on workshop to learn practical AI 'vibe coding' safely, from zero to MVP. Short on time? Drop a bounty and someone in the MLAI community can build your feature or automation for you.",
-    image: "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Screenshot%202026-01-17%20at%207.14.23%E2%80%AFPM.png?alt=media&token=55ffa63b-c525-4bd0-a0b6-57701442784d",
-    rotation: "-rotate-3",
-    zIndex: 10,
+    t: "Vibe Coding",
+    d: "Learn AI vibe coding hands-on, from zero to MVP — or drop a bounty and someone in the MLAI community builds your feature for you.",
   },
   {
-    id: "marketing",
-    title: "Vibe Marketing",
-    bgColor: "#00ffd7", // Mint - from sidebar
+    c: "teal",
     icon: "📣",
-    explanation:
-      "Got a site or product? Now get traction. Learn how to use AI to publish content, rank in search, and show up in answer engines so the right customers find you. Simple systems that compound while you keep building.",
-    image: "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Screenshot%202026-01-17%20at%207.14.09%E2%80%AFPM.png?alt=media&token=9fae98ac-b534-47c9-8f99-a0aff50a2a5a",
-    href: "/founder-tools/marketing",
-    rotation: "rotate-2",
-    zIndex: 20,
+    t: "Vibe Marketing",
+    d: "Use AI to publish content, rank in search, and show up in answer engines so the right customers actually find you.",
   },
   {
-    id: "raising",
-    title: "Vibe Raising",
-    bgColor: "#4b0db3", // Purple - from sidebar
+    c: "purple",
     icon: "🤝",
-    explanation:
-      "Investor networks take years to build. If you share consistent, authentic monthly updates, we'll warm-intro you to investors with a real track record in startups like yours, in Australia and overseas.",
-    image: "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Screenshot%202026-01-17%20at%207.19.26%E2%80%AFPM.png?alt=media&token=560f5b25-a414-4967-8c5c-e942342a9031",
-    href: "/founder-tools/updates",
-    rotation: "-rotate-2",
-    zIndex: 30,
+    t: "Vibe Raising",
+    d: "Share authentic monthly updates and we'll warm-intro you to investors with a real track record in startups like yours.",
   },
   {
-    id: "coworking",
-    title: "Vibe Coworking",
-    bgColor: "#fefc22", // Yellow - from sidebar
+    c: "yellow",
     icon: "🏢",
-    explanation:
-      "Founding is lonely, so don't do it solo. Get free coworking in Australian capital cities for MLAI volunteers, plus a room full of founders swapping learnings, tools, and momentum.",
-    image: "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Screenshot%202026-01-17%20at%207.23.16%E2%80%AFPM.png?alt=media&token=65134cae-3689-40e4-bff0-88d22dd3a981",
-    rotation: "rotate-3",
-    zIndex: 40,
+    t: "Vibe Coworking",
+    d: "Free coworking for MLAI volunteers across Australian capitals — a room full of founders swapping tools and momentum.",
   },
 ];
 
-// Mobile stack layout constants
-const PEEK_HEIGHT = 70;   // How much of each unselected card is visible
-const CARD_HEIGHT = 280;  // Full card height on mobile
+const DECK_CSS = `
+.ft-deck { display: flex; justify-content: center; align-items: center; margin-top: 40px; padding: 46px 0 30px; }
+.ft-card {
+  position: relative; flex: 0 0 252px; width: 252px; min-height: 446px; border-radius: 30px;
+  padding: 30px 26px; display: flex; flex-direction: column; align-items: center; text-align: center;
+  justify-content: space-between; transform-origin: bottom center; cursor: pointer;
+  transition: transform .3s cubic-bezier(.2,.7,.2,1), filter .3s ease, box-shadow .3s ease;
+}
+.ft-card:nth-child(1) { transform: rotate(-8deg) translateY(12px); z-index: 1; }
+.ft-card:nth-child(2) { transform: rotate(-3deg); z-index: 2; margin-left: -60px; }
+.ft-card:nth-child(3) { transform: rotate(3deg); z-index: 3; margin-left: -60px; }
+.ft-card:nth-child(4) { transform: rotate(8deg) translateY(12px); z-index: 2; margin-left: -60px; }
+.ft-deck:hover .ft-card { filter: brightness(.55) saturate(.85); }
+.ft-deck .ft-card:hover { transform: rotate(0deg) translateY(-30px) scale(1.07); z-index: 20; filter: brightness(1.06) saturate(1.05); }
+
+.ft-orange { background: #ff3c00; color: #fff;     box-shadow: 0 22px 60px -24px rgba(255,60,0,.7); }
+.ft-teal   { background: #00ffd7; color: #1a1a1a;  box-shadow: 0 22px 60px -24px rgba(0,255,215,.5); }
+.ft-purple { background: #4b0db3; color: #fff;     box-shadow: 0 22px 60px -24px rgba(75,13,179,.8); }
+.ft-yellow { background: #fefc22; color: #1a1a1a;  box-shadow: 0 22px 60px -24px rgba(254,252,34,.45); }
+.ft-deck .ft-orange:hover { box-shadow: 0 40px 96px -20px rgba(255,60,0,.95); }
+.ft-deck .ft-teal:hover   { box-shadow: 0 40px 96px -20px rgba(0,255,215,.8); }
+.ft-deck .ft-purple:hover { box-shadow: 0 40px 96px -20px rgba(108,40,217,1); }
+.ft-deck .ft-yellow:hover { box-shadow: 0 40px 96px -20px rgba(254,252,34,.75); }
+
+.ft-top { width: 100%; display: flex; justify-content: center; position: relative; }
+.ft-badge { width: 58px; height: 58px; border-radius: 999px; display: grid; place-items: center; font-size: 27px; background: rgba(255,255,255,.2); transition: transform .3s cubic-bezier(.2,.9,.3,1.4); }
+.ft-teal .ft-badge, .ft-yellow .ft-badge { background: rgba(26,26,26,.12); }
+.ft-card:hover .ft-badge { transform: scale(1.12) rotate(-6deg); }
+.ft-title { font-family: 'Oswald', 'Arial Narrow', sans-serif; font-weight: 700; text-transform: uppercase; font-size: 25px; line-height: 1.04; margin: 0; letter-spacing: -.01em; }
+.ft-slot { position: relative; width: 100%; min-height: 132px; display: flex; align-items: flex-start; justify-content: center; }
+.ft-hint, .ft-desc { position: absolute; left: 0; right: 0; top: 0; transition: opacity .26s ease, transform .26s ease; }
+.ft-hint { font-family: 'Roboto', system-ui, sans-serif; font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .07em; opacity: .9; padding-top: 30px; }
+.ft-desc { font-family: 'Roboto', system-ui, sans-serif; font-size: 14.5px; line-height: 1.5; opacity: 0; transform: translateY(10px); }
+.ft-card:hover .ft-hint { opacity: 0; transform: translateY(-8px); }
+.ft-card:hover .ft-desc { opacity: 1; transform: none; }
+@media (max-width: 820px) {
+  .ft-deck { flex-direction: column; align-items: center; padding: 8px 0 0; margin-top: 24px; }
+  .ft-card { flex: none; width: 100%; max-width: 440px; min-height: 0; margin-left: 0 !important; transform: none !important; filter: none !important; margin-bottom: 16px; justify-content: flex-start; gap: 18px; }
+  .ft-deck:hover .ft-card { filter: none !important; }
+  .ft-slot { min-height: 0; }
+  .ft-hint { display: none; }
+  .ft-desc { position: static; opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ft-card, .ft-badge, .ft-hint, .ft-desc { transition: none; }
+}
+`;
 
 export default function FounderTools() {
-  const [hoveredTool, setHoveredTool] = useState<string | null>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [selectedTool, setSelectedTool] = useState<string>("coding"); // For mobile tap selection
-  const [prevSelectedTool, setPrevSelectedTool] = useState<string | null>(null); // Track previous for smooth z-index
-  const [isTransitioning, setIsTransitioning] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const transitionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  // Handle card selection with transition tracking
-  const handleCardSelect = (toolId: string) => {
-    const tool = tools.find((item) => item.id === toolId);
-    if (tool?.href) {
-      window.location.assign(tool.href);
-      return;
-    }
-
-    if (toolId === selectedTool) return;
-
-    // Track the previous selection for z-index during transition
-    setPrevSelectedTool(selectedTool);
-    setSelectedTool(toolId);
-    setIsTransitioning(true);
-
-    // Clear any existing timeout
-    if (transitionTimeoutRef.current) {
-      clearTimeout(transitionTimeoutRef.current);
-    }
-
-    // After animation completes, clear the transitioning state
-    transitionTimeoutRef.current = setTimeout(() => {
-      setIsTransitioning(false);
-      setPrevSelectedTool(null);
-    }, 450); // Slightly longer than animation duration
-  };
-
-  const handleDesktopCardClick = (tool: ToolCard) => {
-    if (!tool.href) return;
-    window.location.assign(tool.href);
-  };
-
-  // Detect mobile viewport
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 639px)");
-    setIsMobile(mediaQuery.matches);
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      setIsMobile(e.matches);
-    };
-
-    mediaQuery.addEventListener("change", handleChange);
-    return () => mediaQuery.removeEventListener("change", handleChange);
-  }, []);
-
-  // Preload all images on component mount
-  useEffect(() => {
-    tools.forEach((tool) => {
-      if (tool.image) {
-        const img = new Image();
-        img.src = tool.image;
-      }
-    });
-  }, []);
-
-  const handleMouseEnter = (toolId: string) => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-    setHoveredTool(toolId);
-    setIsExpanded(true);
-  };
-
-  const handleMouseLeave = () => {
-    timeoutRef.current = setTimeout(() => {
-      setIsExpanded(false);
-      setTimeout(() => setHoveredTool(null), 300);
-    }, 150);
-  };
-
-  const handleExpandedMouseEnter = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-  };
-
-  const handleExpandedMouseLeave = () => {
-    handleMouseLeave();
-  };
-
-  const hoveredToolData = tools.find((tool) => tool.id === hoveredTool);
-  const hoveredToolIndex = tools.findIndex((tool) => tool.id === hoveredTool);
-
-  const perCardPercent = 100 / tools.length;
-
-  // Get the selected tool data for mobile view
-  const selectedToolData = tools.find((tool) => tool.id === selectedTool);
-  const selectedToolIndex = tools.findIndex((tool) => tool.id === selectedTool);
-
-  // Calculate position for mobile stacked cards
-  const getStackPosition = (cardIndex: number, toolId: string) => {
-    const unselectedCount = tools.length - 1;
-    const peekStackHeight = unselectedCount * PEEK_HEIGHT;
-
-    if (cardIndex === selectedToolIndex) {
-      // Selected card - positioned after all the peeks, highest z-index
-      return {
-        translateY: peekStackHeight,
-        zIndex: 50,
-        scale: 1,
-      };
-    }
-
-    // Calculate position in the peek stack (excluding selected card)
-    let peekPosition = cardIndex;
-    if (cardIndex > selectedToolIndex) {
-      peekPosition = cardIndex - 1;
-    }
-
-    // During transition, keep the previously selected card at a higher z-index
-    // so it doesn't disappear behind other cards while animating back
-    let zIndex = 10 + peekPosition;
-    if (isTransitioning && toolId === prevSelectedTool) {
-      zIndex = 45; // Just below the newly selected card
-    }
-
-    return {
-      translateY: peekPosition * PEEK_HEIGHT,
-      zIndex,
-      scale: 1,
-    };
-  };
-
-  // Calculate total height for mobile stack container
-  const mobileStackHeight = (tools.length - 1) * PEEK_HEIGHT + CARD_HEIGHT;
-
   return (
     <div className="w-full bg-[var(--brutalist-beige)] p-2 lg:p-3">
-      <div className="w-full bg-gray-900 rounded-2xl sm:rounded-[2.5rem] py-12 sm:py-16 lg:py-20 px-4 sm:px-6 lg:px-8">
+      <div className="w-full bg-gray-900 rounded-2xl sm:rounded-[2.5rem] py-12 sm:py-16 lg:py-20 px-4 sm:px-6 lg:px-8 overflow-hidden">
+        <style>{DECK_CSS}</style>
         <div className="max-w-7xl mx-auto">
           {/* Header */}
-          <div className="text-center mb-16">
+          <div className="text-center">
             <p className="text-gray-400 text-sm uppercase tracking-widest mb-4">
               FOUNDER TOOLS
             </p>
@@ -221,308 +111,21 @@ export default function FounderTools() {
             </p>
           </div>
 
-          {/* Cards - Mobile Stacked / Desktop Overlapping */}
-          {isMobile ? (
-            /* Mobile: Stacked card layout */
-            <div
-              className="relative mx-auto mb-8 px-4"
-              style={{ height: mobileStackHeight }}
-            >
-              {tools.map((tool, index) => {
-                const isYellow = tool.bgColor === "#fefc22";
-                const isMint = tool.bgColor === "#00ffd7";
-                const useDarkText = isYellow || isMint;
-                const isSelected = selectedTool === tool.id;
-                const position = getStackPosition(index, tool.id);
-
-                return (
-                  <div
-                    key={tool.id}
-                    onClick={() => handleCardSelect(tool.id)}
-                    className={`absolute left-4 right-4 rounded-3xl cursor-pointer transition-all duration-400`}
-                    style={{
-                      backgroundColor: tool.bgColor,
-                      height: CARD_HEIGHT,
-                      transform: `translateY(${position.translateY}px) scale(${position.scale})`,
-                      zIndex: position.zIndex,
-                      boxShadow: isSelected
-                        ? `0 0 60px ${tool.bgColor}60, 0 0 100px ${tool.bgColor}30, 0 10px 40px rgba(0,0,0,0.3)`
-                        : `0 0 30px ${tool.bgColor}40, 0 4px 20px rgba(0,0,0,0.2)`,
-                      transitionTimingFunction: "cubic-bezier(0.34, 1.56, 0.64, 1)",
-                    }}
-                  >
-                    {/* Peek header - icon and title side by side */}
-                    <div className="absolute top-4 left-4 right-4 flex items-center gap-3">
-                      <div
-                        className={`w-10 h-10 rounded-full flex-shrink-0 ${useDarkText ? "bg-black/10" : "bg-white/20"
-                          } backdrop-blur-sm flex items-center justify-center text-xl`}
-                      >
-                        {tool.icon}
-                      </div>
-                      <h3
-                        className={`text-lg font-bold ${useDarkText ? "text-black" : "text-white"
-                          }`}
-                      >
-                        {tool.title}
-                      </h3>
-                    </div>
-
-                    {/* Full content - only visible on selected card */}
-                    {isSelected && (
-                      <div className="absolute bottom-6 left-0 right-0 text-center px-4">
-                      <span
-                        className={`text-sm font-medium ${useDarkText ? "text-black/70" : "text-white/80"
-                          }`}
-                      >
-                          See what's inside
-                      </span>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            /* Desktop: Overlapping horizontal layout */
-            <div className="flex flex-wrap justify-center items-center gap-4 sm:gap-0 mb-8 px-4 sm:px-0">
-              {tools.map((tool, index) => {
-                const isYellow = tool.bgColor === "#fefc22";
-                const isMint = tool.bgColor === "#00ffd7";
-                const useDarkText = isYellow || isMint;
-                const isHovered = hoveredTool === tool.id;
-
-                return (
-                  <div
-                    key={tool.id}
-                    onMouseEnter={() => handleMouseEnter(tool.id)}
-                    onMouseLeave={handleMouseLeave}
-                    onClick={() => handleDesktopCardClick(tool)}
-                    role={tool.href ? "link" : undefined}
-                    tabIndex={tool.href ? 0 : undefined}
-                    onKeyDown={(event) => {
-                      if (!tool.href) return;
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        window.location.assign(tool.href);
-                      }
-                    }}
-                    className={`relative overflow-hidden rounded-3xl p-8 w-64 h-80 transition-all duration-300 cursor-pointer
-                      ${tool.rotation}
-                      ${isHovered ? "scale-110" : "hover:scale-105"}
-                      ${index > 0 ? "sm:-ml-8 lg:-ml-10" : ""}`}
-                    style={{
-                      backgroundColor: tool.bgColor,
-                      zIndex: isHovered ? 50 : tool.zIndex,
-                      boxShadow: isHovered
-                        ? `0 0 60px ${tool.bgColor}60, 0 0 100px ${tool.bgColor}30`
-                        : `0 0 40px ${tool.bgColor}40, 0 0 80px ${tool.bgColor}20`,
-                    }}
-                  >
-                    {/* Icon */}
-                    <div className="absolute top-8 left-1/2 -translate-x-1/2">
-                      <div
-                        className={`w-16 h-16 rounded-full ${useDarkText ? "bg-black/10" : "bg-white/20"
-                          } backdrop-blur-sm flex items-center justify-center text-3xl`}
-                      >
-                        {tool.icon}
-                      </div>
-                    </div>
-
-                    {/* Title */}
-                    <div className="absolute bottom-20 left-0 right-0 text-center px-4">
-                      <h3
-                        className={`text-2xl font-bold mb-2 ${useDarkText ? "text-black" : "text-white"
-                          }`}
-                      >
-                        {tool.title}
-                      </h3>
-                    </div>
-
-                    {/* Preview Badge */}
-                    <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
-                      <span
-                        className={`text-sm font-medium ${useDarkText ? "text-black/70" : "text-white/80"
-                          }`}
-                      >
-                        See what's inside
-                      </span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Description Panel */}
-          {isMobile ? (
-            /* Mobile: Always visible description for selected tool */
-            <div className="bg-gray-800 rounded-3xl p-6 mt-4 mx-4">
-              {selectedToolData && (
-                <div key={selectedTool} className="space-y-6">
-                  {/* Text Content */}
-                  <div className="text-white">
-                    <h3 className="text-xl font-bold mb-3">
-                      How it works
-                    </h3>
-                    <p className="text-gray-300 text-base leading-relaxed">
-                      {selectedToolData.explanation}
-                    </p>
-                  </div>
-
-                  {/* Image */}
-                  <div className="relative">
-                    <div className="aspect-video rounded-2xl bg-gray-700 overflow-hidden border-2 border-white shadow-xl">
-                      <img
-                        src={
-                          selectedToolData.image ||
-                          "https://images.unsplash.com/photo-1600880292203-757bb62b4baf?w=800&h=600&fit=crop"
-                        }
-                        alt={`${selectedToolData.title} preview`}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  </div>
-
-                  {/* Access Tools Button */}
-                  <div className="text-center">
-                    {selectedToolData.href ? (
-                      <a
-                        href={selectedToolData.href}
-                        className={`font-bold py-3 px-8 rounded-full text-base transition-all duration-300 hover:scale-105 active:scale-95 inline-block ${selectedToolData.bgColor === "#fefc22" || selectedToolData.bgColor === "#00ffd7"
-                          ? "text-black"
-                          : "text-white"
-                          }`}
-                        style={{
-                          backgroundColor: selectedToolData.bgColor,
-                          boxShadow: `0 0 30px ${selectedToolData.bgColor}60, 0 4px 15px rgba(0, 0, 0, 0.3)`
-                        }}
-                      >
-                        Open {selectedToolData.title}
-                      </a>
-                    ) : (
-                      <button
-                        className={`font-bold py-3 px-8 rounded-full text-base transition-all duration-300 ${selectedToolData.bgColor === "#fefc22" || selectedToolData.bgColor === "#00ffd7"
-                          ? "text-black"
-                          : "text-white"
-                          }`}
-                        style={{
-                          backgroundColor: selectedToolData.bgColor,
-                          boxShadow: `0 0 30px ${selectedToolData.bgColor}60, 0 4px 15px rgba(0, 0, 0, 0.3)`
-                        }}
-                      >
-                        Open {selectedToolData.title}
-                      </button>
-                    )}
-                  </div>
+          {/* Fanned deck — hover a card to straighten it and reveal the blurb */}
+          <div className="ft-deck">
+            {TOOLS.map((card) => (
+              <div key={card.t} className={`ft-card ft-${card.c}`}>
+                <div className="ft-top">
+                  <div className="ft-badge">{card.icon}</div>
                 </div>
-              )}
-            </div>
-          ) : (
-            /* Desktop: Hover-based expanding panel */
-            <div className="relative">
-              {/* Arrow pointer */}
-              {hoveredToolData && (
-                <div
-                  className={`absolute -top-3 transition-all duration-300 ease-out ${isExpanded ? "opacity-100" : "opacity-0"
-                    }`}
-                  style={{
-                    left: `calc(${(hoveredToolIndex + 0.5) * perCardPercent}% - 12px)`,
-                  }}
-                >
-                  <div
-                    className="w-6 h-6 rotate-45 bg-gray-800"
-                    style={{
-                      marginLeft:
-                        hoveredToolIndex === 0
-                          ? "20px"
-                          : hoveredToolIndex === tools.length - 1
-                            ? "-20px"
-                            : "0",
-                    }}
-                  />
-                </div>
-              )}
-
-              {/* Expandable content container */}
-              <div
-                onMouseEnter={handleExpandedMouseEnter}
-                onMouseLeave={handleExpandedMouseLeave}
-                className={`overflow-hidden transition-all ease-out ${isExpanded
-                  ? "max-h-[500px] opacity-100 duration-500"
-                  : "max-h-0 opacity-0 duration-300"
-                  }`}
-                style={{
-                  transitionTimingFunction: isExpanded
-                    ? "cubic-bezier(0.34, 1.56, 0.64, 1)"
-                    : "ease-out",
-                }}
-              >
-                <div className="bg-gray-800 rounded-3xl p-8 md:p-12 mt-4">
-                  {hoveredToolData && (
-                    <div key={hoveredTool} className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
-                      {/* Text Content */}
-                      <div className="text-white">
-                        <h3 className="text-2xl md:text-3xl font-bold mb-4">
-                          How it works
-                        </h3>
-                        <p className="text-gray-300 text-lg leading-relaxed">
-                          {hoveredToolData.explanation}
-                        </p>
-                      </div>
-
-                      {/* Image */}
-                      <div className="relative">
-                        <div className="aspect-video rounded-2xl bg-gray-700 overflow-hidden border-4 border-white shadow-2xl">
-                          <img
-                            src={
-                              hoveredToolData.image ||
-                              "https://images.unsplash.com/photo-1600880292203-757bb62b4baf?w=800&h=600&fit=crop"
-                            }
-                            alt={`${hoveredToolData.title} preview`}
-                            className="w-full h-full object-cover"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Access Tools Button */}
-                  <div className="mt-8 text-center">
-                    {hoveredToolData && (
-                      hoveredToolData.href ? (
-                        <a
-                          href={hoveredToolData.href}
-                          className={`font-bold py-4 px-12 rounded-full text-lg transition-all duration-300 hover:scale-105 inline-block ${hoveredToolData.bgColor === "#fefc22" || hoveredToolData.bgColor === "#00ffd7"
-                            ? "text-black"
-                            : "text-white"
-                            }`}
-                          style={{
-                            backgroundColor: hoveredToolData.bgColor,
-                            boxShadow: `0 0 40px ${hoveredToolData.bgColor}60, 0 4px 20px rgba(0, 0, 0, 0.3)`
-                          }}
-                        >
-                          Open {hoveredToolData.title}
-                        </a>
-                      ) : (
-                        <button
-                          className={`font-bold py-4 px-12 rounded-full text-lg transition-all duration-300 ${hoveredToolData.bgColor === "#fefc22" || hoveredToolData.bgColor === "#00ffd7"
-                            ? "text-black"
-                            : "text-white"
-                            }`}
-                          style={{
-                            backgroundColor: hoveredToolData.bgColor,
-                            boxShadow: `0 0 40px ${hoveredToolData.bgColor}60, 0 4px 20px rgba(0, 0, 0, 0.3)`
-                          }}
-                        >
-                          Open {hoveredToolData.title}
-                        </button>
-                      )
-                    )}
-                  </div>
+                <h3 className="ft-title">{card.t}</h3>
+                <div className="ft-slot">
+                  <span className="ft-hint">See what's inside →</span>
+                  <p className="ft-desc">{card.d}</p>
                 </div>
               </div>
-            </div>
-          )}
+            ))}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Per Sam: the `/mlai-studio` 'Why join' cards animate much more nicely than the homepage Founder Tools deck — so this swaps the homepage deck for that exact animation, with Founder Tools text.

## What changed
- **`app/components/FounderTools.tsx` rewritten** to use the studio page's fanned `.deck` animation: cards fan out, hovering the deck dims the others, hovering a card straightens + lifts it, pops the badge, and cross-fades `See what's inside →` into the blurb. Mobile collapses to a plain stack with blurbs shown (same as the studio page).
- The studio deck CSS is **recreated self-contained** here (the originals are `.ms-scope`-scoped and don't apply on the homepage) — concrete brand colours under `ft-` classes, embedded in a `<style>` block, exactly like `MlaiStudioTeaser` already does.
- Cards carry the **four Founder Tools tracks** — Vibe Coding / Marketing / Raising / Coworking (orange/teal/purple/yellow, matching the studio deck) — in the studio card style: flat colour + emoji + hover-reveal description.

## Decisions (confirmed with Sam)
- **Match studio exactly:** dropped the previous deck's background images and click-through links (Marketing → /founder-tools/marketing, Raising → /founder-tools/updates). Those pages remain reachable from the sidebar/other nav.
- Section header (eyebrow + 'Founder-built tools to launch faster' + subtitle) is kept.

## Verified locally
DOM-confirmed on the homepage: 4 cards, correct fan rotations, studio colours (`#ff3c00` / `#00ffd7` / `#4b0db3` / `#fefc22`), all four hover rules present, correct default crossfade (hint shown / desc hidden), and every description fits its card. The studio page's own deck is unaffected (no class leakage). `bun run typecheck` passes; console clean after a Vite cache reset.

> Note: the preview screenshot tool blanks out when this homepage is scrolled (a long-standing quirk in my environment — it works fine at the top of the page), so verification here is via computed-style/DOM measurements rather than a pasted image. Worth a quick local eyeball of the hover on desktop before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)