### PR TITLE
Return to originating page after GitHub install + auto-run scan

### DIFF
--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -641,10 +641,16 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (intent === "connect-github") {
       const githubRepo = stringFromForm(formData, "githubRepo");
       const forceReconnect = stringFromForm(formData, "forceReconnect") === "true";
+      const returnUrl = new URL(
+        "/founder-tools/marketing/create?step=articleSystem",
+        new URL(request.url).origin,
+      ).toString();
       const response = await connectVibeMarketingGithub(
         env,
         request,
         {
+          returnUrl,
+          return_url: returnUrl,
           ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),
           ...(forceReconnect ? { forceReconnect: true, force_reconnect: true } : {}),
         },
@@ -980,6 +986,26 @@ export default function FounderToolsMarketingCreate() {
   const setupChildProgressAtRef = useRef(Date.now());
   const setupChildProgressSignatureRef = useRef("");
   const [pageVisible, setPageVisible] = useState(true);
+  // Returning from the GitHub App install, the backend appends
+  // `?github=connected&repo=...`. Kick off the repo scan automatically so the
+  // founder lands back on the article-system step with the scan already running.
+  // The start-scan action redirects to `?scanRunId=...`, which clears the
+  // `github` param so this never re-fires on refresh.
+  const autoScanFetcher = useFetcher();
+  const autoScanStartedRef = useRef(false);
+  const justConnectedGithub = searchParams.get("github") === "connected";
+  useEffect(() => {
+    if (autoScanStartedRef.current) return;
+    if (!justConnectedGithub) return;
+    const repo = (searchParams.get("repo") || "").trim() || bootstrap.settings.githubRepo || "";
+    if (!repo) return; // repo still needs selecting (multiple_repos / no_repo) — leave it to the UI
+    autoScanStartedRef.current = true;
+    const formData = new FormData();
+    formData.set("intent", "start-scan");
+    formData.set("githubRepo", repo);
+    formData.set("scanPurpose", "inventory");
+    autoScanFetcher.submit(formData, { method: "post" });
+  }, [justConnectedGithub, searchParams, bootstrap.settings.githubRepo, autoScanFetcher]);
   const articleSetupState = bootstrap.articleSetupState ?? null;
   const canonicalScanRun =
     findRunById(bootstrap.latestRuns, articleSetupState?.scanRunId) ??

--- a/app/routes/founder-tools.marketing.github-connect.tsx
+++ b/app/routes/founder-tools.marketing.github-connect.tsx
@@ -68,8 +68,15 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const forceReconnect = boolFromSearch(url.searchParams.get("forceReconnect"));
   const githubRepo = String(url.searchParams.get("githubRepo") || "").trim();
 
+  // Absolute URL of the page to land back on after the GitHub App install. The
+  // backend embeds this in the OAuth state and redirects the browser here once
+  // the install completes (it re-validates the origin against mlai.au first).
+  const returnUrl = new URL(returnTo, url.origin).toString();
+
   try {
     const response = await connectVibeMarketingGithub(env, request, {
+      returnUrl,
+      return_url: returnUrl,
       ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),
       ...(forceReconnect ? { forceReconnect: true, force_reconnect: true } : {}),
     });


### PR DESCRIPTION
## Problem
After installing the GitHub App from the article-system step, founders were dumped on `https://mlai.au/?github=connected&domain=…&repo=…` (the app home) instead of the page they came from, and no scan ran.

## Root cause
The backend (mlai-backend [#459](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/459)) now redirects the browser to a `return_url` carried through the GitHub OAuth `state` — but the frontend never sent one, so the backend fell back to the home page.

## Change
- **Forward `return_url`** on both connect paths — the dedicated `github-connect` route loader and the create page's `connect-github` action — as an **absolute** URL (request origin + `/founder-tools/marketing/create?step=articleSystem`). It must be absolute because the backend re-validates the origin against `mlai.au` to block open redirects.
- **Auto-run the scan on return.** The backend appends `?github=connected&repo=…`; the create page now detects that and submits the existing `start-scan` intent once (using the connected repo, falling back to `bootstrap.settings.githubRepo`), so the founder lands back on the article-system step with the repo scan already running.

The `start-scan` action redirects to `?step=articleSystem&scanRunId=<new>`, which clears the `github` param — so the auto-scan never re-fires on refresh. If the repo still needs selecting (`multiple_repos`/`no_repo`), it skips the auto-scan and leaves it to the UI.

## Verification
`react-router typegen && tsc -b` passes clean.

Requires backend [#459](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/459) (already merged to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)