### PR TITLE
Authors setup section + per-article byline picker (marketing wizard)

### DIFF
--- a/app/components/VibeMarketingAuthorsSetup.tsx
+++ b/app/components/VibeMarketingAuthorsSetup.tsx
@@ -1,0 +1,221 @@
+import { useState } from "react";
+import { Form } from "react-router";
+import { Star, Trash2, UserPlus, Users } from "lucide-react";
+
+import type { VibeMarketingAuthor } from "~/types/vibe-marketing";
+
+type AuthorDraft = {
+  /** Stable row key. Existing authors keep their server id; new rows use a `new-*` placeholder. */
+  id: string;
+  name: string;
+  role: string;
+  bio: string;
+  avatarUrl: string;
+  url: string;
+};
+
+const INPUT_CLASS =
+  "w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-900 outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10";
+const LABEL_CLASS = "mb-1.5 block text-xs font-bold uppercase tracking-wide text-gray-500";
+
+let newRowSeq = 0;
+
+function newRowId(): string {
+  newRowSeq += 1;
+  return `new-${newRowSeq}`;
+}
+
+function emptyDraft(id: string): AuthorDraft {
+  return { id, name: "", role: "", bio: "", avatarUrl: "", url: "" };
+}
+
+function toDraft(author: VibeMarketingAuthor): AuthorDraft {
+  return {
+    id: author.id,
+    name: author.name ?? "",
+    role: author.role ?? "",
+    bio: author.bio ?? "",
+    avatarUrl: author.avatarUrl ?? "",
+    url: author.url ?? "",
+  };
+}
+
+/** Slugify a name the same way the backend derives author ids, so the default pointer resolves. */
+function slugifyName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "author";
+}
+
+function resolvedId(draft: AuthorDraft): string {
+  return draft.id.startsWith("new-") ? slugifyName(draft.name) : draft.id;
+}
+
+export default function VibeMarketingAuthorsSetup({
+  authors,
+  defaultAuthorId,
+  isSubmitting,
+}: {
+  authors: VibeMarketingAuthor[];
+  defaultAuthorId: string | null;
+  isSubmitting: boolean;
+}) {
+  const [drafts, setDrafts] = useState<AuthorDraft[]>(() =>
+    authors.length ? authors.map(toDraft) : [emptyDraft("new-0")],
+  );
+  const [selectedRowId, setSelectedRowId] = useState<string>(
+    () => authors.find((author) => author.id === defaultAuthorId)?.id ?? authors[0]?.id ?? "new-0",
+  );
+
+  const patch = (id: string, partial: Partial<AuthorDraft>) =>
+    setDrafts((current) => current.map((draft) => (draft.id === id ? { ...draft, ...partial } : draft)));
+
+  const namedDrafts = drafts.filter((draft) => draft.name.trim());
+  const selectedDraft =
+    namedDrafts.find((draft) => draft.id === selectedRowId) ?? namedDrafts[0] ?? null;
+
+  const serializedAuthors = namedDrafts.map((draft) => ({
+    id: resolvedId(draft),
+    name: draft.name.trim(),
+    role: draft.role.trim(),
+    bio: draft.bio.trim(),
+    avatarUrl: draft.avatarUrl.trim(),
+    url: draft.url.trim(),
+  }));
+  const serializedDefaultId = selectedDraft ? resolvedId(selectedDraft) : "";
+
+  return (
+    <div className="mt-6 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-violet-50 text-violet-600">
+          <Users className="h-5 w-5" />
+        </span>
+        <div>
+          <h3 className="text-base font-black text-gray-900">Article authors</h3>
+          <p className="mt-1 text-sm font-medium leading-6 text-gray-500">
+            Every generated article is published under an author byline. Add the people who write for you and pick
+            a default — you can choose a different author per article when you generate one.
+          </p>
+        </div>
+      </div>
+
+      <Form method="POST" className="mt-5 space-y-4">
+        <input type="hidden" name="intent" value="save-authors" />
+        <input type="hidden" name="authors" value={JSON.stringify(serializedAuthors)} />
+        <input type="hidden" name="defaultAuthorId" value={serializedDefaultId} />
+
+        <div className="space-y-3">
+          {drafts.map((draft, index) => {
+            const hasName = Boolean(draft.name.trim());
+            const isDefault = selectedDraft?.id === draft.id && hasName;
+            return (
+              <div key={draft.id} className="rounded-xl border border-gray-200 bg-gray-50/70 p-4">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <label
+                    className={`inline-flex items-center gap-2 text-sm font-bold ${
+                      isDefault ? "text-violet-600" : "text-gray-500"
+                    } ${hasName ? "cursor-pointer" : "cursor-not-allowed opacity-50"}`}
+                  >
+                    <input
+                      type="radio"
+                      name="__defaultAuthorRow"
+                      className="h-4 w-4 accent-violet-600"
+                      checked={isDefault}
+                      disabled={!hasName}
+                      onChange={() => setSelectedRowId(draft.id)}
+                    />
+                    <Star className={`h-4 w-4 ${isDefault ? "fill-violet-600 text-violet-600" : ""}`} />
+                    {isDefault ? "Default byline" : "Set as default"}
+                  </label>
+                  {drafts.length > 1 ? (
+                    <button
+                      type="button"
+                      onClick={() => setDrafts((current) => current.filter((item) => item.id !== draft.id))}
+                      className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-bold text-gray-400 transition hover:bg-white hover:text-red-600"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Remove
+                    </button>
+                  ) : null}
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  <label className="block">
+                    <span className={LABEL_CLASS}>Name</span>
+                    <input
+                      value={draft.name}
+                      onChange={(event) => patch(draft.id, { name: event.target.value })}
+                      placeholder="Dr Sam Donegan"
+                      className={INPUT_CLASS}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className={LABEL_CLASS}>Role / title</span>
+                    <input
+                      value={draft.role}
+                      onChange={(event) => patch(draft.id, { role: event.target.value })}
+                      placeholder="Founder &amp; Lead Editor"
+                      className={INPUT_CLASS}
+                    />
+                  </label>
+                </div>
+
+                <label className="mt-3 block">
+                  <span className={LABEL_CLASS}>Short bio</span>
+                  <textarea
+                    value={draft.bio}
+                    onChange={(event) => patch(draft.id, { bio: event.target.value })}
+                    rows={2}
+                    placeholder="One or two sentences shown in the article's author box."
+                    className={INPUT_CLASS}
+                  />
+                </label>
+
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <label className="block">
+                    <span className={LABEL_CLASS}>Avatar URL</span>
+                    <input
+                      value={draft.avatarUrl}
+                      onChange={(event) => patch(draft.id, { avatarUrl: event.target.value })}
+                      placeholder="https://…/avatar.png"
+                      className={INPUT_CLASS}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className={LABEL_CLASS}>Profile URL</span>
+                    <input
+                      value={draft.url}
+                      onChange={(event) => patch(draft.id, { url: event.target.value })}
+                      placeholder="https://www.linkedin.com/in/…"
+                      className={INPUT_CLASS}
+                    />
+                  </label>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => setDrafts((current) => [...current, emptyDraft(newRowId())])}
+            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-bold text-gray-700 transition hover:border-gray-300 hover:bg-gray-50"
+          >
+            <UserPlus className="h-4 w-4" />
+            Add author
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting || serializedAuthors.length === 0}
+            className="inline-flex items-center gap-2 rounded-xl bg-gray-950 px-5 py-2.5 text-sm font-black text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? "Saving…" : "Save authors"}
+          </button>
+        </div>
+      </Form>
+    </div>
+  );
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -3,6 +3,7 @@ import { readableBackendErrors } from "~/lib/backend-error";
 import { hasAcceptedAutofillRun } from "~/lib/vibe-marketing-autofill-state";
 import { blockingCodeFromPayload, blockingReasonFromPayload } from "~/lib/vibe-marketing-run-failures";
 import type {
+  VibeMarketingAuthor,
   VibeMarketingBootstrap,
   VibeMarketingArticleSetupState,
   VibeMarketingComponentFeedback,
@@ -71,6 +72,47 @@ function asStringList(value: unknown): string[] {
       .filter(Boolean);
   }
   return [];
+}
+
+function asSocialLinks(value: unknown): Array<{ label: string; href: string }> {
+  if (!Array.isArray(value)) return [];
+  const links: Array<{ label: string; href: string }> = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const href = asNullableString(record.href) ?? asNullableString(record.url);
+    if (!href) continue;
+    links.push({ label: asNullableString(record.label) ?? asNullableString(record.name) ?? "Profile", href });
+  }
+  return links;
+}
+
+function normalizeMarketingAuthors(value: unknown): VibeMarketingAuthor[] {
+  if (!Array.isArray(value)) return [];
+  const authors: VibeMarketingAuthor[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const name = asNullableString(record.name) ?? asNullableString(record.author);
+    if (!name) continue;
+    const id =
+      asNullableString(record.id) ??
+      asNullableString(record.personId) ??
+      name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") ??
+      "author";
+    authors.push({
+      id: id || "author",
+      name,
+      role: asNullableString(record.role) ?? asNullableString(record.authorTitle),
+      credentials: asNullableString(record.credentials),
+      bio: asNullableString(record.bio) ?? asNullableString(record.authorBio),
+      avatarUrl: asNullableString(record.avatarUrl) ?? asNullableString(record.avatar),
+      avatarAlt: asNullableString(record.avatarAlt),
+      url: asNullableString(record.url) ?? asNullableString(record.website),
+      sameAs: asSocialLinks(record.sameAs ?? record.same_as),
+    });
+  }
+  return authors;
 }
 
 function asNumber(value: unknown): number | null {
@@ -430,6 +472,9 @@ function normalizeBootstrap(raw: unknown): VibeMarketingBootstrap {
       githubConnectionState:
         asNullableString(settings.githubConnectionState) ??
         asNullableString(settings.github_connection_state),
+      authors: normalizeMarketingAuthors(settings.authors),
+      defaultAuthorId:
+        asNullableString(settings.defaultAuthorId) ?? asNullableString(settings.default_author_id),
     },
     startupProfile: normalizeStartupProfile(startupProfile),
     websiteBaseline: normalizeWebsiteBaseline(payload.websiteBaseline ?? payload.website_baseline),

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -16,6 +16,7 @@ import { clsx } from "clsx";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import ArticleSystemConnectionPanel from "~/components/ArticleSystemConnectionPanel";
+import VibeMarketingAuthorsSetup from "~/components/VibeMarketingAuthorsSetup";
 import ArticlesSetupProgressCard from "~/components/ArticlesSetupProgressCard";
 import CancelSetupBuildButton, { CANCEL_SETUP_BUILD_INTENT, canCancelSetupBuild } from "~/components/CancelSetupBuildButton";
 import { RooPointCost } from "~/components/RooPointCost";
@@ -882,9 +883,24 @@ export async function action({ request, context }: Route.ActionArgs) {
         deliveryModeExplicit,
         deliveryModeConfirmed: deliveryModeExplicit,
         sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
+        authorId: stringFromForm(formData, "authorId"),
       });
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       return redirect("/founder-tools/marketing/create?step=writeCheck");
+    }
+
+    if (intent === "save-authors") {
+      let authors: unknown = [];
+      try {
+        authors = JSON.parse(stringFromForm(formData, "authors") || "[]");
+      } catch {
+        authors = [];
+      }
+      await saveVibeMarketingSettings(env, request, {
+        authors,
+        defaultAuthorId: stringFromForm(formData, "defaultAuthorId"),
+      });
+      return redirect("/founder-tools/marketing/create?step=articleSystem");
     }
 
     if (intent === "save-daily") {
@@ -1521,6 +1537,14 @@ export default function FounderToolsMarketingCreate() {
                 </Link>
               </div>
             ) : null}
+
+            {activeStep === "articleSystem" ? (
+              <VibeMarketingAuthorsSetup
+                authors={bootstrap.settings.authors ?? []}
+                defaultAuthorId={bootstrap.settings.defaultAuthorId ?? null}
+                isSubmitting={isSubmitting}
+              />
+            ) : null}
           </>
         ) : null}
 
