### PR TITLE
Fix Luma connection not showing as connected after linking

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1306,6 +1306,7 @@ function normalizeInputSourceProvider(value: unknown): VibeRaisingInputSourceKey
   if (normalized === "google_drive" || normalized === "drive") return "google_drive";
   if (normalized === "slack") return "slack";
   if (normalized === "linear") return "linear";
+  if (normalized === "luma") return "luma";
   if (normalized === "manual_documents" || normalized === "manual") return "manual_documents";
   return null;
 }


### PR DESCRIPTION
## Bug
After linking Luma, the card stayed "Not connected" (never went green) even though the key was saved — and re-opening the modal felt like the key hadn't persisted.

## Root cause
Frontend-only. `normalizeInputSourceProvider()` (used when reading `/sources/status`) had no `"luma"` case, so it returned `null` and `normalizeInputSourceSummaries` **skipped** the connected Luma entry. `getVibeRaisingInputSourcesStatus` then defaulted Luma to `not_connected`. The backend was persisting the encrypted key + connection correctly the whole time.

## Fix
Add the `luma` case to `normalizeInputSourceProvider` so the connected status round-trips and the card shows green.

`bun run typecheck` and `bun run build` pass. Follow-up to MLAI-AUS-Inc/mlai-au#1017 / #1018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)