### PR TITLE
View article anytime + resume a failed publish

### DIFF
--- a/app/components/ArticleRunStageProgress.tsx
+++ b/app/components/ArticleRunStageProgress.tsx
@@ -5,6 +5,7 @@ import {
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import { clsx } from "clsx";
+import { Link } from "react-router";
 
 import type { VibeMarketingRunSummary, VibeMarketingStepState } from "~/types/vibe-marketing";
 
@@ -37,6 +38,9 @@ interface StageView extends StageDefinition {
 interface ArticleRunStageProgressProps {
   run: VibeMarketingRunSummary;
   variant?: "standalone" | "embedded";
+  // When set, the "Ready for review" chip becomes a link to the article preview,
+  // letting the user jump back to review at any point in the flow.
+  reviewHref?: string | null;
 }
 
 const ARTICLE_PROGRESS_STAGES: StageDefinition[] = [
@@ -317,7 +321,7 @@ export function articleRunTechnicalProgressLabel(run: VibeMarketingRunSummary) {
   return `${completed} of ${total} checks complete`;
 }
 
-export default function ArticleRunStageProgress({ run, variant = "standalone" }: ArticleRunStageProgressProps) {
+export default function ArticleRunStageProgress({ run, variant = "standalone", reviewHref }: ArticleRunStageProgressProps) {
   const stages = deriveArticleProgressStages(run);
   const embedded = variant === "embedded";
   const activeStage =
@@ -354,26 +358,38 @@ export default function ArticleRunStageProgress({ run, variant = "standalone" }:
       </div>
 
       <div className={clsx("grid gap-2 sm:grid-cols-2 lg:grid-cols-5", !embedded && "mt-5")}>
-        {stages.map((stage) => (
-          <div
-            key={stage.id}
-            className={clsx(
-              "rounded-xl border px-3 py-3 transition",
-              stage.status === "running" && "shadow-sm ring-2 ring-violet-100",
-              stageStatusTone(stage.status),
-            )}
-          >
+        {stages.map((stage) => {
+          const chipClass = clsx(
+            "block rounded-xl border px-3 py-3 transition",
+            stage.status === "running" && "shadow-sm ring-2 ring-violet-100",
+            stageStatusTone(stage.status),
+          );
+          const chipInner = (
             <div className="flex items-center gap-3">
               <span className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white/80">
                 <StageIcon status={stage.status} />
               </span>
               <div className="min-w-0">
                 <p className="text-sm font-black text-gray-950">{stage.label}</p>
-                <p className="mt-0.5 text-xs font-black uppercase tracking-wide">{stageStatusLabel(stage.status)}</p>
+                <p className="mt-0.5 text-xs font-black uppercase tracking-wide">
+                  {stage.id === "review" && reviewHref ? "View article" : stageStatusLabel(stage.status)}
+                </p>
               </div>
             </div>
-          </div>
-        ))}
+          );
+          if (stage.id === "review" && reviewHref) {
+            return (
+              <Link key={stage.id} to={reviewHref} className={clsx(chipClass, "cursor-pointer hover:ring-2 hover:ring-violet-200")}>
+                {chipInner}
+              </Link>
+            );
+          }
+          return (
+            <div key={stage.id} className={chipClass}>
+              {chipInner}
+            </div>
+          );
+        })}
       </div>
 
       {run.errors.length > 0 ? (

--- a/app/lib/vibe-marketing-run-view.ts
+++ b/app/lib/vibe-marketing-run-view.ts
@@ -34,6 +34,7 @@ const POLLING_STATUSES = new Set([
 const APPROVAL_GATE_STATUSES = new Set(["awaiting_approval", "approval_required"]);
 
 export type ArticleSetupStepViewForRun = "generate" | "review" | "publish";
+export type ArticleStepViewForRun = "generate" | "review" | "publish";
 
 function isArticleWorkflow(workflow: string | null | undefined) {
   return ARTICLE_WORKFLOWS.has(String(workflow ?? ""));
@@ -180,6 +181,7 @@ export function viewedWorkflowStepIdForRun(
   run: VibeMarketingRunSummary,
   requestedSetupStep?: ArticleSetupStepViewForRun | null,
   setupWorkflowStepId?: string | null,
+  requestedArticleStep?: ArticleStepViewForRun | null,
 ) {
   const workflow = String(run.workflow ?? "");
   if (DISCOVERY_WORKFLOWS.has(workflow)) {
@@ -188,6 +190,9 @@ export function viewedWorkflowStepIdForRun(
   if (SCAN_WORKFLOWS.has(workflow)) return "article_system";
   if (workflow === "article_system_setup") return requestedSetupStep ?? setupWorkflowStepId ?? "generate";
   if (workflow === "website_baseline") return "baseline";
+  // Explicit user override (e.g. ?articleStep=review) lets the user jump back to
+  // the article preview at any point, even after the run has moved to publish.
+  if (requestedArticleStep && ARTICLE_GENERATION_WORKFLOWS.has(workflow)) return requestedArticleStep;
   if (workflow === "article_revision") return hasPublishHandoffEvidence(run) ? "publish" : "revise";
   if (ARTICLE_GENERATION_WORKFLOWS.has(workflow)) {
     if (isArticleReviewPreviewReady(run)) return "review";

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -5,6 +5,7 @@ import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useLoca
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
+  ArrowRightIcon,
   CheckCircleIcon,
   EllipsisHorizontalIcon,
   ExclamationTriangleIcon,
@@ -532,10 +533,16 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       await removeNotificationChannel(env, request, stringFromForm(formData, "channelId"));
     } else if (["approve", "deny", "resume", "restart", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
       const sourceRunId = stringFromForm(formData, "sourceRunId");
+      const targetRunId = stringFromForm(formData, "targetRunId");
       const autoMerge =
         stringFromForm(formData, "autoMerge") === "true" &&
         ["approve", "promote-bundle", "publish-pr"].includes(intent);
-      const controlRunId = intent === "promote-bundle" || intent === "publish-pr" ? sourceRunId || runId : runId;
+      const controlRunId =
+        intent === "promote-bundle" || intent === "publish-pr"
+          ? sourceRunId || runId
+          : (intent === "resume" || intent === "restart") && targetRunId
+            ? targetRunId
+            : runId;
       const payload: Record<string, unknown> = {};
       if (sourceRunId) payload.sourceRunId = sourceRunId;
       if (autoMerge) payload.autoMerge = true;
@@ -2730,6 +2737,7 @@ function PublishAndAutomateDetail({
   const checksStatus = stringResultValue(run, "checks_status", "checksStatus");
   const promotePending = isActionPending?.("promote-bundle", "publish-pr") ?? isSubmitting;
   const mergePending = isActionPending?.("merge-publish-pr") ?? isSubmitting;
+  const resumePending = isActionPending?.("resume") ?? isSubmitting;
   const enableDailyPending = isActionPending?.("enable-daily-automation") ?? isSubmitting;
   const runDailyPending = isActionPending?.("run-daily-discovery-now") ?? isSubmitting;
   const mergeStatus = stringResultValue(run, "merge_status", "mergeStatus");
@@ -2750,6 +2758,16 @@ function PublishAndAutomateDetail({
       !publishedWithoutPr &&
       (publishChildStatus === "failed" || (publishChildRunId === run.runId && run.status === "failed")),
   );
+  // The article content lives on the run that has the component manifest — the
+  // current run if it has one, otherwise the source (parent) run. The failed
+  // publish child has no manifest, so this resolves to the parent.
+  const articleViewRunId = run.componentManifest ? run.runId : publishSourceRunId || run.runId;
+  const canViewArticle = Boolean(run.componentManifest || publishSourceRunId);
+  const viewArticleHref = `/founder-tools/marketing/runs/${encodeURIComponent(articleViewRunId)}?articleStep=review`;
+  // Resume targets the failed publish run. When viewing the article (parent),
+  // that's the child via targetRunId; when viewing the child itself, the
+  // current run (no targetRunId needed).
+  const resumePublishTargetRunId = publishChildRunId && publishChildRunId !== run.runId ? publishChildRunId : "";
   const dailyCheck = bootstrap.checks.dailyAutomation as
     | (VibeMarketingBootstrap["checks"][string] & { ready?: boolean; enabled?: boolean })
     | undefined;
@@ -2764,7 +2782,9 @@ function PublishAndAutomateDetail({
 
   return (
     <div className="space-y-5">
-      {publishChildMissingRemote ? null : <ArticleRunStageProgress run={run} variant="embedded" />}
+      {publishChildMissingRemote ? null : (
+        <ArticleRunStageProgress run={run} variant="embedded" reviewHref={canViewArticle ? viewArticleHref : undefined} />
+      )}
       <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
@@ -2773,6 +2793,15 @@ function PublishAndAutomateDetail({
             <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
               Publish the article — the PR merges to main automatically once checks pass — then turn on daily research prompts (Slack, email or WhatsApp) for the next article.
             </p>
+            {canViewArticle ? (
+              <Link
+                to={viewArticleHref}
+                className="mt-3 inline-flex items-center gap-1 text-sm font-black text-violet-700 transition hover:text-violet-900"
+              >
+                View article
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+            ) : null}
           </div>
           <WorkflowStatusPill status={automationStep?.status === "complete" ? "complete" : publishStep?.status ?? "ready"} />
         </div>
@@ -2940,16 +2969,32 @@ function PublishAndAutomateDetail({
             ) : publishChildFailed ? (
               <div className="space-y-3">
                 <p className="text-sm font-semibold text-gray-600">
-                  The publish run failed before a PR was created. Open it to see the error details.
+                  {publishChildWaitReason ||
+                    "The publish run failed before a PR was created — a worker likely stalled mid-run. Resume to continue from where it stopped."}
                 </p>
-                {publishChildRunId && publishChildRunId !== run.runId ? (
-                  <a
-                    href={`/founder-tools/marketing/runs/${encodeURIComponent(publishChildRunId)}`}
-                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black"
-                  >
-                    Open publish run
-                  </a>
-                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  <Form method="POST">
+                    {resumePublishTargetRunId ? <input type="hidden" name="targetRunId" value={resumePublishTargetRunId} /> : null}
+                    <button
+                      type="submit"
+                      name="intent"
+                      value="resume"
+                      disabled={isSubmitting}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
+                    >
+                      <ArrowPathIcon className={clsx("h-4 w-4", resumePending && "animate-spin")} />
+                      {resumePending ? "Resuming..." : "Resume publish"}
+                    </button>
+                  </Form>
+                  {publishChildRunId && publishChildRunId !== run.runId ? (
+                    <a
+                      href={`/founder-tools/marketing/runs/${encodeURIComponent(publishChildRunId)}`}
+                      className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                    >
+                      Open publish run
+                    </a>
+                  ) : null}
+                </div>
               </div>
             ) : publishChildRecoverable ? (
               <Form method="POST" className="space-y-3">
@@ -3777,6 +3822,11 @@ function setupStepViewFromSearch(search: string): ArticleSetupStepView | null {
   return value && SETUP_STEP_VIEW_VALUES.has(value) ? (value as ArticleSetupStepView) : null;
 }
 
+function articleStepViewFromSearch(search: string): "generate" | "review" | "publish" | null {
+  const value = new URLSearchParams(search).get("articleStep");
+  return value && SETUP_STEP_VIEW_VALUES.has(value) ? (value as "generate" | "review" | "publish") : null;
+}
+
 function workflowProgressForRunPage(
   run: VibeMarketingRunSummary,
   fallbackProgress: VibeMarketingWorkflowProgress | null | undefined,
@@ -3923,7 +3973,8 @@ export default function FounderToolsMarketingRun() {
     [discoveryCandidates, selectedDiscoveryCandidateId],
   );
   const requestedSetupStep = isArticleSystemSetupRun ? setupStepViewFromSearch(location.search) : null;
-  const viewedWorkflowStepId = viewedWorkflowStepIdForRun(run, requestedSetupStep, setupWorkflowStepIdForRun(run));
+  const requestedArticleStep = isArticleGenerationRun ? articleStepViewFromSearch(location.search) : null;
+  const viewedWorkflowStepId = viewedWorkflowStepIdForRun(run, requestedSetupStep, setupWorkflowStepIdForRun(run), requestedArticleStep);
   const workflowProgress = workflowProgressForRunPage(run, bootstrap.workflowProgress);
   const deliveryMode = deliveryModeForRun(run, bootstrap);
   const directPublishMode = deliveryMode === "publish_code";


### PR DESCRIPTION
## What

Two fixes for the article publish flow (the "Publish & automate" step).

### 1. View the article at any point
Once a publish PR/child exists, the run page locked to the publish view and the article preview disappeared — with no override for article-generation runs.
- Adds a `?articleStep=review` override to `viewedWorkflowStepIdForRun`.
- Surfaces it via a **"View article"** link in the Publish & automate header and a clickable **"Ready for review"** stage chip, resolving to the run that actually holds the article (the **source/parent** run when you're viewing a publish child).
- Reuses the existing `LiveArticlePreviewPanel` — no new preview code.

### 2. Recover a failed publish
The `publishChildFailed` card was a dead end (text only) when viewing the failed child.
- Now offers **"Resume publish"** (`intent=resume` — the stalled-run reaper marks the child resumable) plus **"Open publish run"**.
- The action handler honours a `targetRunId` so resume can target the child run even when viewing the parent; the post-action redirect lands on the resumed run to watch progress.

## Verify

`bun run typecheck` (react-router typegen + `tsc -b`) passes on `main`. Manual: drive an article to publish → "View article" opens the preview inline → return via the wizard; for a failed publish, the card shows **Resume publish** + **Open publish run** and Resume re-queues.

Pairs with backend PR: MLAI-AUS-Inc/mlai-backend#447 (independent/additive — frontend honours `?articleStep` and resume works against the current backend; no deploy-order dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)