### PR TITLE
Force axios fetch adapter for SSR backend calls (root cause of the hung reset)

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -101,11 +101,20 @@ export const API_URL = resolveApiBase();
 // backend call never returns) leaves the UI "…ing" forever with no recovery.
 export const API_REQUEST_TIMEOUT_MS = 60_000;
 
+// Cloudflare Workers run with nodejs_compat, which makes axios fall back to the
+// Node http/https adapter — its outbound-POST handling hangs in the Workers
+// runtime (the request body never reaches the origin, so e.g. the article-setup
+// reset POST spins forever and the backend never logs it). Force the
+// Worker-native fetch adapter so SSR loaders AND actions work. The dev stub
+// adapter (applyDevStubAdapter) still overrides this in local development.
+const WORKER_SAFE_ADAPTER = "fetch" as const;
+
 // ... existing code ...
 export const axiosInstance = axios.create({
     baseURL: API_URL,
     withCredentials: true,
     timeout: API_REQUEST_TIMEOUT_MS,
+    adapter: WORKER_SAFE_ADAPTER,
 });
 applyDevStubAdapter(axiosInstance);
 
@@ -131,6 +140,7 @@ export function createApiClient(env: any, request?: Request) {
         withCredentials: true,
         headers,
         timeout: API_REQUEST_TIMEOUT_MS,
+        adapter: WORKER_SAFE_ADAPTER,
     });
     applyDevStubAdapter(client);
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -37,6 +37,17 @@ export function shouldUseDevBackendFallback(error?: unknown) {
     );
 }
 
+// True when a backend call rejected with HTTP 404. Works across axios adapters — the
+// xhr/http/fetch adapters all populate `error.response.status`, and some thrown shapes
+// only carry a top-level `status`. SSR loaders use this to treat a deleted/reset run as
+// "gone" instead of letting the 404 throw and SSR-500 the whole page.
+export function isApiNotFoundError(error: unknown): boolean {
+    const status =
+        (error as { response?: { status?: number } } | null)?.response?.status ??
+        (error as { status?: number } | null)?.status;
+    return status === 404;
+}
+
 // Catch-all stub adapter for local development only. When
 // VITE_STUB_BACKEND=true, every API request short-circuits and returns a
 // fake empty response instead of hitting api.mlai.au.

--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/founder-tools.marketing.run-status";
 import { redirect } from "react-router";
 
+import { isApiNotFoundError } from "~/lib/api";
 import { getEnv } from "~/lib/env.server";
 import { getVibeMarketingRun, refreshVibeMarketingLivePreview } from "~/lib/vibe-marketing";
 import { shouldPollArticleSystemSetupRun } from "~/lib/vibe-marketing-run-polling";
@@ -28,13 +29,6 @@ function shouldRefreshSetupLivePreview(run: VibeMarketingRunSummary) {
   const platformStatus = String(run.livePreview?.platformStatus || "").trim().toLowerCase();
   return ["queued", "pending", "starting", "building", "running", "awaiting_approval", "approval_required"].includes(status) ||
     ["queued", "pending", "starting", "building", "running"].includes(platformStatus);
-}
-
-function isRunNotFoundError(error: unknown): boolean {
-  const status =
-    (error as { response?: { status?: number } } | null)?.response?.status ??
-    (error as { status?: number } | null)?.status;
-  return status === 404;
 }
 
 // A deleted/reset run (e.g. after an article-setup reset) 404s on status polling while a
