### PR TITLE
Fix CI: remove accidentally-committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
-/node_modules/
+# No trailing slash: also ignores a `node_modules` *symlink* (a worktree dev
+# convenience), not just the directory — a committed symlink broke CI once.
+/node_modules
 *.tsbuildinfo
 
 # React Router

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/samdonegan/Documents/Code/mlai-au/node_modules


### PR DESCRIPTION
## Problem
Every Build (and Cloudflare Workers) run failed at `bun install`:
```
ENOENT: could not open the "node_modules" directory
```
Not a Bun bug. **PR #1261 accidentally committed a `node_modules` symlink** (git mode `120000` → `/Users/.../mlai-au/node_modules`). The worktree dev flow symlinks `node_modules` to the main checkout for local typechecking, and a `git add -A` swept it into the commit. `.gitignore` only had `/node_modules/` (trailing slash = directories only), so a *symlink* of that name wasn't ignored.

Locally the symlink resolves → nothing breaks. In CI the absolute target doesn't exist → `bun install` follows the dangling symlink and ENOENTs. It hit on every Bun version (the earlier 1.3.5 "pin" reproduced the exact same error), confirming it was the symlink, not Bun.

## Fix
- `git rm --cached node_modules` (removes the committed symlink; `bun install` recreates a real `node_modules` in CI)
- `.gitignore`: `/node_modules/` → `/node_modules` (no trailing slash) so a `node_modules` symlink can't be re-committed by `git add -A` again
- build.yml unchanged (`bun-version: latest` retained — it was never the cause)