### PR TITLE
Surface the ACN registration gate in vibe-raising

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -2474,7 +2474,11 @@ export default function VibeMarketingStartupBaselineSetup({
                 {companySetupWorkflow ? (
                   <>
                     <div className="grid gap-5 md:grid-cols-2">
-                      <FormField label="ABN" badge={<RequiredPill />}>
+                      <FormField
+                        label="ABN"
+                        badge={<RequiredPill />}
+                        help="Vibe Raising is for registered Australian companies (Pty Ltd / Ltd). We verify your ABN against the Australian Business Register and confirm the matching ACN."
+                      >
                         <div className="relative">
                           <ControlIcon icon={BadgeInfo} />
                           <input

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1562,8 +1562,10 @@ export type VibeMarketingLocationSuggestion = {
 
 export type VibeMarketingAbnSuggestion = {
   abn: string;
+  acn?: string;
   entityName?: string;
   businessName?: string;
+  entityTypeName?: string;
   status?: string;
   state?: string;
   postcode?: string;
@@ -1597,8 +1599,10 @@ function normalizeAbnSuggestion(raw: unknown): VibeMarketingAbnSuggestion | null
   if (!abn) return null;
   return {
     abn,
+    acn: asNullableString(payload.acn) ?? undefined,
     entityName: asNullableString(payload.entityName) ?? asNullableString(payload.entity_name) ?? undefined,
     businessName: asNullableString(payload.businessName) ?? asNullableString(payload.business_name) ?? undefined,
+    entityTypeName: asNullableString(payload.entityTypeName) ?? asNullableString(payload.entity_type_name) ?? undefined,
     status: asNullableString(payload.status) ?? undefined,
     state: asNullableString(payload.state) ?? undefined,
     postcode: asNullableString(payload.postcode) ?? undefined,

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -264,6 +264,16 @@ function normalizeCompany(raw: unknown): VibeRaisingCompany {
     asNullableString(payload.abn) ??
     asNullableString(payload.companyAbn) ??
     asNullableString(payload.company_abn);
+  const acn =
+    asNullableString(payload.acn) ??
+    asNullableString(payload.companyAcn) ??
+    asNullableString(payload.company_acn);
+  const entityTypeName =
+    asNullableString(payload.entityTypeName) ??
+    asNullableString(payload.entity_type_name);
+  const abrVerifiedAt =
+    asNullableString(payload.abrVerifiedAt) ??
+    asNullableString(payload.abr_verified_at);
   const companyLinkedInUrl =
     asNullableString(payload.companyLinkedInUrl) ??
     asNullableString(payload.company_linkedin_url);
@@ -335,6 +345,9 @@ function normalizeCompany(raw: unknown): VibeRaisingCompany {
     domain,
     companyLinkedInUrl,
     abn,
+    acn,
+    entityTypeName,
+    abrVerifiedAt,
     location,
     avatarUrl,
     founderProfiles,
@@ -1892,6 +1905,7 @@ export async function saveVibeRaisingCompany(
     domain?: string | null;
     companyLinkedInUrl?: string | null;
     abn?: string | null;
+    acn?: string | null;
     location?: string | null;
     registered?: boolean;
     brandName?: string | null;

--- a/app/routes/founder-tools.index.tsx
+++ b/app/routes/founder-tools.index.tsx
@@ -55,11 +55,21 @@ export default function FounderToolsIndex() {
   const { triggerAnnouncement } = useOutletContext<{ triggerAnnouncement: (cb?: () => void) => void }>();
   if (!user) return null;
   const activeCompany = getActiveVibeRaisingCompany(user);
+  const isVerifiedCompany = Boolean(activeCompany?.abrVerifiedAt && activeCompany?.acn);
   const details = [
     { label: "Website", value: detailValue(activeCompany?.domain), icon: GlobeAltIcon },
     { label: "Location", value: detailValue(activeCompany?.location), icon: MapPinIcon },
     { label: "ABN", value: detailValue(activeCompany?.abn), icon: IdentificationIcon },
-    { label: "Status", value: activeCompany?.registered ? "Set up" : "Incomplete", icon: CheckBadgeIcon },
+    { label: "ACN", value: detailValue(activeCompany?.acn), icon: IdentificationIcon },
+    {
+      label: "Status",
+      value: isVerifiedCompany
+        ? "Verified registered company"
+        : activeCompany?.registered
+          ? "Set up"
+          : "Incomplete",
+      icon: CheckBadgeIcon,
+    },
   ];
   const productLinks = [
     {

--- a/app/routes/vibe-raising-app.companies.tsx
+++ b/app/routes/vibe-raising-app.companies.tsx
@@ -162,7 +162,7 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                                             }}
                                         >
                                             <CheckBadgeIcon className="w-3.5 h-3.5" />
-                                            Registered
+                                            {activeCompany.abrVerifiedAt && activeCompany.acn ? "Verified" : "Registered"}
                                         </span>
                                     )}
                                 </div>
@@ -191,11 +191,24 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                             </div>
                             <div>
                                 <div className="vr-company-info-label flex items-center gap-1.5">
+                                    <IdentificationIcon className="w-3 h-3" />
+                                    ACN
+                                </div>
+                                <div className="vr-company-info-value">
+                                    {activeCompany.acn || "—"}
+                                </div>
+                            </div>
+                            <div>
+                                <div className="vr-company-info-label flex items-center gap-1.5">
                                     <CheckBadgeIcon className="w-3 h-3" />
                                     Status
                                 </div>
                                 <div className="vr-company-info-value">
-                                    {activeCompany.registered ? "Registered" : "Not yet registered"}
+                                    {activeCompany.abrVerifiedAt && activeCompany.acn
+                                        ? "Verified registered company"
+                                        : activeCompany.registered
+                                            ? "Registered"
+                                            : "Not yet registered"}
                                 </div>
                             </div>
                         </div>

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -43,6 +43,7 @@ const COMPANY_SETUP_FIELD_LABELS: Record<string, string> = {
   name: "Company name",
   domain: "Website domain",
   abn: "ABN",
+  acn: "ACN",
   location: "Startup location",
   stage: "Stage",
   shortDescription: "Short description",
@@ -313,6 +314,9 @@ export async function action({ request, context }: Route.ActionArgs) {
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
       location,
       abn,
+      // Optional manual ACN fallback; the backend cross-checks it against the ABN/ABR
+      // and otherwise derives the ACN itself, so an empty value is fine.
+      acn: stringFromForm(formData, "acn"),
       brandName: companyName,
       companyContext,
       competitors: listFromForm(formData.get("competitors")),

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -513,6 +513,17 @@ function buildMonthlyUpdateSavePayload(formData: FormData) {
     };
 }
 
+// The backend blocks update creation for a company that isn't a verified registered
+// Australian company (HTTP 422, code ACN_REQUIRED). Send the founder back to company
+// setup to complete verification rather than dead-ending on the update form.
+function acnGateRedirect(error: unknown) {
+    const data = (error as any)?.response?.data ?? (error as any)?.data;
+    if (data && typeof data === "object" && data.code === "ACN_REQUIRED") {
+        return redirect(typeof data.redirect === "string" ? data.redirect : "/founder-tools/company-setup");
+    }
+    return null;
+}
+
 function extractVibeRaisingActionError(error: unknown, fallback: string) {
     const responseData = (error as any)?.response?.data;
     if (typeof responseData?.detail === "string" && responseData.detail.trim()) {
@@ -623,6 +634,8 @@ export async function action({ request, context }: Route.ActionArgs) {
                 savedUpdate,
             }));
         } catch (error) {
+            const gate = acnGateRedirect(error);
+            if (gate) return gate;
             console.warn("Unable to publish Vibe Raising monthly update.", (error as any)?.response?.data ?? error);
             return {
                 step: "publish-error",
@@ -654,6 +667,9 @@ export async function action({ request, context }: Route.ActionArgs) {
         .filter(Boolean);
 
     if (activeCompany && formData.has("founderProfiles")) {
+        // This is an incidental founder-profile sync — it must not re-trigger the
+        // registration gate, so `registered` is intentionally omitted (sending it true
+        // would force a fresh ABR re-verification on every save).
         await saveVibeRaisingCompany(env, request, {
             companyId: activeCompany.id,
             name: activeCompany.name || appUser.companyName,
@@ -666,15 +682,21 @@ export async function action({ request, context }: Route.ActionArgs) {
                 : (activeCompany.founderNames ?? []),
             founderProfiles: founderProfilesForCompanySave,
             stage: activeCompany.stage ?? appUser.stage ?? null,
-            registered: activeCompany.registered ?? appUser.companyRegistered,
         });
     }
 
     if (intent === "review") {
-        const savedUpdate = await saveVibeRaisingMonthlyUpdate(env, request, {
-            ...savePayload,
-            saveMode: "ready",
-        });
+        let savedUpdate;
+        try {
+            savedUpdate = await saveVibeRaisingMonthlyUpdate(env, request, {
+                ...savePayload,
+                saveMode: "ready",
+            });
+        } catch (error) {
+            const gate = acnGateRedirect(error);
+            if (gate) return gate;
+            throw error;
+        }
 
         // Mock AI analysis
         return {
@@ -701,10 +723,17 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "save-draft") {
-        const update = await saveVibeRaisingMonthlyUpdate(env, request, {
-            ...savePayload,
-            saveMode: "draft",
-        });
+        let update;
+        try {
+            update = await saveVibeRaisingMonthlyUpdate(env, request, {
+                ...savePayload,
+                saveMode: "draft",
+            });
+        } catch (error) {
+            const gate = acnGateRedirect(error);
+            if (gate) return gate;
+            throw error;
+        }
         const cookie = update ? createVibeRaisingLocalDraftUpdateCookie(update) : null;
 
         return Response.json(

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -13,6 +13,9 @@ export interface VibeRaisingCompany {
   domain?: string | null;
   companyLinkedInUrl?: string | null;
   abn?: string | null;
+  acn?: string | null;
+  entityTypeName?: string | null;
+  abrVerifiedAt?: string | null;
   location?: string | null;
   avatarUrl?: string | null;
   founderProfiles?: VibeRaisingFounderProfile[];


### PR DESCRIPTION
## What

Frontend half of the Vibe Raising **ACN gate**. Pairs with the backend PR (MLAI-AUS-Inc/mlai-backend#499): a founder company must be a verified registered Australian company before it can create investor updates.

## Changes

- **F1 (data):** carry `acn` + `entityTypeName` on ABN lookup suggestions, and `acn` / `entityTypeName` / `abrVerifiedAt` on the company model + types (`normalizeCompany`). The company-setup ABN field is plain text, so the ACN is **derived server-side** from the typed ABN; the autocomplete auto-fill on the marketing surface is deferred to avoid the in-flight companyId-threading work.
- **F2:** pass an optional ACN through the company save; clarify on the ABN field that Vibe Raising is for registered Australian companies and the ABN is verified against the ABR. The structured 422 `detail` already surfaces via `readableBackendError`.
- **F3:** show the ACN and a "Verified registered company" status/badge on the founder dashboard and the companies view.
- **F4:** redirect a founder back to company setup when the update endpoints return the ACN gate (422 `ACN_REQUIRED`) instead of dead-ending, and stop the incidental founder-profile sync from re-triggering ABR verification.

## Notes

- Built in a clean worktree off `origin/main`; does not touch the in-flight `claude/multi-startup-companyid-threading` work.
- `tsc -b` clean.
- Depends on the backend PR being deployed (new serializer fields + structured 422s + lookup `acn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)