### PR TITLE
Wire article publish buckets into the founder-tools dashboard + auto-revalidate

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -25,7 +25,10 @@ import type {
   VibeMarketingStartupProfile,
   VibeMarketingWebsiteBaseline,
   VibeMarketingGoogleBaselineConnection,
+  VibeMarketingArticleBucket,
   VibeMarketingArticlePublishStatus,
+  VibeMarketingPublishAttempt,
+  VibeMarketingPublishAttemptState,
   VibeMarketingTopicCandidate,
   VibeMarketingTopicFeedback,
   VibeMarketingTopicPillar,
@@ -697,11 +700,43 @@ function asArticlePublishStatus(value: unknown): VibeMarketingArticlePublishStat
   return text && ARTICLE_PUBLISH_STATUSES.has(text) ? (text as VibeMarketingArticlePublishStatus) : null;
 }
 
+function asArticleBucket(
+  value: unknown,
+  fallback: { onMain: boolean; publishStatus: VibeMarketingArticlePublishStatus | null },
+): VibeMarketingArticleBucket {
+  const text = asNullableString(value)?.toLowerCase() ?? null;
+  if (text === "published" || text === "publishing") return text;
+  // Derive the same way the backend's article_bucket() does, so older payloads
+  // (without an explicit bucket) still split correctly.
+  return fallback.onMain || fallback.publishStatus === "live" ? "published" : "publishing";
+}
+
+const PUBLISH_ATTEMPT_STATES: ReadonlySet<string> = new Set([
+  "in_progress",
+  "needs_approval",
+  "stuck",
+  "failed",
+]);
+
+function asPublishAttempt(value: unknown): VibeMarketingPublishAttempt | null {
+  const payload = value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  if (!payload) return null;
+  const state = asNullableString(payload.state)?.toLowerCase() ?? null;
+  if (!state || !PUBLISH_ATTEMPT_STATES.has(state)) return null;
+  return {
+    state: state as VibeMarketingPublishAttemptState,
+    reason: asNullableString(payload.reason),
+    recoverable: asBoolean(payload.recoverable),
+  };
+}
+
 export function normalizeWrittenTopic(raw: unknown): VibeMarketingWrittenTopic | null {
   const payload = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
   const title = asNullableString(payload.title);
   const keyword = asNullableString(payload.keyword) ?? asNullableString(payload.primary_keyword);
   if (!title && !keyword) return null;
+  const publishStatus = asArticlePublishStatus(payload.publishStatus ?? payload.publish_status);
+  const onMain = asBoolean(payload.onMain ?? payload.on_main);
   return {
     id: asNullableString(payload.id) ?? undefined,
     title: title ?? keyword ?? "Written article",
@@ -710,8 +745,13 @@ export function normalizeWrittenTopic(raw: unknown): VibeMarketingWrittenTopic |
     articleUrl: asNullableString(payload.articleUrl) ?? asNullableString(payload.article_url),
     prUrl: asNullableString(payload.prUrl) ?? asNullableString(payload.pr_url),
     prNumber: asNumber(payload.prNumber) ?? asNumber(payload.pr_number),
-    publishStatus: asArticlePublishStatus(payload.publishStatus ?? payload.publish_status),
+    publishStatus,
     liveUrl: asNullableString(payload.liveUrl) ?? asNullableString(payload.live_url),
+    bucket: asArticleBucket(payload.bucket, { onMain, publishStatus }),
+    onMain,
+    onMainAt: asNullableString(payload.onMainAt) ?? asNullableString(payload.on_main_at),
+    mergeCommitSha: asNullableString(payload.mergeCommitSha) ?? asNullableString(payload.merge_commit_sha),
+    publishAttempt: asPublishAttempt(payload.publishAttempt ?? payload.publish_attempt),
     runId:
       asNullableString(payload.runId) ??
       asNullableString(payload.run_id) ??

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -21,6 +21,7 @@ import {
   PenLine,
   Plus,
   Rocket,
+  RotateCw,
   Save,
   Search,
   Send,
@@ -2542,7 +2543,55 @@ function TopicRow({
   );
 }
 
+// Overlay tone for an in-flight publish attempt — surfaces stuck/failed/awaiting
+// states the publishStatus pill can't express. Returns null for states that map
+// cleanly to the normal pill.
+function publishAttemptTone(attempt: NonNullable<VibeMarketingWrittenTopic["publishAttempt"]>) {
+  switch (attempt.state) {
+    case "failed":
+      return {
+        label: "Publish failed",
+        pill: "bg-red-50 text-red-700",
+        dot: "bg-red-500",
+        hint: attempt.reason || "The publish didn’t open a PR. Open the run to retry.",
+      };
+    case "stuck":
+      return {
+        label: "Publish stalled",
+        pill: "bg-amber-50 text-amber-700",
+        dot: "bg-amber-500",
+        hint: attempt.reason || "The publish stalled before opening a PR. Open the run to retry.",
+      };
+    case "needs_approval":
+      return {
+        label: "Awaiting approval",
+        pill: "bg-amber-50 text-amber-700",
+        dot: "bg-amber-500",
+        hint: attempt.reason || "Open the run to approve and publish.",
+      };
+    case "in_progress":
+      return {
+        label: "Publishing…",
+        pill: "bg-violet-50 text-violet-700",
+        dot: "bg-violet-500",
+        hint: attempt.reason || "Publishing is in progress.",
+      };
+    default:
+      return null;
+  }
+}
+
 function articlePublishStatusTone(article: VibeMarketingWrittenTopic) {
+  // On origin/main is the authoritative "published" fact — surface it as Live
+  // even when the sitemap signal (publishStatus "live") hasn't caught up.
+  if (article.onMain) {
+    return {
+      label: "Live",
+      pill: "bg-emerald-50 text-emerald-600",
+      dot: "bg-emerald-500",
+      hint: "Verified on origin/main.",
+    };
+  }
   switch (article.publishStatus) {
     case "live":
       return {
@@ -2595,9 +2644,13 @@ function RecentArticleRow({
   skipDiscardConfirmation: boolean;
   onDiscardRequest: (request: { articleId: string; title: string }) => void;
 }) {
-  const tone = articlePublishStatusTone(article);
+  const attempt = article.publishAttempt ?? null;
+  const tone = (attempt ? publishAttemptTone(attempt) : null) ?? articlePublishStatusTone(article);
   const href =
-    (article.publishStatus === "live" ? article.liveUrl : null) ?? article.prUrl ?? article.articleUrl ?? null;
+    (article.onMain || article.publishStatus === "live" ? article.liveUrl : null) ??
+    article.prUrl ??
+    article.articleUrl ??
+    null;
   const title = article.title || article.keyword;
   const articleId = article.id ?? "";
   // merged/live articles are on (or headed to) the site; discard is only for
@@ -2627,6 +2680,17 @@ function RecentArticleRow({
       )}
       <p className="text-sm font-bold text-slate-500">{formatArticleDate(article.writtenAt)}</p>
       <div className="flex items-center justify-end gap-1">
+        {attempt?.recoverable && article.runId ? (
+          <Link
+            to={`/founder-tools/marketing/runs/${encodeURIComponent(article.runId)}`}
+            title={attempt.reason || "Open the run to retry publishing"}
+            aria-label={`Retry publishing: ${title}`}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-black text-amber-700 transition hover:bg-amber-100 focus:outline-none focus:ring-4 focus:ring-amber-100"
+          >
+            <RotateCw className="h-3.5 w-3.5" />
+            Retry
+          </Link>
+        ) : null}
         {article.runId ? (
           <Link
             to={`/founder-tools/marketing/runs/${encodeURIComponent(article.runId)}`}
@@ -3621,6 +3685,46 @@ function ReturningTopicPickerPage({
     () => filterDiscardedWrittenTopics(bootstrap.writtenTopics ?? [], optimisticallyDiscardedArticleIds),
     [bootstrap.writtenTopics, optimisticallyDiscardedArticleIds],
   );
+  // Split by bucket: "Your recent articles" lists only what's confirmed on
+  // origin/main; everything still in flight (written / PR open / merged-and-
+  // deploying) gets its own "Publishing" section so it never silently vanishes.
+  const publishedArticles = useMemo(
+    () => visibleWrittenTopics.filter((article) => (article.bucket ?? "publishing") === "published"),
+    [visibleWrittenTopics],
+  );
+  const publishingArticles = useMemo(
+    () => visibleWrittenTopics.filter((article) => (article.bucket ?? "publishing") !== "published"),
+    [visibleWrittenTopics],
+  );
+  // Poll the dashboard while something is actively progressing server-side, so
+  // in-flight states (a publish run finishing, a PR merging, on-main
+  // verification) update without a manual refresh. Stuck/failed states need user
+  // action and don't auto-progress, so they never keep us polling.
+  const hasInFlightWork = useMemo(() => {
+    const activeDraft = visibleDraftArticles.some(
+      (draft) => draft.status === "queued" || draft.status === "running",
+    );
+    const inFlightArticle = publishingArticles.some(
+      (article) =>
+        article.publishAttempt?.state === "in_progress" ||
+        article.publishStatus === "pr_open" ||
+        article.publishStatus === "merged",
+    );
+    return activeDraft || inFlightArticle;
+  }, [visibleDraftArticles, publishingArticles]);
+  // Ref so the interval always sees the current revalidator without re-creating
+  // the timer on every state transition (idle -> loading -> idle).
+  const revalidatorRef = useRef(revalidator);
+  revalidatorRef.current = revalidator;
+  useEffect(() => {
+    if (!hasInFlightWork) return;
+    const interval = setInterval(() => {
+      if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
+      const current = revalidatorRef.current;
+      if (current.state === "idle") current.revalidate();
+    }, 15000);
+    return () => clearInterval(interval);
+  }, [hasInFlightWork]);
 
   const submitSelectedTopic = useCallback(() => {
     if (articleSubmitting || !selectedTopic) return;
@@ -4495,6 +4599,29 @@ function ReturningTopicPickerPage({
             onDeleteRequest={setDraftDeleteRequest}
           />
 
+          {publishingArticles.length ? (
+            <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <div>
+                <h2 className="text-lg font-black text-slate-950">Publishing</h2>
+                <p className="mt-1 text-sm font-semibold text-slate-500">
+                  On their way to your site — in review, PR open, or merged and deploying. Each moves to recent articles once confirmed on main.
+                </p>
+              </div>
+              <div className="mt-5">
+                {publishingArticles.slice(0, 5).map((article) => (
+                  <RecentArticleRow
+                    key={article.id ?? article.slug ?? article.title}
+                    article={article}
+                    submitting={discardArticleSubmitting}
+                    discarding={discardArticleSubmitting && discardingArticleId === (article.id ?? "")}
+                    skipDiscardConfirmation={skipArticleDiscardConfirmation}
+                    onDiscardRequest={setArticleDiscardRequest}
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
           <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-lg font-black text-slate-950">Your recent articles</h2>
@@ -4504,8 +4631,8 @@ function ReturningTopicPickerPage({
               </Link>
             </div>
             <div className="mt-5">
-              {visibleWrittenTopics.length ? (
-                visibleWrittenTopics.slice(0, 3).map((article) => (
+              {publishedArticles.length ? (
+                publishedArticles.slice(0, 3).map((article) => (
                   <RecentArticleRow
                     key={article.id ?? article.slug ?? article.title}
                     article={article}
@@ -4518,8 +4645,8 @@ function ReturningTopicPickerPage({
               ) : (
                 <div className="rounded-xl bg-slate-50 px-5 py-8 text-center">
                   <FileText className="mx-auto h-7 w-7 text-slate-400" />
-                  <p className="mt-3 text-sm font-black text-slate-950">No completed articles yet.</p>
-                  <p className="mt-1 text-sm font-semibold text-slate-500">Your published article memory will appear here.</p>
+                  <p className="mt-3 text-sm font-black text-slate-950">No published articles yet.</p>
+                  <p className="mt-1 text-sm font-semibold text-slate-500">Articles appear here once they’re confirmed live on origin/main.</p>
                 </div>
               )}
             </div>

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -399,6 +399,26 @@ export type VibeMarketingArticlePublishStatus =
   | "merged"
   | "live";
 
+// Which dashboard list an article belongs to. Mirrors the backend
+// article_bucket(): "published" once confirmed on origin's default branch (the
+// source of truth), otherwise still "publishing". A written article is never a
+// draft.
+export type VibeMarketingArticleBucket = "publishing" | "published";
+
+// A stuck/failed/in-flight publish attempt the publishStatus pill can't express
+// (the article stays "written" while its publish run is the one in trouble).
+export type VibeMarketingPublishAttemptState =
+  | "in_progress"
+  | "needs_approval"
+  | "stuck"
+  | "failed";
+
+export interface VibeMarketingPublishAttempt {
+  state: VibeMarketingPublishAttemptState;
+  reason?: string | null;
+  recoverable?: boolean | null;
+}
+
 export interface VibeMarketingWrittenTopic {
   id?: string;
   title: string;
@@ -409,6 +429,14 @@ export interface VibeMarketingWrittenTopic {
   prNumber?: number | null;
   publishStatus?: VibeMarketingArticlePublishStatus | null;
   liveUrl?: string | null;
+  // Authoritative publish facts (backend Phase 0). `bucket` gates which list the
+  // article shows in; `onMain` is the proven "it's on origin/main" fact,
+  // independent of the weaker sitemap `liveUrl`.
+  bucket?: VibeMarketingArticleBucket | null;
+  onMain?: boolean | null;
+  onMainAt?: string | null;
+  mergeCommitSha?: string | null;
+  publishAttempt?: VibeMarketingPublishAttempt | null;
   runId?: string | null;
   writtenAt?: string | null;
 }


### PR DESCRIPTION
Frontend half of the article-state unification (backend: MLAI-AUS-Inc/mlai-backend#465).

Consumes the backend's `bucket` / `onMain` / `publishAttempt` facts:

- **"Your recent articles" now lists only published (on-main) articles.** In-flight articles get a dedicated **Publishing** section ("in review, PR open, or merged and deploying… moves to recent once confirmed on main"), so nothing vanishes.
- The status pill treats **on-main as authoritative "Live (verified on origin/main)"**, even before the sitemap catches up.
- `publishAttempt` surfaces **stuck / failed / awaiting-approval / publishing** states the old pill couldn't express, with a **Retry** link to the run page.
- **Auto-revalidate every 15s while anything is in flight** (visible tab only, idle-guarded), so in-flight states update without a manual refresh.

Typechecks clean (`react-router typegen && tsc -b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
