### PR TITLE
Double Roo Points in upgrade page fallback packs

### DIFF
--- a/app/routes/founder-tools.upgrade.tsx
+++ b/app/routes/founder-tools.upgrade.tsx
@@ -24,9 +24,9 @@ type TopupPack = {
 // Mirrors the backend ROO_TOPUP_PACKS as a resilient fallback if /packs/ is
 // unavailable. The loader prefers the live list so prices stay in sync.
 const FALLBACK_PACKS: TopupPack[] = [
-  { pack_id: "topup_5", points: 5, amount_cents: 1999, currency: "aud", label: "5 Top-up Roo Points" },
-  { pack_id: "topup_10", points: 10, amount_cents: 3699, currency: "aud", label: "10 Top-up Roo Points" },
-  { pack_id: "topup_25", points: 25, amount_cents: 6399, currency: "aud", label: "25 Top-up Roo Points" },
+  { pack_id: "topup_5", points: 10, amount_cents: 1999, currency: "aud", label: "10 Top-up Roo Points" },
+  { pack_id: "topup_10", points: 20, amount_cents: 3699, currency: "aud", label: "20 Top-up Roo Points" },
+  { pack_id: "topup_25", points: 50, amount_cents: 6399, currency: "aud", label: "50 Top-up Roo Points" },
 ];
 
 const POPULAR_PACK_ID = "topup_10";


### PR DESCRIPTION
Keeps the static `FALLBACK_PACKS` in `founder-tools.upgrade.tsx` in sync with the doubled backend packs (mlai-backend #471): 10/20/50 points for A$19.99 / A$36.99 / A$63.99.

This list is only used if `GET /api/v1/points/packs/` is unreachable; in normal operation the page renders the live (doubled) amounts from the backend. Pack ids unchanged, so the "most popular" key still resolves.

`react-router typegen` + `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)