### PR TITLE
[codex] Add Roo Points balance to Founder Tools header

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -16,6 +16,7 @@ import {
 import { Link, useLocation, Form } from 'react-router';
 import { ImageWithFallback } from './ImageWithFallback';
 import { getInitials, generateAvatarUrl } from '~/lib/avatar';
+import type { RooPointsBalance } from '~/lib/roo-points';
 import type { User } from '~/types/user';
 
 interface AuthenticatedLayoutProps {
@@ -23,6 +24,7 @@ interface AuthenticatedLayoutProps {
     user: User;
     navigation?: NavigationItem[];
     userNavigation?: { name: string; href: string }[];
+    rooPointsBalance?: RooPointsBalance | null;
     logoutAction?: string;
 }
 
@@ -34,12 +36,42 @@ const VIBE_RAISING_TOP_NAVIGATION = [
     { name: 'My Companies', href: '/founder-tools/companies' },
 ];
 const MLAI_LOGO_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/MLAI-Logo.png?alt=media&token=9d844530-e3b5-4944-a1c7-5be3112d5d84";
+const ROO_POINTS_COIN_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Robotics%20%26%20AI%20For%20Everyone%20(9)%20(1)%20(1).png?alt=media&token=a43ec994-1637-410c-b3ea-a39bb45f3cd3";
 
 function classNames(...classes: (string | undefined | boolean)[]) {
     return classes.filter(Boolean).join(' ');
 }
 
-export default function AuthenticatedLayout({ children, user, navigation: customNavigation, userNavigation: customUserNavigation, logoutAction = "/platform/logout" }: AuthenticatedLayoutProps) {
+function formatRooPointsBalance(balance: number) {
+    return new Intl.NumberFormat("en-AU", { maximumFractionDigits: 0 }).format(balance);
+}
+
+function RooPointsBadge({ balance }: { balance: number }) {
+    const formattedBalance = formatRooPointsBalance(balance);
+
+    return (
+        <div
+            className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[rgba(15,23,42,0.12)] bg-white/85 px-2.5 text-[var(--vr-color-text)] shadow-sm"
+            aria-label={`${formattedBalance} Roo Points`}
+            title={`${formattedBalance} Roo Points`}
+        >
+            <ImageWithFallback
+                src={ROO_POINTS_COIN_URL}
+                fallbackSrc={MLAI_LOGO_URL}
+                alt="Roo Points"
+                width={28}
+                height={28}
+                className="h-7 w-7 shrink-0 rounded-full object-cover"
+            />
+            <span className="tabular-nums text-sm font-black leading-none">{formattedBalance}</span>
+            <span className="hidden text-xs font-black uppercase text-[var(--vr-color-text-sub)] xl:inline">
+                pts
+            </span>
+        </div>
+    );
+}
+
+export default function AuthenticatedLayout({ children, user, navigation: customNavigation, userNavigation: customUserNavigation, rooPointsBalance, logoutAction = "/platform/logout" }: AuthenticatedLayoutProps) {
     const [sidebarOpen, setSidebarOpen] = useState(false);
     const [isExpanded, setIsExpanded] = useState(false);
     const location = useLocation();
@@ -432,6 +464,9 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                                 <div />
                             )}
                             <div className={classNames("ml-auto flex shrink-0 items-center gap-x-2 sm:gap-x-4 lg:gap-x-6", isFounderToolsApp && "hidden sm:flex")}>
+                                {isFounderToolsApp && rooPointsBalance ? (
+                                    <RooPointsBadge balance={rooPointsBalance.balance} />
+                                ) : null}
                                 <Menu as="div" className="relative">
                                     <Menu.Button className="-m-1.5 flex items-center p-1.5">
                                         <span className="sr-only">Open user menu</span>

--- a/app/lib/roo-points.ts
+++ b/app/lib/roo-points.ts
@@ -1,0 +1,76 @@
+import { createApiClient, shouldUseDevBackendStub } from "~/lib/api";
+
+const CURRENT_BALANCE_PATH = "/api/v1/points/me/balance/";
+
+export type RooPointsBalance = {
+  userId?: number | null;
+  email?: string | null;
+  slackUserId?: string | null;
+  balance: number;
+  earnedBalance: number;
+  purchasedTopupBalance: number;
+  lifetimeEarned: number;
+  lifetimePurchasedTopup: number;
+  lifetimeSpent: number;
+  expiredOrReversedPoints: number;
+};
+
+const DEV_ROO_POINTS_BALANCE: RooPointsBalance = {
+  userId: 1,
+  email: "dev@example.com",
+  slackUserId: "UDEVROOPOINTS",
+  balance: 42,
+  earnedBalance: 42,
+  purchasedTopupBalance: 0,
+  lifetimeEarned: 42,
+  lifetimePurchasedTopup: 0,
+  lifetimeSpent: 0,
+  expiredOrReversedPoints: 0,
+};
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeRooPointsBalance(raw: unknown): RooPointsBalance | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const payload = raw as Record<string, unknown>;
+  const balance = asNumber(payload.balance);
+  if (balance === null) return null;
+
+  return {
+    userId: asNumber(payload.userId ?? payload.user_id),
+    email: asString(payload.email),
+    slackUserId: asString(payload.slackUserId ?? payload.slack_user_id),
+    balance,
+    earnedBalance: asNumber(payload.earnedBalance ?? payload.earned_balance) ?? 0,
+    purchasedTopupBalance: asNumber(payload.purchasedTopupBalance ?? payload.purchased_topup_balance) ?? 0,
+    lifetimeEarned: asNumber(payload.lifetimeEarned ?? payload.lifetime_earned) ?? 0,
+    lifetimePurchasedTopup: asNumber(payload.lifetimePurchasedTopup ?? payload.lifetime_purchased_topup) ?? 0,
+    lifetimeSpent: asNumber(payload.lifetimeSpent ?? payload.lifetime_spent) ?? 0,
+    expiredOrReversedPoints: asNumber(payload.expiredOrReversedPoints ?? payload.expired_or_reversed_points) ?? 0,
+  };
+}
+
+export async function getCurrentRooPointsBalance(env: Env, request: Request): Promise<RooPointsBalance | null> {
+  if (shouldUseDevBackendStub()) return DEV_ROO_POINTS_BALANCE;
+
+  try {
+    const client = createApiClient(env, request);
+    const response = await client.get(CURRENT_BALANCE_PATH);
+    return normalizeRooPointsBalance(response.data);
+  } catch {
+    return null;
+  }
+}

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -13,6 +13,7 @@ import {
 import AuthenticatedLayout from "~/components/AuthenticatedLayout";
 import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import { getEnv } from "~/lib/env.server";
+import { getCurrentRooPointsBalance } from "~/lib/roo-points";
 import {
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
@@ -60,10 +61,23 @@ export const meta: Route.MetaFunction = () => [
 ];
 
 export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
+  if (shouldRefreshShellAfterAction(args.actionResult)) {
+    return true;
+  }
   if (shouldSkipVibeMarketingCreateRevalidation(args)) {
     return false;
   }
   return args.defaultShouldRevalidate;
+}
+
+function shouldRefreshShellAfterAction(actionResult: unknown) {
+  if (!actionResult || typeof actionResult !== "object") return false;
+  const payload = actionResult as Record<string, unknown>;
+  const intent = typeof payload.intent === "string" ? payload.intent : "";
+  if (intent !== "start-content-island-discovery") return false;
+  const error = typeof payload.error === "string" ? payload.error.trim() : "";
+  const runId = typeof payload.runId === "string" ? payload.runId.trim() : "";
+  return Boolean(runId && !error);
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -87,16 +101,19 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     throw redirect("/founder-tools/company-setup");
   }
 
+  const rooPointsBalance = await getCurrentRooPointsBalance(env, request);
+
   return {
     user: vibeContext.authUser,
     profile: vibeContext.profile,
     appUser: vibeContext.appUser,
+    rooPointsBalance,
     backendBaseUrl: String(env.BACKEND_BASE_URL || "https://api.mlai.au"),
   };
 }
 
 export default function VibeRaisingApp() {
-  const { user, backendBaseUrl } = useLoaderData<typeof loader>();
+  const { user, backendBaseUrl, rooPointsBalance } = useLoaderData<typeof loader>();
   const [showAnnouncement, setShowAnnouncement] = useState(false);
   const [onCompleteCallback, setOnCompleteCallback] =
     useState<(() => void) | undefined>();
@@ -111,6 +128,7 @@ export default function VibeRaisingApp() {
       user={user}
       navigation={BASE_FOUNDER_NAVIGATION}
       userNavigation={FOUNDER_USER_NAVIGATION}
+      rooPointsBalance={rooPointsBalance}
       logoutAction="/founder-tools/logout"
     >
       {showAnnouncement ? (


### PR DESCRIPTION
## Summary
- Add a server-side Roo Points balance fetch wrapper for Founder Tools.
- Render a compact Roo Points coin/balance badge immediately before the user menu in the Founder Tools top bar.
- Revalidate the Founder Tools shell after successful in-place content-island discovery starts so the header balance refreshes after paid actions.

## Validation
- `bun install --frozen-lockfile && bun run typecheck`
