### PR TITLE
Don't report a failed articles setup as a stale scan needing re-scan

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -649,7 +649,16 @@ export default function ArticleSystemConnectionPanel({
       (effectiveScanRun && setupTargetScan && (scanNeedsSetupApproval || setupRunId)),
   );
   const persistedSetupReady = Boolean(articleSetupState?.setupRunId || articleSetupState?.routePath);
-  const persistedSetupIsStale = Boolean(persistedSetupReady && (scanFailed || scanStale));
+  // A previously-FAILED setup attempt (e.g. preview_failed) is already surfaced by the
+  // scaffold status card with the real error + a retry action. It must NOT also be reported
+  // as a stale "saved location / the scan needs attention", which wrongly tells the user to
+  // re-scan — re-scanning can never fix a failed setup preview.
+  const persistedSetupFailed = Boolean(
+    articleSetupState?.error ||
+      SETUP_FAILED_STATUSES.has(normalizedStatus(articleSetupState?.setupStatus)) ||
+      SETUP_FAILED_STATUSES.has(normalizedStatus(articleSetupState?.setupRunStatus)),
+  );
+  const persistedSetupIsStale = Boolean(persistedSetupReady && !persistedSetupFailed && (scanFailed || scanStale));
   const scanStartPending = actionPending("start-scan");
   const retryScanPending = actionPending("retry-scan");
   const cancelScanPending = actionPending("cancel-scan");


### PR DESCRIPTION
## Problem
When an article-system setup had **failed** (e.g. `preview_failed`), the backend still returned a `setupRunId`, so `persistedSetupReady` was true. Combined with a blocked/failed scan, the wizard rendered *"A previous articles/blogs location is saved, but the latest scan did not complete cleanly"* / *"the latest repository scan needs attention — re-scan"*. That misattributes a **setup-preview** failure to the **scan**, and re-scanning can never fix a failed preview — which reads to the user as "it found an articles/blogs location that doesn't exist".

## Fix
Exclude a failed setup from `persistedSetupIsStale` via a new `persistedSetupFailed` flag (derived from `articleSetupState.error` / `setupStatus` / `setupRunStatus` ∈ `SETUP_FAILED_STATUSES`). A failed setup now flows only to the scaffold status card (which already shows the real error + a retry action); a genuinely stale-but-good saved location behaves exactly as before.

`react-router typegen && tsc -b` → 0 errors.

## Context
Paired with content-factory#455, which fixes the underlying cause (react-router-dom v6 SPAs couldn't be scaffolded, so the setup kept failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
