### PR TITLE
Reskin articles-setup final stage as a friendly "Publish" step

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -922,17 +922,17 @@ export default function ArticleSystemConnectionPanel({
     },
     review_ready: {
       title: "Articles setup preview is ready",
-      body: "Review the setup preview and approve it before a setup PR is created.",
+      body: "Review the setup preview and approve it before it's published.",
       tone: "violet",
     },
     publish_ready: {
-      title: "Setup PR needs finishing",
-      body: "Finish the setup PR so the articles scaffold can be merged to the website.",
+      title: "Ready to publish",
+      body: "Publish the articles setup so it goes live on your website.",
       tone: "amber",
     },
     verifying: {
-      title: "Verifying merged articles scaffold",
-      body: "The merge is being checked before article generation unlocks.",
+      title: "Verifying published articles scaffold",
+      body: "Your published setup is being verified before article generation unlocks.",
       tone: "emerald",
     },
     ready: {
@@ -942,7 +942,7 @@ export default function ArticleSystemConnectionPanel({
     },
     legacy_ready: {
       title: "Articles scaffold check passed",
-      body: `Scaffold check passed for ${scaffoldRouteLabel}. No setup PR merge record was found.`,
+      body: `Scaffold check passed for ${scaffoldRouteLabel}. No publish record was found.`,
       tone: "emerald",
     },
     failed: {
@@ -965,8 +965,8 @@ export default function ArticleSystemConnectionPanel({
     ready_to_build: "Build the scaffold preview for review.",
     building: "Track build progress and open the preview when it is ready.",
     review_ready: "Inspect the preview and approve it when it looks right.",
-    publish_ready: "Create or merge the setup PR from the setup run.",
-    verifying: "Waiting for the merged scaffold to verify.",
+    publish_ready: "Publish the articles setup from the setup run.",
+    verifying: "Waiting for the published scaffold to verify.",
     ready: "The scaffold is ready. Continue to topic research.",
     legacy_ready: "The scaffold check has passed. Continue to topic research.",
     failed: "Open the setup build to review the failure.",

--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -149,8 +149,8 @@ const ARTICLE_SETUP_WORKFLOW_DISPLAY_GROUPS: WorkflowDisplayGroupDefinition[] = 
   },
   {
     id: "publish_automation",
-    label: "Publish setup PR",
-    summary: "Approve the exact setup preview to create the setup pull request.",
+    label: "Publish",
+    summary: "Publish the articles setup so article generation unlocks.",
     stepIds: ["package", "publish"],
     completionStepId: "publish",
     icon: RocketLaunchIcon,

--- a/app/lib/article-system-connection-steps.ts
+++ b/app/lib/article-system-connection-steps.ts
@@ -42,8 +42,8 @@ export function articleSystemScaffoldActionLabel(status: ArticleSystemScaffoldSt
   if (status === "ready_to_build") return "Build articles scaffold";
   if (status === "building") return "Open setup build";
   if (status === "review_ready") return "Review setup preview";
-  if (status === "publish_ready") return "Finish setup PR";
-  if (status === "verifying") return "Verifying merged scaffold...";
+  if (status === "publish_ready") return "Publish setup";
+  if (status === "verifying") return "Verifying published scaffold...";
   if (status === "ready" || status === "legacy_ready") return "Continue to topic research";
   if (status === "failed") return "Open setup build";
   return "Choose articles route first";

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -561,7 +561,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } else if (intent === "start-article") {
       const bootstrap = await getVibeMarketingBootstrap(env, request);
       if (isArticleSystemSetupBlocked(bootstrap)) {
-        return { intent, error: "Merge the articles setup PR before generating articles. If you merged it in GitHub, refresh merge status." };
+        return { intent, error: "Publish the articles setup before generating articles. If you've already published it, refresh status." };
       }
       const topicCandidateId = stringFromForm(formData, "topicCandidateId");
       const isCustomTopic = !topicCandidateId || topicCandidateId === "__custom__";
@@ -1151,14 +1151,14 @@ function ArticleSystemSetupPreviewPanel({
         <div>
           <h2 className="text-lg font-black text-gray-950">Articles setup preview</h2>
           <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-            Review the drafted articles/blogs setup before a setup PR is created for the website repo.
+            Review the drafted articles/blogs setup before it's published to the website repo.
           </p>
           <div className="mt-3 flex flex-wrap gap-2 text-xs font-black">
             {repo ? <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-700">{repo}</span> : null}
             {route ? <span className="rounded-full bg-violet-50 px-3 py-1 text-violet-700">{route}</span> : null}
             {prUrl ? (
               <a href={prUrl} target="_blank" rel="noreferrer" className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-700 hover:text-emerald-900">
-                Open PR
+                View changes
               </a>
             ) : null}
           </div>
@@ -1279,9 +1279,9 @@ function ArticleSystemSetupPreviewPanel({
       {manualMergeRequired ? (
         <div className="flex flex-col gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-sm font-black text-amber-950">Manual merge required</p>
+            <p className="text-sm font-black text-amber-950">Publishing needs a quick manual step</p>
             <p className="mt-1 text-sm font-semibold leading-6 text-amber-800">
-              Merge the setup PR in GitHub, then refresh merge status to unlock article generation.
+              Open the changes in GitHub to finish publishing, then refresh status to unlock article generation.
             </p>
           </div>
           {prUrl ? (
@@ -1291,7 +1291,7 @@ function ArticleSystemSetupPreviewPanel({
               rel="noreferrer"
               className="inline-flex items-center justify-center rounded-xl bg-amber-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-amber-700"
             >
-              Open setup PR
+              View changes
             </a>
           ) : null}
         </div>
@@ -1414,7 +1414,7 @@ function ArticleSystemSetupPreviewUnavailable({
     (previewActive || actionRetryPending
     ? ""
     : isGithubAppWriteAccessError
-      ? "MLAI Tools can read this repository, but needs Contents: Read/Write and Pull requests: Read/Write to create the setup PR."
+      ? "MLAI Tools can read this repository, but needs Contents: Read/Write and Pull requests: Read/Write to publish the articles setup."
       : isNextAppRootLayoutMissing
         ? "Content Factory found a Next.js App Router project but could not confirm a root app/layout.* file from the latest repository context. Re-run the repository scan, then retry setup."
       : rawError || (terminalFailure ? "The articles setup build did not advance." : ""));
@@ -2537,94 +2537,119 @@ function ArticleSetupPublishDetail({
     .map((channel) => ({ slack: "Slack", email: "Email", whatsapp: "WhatsApp" })[channel.channelType])
     .filter(Boolean);
 
+  // Present the two underlying setup steps (create, then merge) as one friendly "Publish" action.
+  const publishPending = approvePending || mergePending;
+  const publishIntent = prUrl && !setupMerged ? "merge-setup-pr" : "approve";
+  const publishLabel = publishPending
+    ? "Publishing..."
+    : prCreateFailed || mergeBlockedReason
+      ? "Retry publish"
+      : "Publish";
+  // Keep the backend's git phrasing out of the UI when a publish can't finish automatically.
+  const blockedMessage =
+    mergeBlockedReason && /merge the setup pr/i.test(mergeBlockedReason)
+      ? "Publishing couldn't finish automatically — retry, or view changes to check the latest status."
+      : mergeBlockedReason;
+  const cardStatus = setupMerged
+    ? "complete"
+    : blockedMessage || prCreateFailed
+      ? "blocked"
+      : publishPending || prUrl
+        ? "running"
+        : "ready";
+  const cardEyebrow = setupMerged
+    ? "Published"
+    : blockedMessage
+      ? "Needs a retry"
+      : prCreateFailed
+        ? "Retry needed"
+        : prUrl
+          ? checksStatus
+            ? `Checks ${checksStatus}`
+            : "Publishing"
+          : "Ready";
+
   return (
     <div className="space-y-5">
       <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <p className="text-xs font-black uppercase tracking-wide text-violet-700">Publish setup PR</p>
+            <p className="text-xs font-black uppercase tracking-wide text-violet-700">Publish &amp; automate</p>
             <h2 className="mt-1 text-xl font-black text-gray-950">Finish articles setup</h2>
             <p className="mt-2 max-w-3xl text-sm font-semibold leading-6 text-gray-600">
-              Review the setup PR and merge it after checks pass. Once merged, article generation unlocks without a repo re-scan.
+              Publish the articles setup — it goes live with the next site build. Once it&apos;s published, article generation unlocks and you can turn on daily research reminders.
             </p>
           </div>
-          <WorkflowStatusPill status={setupMerged ? "complete" : prUrl ? "needs_action" : "ready"} />
+          <WorkflowStatusPill status={setupMerged ? "complete" : prUrl ? "running" : "ready"} />
         </div>
 
-        <div className="mt-5 grid gap-4 lg:grid-cols-3">
-          <PublishFlowCard title="Setup PR" status={prUrl ? "complete" : prCreateFailed ? "needs_action" : "ready"} eyebrow={prUrl ? "PR ready" : prCreateFailed ? "Retry needed" : "Ready"}>
-            {prUrl ? (
+        <div className="mt-5 grid gap-4 lg:grid-cols-2">
+          <PublishFlowCard title="Publish" status={cardStatus} eyebrow={cardEyebrow}>
+            {setupMerged ? (
               <div className="space-y-3">
                 <p className="text-sm font-semibold text-gray-600">
-                  {prNumber ? `Pull request #${prNumber} is ready for final review.` : "The setup pull request is ready for final review."}
+                  Articles setup is published — article generation is unlocked. Choose a topic to generate your first article.
                 </p>
-                <a
-                  href={prUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center justify-center rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-black"
-                >
-                  Open PR
-                </a>
+                {prUrl ? (
+                  <a
+                    href={prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                  >
+                    View changes
+                  </a>
+                ) : null}
               </div>
             ) : (
               <Form method="POST" className="space-y-3">
                 <p className="text-sm font-semibold text-gray-600">
-                  {prCreateFailed
-                    ? "Approval succeeded, but PR creation did not complete. Retry will recreate or reuse the setup PR."
-                    : "Create the setup PR from the approved preview."}
+                  {blockedMessage
+                    ? blockedMessage
+                    : prCreateFailed
+                      ? "Publishing didn't finish last time. Retry to publish the approved setup."
+                      : prUrl
+                        ? "Your setup is publishing. This page updates on its own once it's live."
+                        : "Publish the approved setup. It goes live with the next site build and unlocks article generation."}
                 </p>
-                <button
-                  type="submit"
-                  name="intent"
-                  value="approve"
-                  disabled={isSubmitting}
-                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50"
-                >
-                  {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                  {approvePending ? "Creating..." : prCreateFailed ? "Retry create PR" : "Create setup PR"}
-                </button>
-              </Form>
-            )}
-          </PublishFlowCard>
-
-          <PublishFlowCard title="Merge to main" status={setupMerged ? "complete" : mergePending ? "running" : prUrl ? "ready" : "locked"} eyebrow={setupMerged ? "Merged" : checksStatus || mergeStatus || (prUrl ? "Ready" : "Waiting")}>
-            {setupMerged ? (
-              <p className="text-sm font-semibold text-gray-600">Articles setup is complete. Choose a topic to generate the next article.</p>
-            ) : prUrl ? (
-              <Form method="POST" className="space-y-3">
-                <p className="text-sm font-semibold text-gray-600">
-                  {mergeBlockedReason || "Merge the setup PR, then article generation unlocks."}
-                </p>
-                <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+                <div className="flex flex-wrap items-center gap-2">
                   <button
                     type="submit"
                     name="intent"
-                    value="merge-setup-pr"
+                    value={publishIntent}
                     disabled={isSubmitting}
                     className="inline-flex items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
                   >
-                    {mergePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PlayIcon className="h-4 w-4" />}
-                    {mergePending ? "Checking..." : "Check and merge"}
+                    {publishPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+                    {publishLabel}
                   </button>
+                  {prUrl ? (
+                    <a
+                      href={prUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-black text-gray-700 shadow-sm transition hover:bg-gray-50"
+                    >
+                      View changes
+                    </a>
+                  ) : null}
+                </div>
+                {prUrl ? (
                   <button
                     type="submit"
                     name="intent"
                     value="refresh-setup-pr-status"
                     disabled={isSubmitting}
-                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50 disabled:opacity-50"
+                    className="text-xs font-bold text-gray-400 underline-offset-2 transition hover:text-gray-600 hover:underline disabled:opacity-50"
                   >
-                    {refreshMergePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                    {refreshMergePending ? "Refreshing..." : "I merged this in GitHub"}
+                    {refreshMergePending ? "Refreshing status..." : "Already published it yourself? Refresh status"}
                   </button>
-                </div>
+                ) : null}
               </Form>
-            ) : (
-              <p className="text-sm font-semibold text-gray-500">Create the setup PR before merging to main.</p>
             )}
           </PublishFlowCard>
 
-          <PublishFlowCard title="Daily article reminders" status={dailyEnabled ? "complete" : setupMerged ? "ready" : "locked"} eyebrow={dailyEnabled ? (activeChannelLabels.length ? `${activeChannelLabels.join(" + ")} enabled` : "Enabled") : setupMerged ? "Ready" : "Merge first"}>
+          <PublishFlowCard title="Daily article reminders" status={dailyEnabled ? "complete" : setupMerged ? "ready" : "locked"} eyebrow={dailyEnabled ? (activeChannelLabels.length ? `${activeChannelLabels.join(" + ")} enabled` : "Enabled") : setupMerged ? "Ready" : "Publish first"}>
             {setupMerged ? (
               <div className="space-y-3">
                 <DailyReminderChannels channels={dailyChannels} isSubmitting={isSubmitting} />
@@ -2663,7 +2688,7 @@ function ArticleSetupPublishDetail({
                 </Form>
               </div>
             ) : (
-              <p className="text-sm font-semibold text-gray-500">Daily reminders unlock after the setup PR is merged.</p>
+              <p className="text-sm font-semibold text-gray-500">Daily reminders unlock once the articles setup is published.</p>
             )}
           </PublishFlowCard>
         </div>
@@ -3875,13 +3900,13 @@ function workflowProgressForRunPage(
         if (step.id === "package" || step.id === "publish") {
           return {
             ...step,
-            label: step.id === "publish" ? "Publish setup PR" : "Setup PR ready",
+            label: step.id === "publish" ? "Publish" : "Publish ready",
             href: `/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}?setupStep=publish`,
             summary: setupComplete
-              ? "Merged setup PR is being verified on the default branch."
+              ? "Your published setup is being verified."
               : setupPrCreated
-                ? "Open the setup PR, merge it, then enable daily article reminders."
-                : "Approve the exact setup preview to create the setup pull request.",
+                ? "Publish the articles setup, then enable daily article reminders."
+                : "Publish the approved setup preview.",
             status: setupComplete ? "complete" : setupPrCreated || manualMergeRequired ? "needs_action" : "locked",
           };
         }
@@ -4165,7 +4190,7 @@ export default function FounderToolsMarketingRun() {
             />
           ) : undefined
         }
-        activeDetailLabel={isSetupPublishView ? "Publish setup PR" : isSetupGenerateView ? "Build setup page" : isSetupReviewView ? "Review setup preview" : isArticleSetupContext ? "Articles setup progress" : isPublishAutomateView ? "Publish & automate progress" : "Generating article progress"}
+        activeDetailLabel={isSetupPublishView ? "Publish" : isSetupGenerateView ? "Build setup page" : isSetupReviewView ? "Review setup preview" : isArticleSetupContext ? "Articles setup progress" : isPublishAutomateView ? "Publish & automate progress" : "Generating article progress"}
       />
 
       {isPublishApproval && directPublishMode ? <PublishApprovalPanel run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : null}

--- a/tests/article-system-connection-steps.test.ts
+++ b/tests/article-system-connection-steps.test.ts
@@ -100,7 +100,7 @@ describe("article system connection step states", () => {
     });
 
     expect(steps.buildSetup.status).toBe("active");
-    expect(articleSystemScaffoldActionLabel("publish_ready")).toBe("Finish setup PR");
+    expect(articleSystemScaffoldActionLabel("publish_ready")).toBe("Publish setup");
   });
 
   test("blocks the scaffold step when setup failed", () => {


### PR DESCRIPTION
## What

The articles-setup wizard's final stage exposed git-native language — "Publish setup PR", "Setup PR", "Pull request #1", "Merge to main", "Check and merge", "I merged this in GitHub". Article *generation* already presents publishing with a single friendly **"Publish"** card that hides the PR/merge mechanics. This makes the setup stage match.

**Frontend only.** Auto-merge isn't available for the `article_system_setup` workflow (gated to article workflows in the backend), so the existing two intents (`approve` → `merge-setup-pr`) are presented behind one "Publish" button whose intent is chosen by state; the page's existing polling auto-advances **ready → Publishing → Published**. No new intents, no backend change.

## Changes

- **`ArticleSetupPublishDetail`**: three git cards ("Setup PR" / "Merge to main" / "Daily reminders") → one **"Publish"** card (modeled on the article `PublishAndAutomateDetail` flow) + the daily-reminder card. Friendly copy, a single neutral **"View changes"** link, and the merge-blocked path no longer surfaces the backend's "merge the setup PR" phrasing.
- **Progress rail + "Next required step" banner** (`MarketingWorkflowShell` `publish_automation` group), child-step labels, and the detail header label → **"Publish"**.
- **Adjacent setup surfaces** scrubbed of PR/merge wording: the start-article block error, the setup-preview review banner, the manual-merge banner, and the GitHub write-access hint (kept the literal GitHub permission names).
- **Dashboard connection panel** (`ArticleSystemConnectionPanel` scaffold status/help copy) + `articleSystemScaffoldActionLabel` ("Finish setup PR" → "Publish setup") and its test.

The article-generation flow (`PublishAndAutomateDetail`) and the shared `PublishFlowCard` / `WorkflowStatusPill` components are **untouched**.

## Verification

- `tsc -b` clean
- `bun test` — **86 pass / 0 fail**
- Grep confirms no "Setup PR / merge to main / pull request / Check and merge / I merged this in GitHub" remains in the setup surfaces (only the article-generation flow retains its own wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)