### PR TITLE
Show article contract-health (readiness proofs + reason) in the setup wizard

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -746,6 +746,25 @@ export default function ArticleSystemConnectionPanel({
       articleSetupState?.setupMerged ||
       articleSetupState?.published,
   );
+  // Contract-health rollup from the backend (compute_article_readiness): the individual
+  // readiness signals + a plain-language reason the org can't generate yet, so the wizard
+  // explains WHICH step is missing instead of a generic "needs attention".
+  const readinessProofs = scaffoldCheck?.readinessProofs ?? null;
+  const readinessBlockingReason = scaffoldCheck?.blockingReason ?? null;
+  const readinessProofRows = readinessProofs
+    ? (
+        [
+          ["articles_scaffolded", "Articles scaffold built"],
+          ["article_system_published", "Publishing surface live"],
+          ["setup_merged", "Setup PR merged"],
+          ["generation_history", "Article generated before"],
+        ] as const
+      ).map(([key, label]) => ({
+        key,
+        label,
+        passed: Boolean(readinessProofs[key]),
+      }))
+    : [];
   const setupStatus = normalizedStatus(
     articleSetupState?.setupRunStatus ||
       articleSetupState?.setupStatus ||
@@ -1589,6 +1608,29 @@ export default function ArticleSystemConnectionPanel({
                   <p className="mt-1 text-sm font-semibold leading-6 text-slate-600">{scaffoldStatusContent.body}</p>
                   {displayedSurfaceUrl ? (
                     <p className="mt-1 break-all text-sm font-semibold text-slate-600">Public route: {displayedSurfaceUrl}</p>
+                  ) : null}
+                  {readinessProofRows.length ? (
+                    <div className="mt-3 border-t border-slate-200 pt-3">
+                      <p className="text-xs font-black uppercase tracking-wide text-slate-500">Contract health</p>
+                      <ul className="mt-2 grid gap-1.5 sm:grid-cols-2">
+                        {readinessProofRows.map((proof) => (
+                          <li key={proof.key} className="flex items-center gap-2 text-xs font-semibold">
+                            {proof.passed ? (
+                              <CheckCircle2 className="h-4 w-4 flex-shrink-0 text-emerald-600" />
+                            ) : (
+                              <span className="h-3.5 w-3.5 flex-shrink-0 rounded-full border-2 border-slate-300" aria-hidden />
+                            )}
+                            <span className={clsx(proof.passed ? "text-slate-700" : "text-slate-400")}>{proof.label}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      {readinessBlockingReason ? (
+                        <p className="mt-2 flex items-start gap-2 text-xs font-semibold leading-5 text-orange-700">
+                          <LockKeyhole className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                          <span>{readinessBlockingReason}</span>
+                        </p>
+                      ) : null}
+                    </div>
                   ) : null}
                   {selectedFiles.length && selectedSurfaceUrl ? (
                     <div className="mt-2 flex flex-wrap gap-2">

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -309,6 +309,19 @@ export interface VibeMarketingCheck {
   scaffoldDisconnectedAt?: string | null;
   defaultPublishTargetId?: string | null;
   routePath?: string | null;
+  // Article-generation readiness rollup (backend compute_article_readiness):
+  // a human-readable reason the org can't generate yet, a machine code for it,
+  // and the individual readiness signals behind the verdict.
+  blockingReason?: string | null;
+  reasonCode?: string | null;
+  readinessProofs?: VibeMarketingReadinessProofs | null;
+}
+
+export interface VibeMarketingReadinessProofs {
+  articles_scaffolded?: boolean;
+  article_system_published?: boolean;
+  setup_merged?: boolean;
+  generation_history?: boolean;
 }
 
 export type VibeMarketingNotificationChannelType = "slack" | "whatsapp" | "email";


### PR DESCRIPTION
## Phase 3 of the article-surface robustness plan: surface the readiness reason in the wizard

Consumes the rollup shipped in **mlai-backend#492**. That PR made `compute_article_readiness` emit, inside the bootstrap `checks.scaffold` object, the individual readiness signals (`readinessProofs`) plus a plain-language `blockingReason` / `reasonCode` for *why* an org can't generate yet. This surfaces them so the user sees **which** step is missing instead of a generic "needs attention".

### Changes (additive, +55 lines, 2 files)
- **`app/types/vibe-marketing.ts`** — extend `VibeMarketingCheck` with `blockingReason` / `reasonCode` / `readinessProofs` (+ a `VibeMarketingReadinessProofs` type). The fields flow through the existing bootstrap normalization with no parsing changes.
- **`app/components/ArticleSystemConnectionPanel.tsx`** — in the scaffold status card, render a **"Contract health"** sub-panel: a check/▢ row per proof (Articles scaffold built · Publishing surface live · Setup PR merged · Article generated before) and, when blocked, the backend's `blockingReason`. Reuses the existing `CheckCircle2` + `clsx` tone idiom; no flow/step changes.

### Scope notes
- Rendered in the in-progress/not-yet-connected scaffold card — exactly where "why can't I generate?" matters. The connected/ready happy-path card is left untouched.
- The setup-blocked **409** path already carries the richer `detail` + new `reasonCode` from #492; this PR focuses on the bootstrap-driven wizard display (the primary surface). No 409 action-handler change needed.

### Verification
`react-router typegen && tsc -b` passes clean (exit 0). Backwards-compatible: if the backend hasn't deployed #492 yet, `readinessProofs` is absent and the sub-panel simply doesn't render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)