### PR TITLE
[codex] Shrink middle Roo Points stack

### DIFF
--- a/app/routes/founder-tools.upgrades.tsx
+++ b/app/routes/founder-tools.upgrades.tsx
@@ -87,12 +87,12 @@ const PACK_ARTWORK_LAYOUT: Record<TopupPackArtwork, PackArtworkLayout> = {
   },
   "small-stack": {
     stack: {
-      width: 164,
-      height: 156,
+      width: 136,
+      height: 130,
       style: {
-        bottom: 10,
-        left: 43,
-        width: 164,
+        bottom: 20,
+        left: 57,
+        width: 136,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Reduce the 20-point Roo Points stack artwork from 164px to 136px.
- Keep the middle stack centered in the package card artwork stage.

## Validation
- bun run typecheck
- Browser checked /founder-tools/upgrades locally after the same sizing change.