### PR TITLE
Don't 500 the marketing wizard when polling a deleted/reset run

### DIFF
--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1021,6 +1021,8 @@ export default function FounderToolsMarketingCreate() {
       : null;
   const [polledSetupScan, setPolledSetupScan] = useState<VibeMarketingRunSummary | null>(null);
   const [polledSetupChildRun, setPolledSetupChildRun] = useState<VibeMarketingRunSummary | null>(null);
+  // Run ids the backend reported gone (deleted/reset); never poll or render these again.
+  const goneSetupRunIdsRef = useRef<Set<string>>(new Set());
   const pendingArticleSystemScan =
     polledSetupScan?.runId === bootstrapPendingArticleSystemScan?.runId ? polledSetupScan : bootstrapPendingArticleSystemScan;
   const pendingArticleSystemSetupRunId =
@@ -1244,14 +1246,24 @@ export default function FounderToolsMarketingCreate() {
 
   useEffect(() => {
     if (setupChildStatusFetcher.state !== "idle") return;
-    if (!setupChildStatusFetcher.data?.runId || setupChildStatusFetcher.data.runId !== pendingArticleSystemSetupRunId) {
+    const data = setupChildStatusFetcher.data;
+    if (!data?.runId || data.runId !== pendingArticleSystemSetupRunId) {
       return;
     }
-    setPolledSetupChildRun(setupChildStatusFetcher.data);
+    if (data.gone) {
+      // The run was deleted (e.g. an article-setup reset). Record it so the poll loop
+      // below stops, and drop the polled run so the wizard doesn't render a dead setup.
+      goneSetupRunIdsRef.current.add(data.runId);
+      setPolledSetupChildRun(null);
+      return;
+    }
+    setPolledSetupChildRun(data);
   }, [pendingArticleSystemSetupRunId, setupChildStatusFetcher.data, setupChildStatusFetcher.state]);
 
   useEffect(() => {
     if (!pendingArticleSystemSetupRunId || setupChildStatusFetcher.state !== "idle") return;
+    // Never re-poll a run the backend reported gone (deleted/reset) — pre-fix, that 404 SSR-500'd the wizard.
+    if (goneSetupRunIdsRef.current.has(pendingArticleSystemSetupRunId)) return;
     if (!pageVisible) return;
     if (setupChildRun && isSetupProgressTerminal(setupChildRun)) return;
     const hasLoadedCurrentRun = setupChildStatusFetcher.data?.runId === pendingArticleSystemSetupRunId;

--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -30,6 +30,33 @@ function shouldRefreshSetupLivePreview(run: VibeMarketingRunSummary) {
     ["queued", "pending", "starting", "building", "running"].includes(platformStatus);
 }
 
+function isRunNotFoundError(error: unknown): boolean {
+  const status =
+    (error as { response?: { status?: number } } | null)?.response?.status ??
+    (error as { status?: number } | null)?.status;
+  return status === 404;
+}
+
+// A deleted/reset run (e.g. after an article-setup reset) 404s on status polling while a
+// stale wizard session is still pinned to it. Return a terminal, explicitly-"gone" summary
+// so the poller stops instead of letting the 404 throw — an unhandled throw here SSR-500s
+// the whole marketing page while it polls the old run.
+function goneRunSummary(runId: string): VibeMarketingRunSummary {
+  return {
+    runId,
+    workflow: "article_system_setup",
+    domain: "",
+    status: "not_found",
+    gone: true,
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: [],
+    artifacts: [],
+    diagnostics: {},
+  };
+}
+
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   const runId = params.runId ?? "";
@@ -39,7 +66,13 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   }
 
   await requireVibeRaisingFounder(env, request);
-  let run = await getVibeMarketingRun(env, request, runId, null, "status");
+  let run = await getVibeMarketingRun(env, request, runId, null, "status").catch((error: unknown) => {
+    if (isRunNotFoundError(error)) return null;
+    throw error;
+  });
+  if (run === null) {
+    return Response.json(goneRunSummary(runId));
+  }
   if (shouldRefreshSetupLivePreview(run)) {
     try {
       run = await refreshVibeMarketingLivePreview(env, request, runId);

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -75,6 +75,9 @@ export interface VibeMarketingRunSummary {
   stale?: boolean;
   staleReason?: string | null;
   retryAvailable?: boolean;
+  /** Set by the run-status loader when the run no longer exists (deleted/reset) so the
+   *  poller treats it as terminal instead of throwing on the 404. */
+  gone?: boolean;
   queueName?: string | null;
   queuedAt?: string | null;
   resumeGeneration?: number | null;


### PR DESCRIPTION
## Problem

After the article-setup deep reset deletes an org's `article_system_setup` runs ([mlai-backend #475](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/475)), a **stale wizard browser session** keeps polling the now-deleted run: `GET /api/v1/vibe-marketing/runs/<id>?view=status`. The `run-status.tsx` loader called `getVibeMarketingRun` with **no try/catch**, so the backend 404 threw and React Router **SSR-500'd the whole marketing page**. That's the recurring "click Reset → immediately hit a 500 on `?step=articleSystem`".

Verified on prod: the frontend was repeatedly hitting `/runs/6714669e-…?view=status → 404` (skedy's deleted scaffold run) while sitting on the create wizard.

## Fix

- **`run-status.tsx` loader** — catch a 404 / "run not found" from `getVibeMarketingRun` and return a terminal, explicitly-`gone` run summary instead of throwing. This is the actual *no-500* guarantee: any missing run now fails safe.
- **`create.tsx`** — when the setup-child status fetcher reports a `gone` run, record it (`goneSetupRunIdsRef`), drop the polled run, and stop the poll loop. The wizard stops hammering the dead run immediately after a reset, no manual refresh needed.
- **`VibeMarketingRunSummary`** — add the optional `gone` flag.

Pairs with [mlai-backend #480](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/480), which returns an explicit `{code: "run_not_found", gone: true}` 404 so the loader has a stable signal (defense-in-depth).

`tsc -b` clean. (No frontend test runner in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)