### PR TITLE
Show Luma in the AI-drafting picker + render its metrics

### DIFF
--- a/app/lib/vibe-raising-metrics.tsx
+++ b/app/lib/vibe-raising-metrics.tsx
@@ -3,7 +3,9 @@ import {
     ArrowPathIcon,
     ArrowRightIcon,
     BanknotesIcon,
+    CalendarDaysIcon,
     ChartBarIcon,
+    CheckCircleIcon,
     CurrencyDollarIcon,
     FireIcon,
     LightBulbIcon,
@@ -43,6 +45,10 @@ export const VIBE_METRIC_OPTIONS: MetricOption[] = [
     { key: "experimentsRun", label: "Experiments Run", placeholder: "4", icon: <LightBulbIcon className="w-4 h-4 text-gray-400" />, info: "Validation, growth, product, or pricing experiments completed." },
     { key: "pilotCount", label: "Pilots", placeholder: "3", icon: <SparklesIcon className="w-4 h-4 text-gray-400" />, info: "Active pilots, design partners, or trials." },
     { key: "qualifiedPipeline", label: "Qualified Pipeline", placeholder: "250,000", prefix: "$", icon: <BanknotesIcon className="w-4 h-4 text-gray-400" />, info: "Qualified sales pipeline with customer intent." },
+    { key: "eventsRun", label: "Events Run", placeholder: "8", icon: <CalendarDaysIcon className="w-4 h-4 text-gray-400" />, info: "Events you ran through Luma this month." },
+    { key: "eventRegistrations", label: "Event Registrations", placeholder: "350", icon: <UsersIcon className="w-4 h-4 text-gray-400" />, info: "Total registrations across your Luma events this month." },
+    { key: "eventAttendees", label: "Checked-in Attendees", placeholder: "280", icon: <CheckCircleIcon className="w-4 h-4 text-gray-400" />, info: "People who checked in to your Luma events this month." },
+    { key: "eventCheckInRate", label: "Check-in Rate", placeholder: "80%", icon: <ChartBarIcon className="w-4 h-4 text-gray-400" />, info: "Share of registrations who checked in to your Luma events." },
 ];
 
 export const VIBE_METRIC_OPTION_MAP = new Map(

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -85,6 +85,7 @@ const VALID_INPUT_SOURCE_KEYS = new Set<VibeRaisingInputSourceKey>([
     "google_drive",
     "slack",
     "linear",
+    "luma",
     "manual_documents",
 ]);
 
@@ -105,6 +106,7 @@ const INPUT_SOURCE_LABELS: Record<VibeRaisingInputSourceKey, string> = {
 const COMPACT_OPTIONAL_SOURCE_KEYS: VibeRaisingInputSourceKey[] = [
     "google_analytics",
     "stripe",
+    "luma",
     "linear",
     "notion",
     "google_drive",
@@ -2869,7 +2871,7 @@ export default function CreateUpdate() {
         const byKey = new Map(compactSources.map((source) => [source.key, source]));
         return COMPACT_OPTIONAL_SOURCE_KEYS
             .map((key) => byKey.get(key))
-            .filter((source): source is VibeRaisingInputSourceSummary => Boolean(source));
+            .filter((source): source is VibeRaisingInputSourceSummary => Boolean(source && isConnectedInputSource(source)));
     }, [compactSources]);
     const selectedConnectedSourceLabels = useMemo(
         () => compactOptionalSources

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -51,6 +51,11 @@
   <priority>0.8</priority>
  </url>
  <url>
+  <loc>https://mlai.au/press-kit</loc>
+  <changefreq>monthly</changefreq>
+  <priority>0.6</priority>
+ </url>
+ <url>
   <loc>https://mlai.au/privacy</loc>
   <changefreq>yearly</changefreq>
   <priority>0.3</priority>


### PR DESCRIPTION
## What
1. **Luma card** in the "Connect data for AI drafting" picker (`create-update.tsx`): added to `VALID_INPUT_SOURCE_KEYS` + `COMPACT_OPTIONAL_SOURCE_KEYS` (label/logo already existed).
2. **Only connected sources** now show in that picker — filtered the `compactOptionalSources` memo via the existing `isConnectedInputSource`, so not-connected / coming-soon sources (e.g. Google Drive, Notion) drop off.
3. **Luma metrics render** — added `eventsRun`, `eventRegistrations`, `eventAttendees`, `eventCheckInRate` to `VIBE_METRIC_OPTIONS` so they appear in the draft snapshot and trends.

## Backend
Paired with mlai-backend MLAI-AUS-Inc/mlai-backend#454 (merges Luma metrics into the draft) and valley-backend MLAI-AUS-Inc/valley-backend#39 (allows the keys) — both merged + deployed.

## Verification
`bun run typecheck` + `bun run build` pass. (The build regenerated the tracked `public/sitemap.xml`; included incidentally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)