### PR TITLE
[codex] Polish Roo Points coin interactions

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -15,6 +15,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { Link, useLocation, Form } from 'react-router';
 import { ImageWithFallback } from './ImageWithFallback';
+import { ROO_POINTS_ANIMATED_GIF_URL, ROO_POINTS_COIN_URL } from '~/components/RooPointCost';
 import { getInitials, generateAvatarUrl } from '~/lib/avatar';
 import type { RooPointsBalance } from '~/lib/roo-points';
 import type { User } from '~/types/user';
@@ -36,7 +37,6 @@ const VIBE_RAISING_TOP_NAVIGATION = [
     { name: 'My Companies', href: '/founder-tools/companies' },
 ];
 const MLAI_LOGO_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/MLAI-Logo.png?alt=media&token=9d844530-e3b5-4944-a1c7-5be3112d5d84";
-const ROO_POINTS_COIN_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Robotics%20%26%20AI%20For%20Everyone%20(9)%20(1)%20(1).png?alt=media&token=a43ec994-1637-410c-b3ea-a39bb45f3cd3";
 
 function classNames(...classes: (string | undefined | boolean)[]) {
     return classes.filter(Boolean).join(' ');
@@ -48,25 +48,50 @@ function formatRooPointsBalance(balance: number) {
 
 function RooPointsBadge({ balance }: { balance: number }) {
     const formattedBalance = formatRooPointsBalance(balance);
+    const [isHovering, setIsHovering] = useState(false);
+    const [animationKey, setAnimationKey] = useState(0);
+    const animationSrc = isHovering
+        ? `${ROO_POINTS_ANIMATED_GIF_URL}${ROO_POINTS_ANIMATED_GIF_URL.includes("?") ? "&" : "?"}hover=${animationKey}`
+        : ROO_POINTS_COIN_URL;
+
+    const startAnimation = () => {
+        if (
+            typeof window !== "undefined" &&
+            window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ) {
+            return;
+        }
+        setAnimationKey((current) => current + 1);
+        setIsHovering(true);
+    };
+
+    const stopAnimation = () => {
+        setIsHovering(false);
+    };
 
     return (
         <div
-            className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[rgba(15,23,42,0.12)] bg-white/85 px-2.5 text-[var(--vr-color-text)] shadow-sm"
+            role="img"
+            tabIndex={0}
+            onPointerEnter={startAnimation}
+            onPointerLeave={stopAnimation}
+            onFocus={startAnimation}
+            onBlur={stopAnimation}
+            className="inline-flex h-9 shrink-0 cursor-default select-none items-center gap-2 rounded-full border border-[rgba(15,23,42,0.12)] bg-white/85 px-2.5 text-[var(--vr-color-text)] shadow-sm transition hover:bg-white focus:outline-none focus:ring-4 focus:ring-violet-100"
             aria-label={`${formattedBalance} Roo Points`}
             title={`${formattedBalance} Roo Points`}
         >
             <ImageWithFallback
-                src={ROO_POINTS_COIN_URL}
+                src={animationSrc}
                 fallbackSrc={MLAI_LOGO_URL}
-                alt="Roo Points"
+                alt=""
+                aria-hidden="true"
+                draggable={false}
                 width={28}
                 height={28}
-                className="h-7 w-7 shrink-0 rounded-full object-cover"
+                className="pointer-events-none h-7 w-7 shrink-0 rounded-full object-cover"
             />
-            <span className="tabular-nums text-sm font-black leading-none">{formattedBalance}</span>
-            <span className="hidden text-xs font-black uppercase text-[var(--vr-color-text-sub)] xl:inline">
-                pts
-            </span>
+            <span className="pointer-events-none tabular-nums text-sm font-black leading-none">{formattedBalance}</span>
         </div>
     );
 }

--- a/app/components/RooPointCost.tsx
+++ b/app/components/RooPointCost.tsx
@@ -1,0 +1,49 @@
+import { ImageWithFallback } from "./ImageWithFallback";
+
+export const ROO_POINTS_COIN_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/Robotics%20%26%20AI%20For%20Everyone%20(9)%20(1)%20(1).png?alt=media&token=a43ec994-1637-410c-b3ea-a39bb45f3cd3";
+export const ROO_POINTS_ANIMATED_GIF_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/RoboticsAIForEveryone-ezgif.com-resize.gif?alt=media&token=1dfcdf90-5385-4552-92e1-0b7d0c139cf0";
+
+const ROO_POINTS_FALLBACK_URL = "https://firebasestorage.googleapis.com/v0/b/mlai-main-website.firebasestorage.app/o/MLAI-Logo.png?alt=media&token=9d844530-e3b5-4944-a1c7-5be3112d5d84";
+
+function classNames(...classes: (string | undefined | boolean)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function RooCoinImage({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <ImageWithFallback
+      src={ROO_POINTS_COIN_URL}
+      fallbackSrc={ROO_POINTS_FALLBACK_URL}
+      alt=""
+      aria-hidden="true"
+      width={18}
+      height={18}
+      className={classNames("shrink-0 rounded-full object-cover", className)}
+    />
+  );
+}
+
+export function RooPointCost({
+  points,
+  className,
+  coinClassName = "h-4 w-4",
+}: {
+  points: number;
+  className?: string;
+  coinClassName?: string;
+}) {
+  const absolutePoints = Math.abs(points);
+  const visibleCost = `${points < 0 ? "-" : ""}${absolutePoints}`;
+  const pointLabel = absolutePoints === 1 ? "Point" : "Points";
+  const screenReaderLabel = points < 0
+    ? `Costs ${absolutePoints} Roo ${pointLabel}`
+    : `${absolutePoints} Roo ${pointLabel}`;
+
+  return (
+    <span className={classNames("inline-flex items-center gap-1 whitespace-nowrap", className)}>
+      <span aria-hidden="true">{visibleCost}</span>
+      <RooCoinImage className={coinClassName} />
+      <span className="sr-only">{screenReaderLabel}</span>
+    </span>
+  );
+}

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -18,6 +18,7 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
 import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
 import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
+import { RooPointCost } from "~/components/RooPointCost";
 import {
   CustomTopicDecisionCard,
   TopicDecisionCard,
@@ -1639,7 +1640,16 @@ export default function FounderToolsMarketingCreate() {
                     </div>
                     <button type="submit" disabled={isSubmitting || !bootstrap.checks.baseline?.passed} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-60">
                       {articleStartPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <RocketLaunchIcon className="h-4 w-4" />}
-                      {articleStartPending ? "Starting article..." : `Generate draft article (${VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} pts)`}
+                      {articleStartPending ? (
+                        "Starting article..."
+                      ) : (
+                        <>
+                          <span>Generate draft article</span>
+                          <span aria-hidden="true">(</span>
+                          <RooPointCost points={-VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} />
+                          <span aria-hidden="true">)</span>
+                        </>
+                      )}
                     </button>
                   </div>
                 </div>

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -24,6 +24,7 @@ import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPa
 import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
+import { RooPointCost } from "~/components/RooPointCost";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
 import { getEnv } from "~/lib/env.server";
 import {
@@ -4203,7 +4204,16 @@ export default function FounderToolsMarketingRun() {
                       </div>
                       <button type="submit" disabled={isSubmitting} className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50">
                         {pendingActions.isPending("start-article") ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                        {pendingActions.isPending("start-article") ? "Starting article..." : `Generate draft article (${VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} pts)`}
+                        {pendingActions.isPending("start-article") ? (
+                          "Starting article..."
+                        ) : (
+                          <>
+                            <span>Generate draft article</span>
+                            <span aria-hidden="true">(</span>
+                            <RooPointCost points={-VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} />
+                            <span aria-hidden="true">)</span>
+                          </>
+                        )}
                       </button>
                     </div>
                   </div>

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -40,6 +40,7 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import type { MarketingRunProgressTheme } from "~/components/MarketingRunProgressCard";
 import AvatarModal from "~/components/AvatarModal";
 import GitHubMark from "~/components/GitHubMark";
+import { RooPointCost } from "~/components/RooPointCost";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { readableBackendError, readableBackendErrors } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
@@ -2531,7 +2532,14 @@ function TopicRow({
               : rowTheme?.idleButton ?? "bg-violet-50 text-violet-700 hover:bg-violet-100",
           )}
         >
-          {selected ? `Continue (${VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} pts)` : "Select"}
+          {selected ? (
+            <>
+              <span>Continue</span>
+              <span aria-hidden="true">(</span>
+              <RooPointCost points={-VIBE_MARKETING_ARTICLE_JOB_COST_POINTS} />
+              <span aria-hidden="true">)</span>
+            </>
+          ) : "Select"}
           {selected && submitting ? (
             <Loader2 className={clsx("h-4 w-4 animate-spin", rowTheme?.arrow ?? "text-violet-500")} />
           ) : (
@@ -3424,6 +3432,7 @@ function TopicPillarsSection({
                 type="button"
                 onClick={() => onGenerate(pillar)}
                 disabled={submitting || generating}
+                aria-label={confirming ? `Generate topic ideas for ${VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS} Roo Point` : undefined}
                 className={clsx(
                   "mt-auto inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border text-sm font-black transition disabled:cursor-not-allowed disabled:opacity-60",
                   theme.solidButton,
@@ -3436,8 +3445,17 @@ function TopicPillarsSection({
                   </>
                 ) : (
                   <>
-                    {confirming ? `Generate (${VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS} pt)` : "Generate"}
-                    <ArrowRight className="h-4 w-4 text-white" />
+                    {confirming ? (
+                      <>
+                        <RooPointCost points={-VIBE_MARKETING_CONTENT_ISLAND_TOPIC_COST_POINTS} />
+                        <span aria-hidden="true">?</span>
+                      </>
+                    ) : (
+                      <>
+                        Generate
+                        <ArrowRight className="h-4 w-4 text-white" />
+                      </>
+                    )}
                   </>
                 )}
               </button>


### PR DESCRIPTION
## Summary
- Animate the Founder Tools Roo Points badge while the user hovers or focuses the pill, then return to the static coin on leave/blur.
- Remove the header `PTS` label and share the Roo coin asset through a reusable cost display component.
- Replace Founder Tools paid-action `pt/pts` text with inline Roo coin cost labels.

## Validation
- `bun install --frozen-lockfile && bun run typecheck`
- Browser hover verification before PR: static PNG before hover, GIF while hovered after 2.2s, static PNG after mouse leave.
- Reduced-motion browser verification before PR: hover does not switch to GIF.
