### PR TITLE
Fix infinite "Resetting…" spinner (axios timeout + reset-action error handling)

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -96,10 +96,16 @@ const resolveApiBase = () => {
 
 export const API_URL = resolveApiBase();
 
+// Bound every backend call so a hung request surfaces an error instead of an
+// infinite spinner. Without this, a stuck server-side action (e.g. a reset whose
+// backend call never returns) leaves the UI "…ing" forever with no recovery.
+export const API_REQUEST_TIMEOUT_MS = 60_000;
+
 // ... existing code ...
 export const axiosInstance = axios.create({
     baseURL: API_URL,
     withCredentials: true,
+    timeout: API_REQUEST_TIMEOUT_MS,
 });
 applyDevStubAdapter(axiosInstance);
 
@@ -123,7 +129,8 @@ export function createApiClient(env: any, request?: Request) {
     const client = axios.create({
         baseURL,
         withCredentials: true,
-        headers
+        headers,
+        timeout: API_REQUEST_TIMEOUT_MS,
     });
     applyDevStubAdapter(client);
 

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -748,10 +748,20 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (intent === "reset-article-setup") {
       const githubRepo = stringFromForm(formData, "githubRepo");
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before resetting articles setup." };
-      await resetVibeMarketingArticleSetup(env, request, {
-        githubRepo,
-        github_repo: githubRepo,
-      });
+      try {
+        await resetVibeMarketingArticleSetup(env, request, {
+          githubRepo,
+          github_repo: githubRepo,
+        });
+      } catch (error) {
+        return {
+          intent,
+          error: readableBackendError(error, {
+            fallback:
+              "Couldn't reset the articles setup — the request timed out or failed before completing. Please try again.",
+          }),
+        };
+      }
       return redirect("/founder-tools/marketing/create?step=articleSystem");
     }
 

--- a/tests/api-request-timeout.test.ts
+++ b/tests/api-request-timeout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { API_REQUEST_TIMEOUT_MS, axiosInstance, createApiClient } from "../app/lib/api";
+
+// Regression: a hung backend call (e.g. a server-side reset action whose request
+// never returns) used to leave the UI spinning forever because the axios clients
+// had no timeout. Both the shared instance and the per-request SSR clients must
+// be bounded so the call rejects and the action's catch can surface an error.
+describe("api client request timeout", () => {
+  test("a positive request timeout is configured", () => {
+    expect(API_REQUEST_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  test("the shared axios instance is bounded", () => {
+    expect(axiosInstance.defaults.timeout).toBe(API_REQUEST_TIMEOUT_MS);
+  });
+
+  test("per-request SSR clients are bounded too", () => {
+    const client = createApiClient({} as unknown as Record<string, unknown>);
+    expect(client.defaults.timeout).toBe(API_REQUEST_TIMEOUT_MS);
+  });
+});


### PR DESCRIPTION
## Problem
The **"Reset articles setup"** button (Vibe Marketing wizard, step 4) sticks on **"Resetting…"** forever and never completes.

Diagnosed against prod: the request **never reaches the backend** (the route `/api/v1/vibe-marketing/article-setup/reset` exists and is deployed — prod returns 401, not 404 — and other POSTs succeed). The `reset-article-setup` action runs **server-side** and calls the backend via `createApiClient`, which had **no axios `timeout`**. So a hung server-to-server call never returns → React Router navigation stays in `submitting` → the button stays in its disabled "Resetting…" state with no recovery short of a hard reload.

## Fix
- **`app/lib/api.ts`** — add `API_REQUEST_TIMEOUT_MS` (60s) to the shared `axiosInstance` **and** every per-request `createApiClient` (the one SSR loaders/actions use), so a hung call rejects instead of hanging forever.
- **`app/routes/founder-tools.marketing.create.tsx`** — wrap the `reset-article-setup` backend call in `try/catch`, returning a readable error (which clears the pending state) instead of leaving the action to bubble.
- **`tests/api-request-timeout.test.ts`** — assert both axios clients are bounded.

## Verification
- `tsc -b` clean.
- Full `bun test` suite: **89 pass / 0 fail** (incl. the new timeout test).

## Note
This stops the infinite spinner and surfaces an error so the user can retry. It does **not** by itself explain *why* the server-side reset call hangs (the SSR→backend hop, resolved via `getBaseUrl(env)` = `env.BACKEND_BASE_URL`); worth checking the Worker logs for `[API] Request POST …/article-setup/reset` and confirming `BACKEND_BASE_URL` is reachable from the Worker for that (heavier deep-teardown) call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)