### PR TITLE
Fix Google Analytics deselecting itself when a draft starts

### DIFF
--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -3474,13 +3474,14 @@ export default function CreateUpdate() {
                 const runInputSources = (statusResponse.run?.inputSources || []).filter(
                     (key): key is VibeRaisingInputSourceKey => VALID_INPUT_SOURCE_KEYS.has(key as VibeRaisingInputSourceKey),
                 );
-                // Hydrate the source picker from the run ONCE per run (refresh recovery).
-                // Re-applying on every 5s poll would clobber a user's manual source
-                // toggles (e.g. adding Google Analytics) while a draft is running.
+                // Hydrate the source picker from the run for refresh-recovery only —
+                // when the founder hasn't picked any sources yet. Never overwrite a
+                // live selection (e.g. a freshly-ticked Google Analytics) when a run
+                // starts, or the card flips to unchecked and drops out of the run.
                 const runId = statusResponse.runId ?? null;
                 if (runInputSources.length > 0 && runId && hydratedRunInputSourcesRef.current !== runId) {
                     hydratedRunInputSourcesRef.current = runId;
-                    setSelectedDraftInputSources(new Set(runInputSources));
+                    setSelectedDraftInputSources((previous) => (previous.size === 0 ? new Set(runInputSources) : previous));
                 }
                 setMonthConfirmed(true);
                 setSelectedDraftStage("reporting");


### PR DESCRIPTION
## Bug
On the "Connect data for AI drafting" picker, Google Analytics loads connected + selected, but every time the founder triggers a new draft or regenerates, the GA card flips to **unchecked** and the run runs without GA.

## Root cause
`vibe-raising-app.create-update.tsx` hydrated `selectedDraftInputSources` from the active run's `inputSources` (once per run) by **replacing** the selection — `setSelectedDraftInputSources(new Set(runInputSources))`. Intended as refresh-recovery, but it also clobbered a live selection the moment a run appeared. A connected source freshly selected but absent from the reported run (commonly GA — most likely to differ from a prior/regenerated run) got removed, then wasn't sent on the next trigger. The existing code comment even named Google Analytics as the clobber victim. (Backend is fine — it keeps `google_analytics` in a run's `input_sources` even with no property selected.)

## Fix
Hydrate from the run **only when the selection is empty** (genuine refresh-recovery); never overwrite an existing selection:
```js
setSelectedDraftInputSources((previous) => (previous.size === 0 ? new Set(runInputSources) : previous));
```
The founder's selection (incl. GA) is preserved through trigger/regenerate, so GA stays checked → is sent → appears in the run. Refresh-recovery still works.

## Verification
`bun run typecheck` + `bun run build` pass. Diagnosed by tracing the state flow (matches the reported screenshot: GA connected, unchecked, absent from the run summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)