### PR TITLE
Collapse publish + merge into one Publish button

### DIFF
--- a/app/lib/vibe-marketing-run-view.ts
+++ b/app/lib/vibe-marketing-run-view.ts
@@ -147,6 +147,16 @@ export function hasPublishHandoffEvidence(run: VibeMarketingRunSummary) {
   );
 }
 
+export function isPublishFlowSettled(run: VibeMarketingRunSummary) {
+  if (normalized(stringResultValue(run, "merge_status", "mergeStatus")) === "merged") return true;
+  if (publishPrUrlForRun(run)) return false;
+  const childStatus =
+    normalized(run.publishChildStatus ?? "") || normalized(stringResultValue(run, "publish_child_status", "publishChildStatus"));
+  const previewEvidence =
+    publishPreviewUrlForRun(run) || stringResultValue(run, "publish_child_preview_url", "publishChildPreviewUrl");
+  return childStatus === "completed" && Boolean(previewEvidence);
+}
+
 export function isPublishApprovalGate(run: VibeMarketingRunSummary) {
   return Boolean(
     isArticleWorkflow(run.workflow) &&

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -36,6 +36,7 @@ import {
   hasPublishHandoffEvidence,
   isArticleReviewPreviewReady,
   isPublishApprovalGate,
+  isPublishFlowSettled,
   publishPreviewUrlForRun,
   publishPrUrlForRun,
   viewedWorkflowStepIdForRun,
@@ -531,8 +532,14 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       await removeNotificationChannel(env, request, stringFromForm(formData, "channelId"));
     } else if (["approve", "deny", "resume", "restart", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
       const sourceRunId = stringFromForm(formData, "sourceRunId");
+      const autoMerge =
+        stringFromForm(formData, "autoMerge") === "true" &&
+        ["approve", "promote-bundle", "publish-pr"].includes(intent);
       const controlRunId = intent === "promote-bundle" || intent === "publish-pr" ? sourceRunId || runId : runId;
-      const result = await controlVibeMarketingRun(env, request, controlRunId, intent, sourceRunId ? { sourceRunId } : {});
+      const payload: Record<string, unknown> = {};
+      if (sourceRunId) payload.sourceRunId = sourceRunId;
+      if (autoMerge) payload.autoMerge = true;
+      const result = await controlVibeMarketingRun(env, request, controlRunId, intent, payload);
       if ((intent === "merge-setup-pr" || intent === "refresh-setup-pr-status") && isArticleSystemSetupMerged(result)) {
         throw redirect("/founder-tools/marketing?setupMerged=1");
       }
@@ -2227,6 +2234,7 @@ function LiveArticlePreviewPanel({
             <div className="flex flex-col gap-2 sm:flex-row">
               {canAcceptArticleForPublish ? (
                 <Form method="POST">
+                  <input type="hidden" name="autoMerge" value="true" />
                   <button
                     type="submit"
                     name="intent"
@@ -2726,6 +2734,22 @@ function PublishAndAutomateDetail({
   const runDailyPending = isActionPending?.("run-daily-discovery-now") ?? isSubmitting;
   const mergeStatus = stringResultValue(run, "merge_status", "mergeStatus");
   const isMerged = mergeStatus === "merged";
+  const mergeBlockedReason = stringResultValue(run, "merge_blocked_reason", "mergeBlockedReason");
+  const autoMergeState = stringResultValue(run, "publish_auto_merge_state", "publishAutoMergeState");
+  const autoMergeEnabled = run.result?.["publish_auto_merge"] === true;
+  const publishChildPreviewUrl = stringResultValue(run, "publish_child_preview_url", "publishChildPreviewUrl");
+  const publishedWithoutPr = Boolean(!prUrl && (previewUrl || publishChildPreviewUrl) && publishChildStatus === "completed");
+  const mergeBlocked = Boolean(
+    prUrl &&
+      !isMerged &&
+      (autoMergeState === "blocked" || ["failed", "failure", "error", "closed"].includes(checksStatus)),
+  );
+  const publishChildFailed = Boolean(
+    !prUrl &&
+      !isMerged &&
+      !publishedWithoutPr &&
+      (publishChildStatus === "failed" || (publishChildRunId === run.runId && run.status === "failed")),
+  );
   const dailyCheck = bootstrap.checks.dailyAutomation as
     | (VibeMarketingBootstrap["checks"][string] & { ready?: boolean; enabled?: boolean })
     | undefined;
@@ -2747,48 +2771,162 @@ function PublishAndAutomateDetail({
             <p className="text-xs font-black uppercase tracking-wide text-violet-700">Publish & automate</p>
             <h2 className="mt-1 text-xl font-black text-gray-950">Finish publishing this article</h2>
             <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
-              Create the publish PR, merge it after checks pass, then turn on daily research prompts (Slack, email or WhatsApp) for the next article.
+              Publish the article — the PR merges to main automatically once checks pass — then turn on daily research prompts (Slack, email or WhatsApp) for the next article.
             </p>
           </div>
           <WorkflowStatusPill status={automationStep?.status === "complete" ? "complete" : publishStep?.status ?? "ready"} />
         </div>
 
-        <div className="mt-5 grid gap-4 lg:grid-cols-3">
+        <div className="mt-5 grid gap-4 lg:grid-cols-2">
           <PublishFlowCard
-            title="Publish PR"
-            status={prUrl ? "complete" : publishPending ? "running" : "ready"}
+            title="Publish"
+            status={
+              isMerged || publishedWithoutPr
+                ? "complete"
+                : mergeBlocked || publishChildFailed
+                  ? "blocked"
+                  : prUrl || publishPending
+                    ? "running"
+                    : "ready"
+            }
             eyebrow={
-              prUrl
-                ? "PR ready"
-                : publishPending
-                  ? "Preparing PR"
-                  : publishChildRecoverable
-                    ? "Resume needed"
-                    : publishChildApprovalRequired
-                      ? "Review needed"
-                      : publishHandoffStale
-                        ? "Retry needed"
-                        : "Ready"
+              isMerged
+                ? "Merged"
+                : publishedWithoutPr
+                  ? "Published"
+                  : mergeBlocked
+                    ? "Merge blocked"
+                    : prUrl
+                      ? checksStatus
+                        ? `Checks ${checksStatus}`
+                        : "Waiting for checks"
+                      : publishPending
+                        ? "Creating PR"
+                        : publishChildFailed
+                          ? "Publish failed"
+                          : publishChildRecoverable
+                            ? "Resume needed"
+                            : publishChildApprovalRequired
+                              ? "Review needed"
+                              : publishHandoffStale
+                                ? "Retry needed"
+                                : "Ready"
             }
           >
-            {prUrl ? (
+            {isMerged ? (
               <div className="space-y-3">
                 <p className="text-sm font-semibold text-gray-600">
-                  {prNumber ? `Pull request #${prNumber} is ready for review.` : "The publish pull request is ready for review."}
+                  {prNumber
+                    ? `Pull request #${prNumber} has been merged to main. The article deploys with the next site build.`
+                    : "The publish pull request has been merged to main. The article deploys with the next site build."}
                 </p>
+                {prUrl ? (
+                  <a
+                    href={prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black"
+                  >
+                    Open merged PR
+                  </a>
+                ) : null}
+              </div>
+            ) : publishedWithoutPr ? (
+              <div className="space-y-3">
+                <p className="text-sm font-semibold text-gray-600">The article was published without a pull request.</p>
                 <a
-                  href={prUrl}
+                  href={previewUrl || publishChildPreviewUrl}
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black"
                 >
-                  Open PR
+                  Open published article
                 </a>
               </div>
+            ) : mergeBlocked ? (
+              <div className="space-y-3">
+                <p className="text-sm font-semibold text-gray-600">
+                  {mergeBlockedReason || "The PR could not be merged automatically. Open it on GitHub to investigate, then retry."}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <a
+                    href={prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                  >
+                    Open PR
+                  </a>
+                  <Form method="POST">
+                    <button
+                      type="submit"
+                      name="intent"
+                      value="merge-publish-pr"
+                      disabled={isSubmitting}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:opacity-50"
+                    >
+                      {mergePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                      {mergePending ? "Checking..." : "Retry merge"}
+                    </button>
+                  </Form>
+                </div>
+              </div>
+            ) : prUrl && autoMergeEnabled ? (
+              <div className="space-y-3">
+                <p className="text-sm font-semibold text-gray-600">
+                  {prNumber ? `Pull request #${prNumber} is open.` : "The publish pull request is open."} It merges to main
+                  automatically once GitHub checks pass. This page updates on its own.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    disabled
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-100 px-4 py-2.5 text-sm font-black text-gray-500"
+                  >
+                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                    Waiting for checks
+                  </button>
+                  <a
+                    href={prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                  >
+                    Open PR
+                  </a>
+                </div>
+              </div>
+            ) : prUrl ? (
+              <Form method="POST" className="space-y-3">
+                <p className="text-sm font-semibold text-gray-600">
+                  {prNumber ? `Pull request #${prNumber} is ready.` : "The publish pull request is ready."} The app checks
+                  GitHub status before merging. If checks are still pending or failing, it will leave the PR open.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="submit"
+                    name="intent"
+                    value="merge-publish-pr"
+                    disabled={isSubmitting}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:bg-gray-100 disabled:text-gray-500"
+                  >
+                    {mergePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                    {mergePending ? "Checking..." : "Check and merge"}
+                  </button>
+                  <a
+                    href={prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                  >
+                    Open PR
+                  </a>
+                </div>
+              </Form>
             ) : publishPending ? (
               <div className="space-y-3">
                 <p className="text-sm font-semibold text-gray-600">
-                  The publish handoff has started. This page will update when the PR is available.
+                  Creating the publish PR. Once checks pass it merges to main automatically — this page updates on its own.
                 </p>
                 <button
                   type="button"
@@ -2796,12 +2934,27 @@ function PublishAndAutomateDetail({
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-100 px-4 py-2.5 text-sm font-black text-gray-500"
                 >
                   <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                  Preparing PR
+                  Creating PR
                 </button>
+              </div>
+            ) : publishChildFailed ? (
+              <div className="space-y-3">
+                <p className="text-sm font-semibold text-gray-600">
+                  The publish run failed before a PR was created. Open it to see the error details.
+                </p>
+                {publishChildRunId && publishChildRunId !== run.runId ? (
+                  <a
+                    href={`/founder-tools/marketing/runs/${encodeURIComponent(publishChildRunId)}`}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black"
+                  >
+                    Open publish run
+                  </a>
+                ) : null}
               </div>
             ) : publishChildRecoverable ? (
               <Form method="POST" className="space-y-3">
                 {publishSourceRunId ? <input type="hidden" name="sourceRunId" value={publishSourceRunId} /> : null}
+                <input type="hidden" name="autoMerge" value="true" />
                 <p className="text-sm font-semibold text-gray-600">
                   {publishChildMissingRemote
                     ? "The publish job was queued but did not start. Retry will safely recreate the same PR job."
@@ -2815,7 +2968,7 @@ function PublishAndAutomateDetail({
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                 >
                   <ArrowPathIcon className={clsx("h-4 w-4", promotePending && "animate-spin")} />
-                  {promotePending ? "Preparing PR..." : publishChildMissingRemote ? "Retry creating PR" : "Resume publish PR"}
+                  {promotePending ? "Publishing..." : publishChildMissingRemote ? "Retry publishing" : "Resume publishing"}
                 </button>
               </Form>
             ) : publishChildApprovalRequired ? (
@@ -2836,8 +2989,9 @@ function PublishAndAutomateDetail({
               </div>
             ) : publishHandoffStale ? (
               <Form method="POST" className="space-y-3">
+                <input type="hidden" name="autoMerge" value="true" />
                 <p className="text-sm font-semibold text-gray-600">
-                  The previous publish handoff did not produce a PR. Retry will safely reuse any existing publish run if one was created.
+                  The previous publish attempt did not produce a PR. Retry will safely reuse any existing publish run if one was created.
                 </p>
                 <button
                   type="submit"
@@ -2847,13 +3001,14 @@ function PublishAndAutomateDetail({
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                 >
                   <ArrowPathIcon className={clsx("h-4 w-4", promotePending && "animate-spin")} />
-                  {promotePending ? "Preparing PR..." : "Retry creating PR"}
+                  {promotePending ? "Publishing..." : "Retry publishing"}
                 </button>
               </Form>
             ) : (
               <Form method="POST" className="space-y-3">
+                <input type="hidden" name="autoMerge" value="true" />
                 <p className="text-sm font-semibold text-gray-600">
-                  Generate the website changes as a pull request before anything is merged.
+                  Create the publish PR; once GitHub checks pass it merges to main automatically.
                 </p>
                 <button
                   type="submit"
@@ -2863,33 +3018,7 @@ function PublishAndAutomateDetail({
                   className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                 >
                   {promotePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-                  {promotePending ? "Creating PR..." : "Create publish PR"}
-                </button>
-              </Form>
-            )}
-          </PublishFlowCard>
-
-          <PublishFlowCard
-            title="Merge to main"
-            status={isMerged ? "complete" : prUrl ? "ready" : "locked"}
-            eyebrow={isMerged ? "Merged" : checksStatus ? `Checks ${checksStatus}` : prUrl ? "Ready to check" : "Waiting for PR"}
-          >
-            {isMerged ? (
-              <p className="text-sm font-semibold text-gray-600">The publish pull request has been merged.</p>
-            ) : (
-              <Form method="POST" className="space-y-3">
-                <p className="text-sm font-semibold text-gray-600">
-                  The app checks GitHub status before merging. If checks are still pending or failing, it will leave the PR open.
-                </p>
-                <button
-                  type="submit"
-                  name="intent"
-                  value="merge-publish-pr"
-                  disabled={isSubmitting || !prUrl}
-                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black disabled:bg-gray-100 disabled:text-gray-500"
-                >
-                  {mergePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                  {mergePending ? "Checking..." : "Check and merge"}
+                  {promotePending ? "Publishing..." : "Publish article"}
                 </button>
               </Form>
             )}
@@ -2946,9 +3075,14 @@ function PublishAndAutomateDetail({
           </PublishFlowCard>
         </div>
 
-        {previewUrl ? (
+        {previewUrl || publishChildPreviewUrl ? (
           <div className="mt-4 rounded-xl border border-emerald-100 bg-emerald-50 p-4">
-            <a href={previewUrl} target="_blank" rel="noreferrer" className="text-sm font-black text-emerald-800 hover:text-emerald-950">
+            <a
+              href={previewUrl || publishChildPreviewUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm font-black text-emerald-800 hover:text-emerald-950"
+            >
               Open published preview
             </a>
           </div>
@@ -3766,7 +3900,7 @@ export default function FounderToolsMarketingRun() {
     (POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
     setupPreviewActive ||
     hasPendingArticlePreview(run) ||
-    hasPublishHandoffEvidence(run);
+    (hasPublishHandoffEvidence(run) && !isPublishFlowSettled(run));
   const isArticleWorkflowRun = isArticleWorkflow(workflow);
   const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
   const hasArticlePreview = hasReadyArticlePreview(run);


### PR DESCRIPTION
## What

Replaces the two **Publish PR** and **Merge to main** cards in the article generate wizard's "Publish & automate" step with a single **Publish** card. It creates the PR, then shows checks running and merges to main automatically (auto-merge orchestrated backend-side).

## Card states

ready → creating PR → waiting for checks (PR link visible) → merged, plus:
- **blocked** — surfaces `merge_blocked_reason` with Open PR + Retry merge
- **legacy manual** — runs without the auto-merge flag keep the "Check and merge" button
- **publish failed** — links to the publish run

## Changes

- Forward an `autoMerge` flag through the run action handler (`approve`/`promote-bundle`/`publish-pr`) and the review-step "Approve & create PR" form, so approval-initiated publishes auto-merge too.
- `isPublishFlowSettled` stops polling once merged or a no-PR delivery completes.

Verified with `bun run typecheck` (react-router typegen + `tsc -b`) on `main`.

Pairs with the backend PR: MLAI-AUS-Inc/mlai-backend#442 (deploy backend first — an old backend ignores `autoMerge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)