### PR TITLE
Remove blogs wording from article setup reset

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1476,7 +1476,7 @@ export default function ArticleSystemConnectionPanel({
               <div>
                 <p className="text-sm font-black text-red-900">Reset articles setup</p>
                 <p className="mt-1 text-sm font-semibold leading-6 text-red-800">
-                  Clear the saved articles/blogs setup for this repository and start the setup flow again.
+                  Clear the saved articles setup for this repository and start the setup flow again.
                 </p>
               </div>
               <Form


### PR DESCRIPTION
## Summary
- remove the misleading articles/blogs wording from the article setup reset banner
- keep the reset action scoped to the saved articles setup

## Tests
- bun install --frozen-lockfile
- bun test tests/article-system-connection-panel.test.ts