### PR TITLE
ABN optional + moved to top of company setup with ABR autocomplete

### DIFF
--- a/app/components/AbnAutocomplete.tsx
+++ b/app/components/AbnAutocomplete.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+
+import type { VibeMarketingAbnSuggestion } from "~/lib/vibe-marketing";
+
+type LookupResponse = {
+  configured?: boolean;
+  suggestions?: VibeMarketingAbnSuggestion[];
+  error?: string;
+};
+
+function isNumericAbnQuery(value: string) {
+  return /^[\d\s]+$/.test(value.trim());
+}
+
+function suggestionLabel(option: VibeMarketingAbnSuggestion) {
+  const location = [option.state, option.postcode].filter(Boolean).join(" ");
+  return [option.abn, option.entityTypeName, location].filter(Boolean).join(" · ");
+}
+
+/**
+ * ABN field with type-ahead against the ABR lookup. Typing an ABN or business name
+ * shows matching companies; selecting one commits the ABN (+ ACN) and reports the full
+ * suggestion via `onSelect` so the parent can fill the company name. The committed ABN
+ * and ACN are submitted via hidden inputs (`abn`, `acn`).
+ */
+export default function AbnAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  disabled,
+  placeholder = "Search ABN or business name",
+  inputClassName,
+  leadingIcon,
+}: {
+  value: string;
+  onChange: (abn: string) => void;
+  onSelect?: (suggestion: VibeMarketingAbnSuggestion) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  inputClassName?: string;
+  leadingIcon?: ReactNode;
+}) {
+  const [displayValue, setDisplayValue] = useState(value);
+  const [acn, setAcn] = useState("");
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [lookup, setLookup] = useState<LookupResponse>({ configured: true, suggestions: [] });
+
+  // Keep the visible text in sync when the value is set externally (e.g. autofill),
+  // but never stomp what the user is actively typing.
+  useEffect(() => {
+    if (!open) setDisplayValue(value);
+  }, [value, open]);
+
+  useEffect(() => {
+    const query = displayValue.trim();
+    if (!open || query.length < 3) {
+      setLookup((current) => ({ ...current, suggestions: [], error: undefined }));
+      return;
+    }
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ q: query });
+        const response = await fetch(`/api/vibe-marketing/lookups/abns?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        const data = (await response.json()) as LookupResponse;
+        setLookup({
+          configured: data.configured ?? true,
+          suggestions: Array.isArray(data.suggestions) ? data.suggestions : [],
+          error: data.error,
+        });
+        setActiveIndex(0);
+      } catch {
+        if (!controller.signal.aborted) {
+          setLookup({ configured: true, suggestions: [], error: "ABN lookup is unavailable." });
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }, 600);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [displayValue, open]);
+
+  const selectOption = (option: VibeMarketingAbnSuggestion) => {
+    onChange(option.abn);
+    setAcn(option.acn ?? "");
+    setDisplayValue(option.abn);
+    setLookup((current) => ({ ...current, suggestions: [] }));
+    setOpen(false);
+    onSelect?.(option);
+  };
+
+  const handleType = (next: string) => {
+    setDisplayValue(next);
+    setAcn(""); // a manually edited ABN is no longer tied to a selected company's ACN
+    if (isNumericAbnQuery(next)) onChange(next);
+    setOpen(true);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    const suggestions = lookup.suggestions ?? [];
+    if (!open || suggestions.length === 0) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % suggestions.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + suggestions.length) % suggestions.length);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      selectOption(suggestions[activeIndex]);
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const suggestions = lookup.suggestions ?? [];
+
+  return (
+    <div className="relative">
+      <input type="hidden" name="abn" value={value} />
+      <input type="hidden" name="acn" value={acn} />
+      {leadingIcon}
+      <input
+        value={displayValue}
+        onChange={(event) => handleType(event.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => window.setTimeout(() => setOpen(false), 120)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        autoComplete="off"
+        placeholder={placeholder}
+        className={inputClassName}
+      />
+      {open && (suggestions.length > 0 || loading || lookup.error || lookup.configured === false) ? (
+        <div className="absolute z-30 mt-2 w-full overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg">
+          {suggestions.map((option, index) => (
+            <button
+              key={`${option.abn}-${index}`}
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => selectOption(option)}
+              className={`flex w-full flex-col items-start gap-0.5 px-4 py-3 text-left text-sm transition ${
+                index === activeIndex ? "bg-violet-50 text-violet-900" : "text-gray-800 hover:bg-gray-50"
+              }`}
+            >
+              <span className="font-bold">{option.entityName || option.businessName || option.abn}</span>
+              <span className="text-xs font-semibold text-gray-500">{suggestionLabel(option)}</span>
+            </button>
+          ))}
+          {(loading || lookup.error || lookup.configured === false) ? (
+            <div className="px-4 py-2.5 text-xs font-semibold text-gray-500">
+              {loading
+                ? "Searching the business register…"
+                : lookup.configured === false
+                  ? "Business lookup isn't configured — type your ABN manually."
+                  : lookup.error}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -1109,9 +1109,10 @@ function isBasicsComplete(values: StartupSetupValues) {
 }
 
 function isCompanySetupRequiredComplete(values: StartupSetupValues) {
+  // ABN is intentionally NOT required — it verifies the company and unlocks perks, but
+  // must never block the founder from completing setup.
   return (
     isBasicsComplete(values) &&
-    hasSetupText(values.abn) &&
     hasSetupText(values.location) &&
     hasSetupText(values.stage) &&
     hasSetupText(values.organizationKind) &&
@@ -2478,8 +2479,7 @@ export default function VibeMarketingStartupBaselineSetup({
                     <div className="grid gap-5 md:grid-cols-2">
                       <FormField
                         label="ABN"
-                        badge={<RequiredPill />}
-                        help="Vibe Raising is for registered Australian companies (Pty Ltd / Ltd). We verify your ABN against the Australian Business Register and confirm the matching ACN."
+                        help="Optional. Add your ABN to verify your registered Australian company — it unlocks perks like the coworking discount. You can continue without it."
                       >
                         <div className="relative">
                           <ControlIcon icon={BadgeInfo} />
@@ -2488,7 +2488,6 @@ export default function VibeMarketingStartupBaselineSetup({
                             value={startupValues.abn}
                             onChange={(event) => updateValue("abn", event.target.value)}
                             disabled={researchLocked}
-                            required
                             placeholder="Search ABN or business name"
                             className={inputWithIconClass}
                           />

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -42,6 +42,7 @@ import {
   isAutofillStatusPollFailure,
 } from "~/lib/vibe-marketing-autofill-state";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
+import AbnAutocomplete from "~/components/AbnAutocomplete";
 import type {
   VibeMarketingAutofillCompetitor,
   VibeMarketingAutofillResult,
@@ -2442,6 +2443,25 @@ export default function VibeMarketingStartupBaselineSetup({
               </section>
 
               <div className={clsx("mt-7", companySetupWorkflow ? "space-y-5" : "grid gap-5 lg:grid-cols-2")}>
+                {companySetupWorkflow ? (
+                  <FormField
+                    label="ABN"
+                    help="Optional. Search your ABN or business name to find your registered company and auto-fill your details — it unlocks perks like the coworking discount. You can continue without it."
+                  >
+                    <AbnAutocomplete
+                      value={startupValues.abn}
+                      onChange={(abn) => updateValue("abn", abn)}
+                      onSelect={(suggestion) => {
+                        const name = suggestion.entityName || suggestion.businessName;
+                        if (name) updateValue("companyName", name);
+                      }}
+                      disabled={researchLocked}
+                      inputClassName={inputWithIconClass}
+                      leadingIcon={<ControlIcon icon={BadgeInfo} />}
+                    />
+                  </FormField>
+                ) : null}
+
                 <FormField label="Company name" badge={<RequiredPill />} className={companySetupWorkflow ? "" : "lg:col-span-2"}>
                   <div className="relative">
                     <ControlIcon icon={Building2} />
@@ -2476,34 +2496,15 @@ export default function VibeMarketingStartupBaselineSetup({
 
                 {companySetupWorkflow ? (
                   <>
-                    <div className="grid gap-5 md:grid-cols-2">
-                      <FormField
-                        label="ABN"
-                        help="Optional. Add your ABN to verify your registered Australian company — it unlocks perks like the coworking discount. You can continue without it."
-                      >
-                        <div className="relative">
-                          <ControlIcon icon={BadgeInfo} />
-                          <input
-                            name="abn"
-                            value={startupValues.abn}
-                            onChange={(event) => updateValue("abn", event.target.value)}
-                            disabled={researchLocked}
-                            placeholder="Search ABN or business name"
-                            className={inputWithIconClass}
-                          />
-                        </div>
-                      </FormField>
-
-                      <FormField label="Startup location" badge={<RequiredPill />}>
-                        <LocationCombobox
-                          value={startupValues.location}
-                          onChange={(nextLocation) => updateValue("location", nextLocation)}
-                          disabled={researchLocked}
-                          required
-                          inputClassName={inputWithIconClass}
-                        />
-                      </FormField>
-                    </div>
+                    <FormField label="Startup location" badge={<RequiredPill />}>
+                      <LocationCombobox
+                        value={startupValues.location}
+                        onChange={(nextLocation) => updateValue("location", nextLocation)}
+                        disabled={researchLocked}
+                        required
+                        inputClassName={inputWithIconClass}
+                      />
+                    </FormField>
 
                     <FormField label="Do you have revenue?" badge={<RequiredPill />}>
                       <select

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -289,9 +289,8 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (!domain) {
       return { intent, error: "Add your website domain before continuing." };
     }
-    if (!abn) {
-      return { intent, error: "Add your ABN before continuing." };
-    }
+    // ABN is optional — a valid one verifies the company (and unlocks perks like the
+    // coworking discount), but it never blocks setup.
     if (!location) {
       return { intent, error: "Add your startup location before continuing." };
     }


### PR DESCRIPTION
## What

Two changes to the founder company-setup form (pairs with backend #503):

### 1. ABN is no longer blocking
Founders were wall-blocked ("Add your ABN before continuing", "That ABN doesn't look right") and couldn't move through the site. ABN is now **optional** — it verifies the company and unlocks perks (the coworking discount) but never blocks. Removed the required validation, the RequiredPill, the HTML5 `required`, and dropped ABN from the setup-complete check.

### 2. ABN moved to the top + ABR autocomplete
The ABN field now sits **above the company name** and is a type-ahead against the ABR lookup (`/api/vibe-marketing/lookups/abns`): typing an ABN or business name shows matching registered companies, and selecting one fills the **ABN, ACN, and company name**. New reusable `AbnAutocomplete` component (debounced lookup, keyboard nav, hidden `abn`/`acn` inputs). Falls back to plain manual ABN entry when the lookup isn't configured (e.g. before the ABR credential is set).

`tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)