@@ -1680,6 +1704,23 @@ export default function FounderToolsMarketingCreate() {
                       <textarea name="articleContext" rows={4} placeholder="Add any angle, product detail, proof point, or audience note." className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-medium leading-6 outline-none focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10" />
                     </label>
                   </>
+                ) : null}
+                {(bootstrap.settings.authors?.length ?? 0) > 0 ? (
+                  <label className="block">
+                    <span className="mb-2 block text-sm font-bold text-gray-700">Author byline</span>
+                    <select
+                      name="authorId"
+                      defaultValue={bootstrap.settings.defaultAuthorId ?? bootstrap.settings.authors?.[0]?.id ?? ""}
+                      className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm font-bold outline-none focus:border-violet-500 focus:ring-4 focus:ring-violet-500/10"
+                    >
+                      {bootstrap.settings.authors?.map((author) => (
+                        <option key={author.id} value={author.id}>
+                          {author.name}
+                          {author.role ? ` — ${author.role}` : ""}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
                 ) : null}
                 <div className="sticky bottom-4 z-10 rounded-xl border border-violet-100 bg-violet-50/95 p-3 shadow-lg backdrop-blur">
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -239,6 +239,18 @@ export interface VibeMarketingOrganization {
   seedKeywords: string[];
 }
 
+export interface VibeMarketingAuthor {
+  id: string;
+  name: string;
+  role?: string | null;
+  credentials?: string | null;
+  bio?: string | null;
+  avatarUrl?: string | null;
+  avatarAlt?: string | null;
+  url?: string | null;
+  sameAs?: Array<{ label: string; href: string }>;
+}
+
 export interface VibeMarketingSettings {
   brandName?: string | null;
   companyContext?: string | null;
@@ -250,6 +262,8 @@ export interface VibeMarketingSettings {
   dailyDiscoveryPriority?: number | null;
   defaultTimezone?: string | null;
   githubConnectionState?: string | null;
+  authors?: VibeMarketingAuthor[];
+  defaultAuthorId?: string | null;
 }
 
 export interface VibeMarketingStartupProfile {


### PR DESCRIPTION
Frontend for the per-organization **article authors** feature (3 repos: content-factory, mlai-backend, mlai-au).

## Changes
- **`VibeMarketingAuthorsSetup`**: a repeatable authors editor (name, role, bio, avatar, profile URL) with a default-byline radio, rendered in the `articleSystem` step. Serializes to a new `save-authors` action that persists via the vibe-marketing settings endpoint.
- **Bootstrap hydration**: `normalizeBootstrap` parses `authors`/`defaultAuthorId` into `settings`; new `VibeMarketingAuthor` type.
- **Generate-article form**: an author `<select>` picker (default preselected) that sends `authorId` on the run.

Backend persists to `OrganizationContentConfig.authors`; the default byline flows to content-factory per run and per-article picks override it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)