### PR TITLE
Update daily reminder channels

### DIFF
--- a/app/components/DailyReminderChannels.tsx
+++ b/app/components/DailyReminderChannels.tsx
@@ -1,5 +1,5 @@
 import { Form } from "react-router";
-import { ArrowPathIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import { Check, Mail } from "lucide-react";
 import { clsx } from "clsx";
 
@@ -26,9 +26,11 @@ const WHATSAPP_LOGO_URL =
 
 const PUBLISH_CHANNEL_FALLBACK_DETAILS: Record<VibeMarketingNotificationChannelType, string> = {
   slack: "Connected · #mlai-research",
-  email: "you@company.com · Verified",
-  whatsapp: "+61 400 000 000",
+  email: "Account email unavailable",
+  whatsapp: "Coming soon",
 };
+
+type PublishChannelTone = "active" | "warning" | "muted";
 
 function pickChannel(
   channels: VibeMarketingNotificationChannel[],
@@ -94,10 +96,46 @@ function publishChannelDetail(
   type: VibeMarketingNotificationChannelType,
   channel: VibeMarketingNotificationChannel | null,
   accountEmail?: string | null,
+  accountEmailVerified?: boolean | null,
 ) {
+  if (type === "whatsapp") return "Coming soon";
+  if (type === "email" && accountEmail) {
+    const verifiedLabel = accountEmailVerified === false ? "Unverified" : "Verified";
+    return `${accountEmail} · ${verifiedLabel}`;
+  }
   if (channel?.consentState === "active") return activeChannelDetail(type, channel);
-  if (type === "email" && accountEmail) return `${accountEmail} · Verified`;
   return PUBLISH_CHANNEL_FALLBACK_DETAILS[type];
+}
+
+function publishChannelTone(
+  type: VibeMarketingNotificationChannelType,
+  accountEmailVerified?: boolean | null,
+): PublishChannelTone {
+  if (type === "whatsapp") return "muted";
+  if (type === "email" && accountEmailVerified === false) return "warning";
+  return "active";
+}
+
+function PublishChannelStatusBadge({ tone }: { tone: PublishChannelTone }) {
+  if (tone === "muted") {
+    return (
+      <span className="shrink-0 rounded-md bg-slate-100 px-2 py-1 text-[10px] font-black uppercase tracking-wide text-slate-500">
+        Coming soon
+      </span>
+    );
+  }
+  if (tone === "warning") {
+    return (
+      <span className="shrink-0 rounded-md bg-amber-100 px-2 py-1 text-[10px] font-black uppercase tracking-wide text-amber-700">
+        Review
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-violet-600 text-white shadow-sm">
+      <Check className="h-4 w-4" strokeWidth={3} />
+    </span>
+  );
 }
 
 function ChannelIcon({ type }: { type: VibeMarketingNotificationChannelType }) {
@@ -128,16 +166,19 @@ function ChannelRow({
   channel,
   isSubmitting,
   accountEmail,
+  accountEmailVerified,
   variant = "settings",
 }: {
   type: VibeMarketingNotificationChannelType;
   channel: VibeMarketingNotificationChannel | null;
   isSubmitting: boolean;
   accountEmail?: string | null;
+  accountEmailVerified?: boolean | null;
   variant?: "settings" | "publish";
 }) {
   const isActive = channel?.consentState === "active";
   const isPending = channel?.consentState === "pending";
+  const publishTone = publishChannelTone(type, accountEmailVerified);
 
   if (variant === "publish") {
     return (
@@ -147,14 +188,35 @@ function ChannelRow({
           <div className="min-w-0">
             <p className="truncate text-base font-black leading-5 text-gray-950">{CHANNEL_LABELS[type]}</p>
             <p className="mt-1 flex min-w-0 items-center gap-1.5 text-sm font-semibold leading-5 text-slate-600">
-              <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-500" />
-              <span className="truncate">{publishChannelDetail(type, channel, accountEmail)}</span>
+              <span
+                className={clsx(
+                  "h-2 w-2 shrink-0 rounded-full",
+                  publishTone === "active" && "bg-emerald-500",
+                  publishTone === "warning" && "bg-amber-500",
+                  publishTone === "muted" && "bg-slate-400",
+                )}
+              />
+              <span className="truncate">{publishChannelDetail(type, channel, accountEmail, accountEmailVerified)}</span>
             </p>
           </div>
         </div>
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-violet-600 text-white shadow-sm">
-          <Check className="h-4 w-4" strokeWidth={3} />
-        </span>
+        <PublishChannelStatusBadge tone={publishTone} />
+      </div>
+    );
+  }
+
+  if (type === "whatsapp") {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <span className="block truncate text-sm font-black text-gray-900">{CHANNEL_LABELS[type]}</span>
+            <span className="mt-1 inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-slate-500">
+              Coming soon
+            </span>
+          </div>
+        </div>
+        <p className="mt-2 text-xs font-semibold text-gray-500">WhatsApp reminders are not available yet.</p>
       </div>
     );
   }
@@ -216,7 +278,7 @@ function ChannelRow({
           <input
             type="email"
             name="routeId"
-            placeholder={accountEmail || "you@company.com"}
+            placeholder={accountEmail || "name@example.com"}
             className="w-full rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs font-semibold outline-none focus:border-violet-500 focus:ring-2 focus:ring-violet-500/10"
           />
           <button
@@ -230,68 +292,7 @@ function ChannelRow({
           </button>
           <p className="text-[11px] font-medium text-gray-500">Leave blank to use your account email.</p>
         </Form>
-      ) : type === "whatsapp" && isPending && channel?.pendingVerification ? (
-        <Form method="POST" className="mt-2 space-y-2">
-          <input type="hidden" name="channelId" value={channel.id} />
-          <p className="text-xs font-semibold text-gray-600">
-            Code sent to <span className="font-black">{channel.routeId}</span> on WhatsApp.
-          </p>
-          <div className="flex items-center gap-2">
-            <input
-              name="code"
-              inputMode="numeric"
-              maxLength={6}
-              placeholder="6-digit code"
-              className="w-28 rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs font-semibold tracking-widest outline-none focus:border-violet-500 focus:ring-2 focus:ring-violet-500/10"
-            />
-            <button
-              type="submit"
-              name="intent"
-              value="verify-channel-otp"
-              disabled={isSubmitting}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
-            >
-              {isSubmitting ? <ArrowPathIcon className="h-3.5 w-3.5 animate-spin" /> : null}
-              Verify
-            </button>
-            <button
-              type="submit"
-              name="intent"
-              value="resend-channel-otp"
-              disabled={isSubmitting}
-              className="text-xs font-bold text-violet-700 underline-offset-2 hover:underline disabled:opacity-50"
-            >
-              Resend
-            </button>
-          </div>
-          {typeof channel.pendingVerification.attemptsRemaining === "number" &&
-          channel.pendingVerification.attemptsRemaining < 5 ? (
-            <p className="text-[11px] font-medium text-amber-700">
-              {channel.pendingVerification.attemptsRemaining} attempts remaining.
-            </p>
-          ) : null}
-        </Form>
-      ) : (
-        <Form method="POST" className="mt-2 space-y-2">
-          <input type="hidden" name="channelType" value="whatsapp" />
-          <input
-            type="tel"
-            name="routeId"
-            placeholder="+61 400 000 000"
-            className="w-full rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs font-semibold outline-none focus:border-violet-500 focus:ring-2 focus:ring-violet-500/10"
-          />
-          <button
-            type="submit"
-            name="intent"
-            value="connect-channel"
-            disabled={isSubmitting}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-black text-white shadow-sm transition hover:bg-violet-700 disabled:opacity-50"
-          >
-            Send code
-          </button>
-          <p className="text-[11px] font-medium text-gray-500">International format. We&apos;ll send a 6-digit code.</p>
-        </Form>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -300,6 +301,7 @@ export default function DailyReminderChannels({
   channels,
   isSubmitting,
   accountEmail,
+  accountEmailVerified,
   error,
   errorIntent,
   variant = "settings",
@@ -307,6 +309,7 @@ export default function DailyReminderChannels({
   channels: VibeMarketingNotificationChannel[];
   isSubmitting: boolean;
   accountEmail?: string | null;
+  accountEmailVerified?: boolean | null;
   error?: string | null;
   errorIntent?: string | null;
   variant?: "settings" | "publish";
@@ -327,6 +330,7 @@ export default function DailyReminderChannels({
         channel={pickChannel(channels, "email")}
         isSubmitting={isSubmitting}
         accountEmail={accountEmail}
+        accountEmailVerified={accountEmailVerified}
         variant={variant}
       />
       <ChannelRow type="whatsapp" channel={pickChannel(channels, "whatsapp")} isSubmitting={isSubmitting} variant={variant} />

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -306,9 +306,33 @@ function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
   return false;
 }
 
+function booleanFromUnknown(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes"].includes(normalized)) return true;
+    if (["false", "0", "no"].includes(normalized)) return false;
+  }
+  return null;
+}
+
+function accountEmailVerifiedFromAuthUser(authUser: Record<string, unknown>) {
+  const explicitVerified =
+    booleanFromUnknown(authUser.emailVerified) ??
+    booleanFromUnknown(authUser.email_verified) ??
+    booleanFromUnknown(authUser.isEmailVerified) ??
+    booleanFromUnknown(authUser.is_email_verified) ??
+    booleanFromUnknown(authUser.verifiedEmail) ??
+    booleanFromUnknown(authUser.verified_email);
+
+  if (explicitVerified !== null) return explicitVerified;
+
+  return booleanFromUnknown(authUser.isActive) ?? booleanFromUnknown(authUser.is_active) ?? true;
+}
+
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
+  const { authUser, appUser } = await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
   const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
   const run = await getVibeMarketingRun(env, request, runId);
@@ -335,6 +359,8 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     bootstrap,
     setupRun,
     githubRepos,
+    accountEmail: appUser.email || authUser.email || null,
+    accountEmailVerified: accountEmailVerifiedFromAuthUser(authUser as unknown as Record<string, unknown>),
     billingRequestIds: {
       articleJob: createVibeMarketingClientRequestId("vibe-article-job", runId),
     },
@@ -2511,11 +2537,15 @@ function ArticleSetupPublishDetail({
   bootstrap,
   isSubmitting,
   isActionPending,
+  accountEmail,
+  accountEmailVerified,
 }: {
   run: VibeMarketingRunSummary;
   bootstrap: VibeMarketingBootstrap;
   isSubmitting: boolean;
   isActionPending?: (...keys: string[]) => boolean;
+  accountEmail?: string | null;
+  accountEmailVerified?: boolean | null;
 }) {
   const prUrl = articleSystemSetupPrUrl(run);
   const prNumber = articleSystemSetupPrNumber(run);
@@ -2657,7 +2687,12 @@ function ArticleSetupPublishDetail({
           <PublishFlowCard title="Daily article reminders" status={dailyEnabled ? "complete" : setupMerged ? "ready" : "locked"} eyebrow={dailyEnabled ? (activeChannelLabels.length ? `${activeChannelLabels.join(" + ")} enabled` : "Enabled") : setupMerged ? "Ready" : "Publish first"}>
             {setupMerged ? (
               <div className="space-y-3">
-                <DailyReminderChannels channels={dailyChannels} isSubmitting={isSubmitting} />
+                <DailyReminderChannels
+                  channels={dailyChannels}
+                  isSubmitting={isSubmitting}
+                  accountEmail={accountEmail}
+                  accountEmailVerified={accountEmailVerified}
+                />
                 <Form method="POST" className="space-y-3">
                   <label className="block">
                     <span className="text-xs font-black uppercase tracking-wide text-gray-500">Timezone</span>
@@ -2710,6 +2745,8 @@ function PublishDailyResearchReminderCard({
   enableDailyPending,
   runDailyPending,
   isSubmitting,
+  accountEmail,
+  accountEmailVerified,
 }: {
   channels: VibeMarketingNotificationChannel[];
   dailyEnabled: boolean;
@@ -2718,6 +2755,8 @@ function PublishDailyResearchReminderCard({
   enableDailyPending: boolean;
   runDailyPending: boolean;
   isSubmitting: boolean;
+  accountEmail?: string | null;
+  accountEmailVerified?: boolean | null;
 }) {
   const statusLabel = dailyEnabled ? "Enabled" : dailyReady ? "Ready" : "Needs setup";
 
@@ -2745,7 +2784,13 @@ function PublishDailyResearchReminderCard({
       </p>
 
       <div className="mt-6">
-        <DailyReminderChannels channels={channels} isSubmitting={isSubmitting} variant="publish" />
+        <DailyReminderChannels
+          channels={channels}
+          isSubmitting={isSubmitting}
+          accountEmail={accountEmail}
+          accountEmailVerified={accountEmailVerified}
+          variant="publish"
+        />
       </div>
 
       <Form method="POST" className="mt-5 border-t border-gray-200 pt-4">
@@ -2806,11 +2851,15 @@ function PublishAndAutomateDetail({
   bootstrap,
   isSubmitting,
   isActionPending,
+  accountEmail,
+  accountEmailVerified,
 }: {
   run: VibeMarketingRunSummary;
   bootstrap: VibeMarketingBootstrap;
   isSubmitting: boolean;
   isActionPending?: (...keys: string[]) => boolean;
+  accountEmail?: string | null;
+  accountEmailVerified?: boolean | null;
 }) {
   const publishStep = run.workflowProgress?.steps.find((step) => step.id === "publish");
   const automationStep = run.workflowProgress?.steps.find((step) => step.id === "automation");
@@ -3203,6 +3252,8 @@ function PublishAndAutomateDetail({
             enableDailyPending={enableDailyPending}
             runDailyPending={runDailyPending}
             isSubmitting={isSubmitting}
+            accountEmail={accountEmail}
+            accountEmailVerified={accountEmailVerified}
           />
         </div>
 
@@ -4000,7 +4051,15 @@ function workflowProgressForRunPage(
 }
 
 export default function FounderToolsMarketingRun() {
-  const { run: loaderRun, bootstrap, setupRun: loaderSetupRun, githubRepos, billingRequestIds } = useLoaderData<typeof loader>();
+  const {
+    run: loaderRun,
+    bootstrap,
+    setupRun: loaderSetupRun,
+    githubRepos,
+    accountEmail,
+    accountEmailVerified,
+    billingRequestIds,
+  } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const location = useLocation();
@@ -4227,7 +4286,14 @@ export default function FounderToolsMarketingRun() {
         primaryActionSlot={isArticleWorkflowRun && directPublishMode && !isPublishAutomateView ? <ArticleWorkflowPrimaryAction run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : undefined}
         activeDetailSlot={
           isSetupPublishView ? (
-            <ArticleSetupPublishDetail run={run} bootstrap={bootstrap} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
+            <ArticleSetupPublishDetail
+              run={run}
+              bootstrap={bootstrap}
+              isSubmitting={isSubmitting}
+              isActionPending={pendingActions.isPending}
+              accountEmail={accountEmail}
+              accountEmailVerified={accountEmailVerified}
+            />
           ) : isSetupGenerateView ? (
             <ArticleSetupGenerateDetail run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
           ) : isSetupReviewView ? (
@@ -4239,7 +4305,14 @@ export default function FounderToolsMarketingRun() {
               isActionPending={pendingActions.isPending}
             />
           ) : isArticleGenerationRun && isPublishAutomateView ? (
-            <PublishAndAutomateDetail run={run} bootstrap={bootstrap} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} />
+            <PublishAndAutomateDetail
+              run={run}
+              bootstrap={bootstrap}
+              isSubmitting={isSubmitting}
+              isActionPending={pendingActions.isPending}
+              accountEmail={accountEmail}
+              accountEmailVerified={accountEmailVerified}
+            />
           ) : isArticleGenerationRun ? (
             <ArticleGenerationReviewDetail
               run={run}


### PR DESCRIPTION
## Summary
- Mark WhatsApp daily reminder channel as coming soon and remove its OTP entry flow from the reminder UI.
- Populate the publish reminder email row from the authenticated Founder Tools account.
- Show the account email verification state when the backend exposes it.

## Validation
- bun run typecheck
