### PR TITLE
Fix Google Analytics source toggle reverting mid-draft

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -2836,6 +2836,7 @@ export default function CreateUpdate() {
     const [emailDraftPollDelayMs, setEmailDraftPollDelayMs] = useState(EMAIL_DRAFT_POLL_INTERVAL_MS);
     const emailDraftRecoveryKeyRef = useRef<string | null>(null);
     const emailDraftIgnoredRunIdRef = useRef<string | null>(null);
+    const hydratedRunInputSourcesRef = useRef<string | null>(null);
     const pitchDeckLinkInputRef = useRef<HTMLInputElement | null>(null);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
     const mediaStreamRef = useRef<MediaStream | null>(null);
@@ -3445,7 +3446,12 @@ export default function CreateUpdate() {
                 const runInputSources = (statusResponse.run?.inputSources || []).filter(
                     (key): key is VibeRaisingInputSourceKey => VALID_INPUT_SOURCE_KEYS.has(key as VibeRaisingInputSourceKey),
                 );
-                if (runInputSources.length > 0) {
+                // Hydrate the source picker from the run ONCE per run (refresh recovery).
+                // Re-applying on every 5s poll would clobber a user's manual source
+                // toggles (e.g. adding Google Analytics) while a draft is running.
+                const runId = statusResponse.runId ?? null;
+                if (runInputSources.length > 0 && runId && hydratedRunInputSourcesRef.current !== runId) {
+                    hydratedRunInputSourcesRef.current = runId;
                     setSelectedDraftInputSources(new Set(runInputSources));
                 }
                 setMonthConfirmed(true);


### PR DESCRIPTION
## Problem

When a draft run is generating, selecting **Google Analytics** in the "Connect data for AI drafting" picker doesn't stick — its card shows the connected **green dot** instead of the selected **teal checkmark** like the other sources, so it looks visually inconsistent.

## Root cause

The draft-status poll (`processEmailDraftStatus`, fired every 5s by the `EMAIL_DRAFT_POLL_INTERVAL_MS` interval) re-applied the run's `inputSources` to `selectedDraftInputSources` on **every** tick while the run was `queued`/`running`. Any source the user toggled *after* the run started — e.g. Google Analytics, which wasn't part of the in-flight run — got overwritten within ~5s and reverted to the unselected state. It wasn't GA-specific; any post-start toggle was clobbered.

The reset exists for **refresh recovery** (restore the picker if you reload mid-draft), but it was running on every poll instead of once.

## Fix

Hydrate the picker from the run **once per `runId`** (guarded by a new `hydratedRunInputSourcesRef`) instead of on every poll. Refresh recovery and per-run/regenerate hydration still work; manual toggles now persist while a draft generates.

## Notes

- Toggling a source mid-run sets it up for the **next** Regenerate; it does not retroactively add it to the in-flight draft (expected).
- `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)