### PR TITLE
Fix: show source picker when regenerating a monthly update

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -2908,6 +2908,23 @@ export default function CreateUpdate() {
         };
     }, [backendBaseUrl]);
 
+    // On the edit/regenerate path (no ?inputs= deep link), pre-select the founder's
+    // connected sources once so the picker isn't empty and the generate button is enabled.
+    // Bails for create-new, for ?inputs= deep links, and once a selection already exists.
+    const didSeedEditSourcesRef = useRef(false);
+    useEffect(() => {
+        if (didSeedEditSourcesRef.current) return;
+        if (!isEdit || initialSelectedInputSources.length > 0) {
+            didSeedEditSourcesRef.current = true;
+            return;
+        }
+        if (connectedDraftInputSources.length === 0) return;
+        if (selectedDraftInputSources.size === 0) {
+            setSelectedDraftInputSources(new Set(connectedDraftInputSources));
+        }
+        didSeedEditSourcesRef.current = true;
+    }, [isEdit, initialSelectedInputSources, connectedDraftInputSources, selectedDraftInputSources]);
+
     const toggleDraftInputSource = useCallback((source: VibeRaisingInputSourceSummary) => {
         if (!isConnectedInputSource(source)) return;
         setSelectedDraftInputSources((previous) => {
@@ -4067,6 +4084,21 @@ export default function CreateUpdate() {
         }
     }, []);
 
+    // Regenerating an existing draft returns the user to the pristine GENERATE view
+    // (month + source picker + "Draft from X" button) so they can re-pick sources and
+    // re-run with the same generate button. Keep monthConfirmed + selectedDraftStage
+    // ("reporting") so the picker and generate button stay visible; clearing
+    // metricsConfirmed hides the populated template + "Save as Draft".
+    const handleReturnToGenerate = useCallback(() => {
+        setDismissedFeedback(true);
+        resetEmailDraftUi();
+        clearPersistedEmailDraftRun();
+        setMetricsConfirmed(false);
+        if (typeof window !== "undefined") {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+    }, []);
+
     const draftStickyStatusIcon = (
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[rgba(0,255,215,0.14)] text-[var(--vr-color-primary)] ring-1 ring-[rgba(0,255,215,0.26)]">
             {hasDraftTemplate ? <CheckCircleIcon className="h-5 w-5" /> : <SparklesIcon className="h-5 w-5" />}
@@ -4781,7 +4813,7 @@ export default function CreateUpdate() {
         </section>
     );
 
-    const optionalDataSourcesSection = !isEdit ? (
+    const optionalDataSourcesSection = (
         <section className="rounded-[2rem] border border-[var(--vr-color-border)] bg-white p-5 shadow-sm sm:p-6">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                 <div className="min-w-0">
@@ -4901,7 +4933,7 @@ export default function CreateUpdate() {
                 </div>
             </div>
         </section>
-    ) : null;
+    );
 
     const handlePersistDraft = useCallback(() => {
         const draftForm = document.getElementById(DRAFT_REVIEW_FORM_ID);
@@ -4921,10 +4953,7 @@ export default function CreateUpdate() {
         const reviewMonth = String(reviewData?.month || selectedMonth);
         const reviewYear = Number(reviewData?.year || selectedYear);
         const canRegenerateDraftFromReview = regenerateSourcesAvailable;
-        const handleRegenerateDraftFromReview = () => {
-            setDismissedFeedback(true);
-            requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true });
-        };
+        const handleRegenerateDraftFromReview = handleReturnToGenerate;
         const reviewSummary = String(reviewData?.summary || "").trim();
         const reviewSourceUrl = String(reviewData?.sourceUrl || "").trim();
         const reviewPitchDeckUrl = String(reviewData?.pitchDeckUrl || "").trim();
@@ -6309,7 +6338,7 @@ export default function CreateUpdate() {
                 tertiaryLabel={canRunAgainDraft ? "Run again" : isEmailDraftBusy ? (emailDraftCancelBusy ? "Cancelling..." : "Cancel draft") : undefined}
                 mobileTertiaryLabel={canRunAgainDraft ? "Run again" : isEmailDraftBusy ? (emailDraftCancelBusy ? "Cancelling" : "Cancel") : undefined}
                 onTertiary={canRunAgainDraft
-                    ? () => requestDraftFromSelectedInputs({ forceRegenerate: true, clearPersistedRun: true })
+                    ? handleReturnToGenerate
                     : isEmailDraftBusy
                         ? () => { void handleCancelEmailDraft(); }
                         : undefined}


### PR DESCRIPTION
## Bug
On the monthly-update flow, the **"Connect data for AI drafting"** source picker was gated on `!isEdit` in `create-update.tsx`. Editing an existing complete update enters via `?edit={id}` (`isEdit = true`), so the picker was **never rendered** — and clicking **Run again** silently regenerated using "all connected sources" with no way to choose new ones.

**Repro:** complete an update → Edit it → Start draft → (picker missing) → Run again regenerates with no source choice.

## Fix
Two GENERATE/REVIEW views in the one route; "regenerate" resets to a pristine GENERATE view:
- **Decouple the picker from `isEdit`** — visibility stays governed by `monthConfirmed` (line ~4813), so it shows in both create-new and edit.
- **`handleReturnToGenerate`** — shared by the sticky **Run again** and the review **Regenerate draft**: keeps `monthConfirmed` + `selectedDraftStage="reporting"` (picker + "Draft from X" stay visible) and clears `metricsConfirmed` + resets the draft UI (populated template + "Save as Draft" hide). The user re-runs with the **same** generate button — no auto-fire.
- **Seed effect** — on the edit path (no `?inputs=`), pre-select connected sources once so the picker isn't empty and the generate button is enabled.

Retry-on-failure affordances are unchanged. Create-new flow unchanged (seed only fires when `isEdit`). `?inputs=` deep links still honored.

## Test
`bun run typecheck` ✓. Manual: create → generate → review → **Edit** → Start draft → picker visible with sources pre-selected → **Run again** → pristine GENERATE → pick a new source → **Draft from X** → regenerate-confirm → new draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)