@@ -67,7 +61,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 
   await requireVibeRaisingFounder(env, request);
   let run = await getVibeMarketingRun(env, request, runId, null, "status").catch((error: unknown) => {
-    if (isRunNotFoundError(error)) return null;
+    if (isApiNotFoundError(error)) return null;
     throw error;
   });
   if (run === null) {

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -30,6 +30,7 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { RooPointCost } from "~/components/RooPointCost";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
+import { isApiNotFoundError } from "~/lib/api";
 import { getEnv } from "~/lib/env.server";
 import {
   VIBE_MARKETING_ARTICLE_JOB_COST_POINTS,
@@ -335,7 +336,15 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const { authUser, appUser } = await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
   const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
-  const run = await getVibeMarketingRun(env, request, runId);
+  const run = await getVibeMarketingRun(env, request, runId).catch((error: unknown) => {
+    // A deleted/reset run (e.g. after an article-setup teardown) 404s here while a stale
+    // wizard session still links to it. Redirect to the wizard instead of letting the 404
+    // throw and SSR-500 the marketing page. (run-status.tsx handles the status-poll path.)
+    if (isApiNotFoundError(error)) {
+      throw redirect("/founder-tools/marketing");
+    }
+    throw error;
+  });
   let githubRepos: VibeMarketingGithubReposResponse = { status: "unavailable", repos: [], repositories: [] };
   const shouldLoadGithubRepos = ["repo_scan", "content_factory_scan"].includes(run.workflow) && !setupRunIdForRun(run);
   if (shouldLoadGithubRepos) {

--- a/tests/api-request-timeout.test.ts
+++ b/tests/api-request-timeout.test.ts
@@ -20,3 +20,18 @@ describe("api client request timeout", () => {
     expect(client.defaults.timeout).toBe(API_REQUEST_TIMEOUT_MS);
   });
 });
+
+// Root cause of the hung reset: under `nodejs_compat`, axios defaults to the Node
+// http adapter, whose outbound-POST handling hangs in the Cloudflare Worker
+// runtime (the request never reaches the origin). Forcing the fetch adapter makes
+// SSR loaders + actions use the Worker-native fetch.
+describe("api client uses the Worker-native fetch adapter", () => {
+  test("the shared axios instance uses the fetch adapter", () => {
+    expect(axiosInstance.defaults.adapter).toBe("fetch");
+  });
+
+  test("per-request SSR clients use the fetch adapter", () => {
+    const client = createApiClient({} as unknown as Record<string, unknown>);
+    expect(client.defaults.adapter).toBe("fetch");
+  });
+});


### PR DESCRIPTION
Follow-up to #1222 (which stopped the *infinite* "Resetting…" spinner with a timeout). This fixes the **root cause** so the reset actually succeeds.

## Root cause
The "Reset articles setup" POST runs **server-side** in the Cloudflare Worker. The Worker runs with **`nodejs_compat`** (`wrangler.jsonc`), so axios's adapter auto-selection picks the **Node `http`/`https` adapter**. Cloudflare's Node-http compat shim is unreliable for **outbound POST-with-body**: the request hangs and **never reaches the origin** — which is exactly what we observed:
- 0 `…/article-setup/reset` requests at the backend over 2h, while browser-direct POSTs (`/auth`, `/points`, …) succeed.
- GET loaders (via the same axios client) render fine — only the POST hangs.
- The backend reset itself runs in ~1s when invoked directly.

The codebase already had `app/lib/backend.server.ts` using **native `fetch`** for this reason — but it has **0 callers**; all 10 SSR data functions use the axios `createApiClient`.

## Fix
Pin both axios clients (the shared `axiosInstance` and the per-request `createApiClient`) to the **Worker-native `fetch` adapter** (`adapter: "fetch"`, available in axios 1.13). The dev stub adapter still overrides it locally. GETs that work today over node-http will work over fetch too.

## Verification
- `tsc -b` clean; full `bun test` suite **91 pass / 0 fail** (incl. new tests asserting both clients use the fetch adapter).
- ⚠️ **Cannot be reproduced in the node/bun test runtime** — the hang only happens in the Workers runtime. Please confirm on a **preview deploy** (click Reset → it should reach the backend and complete) before/after merging. `wrangler tail` will show `[API] Request POST …/article-setup/reset` followed by a real response instead of silence.

## Blast radius
Changes the adapter for **all** axios calls (SSR + client). Low risk (fetch is the recommended adapter for Workers and works in browsers/node), but it is app-wide — hence the preview-deploy check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)