### PR TITLE
Fix upgrade checkout 403: POST /points/me/purchases/ (not /purchases/me/)

### DIFF
--- a/app/routes/founder-tools.upgrade.tsx
+++ b/app/routes/founder-tools.upgrade.tsx
@@ -69,7 +69,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   const env = getEnv(context);
   const client = createApiClient(env, request);
   try {
-    const response = await client.post("/api/v1/points/purchases/me/", {
+    const response = await client.post("/api/v1/points/me/purchases/", {
       pack_id: packId,
       purchase_from: { source: "web", surface: "founder-tools-upgrade" },
     });


### PR DESCRIPTION
## Bug
On production, clicking "Buy now" on `/founder-tools/upgrade` showed *"We could not start your top-up. Please try again in a moment."* Backend logs:

```
method=POST path=/api/v1/points/purchases/me/
HasRooApiKey: No HTTP_X_API_KEY ... found.
status=403  Forbidden
```

## Cause
The action POSTed to `/api/v1/points/**purchases/me**/`, but the authed endpoint is registered at `/api/v1/points/**me/purchases**/` (mirroring `me/balance/`). The swapped path matched the `PointsPurchaseViewSet` **detail route** (`purchases/<pk=me>/`), which requires the Roo API key → 403.

Backend tests didn't catch it because they call `reverse('current-user-purchase')` (the real URL), not the literal string the frontend hard-codes.

## Fix
One line — point the action at `/api/v1/points/me/purchases/`. No backend change needed.

## Verify
After deploy, "Buy now" POSTs `/api/v1/points/me/purchases/` → `201` → redirect to `/roo/topup/{id}` (no `HasRooApiKey` line in logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)