### PR TITLE
Fix "Reset articles setup" no-op on the run page (pin reset Form to the create action)

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1481,6 +1481,14 @@ export default function ArticleSystemConnectionPanel({
               </div>
               <Form
                 method="POST"
+                // The panel renders on both the create route and the run route
+                // (founder-tools.marketing.run). A `<Form>` with no `action` posts to
+                // the *current* route's action — and the run route's action handles
+                // every article-system intent EXCEPT `reset-article-setup`, so on the
+                // run page the reset silently no-ops and never calls the backend. Pin
+                // the action to the create route, which owns the reset handler, so the
+                // reset works no matter which page the panel is shown on.
+                action="/founder-tools/marketing/create"
                 onSubmit={(event) => {
                   if (typeof window !== "undefined" && !window.confirm("Reset the saved articles setup for this repository?")) {
                     event.preventDefault();


### PR DESCRIPTION
## The real root cause of the broken reset

The **\"Reset articles setup\"** button lives in the shared `ArticleSystemConnectionPanel`, which renders on **both** routes:
- `app/routes/founder-tools.marketing.create.tsx:1466`
- `app/routes/founder-tools.marketing.run.tsx:1089`

Its `<Form method="POST">` had **no `action` prop**, so it submits to the **current** route's action. The run route's action handles every article-system intent (`start-scan`, `retry-scan`, `cancel-scan`, `confirm-article-surface`, `build-article-system-preview`, …) **except `reset-article-setup`** — it doesn't even import `resetVibeMarketingArticleSetup`. So on the runs page the reset **silently no-ops and never calls the backend**.

### Evidence (Cloudflare Worker logs on a reset click)
- `POST https://mlai.au/founder-tools/marketing/runs/<id>.data` → completes, triggers full revalidation.
- **Zero** `[API] Request POST /api/v1/vibe-marketing/article-setup/reset` — the Worker never makes the reset call.
- Every other backend call (profile, bootstrap, runs, github/repos GETs, and the runs-route POST) succeeds — so this was **never** a network/adapter hang. The reset was just posting to the wrong route's action.

This is why a reset spins/no-ops while a scan from the same panel works.

## Fix
Pin the reset `<Form>` `action` to `/founder-tools/marketing/create`, the route that owns the `reset-article-setup` handler — so the reset works regardless of which page renders the panel. It's a no-op on the create page (already the current route) and fixes the run page.

## Relationship to #1229
#1229 (force axios `fetch` adapter, now live) is complementary, not redundant: once the reset correctly reaches the create action, its `createApiClient` SSR POST to the backend benefits from the Worker-native fetch adapter. This PR is the actual fix for the reported \"reset does nothing / spinner\" behavior.

## Verification
- `bun run typecheck` (react-router typegen + `tsc -b` + article-link check) — clean.
- Logic-level: confirmed the run action's intent list omits `reset-article-setup`; create action handles it at `founder-tools.marketing.create.tsx:748`.
- Post-merge: deploy, open a run page, click Reset → expect `[API] Request POST …/article-setup/reset` in the Worker logs and a redirect to the articleSystem step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)