### PR TITLE
Surface scaffold connection status at panel level + calm setup noise when linked

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1107,6 +1107,62 @@ export default function ArticleSystemConnectionPanel({
         <ReassuranceStrip />
       </div>
 
+      {/* Scaffold connection status — surfaced at the top, independent of step gating, so the
+          link/accept state is always visible (the per-step card was hidden inside a locked step). */}
+      {scaffoldConnected || scaffoldBuiltUnlinked ? (
+        <div
+          className={clsx(
+            "mt-6 rounded-2xl border p-4 sm:p-5",
+            scaffoldConnected ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50",
+          )}
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-start gap-3">
+              <span
+                className={clsx(
+                  "flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl",
+                  scaffoldConnected ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
+                )}
+              >
+                {scaffoldConnected ? <Link2 className="h-5 w-5" /> : <Unlink className="h-5 w-5" />}
+              </span>
+              <div className="min-w-0">
+                <p className={clsx("text-sm font-black", scaffoldConnected ? "text-emerald-900" : "text-amber-900")}>
+                  {scaffoldConnected ? "Articles scaffold linked & accepted" : "Articles scaffold built — not linked yet"}
+                </p>
+                <p
+                  className={clsx(
+                    "mt-1 text-sm font-semibold leading-6",
+                    scaffoldConnected ? "text-emerald-800" : "text-amber-800",
+                  )}
+                >
+                  {scaffoldConnected
+                    ? `New articles publish straight to your scaffold${scaffoldConnectionRoute ? ` at ${scaffoldConnectionRoute}` : ""}. Manage or unlink it in the danger zone below.`
+                    : scaffoldDisconnectedAt
+                      ? "You unlinked this scaffold. Re-link it to publish articles into it again."
+                      : "The scaffold is built in your repo but isn't linked as the publish target yet. Link it to start publishing into it."}
+                </p>
+              </div>
+            </div>
+            {!scaffoldConnected ? (
+              <Form method="POST" action="/founder-tools/marketing/create" className="flex-shrink-0">
+                <input type="hidden" name="githubRepo" value={selectedRepo} />
+                <button
+                  type="submit"
+                  name="intent"
+                  value="accept-article-scaffold"
+                  disabled={acceptScaffoldPending || !selectedRepo}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-3 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
+                >
+                  {acceptScaffoldPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}
+                  {acceptScaffoldPending ? "Linking..." : "Accept & link scaffold"}
+                </button>
+              </Form>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
       {persistedSetupIsStale ? (
         <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm font-semibold leading-6 text-amber-900">
           Your last articles/blogs setup is saved, but the latest repository scan needs attention. Re-scan to refresh the choices, or change the saved
@@ -1357,7 +1413,18 @@ export default function ArticleSystemConnectionPanel({
             </div>
           ) : locationChooserReady ? (
             <div className="space-y-3">
-              {manualFallbackReady && scanFailureGuidance ? (
+              {scaffoldConnected ? (
+                <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm font-semibold leading-6 text-emerald-900">
+                  <p className="font-black">
+                    Your articles scaffold is already linked{scaffoldConnectionRoute ? ` at ${scaffoldConnectionRoute}` : ""}.
+                  </p>
+                  <p className="mt-1">
+                    New articles publish there automatically — you only need to choose a route here if you&apos;re moving the
+                    scaffold to a new location.
+                  </p>
+                </div>
+              ) : null}
+              {!scaffoldConnected && manualFallbackReady && scanFailureGuidance ? (
                 <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm font-semibold leading-6 text-amber-900">
                   <p className="font-black">Scan issue: {scanFailureGuidance.reason}</p>
                   <p className="mt-1">Next step: {scanFailureGuidance.nextStep}</p>
@@ -1377,11 +1444,11 @@ export default function ArticleSystemConnectionPanel({
                     }}
                   />
                 ))
-              ) : (
+              ) : !scaffoldConnected ? (
                 <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm font-semibold leading-6 text-amber-900">
                   We did not find a clean public articles route. Paste the correct URL/path, or create a new articles directory.
                 </div>
-              )}
+              ) : null}
 
               <CreateNewChoiceCard
                 selected={selectedChoiceId === "create"}
@@ -1492,65 +1559,6 @@ export default function ArticleSystemConnectionPanel({
               </div>
             </div>
           </div>
-
-          {scaffoldConnected || scaffoldBuiltUnlinked ? (
-            <div
-              className={clsx(
-                "mt-4 rounded-xl border p-4",
-                scaffoldConnected ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50",
-              )}
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 items-start gap-3">
-                  <span
-                    className={clsx(
-                      "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg",
-                      scaffoldConnected ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700",
-                    )}
-                  >
-                    {scaffoldConnected ? <Link2 className="h-5 w-5" /> : <Unlink className="h-5 w-5" />}
-                  </span>
-                  <div className="min-w-0">
-                    <p
-                      className={clsx(
-                        "text-sm font-black",
-                        scaffoldConnected ? "text-emerald-900" : "text-amber-900",
-                      )}
-                    >
-                      {scaffoldConnected ? "Articles scaffold linked & accepted" : "Articles scaffold built — not linked yet"}
-                    </p>
-                    <p
-                      className={clsx(
-                        "mt-1 text-sm font-semibold leading-6",
-                        scaffoldConnected ? "text-emerald-800" : "text-amber-800",
-                      )}
-                    >
-                      {scaffoldConnected
-                        ? `New articles publish straight to this scaffold${scaffoldConnectionRoute ? ` (${scaffoldConnectionRoute})` : ""}.`
-                        : scaffoldDisconnectedAt
-                          ? "You unlinked this scaffold. Re-accept it to publish articles into it again."
-                          : "The scaffold is built in your repo but isn't linked as the publish target yet. Accept it to start publishing into it."}
-                    </p>
-                  </div>
-                </div>
-                {!scaffoldConnected ? (
-                  <Form method="POST" action="/founder-tools/marketing/create" className="flex-shrink-0">
-                    <input type="hidden" name="githubRepo" value={selectedRepo} />
-                    <button
-                      type="submit"
-                      name="intent"
-                      value="accept-article-scaffold"
-                      disabled={acceptScaffoldPending || !selectedRepo}
-                      className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-3 text-sm font-black text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
-                    >
-                      {acceptScaffoldPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}
-                      {acceptScaffoldPending ? "Linking..." : "Accept & link scaffold"}
-                    </button>
-                  </Form>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
         </FlowStep>
 
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex sm:items-center sm:justify-between sm:gap-4">


### PR DESCRIPTION
## Problem
On the article-system wizard, an already-connected org (e.g. **theproductbus**, which has a live `react_article_system` publish target) showed **no "linked" status and no link control** — it looked unlinked with nothing to click.

Root cause: in #1257 I nested the connection card ("linked & accepted" / "Accept & link scaffold") **inside the step-4 `FlowStep`**, which only renders children **when expanded** and disables them (`pointer-events-none`) when the step is gated. When step 4 is collapsed/locked ("Not ready yet" — the fresh scan didn't re-prove the route on top of the already-connected scaffold), the status was invisible and the Accept button unreachable. Only the section-level danger zone showed (correctly reflecting connected = Unlink enabled / Reset disabled).

## Fix
**Part A — hoist the status banner out of the gated step.** The connection banner now renders at panel level (right after the reassurance strip), always visible and never disabled:
- **Connected** → "✓ Articles scaffold linked & accepted — new articles publish at `/articles`. Manage or unlink it in the danger zone below."
- **Built but not linked** → "Articles scaffold built — not linked yet" + **Accept & link scaffold** button (the link control), reachable regardless of step state.

**Part B — calm the misleading setup noise when connected.** When `scaffoldConnected`, the step-3 "Scan issue / we did not find a clean public articles route" amber warnings are suppressed and replaced with a calm emerald note ("Your articles scaffold is already linked at `<route>` — you only need to choose a route here if you're moving it").

Frontend-only; backend (#487) already returns `checks.scaffold.{scaffoldConnected, scaffoldBuiltUnlinked, routePath}`. `react-router typegen && tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)