### PR TITLE
Gate Build-scaffold button on scan approvability

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -748,6 +748,17 @@ export default function ArticleSystemConnectionPanel({
         (setupBlocked && (scaffoldCheck?.rescanRunId || setupStatus === "completed"))),
   );
   const scaffoldPublishReady = Boolean(setupPrUrl || SETUP_PUBLISH_STATUSES.has(setupStatus));
+  // Gate the Build action on the scan's scaffold approvability. A scan that
+  // resolved the requested articles route as ambiguous/unmatched finishes with
+  // scaffoldStatus "not_needed" and no approveUrl, so /approve would 409 and the
+  // page would silently refresh. Defaults to approvable when the scan exposes no
+  // signal (older runs), so existing behaviour is unchanged.
+  const scanScaffoldStatus = normalizedStatus(articleSetupState?.scaffoldStatus);
+  const scanArticleSurfaceState = normalizedStatus(articleSetupState?.articleSurfaceState);
+  const setupApprovable =
+    Boolean(articleSetupState?.approveUrl) ||
+    (scanScaffoldStatus !== "not_needed" &&
+      !["ambiguous", "unmatched", "missing"].includes(scanArticleSurfaceState));
   const scaffoldStatus: ArticleSystemScaffoldStatus = !setupTargetReady && !selectedSurfaceUrl
     ? "not_ready"
     : scaffoldExplicitReady
@@ -778,6 +789,7 @@ export default function ArticleSystemConnectionPanel({
     persistedSetupIsStale: showSavedSetup && persistedSetupIsStale,
     selectedSurfaceUrl,
     scaffoldStatus,
+    setupApprovable,
     setupSurfaceUrl: displayedSurfaceUrl,
   });
 
@@ -951,7 +963,14 @@ export default function ArticleSystemConnectionPanel({
       tone: "red",
     },
   };
-  const scaffoldStatusContent = scaffoldStatusCopy[scaffoldStatus];
+  const scaffoldStatusContent =
+    scaffoldStatus === "ready_to_build" && !selectedSurfaceUrl && !setupApprovable
+      ? {
+          title: "Articles route needs confirming",
+          body: "The latest scan could not confirm the saved articles route in this repository. Re-scan, choose a different route, or create a new articles folder.",
+          tone: "amber" as const,
+        }
+      : scaffoldStatusCopy[scaffoldStatus];
   const scaffoldIconTone = {
     emerald: "bg-emerald-100 text-emerald-700",
     violet: "bg-violet-100 text-violet-700",
@@ -989,6 +1008,11 @@ export default function ArticleSystemConnectionPanel({
             {!savePending ? <ArrowRight className="h-4 w-4" /> : null}
           </button>
         </Form>
+      ) : !setupApprovable ? (
+        <div className="w-full rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-800 sm:max-w-md">
+          The latest scan could not confirm the saved articles route. Re-scan, choose a
+          different route, or create a new articles folder before building the scaffold.
+        </div>
       ) : (
         <Form method="POST" className="w-full sm:w-auto">
           <input type="hidden" name="scanRunId" value={effectiveScanRun?.runId ?? currentScanRunId} />

--- a/app/lib/article-system-connection-steps.ts
+++ b/app/lib/article-system-connection-steps.ts
@@ -36,6 +36,11 @@ export type ArticleSystemConnectionStepInput = {
   selectedSurfaceUrl?: string | null;
   scaffoldStatus?: ArticleSystemScaffoldStatus;
   setupSurfaceUrl?: string | null;
+  // False when the latest scan resolved the requested articles route as
+  // ambiguous/unmatched (scaffold_status "not_needed", no approve_url), so there
+  // is no approvable scaffold and the Build action would 409. Undefined leaves
+  // the existing behaviour unchanged.
+  setupApprovable?: boolean;
 };
 
 export function articleSystemScaffoldActionLabel(status: ArticleSystemScaffoldStatus) {
@@ -191,6 +196,16 @@ export function articleSystemConnectionStepStates(input: ArticleSystemConnection
       defaultExpanded: true,
       disabled: false,
       unavailableReason: "",
+      ...staleSetupAttention,
+    };
+  } else if (input.scaffoldStatus === "ready_to_build" && input.setupApprovable === false) {
+    buildSetup = {
+      id: "buildSetup",
+      status: "blocked",
+      defaultExpanded: true,
+      disabled: false,
+      unavailableReason:
+        "The latest scan couldn't confirm this articles route, so there's nothing to build yet. Re-scan, pick a different route, or create a new articles folder.",
       ...staleSetupAttention,
     };
   } else {

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -119,6 +119,13 @@ export interface VibeMarketingArticleSetupState {
   updatedAt?: string | null;
   articleSurfaceMode?: string | null;
   articleSurfaceHint?: Record<string, unknown> | null;
+  // Scaffold approvability from the latest scan, used to gate the "Build articles
+  // scaffold" action. When the scan resolved the requested route as
+  // ambiguous/unmatched it finishes with scaffoldStatus "not_needed" and no
+  // approveUrl — there is nothing to approve, so the Build action would 409.
+  scaffoldStatus?: string | null;
+  approveUrl?: string | null;
+  articleSurfaceState?: string | null;
 }
 
 export interface VibeMarketingAutofillSource {

--- a/tests/article-system-connection-steps.test.ts
+++ b/tests/article-system-connection-steps.test.ts
@@ -66,6 +66,32 @@ describe("article system connection step states", () => {
     expect(articleSystemScaffoldActionLabel("ready_to_build")).toBe("Build articles scaffold");
   });
 
+  test("blocks the build step when the scan resolved the saved route as not approvable", () => {
+    const steps = articleSystemConnectionStepStates({
+      connected: true,
+      currentScanRunId: "scan-not-approvable",
+      setupTargetReady: true,
+      scaffoldStatus: "ready_to_build",
+      setupApprovable: false,
+    });
+
+    expect(steps.buildSetup.status).toBe("blocked");
+    expect(steps.buildSetup.disabled).toBe(false);
+    expect(steps.buildSetup.unavailableReason).toContain("Re-scan");
+  });
+
+  test("keeps the build step active when the scan is approvable", () => {
+    const steps = articleSystemConnectionStepStates({
+      connected: true,
+      currentScanRunId: "scan-approvable",
+      setupTargetReady: true,
+      scaffoldStatus: "ready_to_build",
+      setupApprovable: true,
+    });
+
+    expect(steps.buildSetup.status).toBe("active");
+  });
+
   test("marks the scaffold step complete when setup is explicitly ready", () => {
     for (const scaffoldStatus of ["ready", "legacy_ready"] as const) {
       const steps = articleSystemConnectionStepStates({


### PR DESCRIPTION
The "Build articles scaffold" action defaulted to `ready_to_build` whenever a saved location existed, never checking the scan's approvability. For a scan that resolved the route as ambiguous/unmatched (`scaffoldStatus: not_needed`, no `approveUrl`) the **saved-location** Build button POSTed `/approve` and 409'd, which the SPA swallowed into a page refresh (skedy.io).

Derive `setupApprovable` from the new scan fields (`scaffoldStatus`/`approveUrl`/`articleSurfaceState`) and, for the saved-location sub-case, show a "route not confirmed — re-scan / pick another / create new" notice instead of an enabled button; mark the build step blocked. Create-new (`selectedSurfaceUrl`) and healthy paths are unchanged.

Steps unit tests: 14/14 pass; `tsc -b` clean. Pairs with content-factory (#499) + mlai-backend (#482).

🤖 Generated with [Claude Code](https://claude.com/claude-code)