### PR TITLE
Multi-company Wins 1–3: companyId threading, create-vs-edit prompt, company switcher

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -27,6 +27,7 @@ interface AuthenticatedLayoutProps {
     userNavigation?: { name: string; href: string }[];
     rooPointsBalance?: RooPointsBalance | null;
     logoutAction?: string;
+    companySwitcher?: React.ReactNode;
 }
 
 type NavigationItem = { name: string; href: string; icon: any; exact?: boolean; matchPaths?: string[] };
@@ -96,7 +97,7 @@ function RooPointsBadge({ balance }: { balance: number }) {
     );
 }
 
-export default function AuthenticatedLayout({ children, user, navigation: customNavigation, userNavigation: customUserNavigation, rooPointsBalance, logoutAction = "/platform/logout" }: AuthenticatedLayoutProps) {
+export default function AuthenticatedLayout({ children, user, navigation: customNavigation, userNavigation: customUserNavigation, rooPointsBalance, logoutAction = "/platform/logout", companySwitcher }: AuthenticatedLayoutProps) {
     const [sidebarOpen, setSidebarOpen] = useState(false);
     const [isExpanded, setIsExpanded] = useState(false);
     const location = useLocation();
@@ -462,6 +463,8 @@ export default function AuthenticatedLayout({ children, user, navigation: custom
                                 isFounderToolsApp ? "hidden bg-[var(--vr-color-border)] sm:block" : "bg-gray-900/10"
                             )}
                         />
+
+                        {companySwitcher}
 
                         <div className="flex flex-1 items-center justify-between gap-x-2 self-stretch sm:gap-x-4 lg:gap-x-6">
                             {showVibeRaisingTopNavigation ? (

--- a/app/components/CompanySwitcher.tsx
+++ b/app/components/CompanySwitcher.tsx
@@ -1,0 +1,138 @@
+import { Fragment } from "react";
+import { Menu, Transition } from "@headlessui/react";
+import { BuildingOffice2Icon, CheckIcon, ChevronDownIcon, Cog6ToothIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { Link, useLocation, useSubmit } from "react-router";
+
+import { safeCompanySwitchPath } from "~/routes/founder-tools.switch-company";
+import type { VibeRaisingCompany } from "~/types/vibe-raising";
+
+function classNames(...classes: (string | undefined | boolean)[]) {
+    return classes.filter(Boolean).join(" ");
+}
+
+function CompanyFavicon({ company, sizeClass = "h-5 w-5" }: { company: VibeRaisingCompany; sizeClass?: string }) {
+    if (!company.domain) {
+        return <BuildingOffice2Icon className={classNames(sizeClass, "shrink-0 text-[var(--vr-color-text-sub)]")} aria-hidden="true" />;
+    }
+    return (
+        <img
+            src={`https://www.google.com/s2/favicons?domain=${company.domain}&sz=64`}
+            alt=""
+            aria-hidden="true"
+            className={classNames(sizeClass, "shrink-0 rounded")}
+        />
+    );
+}
+
+/**
+ * Header dropdown showing which company the founder is working in, with
+ * one-click switching between their startups. Switching stays on the current
+ * page (revalidated for the new company) — detail pages pinned to the old
+ * company fall back to their section root via safeCompanySwitchPath.
+ */
+export default function CompanySwitcher({
+    companies,
+    activeCompanyId,
+}: {
+    companies: VibeRaisingCompany[];
+    activeCompanyId: string | null;
+}) {
+    const location = useLocation();
+    const submit = useSubmit();
+
+    if (!companies.length) return null;
+
+    const activeCompany = companies.find((company) => company.id === activeCompanyId) ?? companies[0];
+
+    const switchTo = (companyId: string) => {
+        submit(
+            { companyId, returnTo: safeCompanySwitchPath(location.pathname) },
+            { method: "post", action: "/founder-tools/switch-company" },
+        );
+    };
+
+    return (
+        <Menu as="div" className="relative min-w-0">
+            <Menu.Button
+                className="flex min-w-0 max-w-[11rem] items-center gap-2 rounded-full border border-[rgba(15,23,42,0.12)] bg-white/85 px-3 py-1.5 text-sm font-black text-[var(--vr-color-text)] shadow-sm transition hover:bg-white sm:max-w-[16rem]"
+                title={`Active company: ${activeCompany.name}`}
+            >
+                <CompanyFavicon company={activeCompany} />
+                <span className="truncate">{activeCompany.name}</span>
+                <ChevronDownIcon className="h-4 w-4 shrink-0 text-[var(--vr-color-text-sub)]" aria-hidden="true" />
+            </Menu.Button>
+            <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+            >
+                <Menu.Items className="absolute left-0 z-50 mt-2 w-72 origin-top-left rounded-xl bg-[var(--vr-color-card,#fff)] py-2 shadow-lg ring-1 ring-[rgba(11,11,11,0.08)] focus:outline-none">
+                    <p className="px-4 pb-1 pt-1 text-[11px] font-black uppercase tracking-[0.12em] text-[var(--vr-color-text-sub)]">
+                        Your companies
+                    </p>
+                    {companies.map((company) => {
+                        const isActive = company.id === activeCompany.id;
+                        return (
+                            <Menu.Item key={company.id} disabled={isActive}>
+                                {({ focus }) => (
+                                    <button
+                                        type="button"
+                                        onClick={() => switchTo(company.id)}
+                                        disabled={isActive}
+                                        className={classNames(
+                                            focus && !isActive && "bg-[rgba(0,255,215,0.14)]",
+                                            "flex w-full items-center gap-3 px-4 py-2 text-left",
+                                            isActive ? "cursor-default" : "cursor-pointer",
+                                        )}
+                                    >
+                                        <CompanyFavicon company={company} sizeClass="h-6 w-6" />
+                                        <span className="min-w-0 flex-1">
+                                            <span className="block truncate text-sm font-black text-[var(--vr-color-text)]">{company.name}</span>
+                                            {company.domain ? (
+                                                <span className="block truncate text-xs font-semibold text-[var(--vr-color-text-sub)]">{company.domain}</span>
+                                            ) : null}
+                                        </span>
+                                        {isActive ? <CheckIcon className="h-4 w-4 shrink-0 text-[var(--vr-color-primary)]" aria-hidden="true" /> : null}
+                                    </button>
+                                )}
+                            </Menu.Item>
+                        );
+                    })}
+                    <div className="my-2 border-t border-[rgba(11,11,11,0.08)]" />
+                    <Menu.Item>
+                        {({ focus }) => (
+                            <Link
+                                to="/founder-tools/company-setup?new=true"
+                                className={classNames(
+                                    focus && "bg-[rgba(0,255,215,0.14)]",
+                                    "flex items-center gap-3 px-4 py-2 text-sm font-black text-[var(--vr-color-text)]",
+                                )}
+                            >
+                                <PlusIcon className="h-5 w-5 shrink-0 text-[var(--vr-color-text-sub)]" aria-hidden="true" />
+                                Register new company
+                            </Link>
+                        )}
+                    </Menu.Item>
+                    <Menu.Item>
+                        {({ focus }) => (
+                            <Link
+                                to="/founder-tools/companies"
+                                className={classNames(
+                                    focus && "bg-[rgba(0,255,215,0.14)]",
+                                    "flex items-center gap-3 px-4 py-2 text-sm font-black text-[var(--vr-color-text)]",
+                                )}
+                            >
+                                <Cog6ToothIcon className="h-5 w-5 shrink-0 text-[var(--vr-color-text-sub)]" aria-hidden="true" />
+                                Manage companies
+                            </Link>
+                        )}
+                    </Menu.Item>
+                </Menu.Items>
+            </Transition>
+        </Menu>
+    );
+}

--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -42,6 +42,7 @@ import {
   isAutofillStatusPollFailure,
 } from "~/lib/vibe-marketing-autofill-state";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
+import { domainConflictFromActionData, type CompanyDomainConflict } from "~/lib/vibe-raising";
 import AbnAutocomplete from "~/components/AbnAutocomplete";
 import type {
   VibeMarketingAutofillCompetitor,
@@ -116,6 +117,7 @@ type SetupVariant = "landing" | "workflow";
 type VibeMarketingStartupBaselineSetupProps = {
   bootstrap: VibeMarketingBootstrap;
   error?: string | null;
+  domainConflict?: CompanyDomainConflict | null;
   variant?: SetupVariant;
   focusSection?: "profile" | "baseline";
   autoRefreshGoogleBaseline?: boolean;
@@ -1883,6 +1885,7 @@ function ProfileResearchProgressCard({
 export default function VibeMarketingStartupBaselineSetup({
   bootstrap,
   error,
+  domainConflict = null,
   variant = "landing",
   focusSection = "profile",
   autoRefreshGoogleBaseline = false,
@@ -1907,6 +1910,7 @@ export default function VibeMarketingStartupBaselineSetup({
     status?: string;
     error?: string;
     errors?: string[];
+    domainConflict?: CompanyDomainConflict | null;
   }>();
   const autofillRunFetcher = useFetcher<VibeMarketingRunSummary>();
   const baselineStartFetcher = useFetcher<{ intent?: string; baselineRunId?: string | null; status?: string; error?: string }>();
@@ -1950,6 +1954,8 @@ export default function VibeMarketingStartupBaselineSetup({
   const [mobileTutorialChecked, setMobileTutorialChecked] = useState(false);
 
   const autofillStartData = autofillStartFetcher.data;
+  const activeDomainConflict =
+    domainConflictFromActionData(autofillStartFetcher.data) ?? domainConflict ?? null;
   const autofillRun = autofillRunFetcher.data as VibeMarketingRunSummary | undefined;
   const autofillStartStatus =
     autofillStartData?.autofillRunId && autofillStartData.autofillRunId === autofillRunId
@@ -2110,7 +2116,7 @@ export default function VibeMarketingStartupBaselineSetup({
     setGeneratedCompanyContext("");
   };
 
-  const startAutofill = () => {
+  const startAutofill = (domainDecision?: "create-new" | "update-existing") => {
     const snapshot = { ...startupValues };
     const now = Date.now();
     setGeneratedCompanyContext("");
@@ -2125,6 +2131,7 @@ export default function VibeMarketingStartupBaselineSetup({
     formData.set("intent", "start-autofill");
     formData.set("companyContext", companyContextFromSetup(snapshot));
     formData.set("notes", snapshot.targetAudience);
+    if (domainDecision) formData.set("domainDecision", domainDecision);
     for (const [field, value] of Object.entries(snapshot)) {
       formData.set(field, value);
     }
@@ -2351,7 +2358,57 @@ export default function VibeMarketingStartupBaselineSetup({
     >
       <input type="hidden" name="intent" value="save-startup-details" />
       <input type="hidden" name="companyContext" value={companyContext} />
-      {error ? (
+      {activeDomainConflict ? (
+        <div className="border-b border-amber-200 bg-amber-50 px-6 py-4">
+          <p className="text-sm font-bold leading-6 text-amber-900">
+            This looks like a different company.{" "}
+            <span className="font-black">{activeDomainConflict.activeCompanyName || "Your current company"}</span> is set
+            up on <span className="font-black">{activeDomainConflict.activeCompanyDomain}</span>, but these details are
+            for <span className="font-black">{activeDomainConflict.submittedDomain}</span>. Adding it as a new company
+            keeps each startup's articles, updates and integrations separate.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {activeDomainConflict.sourceIntent === "start-autofill" ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => startAutofill("create-new")}
+                  className="rounded-lg bg-gray-950 px-4 py-2 text-sm font-black text-white transition hover:bg-black"
+                >
+                  Add as a new company
+                </button>
+                <button
+                  type="button"
+                  onClick={() => startAutofill("update-existing")}
+                  className="rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
+                >
+                  Update {activeDomainConflict.activeCompanyName || "the existing company"} to this domain
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="submit"
+                  name="domainDecision"
+                  value="create-new"
+                  className="rounded-lg bg-gray-950 px-4 py-2 text-sm font-black text-white transition hover:bg-black"
+                >
+                  Add as a new company
+                </button>
+                <button
+                  type="submit"
+                  name="domainDecision"
+                  value="update-existing"
+                  className="rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
+                >
+                  Update {activeDomainConflict.activeCompanyName || "the existing company"} to this domain
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      ) : null}
+      {error && !activeDomainConflict ? (
         <div className="border-b border-rose-100 bg-rose-50 px-6 py-4 text-sm font-bold text-rose-700">{error}</div>
       ) : null}
 
@@ -2361,6 +2418,15 @@ export default function VibeMarketingStartupBaselineSetup({
             {setupEyebrow ? <p className="text-sm font-black uppercase tracking-[0.08em] text-violet-700">{setupEyebrow}</p> : null}
             <h2 className={clsx(setupEyebrow && "mt-3", "font-black tracking-normal text-gray-950", embedded ? "text-4xl leading-tight sm:text-5xl" : "text-3xl")}>{setupTitle}</h2>
             <p className={clsx("mt-4 max-w-3xl font-semibold text-gray-600", embedded ? "text-lg leading-8" : "text-sm leading-6")}>{setupDescription}</p>
+            {bootstrap.company.id && bootstrap.company.name ? (
+              <p className="mt-3 text-sm font-semibold text-gray-500">
+                You're editing <span className="font-black text-gray-800">{bootstrap.company.name}</span>. Setting up a
+                different startup?{" "}
+                <Link to="/founder-tools/company-setup?new=true" className="font-black text-violet-700 underline underline-offset-2">
+                  Register a new company
+                </Link>
+              </p>
+            ) : null}
             <button
               type="button"
               onClick={openMobileTutorial}
@@ -2835,7 +2901,7 @@ export default function VibeMarketingStartupBaselineSetup({
 
               <button
                 type="button"
-                onClick={startAutofill}
+                onClick={() => startAutofill()}
                 disabled={!canStartAutofill}
                 ref={mobileResearchButtonRef}
                 className="mt-7 flex w-full items-center justify-between gap-4 rounded-xl bg-[var(--vr-color-primary)] px-6 py-5 text-left text-white shadow-lg shadow-[rgba(0,128,128,0.18)] transition hover:bg-[var(--vr-palette-black)] disabled:cursor-not-allowed disabled:opacity-50"
@@ -2873,7 +2939,7 @@ export default function VibeMarketingStartupBaselineSetup({
                   startError={autofillStartError}
                   stalled={autofillStalled}
                   unavailable={autofillUnavailable}
-                  onRetry={startAutofill}
+                  onRetry={() => startAutofill()}
                   retryDisabled={!canRetryAutofill}
                 />
               </div>

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1543,10 +1543,16 @@ export async function saveVibeMarketingSettings(env: Env, request: Request, body
   return normalizeBootstrap(response.data);
 }
 
-export async function uploadVibeMarketingCompanyAvatar(env: Env, request: Request, file: File) {
+export async function uploadVibeMarketingCompanyAvatar(
+  env: Env,
+  request: Request,
+  file: File,
+  companyId?: string | null,
+) {
   const client = createApiClient(env, request);
   const formData = new FormData();
   formData.set("avatar", file);
+  if (companyId) formData.set("company_id", companyId);
   const response = await client.post(`${BASE_PATH}/company/avatar/`, formData);
   return normalizeBootstrap(response.data);
 }
@@ -1772,17 +1778,30 @@ export async function recordVibeMarketingTopicFeedback(
   return normalizeTopicFeedback(response.data);
 }
 
-export async function restoreVibeMarketingTopicFeedback(env: Env, request: Request, feedbackId: string) {
+export async function restoreVibeMarketingTopicFeedback(
+  env: Env,
+  request: Request,
+  feedbackId: string,
+  companyId?: string | null,
+) {
   const client = createApiClient(env, request);
-  const response = await client.post(`${BASE_PATH}/topic-feedback/${encodeURIComponent(feedbackId)}/restore`, {});
+  const response = await client.post(
+    `${BASE_PATH}/topic-feedback/${encodeURIComponent(feedbackId)}/restore`,
+    companyId ? { companyId } : {},
+  );
   return normalizeTopicFeedback(response.data);
 }
 
-export async function discardVibeMarketingWrittenArticle(env: Env, request: Request, articleId: string) {
+export async function discardVibeMarketingWrittenArticle(
+  env: Env,
+  request: Request,
+  articleId: string,
+  companyId?: string | null,
+) {
   const client = createApiClient(env, request);
   const response = await client.post(
     `${BASE_PATH}/written-articles/${encodeURIComponent(articleId)}/discard`,
-    {},
+    companyId ? { companyId } : {},
   );
   const payload = (response.data && typeof response.data === "object" ? response.data : {}) as Record<string, unknown>;
   return {

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1724,6 +1724,20 @@ export function getActiveVibeRaisingCompany(
   return activeCompany ?? null;
 }
 
+/**
+ * Resolve the explicit company id to scope a per-request read or mutation to,
+ * mirroring the backend's active-company fallback (pinned active company, else
+ * first company). Passing this through requests keeps multi-startup founders
+ * isolated instead of relying on the backend's mutable server-side
+ * `active_company` state, which another tab may have switched.
+ */
+export function resolveActiveCompanyId(
+  profile: VibeRaisingProfile | VibeRaisingAppUser | null | undefined,
+): string | null {
+  if (!profile) return null;
+  return getActiveVibeRaisingCompany(profile)?.id ?? null;
+}
+
 export function buildVibeRaisingAppUser(
   authUser: User,
   profile: VibeRaisingProfile,

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1738,6 +1738,86 @@ export function resolveActiveCompanyId(
   return getActiveVibeRaisingCompany(profile)?.id ?? null;
 }
 
+export type CompanyDomainConflict = {
+  sourceIntent: string;
+  submittedDomain: string;
+  activeCompanyName: string;
+  activeCompanyDomain: string;
+};
+
+/**
+ * Loose client-side twin of the backend's normalize_company_domain — just
+ * enough to tell "same site, different spelling" apart from "different
+ * company". The backend 409 remains the authoritative backstop.
+ */
+export function normalizeCompanyDomainForCompare(value: string | null | undefined): string {
+  let raw = String(value ?? "").trim().toLowerCase();
+  if (!raw) return "";
+  raw = raw.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
+  raw = raw.split("/")[0] ?? "";
+  raw = raw.split("?")[0] ?? "";
+  raw = raw.split("@").pop() ?? "";
+  raw = raw.split(":")[0] ?? "";
+  if (raw.startsWith("www.")) raw = raw.slice(4);
+  return raw;
+}
+
+/**
+ * A submitted domain that differs from the active company's is the signature
+ * of the destructive "onboard a second startup by overwriting the first" flow.
+ * Callers surface this as a prompt (add as new company vs update existing)
+ * instead of silently rewriting the active company.
+ */
+export function detectCompanyDomainConflict(
+  activeCompany: VibeRaisingCompany | null | undefined,
+  submittedDomain: string,
+  sourceIntent: string,
+): CompanyDomainConflict | null {
+  if (!activeCompany) return null;
+  const existing = normalizeCompanyDomainForCompare(activeCompany.domain);
+  const submitted = normalizeCompanyDomainForCompare(submittedDomain);
+  if (!existing || !submitted || existing === submitted) return null;
+  return {
+    sourceIntent,
+    submittedDomain: submitted,
+    activeCompanyName: activeCompany.name,
+    activeCompanyDomain: existing,
+  };
+}
+
+/** Map the backend's structured 409 (autofill domain-change guard) to a conflict. */
+export function companyDomainConflictFromError(
+  error: unknown,
+  sourceIntent: string,
+): CompanyDomainConflict | null {
+  const payload = error as {
+    data?: Record<string, unknown>;
+    response?: { data?: Record<string, unknown> };
+  } | null;
+  const data = payload?.response?.data ?? payload?.data;
+  if (!data || data.code !== "company_domain_change_requires_confirmation") return null;
+  return {
+    sourceIntent,
+    submittedDomain: String(data.submittedDomain ?? ""),
+    activeCompanyName: String(data.companyName ?? "your current company"),
+    activeCompanyDomain: String(data.existingDomain ?? ""),
+  };
+}
+
+export function domainConflictFromActionData(actionData: unknown): CompanyDomainConflict | null {
+  if (!actionData || typeof actionData !== "object") return null;
+  const conflict = (actionData as { domainConflict?: unknown }).domainConflict;
+  if (!conflict || typeof conflict !== "object") return null;
+  const payload = conflict as Record<string, unknown>;
+  if (!payload.submittedDomain || !payload.activeCompanyDomain) return null;
+  return {
+    sourceIntent: String(payload.sourceIntent ?? ""),
+    submittedDomain: String(payload.submittedDomain),
+    activeCompanyName: String(payload.activeCompanyName ?? "your current company"),
+    activeCompanyDomain: String(payload.activeCompanyDomain),
+  };
+}
+
 export function buildVibeRaisingAppUser(
   authUser: User,
   profile: VibeRaisingProfile,
@@ -1955,6 +2035,7 @@ export async function saveVibeRaisingCompany(
   request: Request,
   body: {
     companyId?: string | null;
+    createNew?: boolean;
     name: string;
     domain?: string | null;
     companyLinkedInUrl?: string | null;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -123,6 +123,7 @@ export default [
     route("updates/:id", "routes/vibe-raising-app.update-detail.tsx"),
     route("discover", "routes/vibe-raising-app.investors.tsx"),
     route("companies", "routes/vibe-raising-app.companies.tsx"),
+    route("switch-company", "routes/founder-tools.switch-company.tsx"),
     route("marketing", "routes/founder-tools.marketing.tsx"),
     route("marketing/create", "routes/founder-tools.marketing.create.tsx"),
     route("marketing/github-connect", "routes/founder-tools.marketing.github-connect.tsx"),

--- a/app/routes/founder-tools.marketing.autofill-run.tsx
+++ b/app/routes/founder-tools.marketing.autofill-run.tsx
@@ -2,7 +2,7 @@ import type { Route } from "./+types/founder-tools.marketing.autofill-run";
 
 import { getEnv } from "~/lib/env.server";
 import { getVibeMarketingRun } from "~/lib/vibe-marketing";
-import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
+import { requireVibeRaisingFounder, resolveActiveCompanyId } from "~/lib/vibe-raising";
 import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
 function runLoaderErrorMessage(error: unknown) {
@@ -50,10 +50,10 @@ function statusPollFailurePayload(runId: string, error: unknown): VibeMarketingR
 
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
+  const { appUser } = await requireVibeRaisingFounder(env, request);
   const runId = params.runId ?? "";
   try {
-    return await getVibeMarketingRun(env, request, runId, null, "status");
+    return await getVibeMarketingRun(env, request, runId, resolveActiveCompanyId(appUser), "status");
   } catch (error) {
     return statusPollFailurePayload(runId, error);
   }

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -61,7 +61,9 @@ import {
 import type { VibeMarketingArticleSetupState, VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 import {
   getActiveVibeRaisingCompany,
+  getOptionalVibeRaisingContext,
   requireVibeRaisingFounder,
+  resolveActiveCompanyId,
   saveVibeRaisingCompany,
   setVibeRaisingActiveCompany,
 } from "~/lib/vibe-raising";
@@ -486,7 +488,13 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     throw redirect(`${url.pathname}?${url.searchParams.toString()}`);
   }
 
-  const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+  const vibeContext = await getOptionalVibeRaisingContext(env, request);
+  const bootstrap = await getVibeMarketingBootstrap(
+    env,
+    request,
+    resolveActiveCompanyId(vibeContext.appUser),
+    "summary",
+  );
   const requestedStep = normalizeStep(url.searchParams.get("step"), "startupDetails");
   if (isArticleSystemSetupBlocked(bootstrap) && ["research", "chooseArticle"].includes(requestedStep)) {
     url.searchParams.set("step", "articleSystem");
@@ -532,6 +540,7 @@ export async function action({ request, context }: Route.ActionArgs) {
   const env = getEnv(context);
   const { appUser } = await requireVibeRaisingFounder(env, request);
   const activeCompany = getActiveVibeRaisingCompany(appUser);
+  const activeCompanyId = activeCompany?.id ?? null;
   const formData = await request.formData();
   const intent = stringFromForm(formData, "intent");
 
@@ -626,17 +635,18 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-baseline") {
-      const result = await startVibeMarketingBaseline(env, request, {});
+      const result = await startVibeMarketingBaseline(env, request, { companyId: activeCompanyId });
       return { intent, baselineRunId: result.runId, status: result.status, error: result.error };
     }
 
     if (intent === "refresh-baseline-google") {
-      const websiteBaseline = await refreshVibeMarketingBaselineGoogle(env, request, {});
+      const websiteBaseline = await refreshVibeMarketingBaselineGoogle(env, request, { companyId: activeCompanyId });
       return { intent, websiteBaseline };
     }
 
     if (intent === "skip-baseline") {
       await skipVibeMarketingBaseline(env, request, {
+        companyId: activeCompanyId,
         reason: stringFromForm(formData, "reason") || "Skipped during onboarding",
       });
       return redirect("/founder-tools/marketing/create?step=articleSystem");
@@ -683,6 +693,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (intent === "start-scan") {
       const scanPurpose = stringFromForm(formData, "scanPurpose") || "inventory";
       const result = await startVibeMarketingScan(env, request, {
+        companyId: activeCompanyId,
         githubRepo: stringFromForm(formData, "githubRepo"),
         github_repo: stringFromForm(formData, "githubRepo"),
         scanPurpose,
@@ -710,6 +721,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before continuing." };
       if (!articleSurfaceUrl) return { intent, error: "Choose or enter an article/blog route before continuing." };
       const result = await startVibeMarketingArticleSystemSetup(env, request, {
+        companyId: activeCompanyId,
         githubRepo,
         github_repo: githubRepo,
         scanPurpose: "setup",
@@ -739,6 +751,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         return { intent, error: "No repository scan was available to update." };
       }
       const result = await controlVibeMarketingRun(env, request, scanRunId, intent === "retry-scan" ? "resume" : "cancel", {
+        companyId: activeCompanyId,
         ...(intent === "cancel-scan" ? { cleanup: true } : {}),
         workflow: "repo_scan",
       });
@@ -752,7 +765,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       const githubRepo = stringFromForm(formData, "githubRepo");
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before linking the articles scaffold." };
       try {
-        await acceptVibeMarketingArticleScaffold(env, request, { githubRepo, github_repo: githubRepo });
+        await acceptVibeMarketingArticleScaffold(env, request, { companyId: activeCompanyId, githubRepo, github_repo: githubRepo });
       } catch (error) {
         return {
           intent,
@@ -767,7 +780,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     if (intent === "disconnect-article-scaffold") {
       const githubRepo = stringFromForm(formData, "githubRepo");
       try {
-        await disconnectVibeMarketingArticleScaffold(env, request, { githubRepo, github_repo: githubRepo });
+        await disconnectVibeMarketingArticleScaffold(env, request, { companyId: activeCompanyId, githubRepo, github_repo: githubRepo });
       } catch (error) {
         return {
           intent,
@@ -784,6 +797,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before resetting articles setup." };
       try {
         await resetVibeMarketingArticleSetup(env, request, {
+          companyId: activeCompanyId,
           githubRepo,
           github_repo: githubRepo,
         });
@@ -804,7 +818,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (!scanRunId) {
         return { intent, error: "Open the scan result before building the articles setup preview." };
       }
-      const result = await controlVibeMarketingRun(env, request, scanRunId, "approve", { workflow: "repo_scan" });
+      const result = await controlVibeMarketingRun(env, request, scanRunId, "approve", { workflow: "repo_scan", companyId: activeCompanyId });
       const setupRunId = setupRunIdForRun(result);
       if (setupRunId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
       return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(scanRunId)}`);
@@ -816,25 +830,26 @@ export async function action({ request, context }: Route.ActionArgs) {
       await controlVibeMarketingRun(env, request, setupRunId, "cancel", {
         cleanup: true,
         workflow: "article_system_setup",
+        companyId: activeCompanyId,
       });
       return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
     }
 
     if (intent === "start-discovery") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      const bootstrap = await getVibeMarketingBootstrap(env, request, activeCompanyId, "summary");
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return {
           intent,
           error: "Merge the articles setup PR before researching topics. If you merged it in GitHub, refresh merge status.",
         };
       }
-      const result = await startVibeMarketingDiscovery(env, request, {});
+      const result = await startVibeMarketingDiscovery(env, request, { companyId: activeCompanyId });
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       return redirect("/founder-tools/marketing/create?step=research");
     }
 
     if (intent === "start-article") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request);
+      const bootstrap = await getVibeMarketingBootstrap(env, request, activeCompanyId);
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return {
           intent,
@@ -871,6 +886,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       }
       const deliveryModeExplicit = stringFromForm(formData, "deliveryModeExplicit") === "true";
       const result = await startVibeMarketingArticle(env, request, {
+        companyId: activeCompanyId,
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
         topic,
@@ -897,6 +913,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         authors = [];
       }
       await saveVibeMarketingSettings(env, request, {
+        companyId: activeCompanyId,
         authors,
         defaultAuthorId: stringFromForm(formData, "defaultAuthorId"),
       });
@@ -905,6 +922,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
     if (intent === "save-daily") {
       await saveVibeMarketingSettings(env, request, {
+        companyId: activeCompanyId,
         dailyDiscoveryEnabled: formData.get("dailyDiscoveryEnabled") === "on",
         defaultTimezone: stringFromForm(formData, "defaultTimezone"),
       });
@@ -912,7 +930,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "daily-replay") {
-      const result = await replayVibeMarketingDaily(env, request, {});
+      const result = await replayVibeMarketingDaily(env, request, { companyId: activeCompanyId });
       if (result.runId) return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
     }
   } catch (error: any) {

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -60,6 +60,9 @@ import {
 } from "~/lib/vibe-marketing";
 import type { VibeMarketingArticleSetupState, VibeMarketingBootstrap, VibeMarketingGithubReposResponse, VibeMarketingRunSummary } from "~/types/vibe-marketing";
 import {
+  companyDomainConflictFromError,
+  detectCompanyDomainConflict,
+  domainConflictFromActionData,
   getActiveVibeRaisingCompany,
   getOptionalVibeRaisingContext,
   requireVibeRaisingFounder,
@@ -543,6 +546,10 @@ export async function action({ request, context }: Route.ActionArgs) {
   const activeCompanyId = activeCompany?.id ?? null;
   const formData = await request.formData();
   const intent = stringFromForm(formData, "intent");
+  // "create-new" | "update-existing" — the user's answer to a domain-conflict
+  // prompt from a previous submit of the startup-details form.
+  const domainDecision = stringFromForm(formData, "domainDecision");
+  const createAsNew = domainDecision === "create-new";
 
   try {
     if (intent === "save-startup-details") {
@@ -554,8 +561,13 @@ export async function action({ request, context }: Route.ActionArgs) {
           problemSolved: stringFromForm(formData, "problemSolved"),
           targetAudience: stringFromForm(formData, "targetAudience"),
         });
+      if (!domainDecision) {
+        const conflict = detectCompanyDomainConflict(activeCompany, stringFromForm(formData, "domain"), intent);
+        if (conflict) return { intent, domainConflict: conflict };
+      }
       const companyId = await saveVibeRaisingCompany(env, request, {
-        companyId: activeCompany?.id ?? null,
+        companyId: createAsNew ? null : activeCompany?.id ?? null,
+        createNew: createAsNew,
         name: stringFromForm(formData, "companyName"),
         domain: stringFromForm(formData, "domain"),
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
@@ -591,7 +603,14 @@ export async function action({ request, context }: Route.ActionArgs) {
           problemSolved: stringFromForm(formData, "problemSolved"),
           targetAudience: stringFromForm(formData, "targetAudience"),
         });
+      if (!domainDecision) {
+        const conflict = detectCompanyDomainConflict(activeCompany, stringFromForm(formData, "domain"), intent);
+        if (conflict) return { intent, domainConflict: conflict };
+      }
       const result = await startVibeMarketingAutofill(env, request, {
+        companyId: createAsNew ? null : activeCompanyId,
+        createNew: createAsNew || undefined,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         companyName: stringFromForm(formData, "companyName"),
         company_name: stringFromForm(formData, "companyName"),
         domain: stringFromForm(formData, "domain"),
@@ -935,6 +954,8 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
+    const conflict = companyDomainConflictFromError(error, intent);
+    if (conflict) return { intent, domainConflict: conflict };
     const fallback =
       intent === "start-autofill"
         ? "AI research could not start. Check the backend logs and try again."
@@ -1044,6 +1065,7 @@ export default function FounderToolsMarketingCreate() {
   const actionData = useActionData<typeof action>();
   const latestActionIntent = actionDataIntent(actionData);
   const latestActionError = actionDataError(actionData);
+  const domainConflict = domainConflictFromActionData(actionData);
   const actionErrorStep = actionIntentStep(latestActionIntent);
   const isRepoArticleStep = activeStep === "github" || activeStep === "scan" || activeStep === "articleSystem";
   const githubAuthError = searchParams.get("githubAuthError");
@@ -1522,6 +1544,7 @@ export default function FounderToolsMarketingCreate() {
           <VibeMarketingStartupBaselineSetup
             bootstrap={bootstrap}
             error={topActionError}
+            domainConflict={domainConflict}
             variant="workflow"
             focusSection={requestedStep === "baseline" ? "baseline" : "profile"}
             autoRefreshGoogleBaseline={shouldRefreshGoogleBaseline}

--- a/app/routes/founder-tools.marketing.run-status.tsx
+++ b/app/routes/founder-tools.marketing.run-status.tsx
@@ -5,7 +5,7 @@ import { isApiNotFoundError } from "~/lib/api";
 import { getEnv } from "~/lib/env.server";
 import { getVibeMarketingRun, refreshVibeMarketingLivePreview } from "~/lib/vibe-marketing";
 import { shouldPollArticleSystemSetupRun } from "~/lib/vibe-marketing-run-polling";
-import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
+import { requireVibeRaisingFounder, resolveActiveCompanyId } from "~/lib/vibe-raising";
 import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
 
 const TERMINAL_ATTENTION_STATUSES = new Set(["blocked", "blocked_verification", "failed", "cancelled", "canceled"]);
@@ -59,8 +59,8 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     throw redirect(runId ? `/founder-tools/marketing/runs/${encodeURIComponent(runId)}` : "/founder-tools/marketing");
   }
 
-  await requireVibeRaisingFounder(env, request);
-  let run = await getVibeMarketingRun(env, request, runId, null, "status").catch((error: unknown) => {
+  const { appUser } = await requireVibeRaisingFounder(env, request);
+  let run = await getVibeMarketingRun(env, request, runId, resolveActiveCompanyId(appUser), "status").catch((error: unknown) => {
     if (isApiNotFoundError(error)) return null;
     throw error;
   });

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -71,7 +71,7 @@ import {
   verifyNotificationChannelOtp,
   canonicalizeTopicCandidates,
 } from "~/lib/vibe-marketing";
-import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
+import { requireVibeRaisingFounder, resolveActiveCompanyId } from "~/lib/vibe-raising";
 import type {
   VibeMarketingComponentManifestItem,
   VibeMarketingComponentCommentAnchor,
@@ -334,9 +334,10 @@ function accountEmailVerifiedFromAuthUser(authUser: Record<string, unknown>) {
 export async function loader({ request, params, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   const { authUser, appUser } = await requireVibeRaisingFounder(env, request);
+  const companyId = resolveActiveCompanyId(appUser);
   const runId = params.runId ?? "";
-  const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
-  const run = await getVibeMarketingRun(env, request, runId).catch((error: unknown) => {
+  const bootstrap = await getVibeMarketingBootstrap(env, request, companyId, "summary");
+  const run = await getVibeMarketingRun(env, request, runId, companyId).catch((error: unknown) => {
     // A deleted/reset run (e.g. after an article-setup teardown) 404s here while a stale
     // wizard session still links to it. Redirect to the wizard instead of letting the 404
     // throw and SSR-500 the marketing page. (run-status.tsx handles the status-poll path.)
@@ -358,7 +359,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   let setupRun: VibeMarketingRunSummary | null = null;
   if (setupRunId && setupRunId !== run.runId) {
     try {
-      setupRun = await getVibeMarketingRun(env, request, setupRunId);
+      setupRun = await getVibeMarketingRun(env, request, setupRunId, companyId);
     } catch {
       setupRun = null;
     }
@@ -389,7 +390,8 @@ export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
 
 export async function action({ request, params, context }: Route.ActionArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
+  const { appUser } = await requireVibeRaisingFounder(env, request);
+  const companyId = resolveActiveCompanyId(appUser);
   const runId = params.runId ?? "";
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
@@ -476,7 +478,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     } else if (intent === CANCEL_SETUP_BUILD_INTENT) {
       let setupRunId = stringFromForm(formData, "setupRunId");
       if (!setupRunId) {
-        const currentRun = await getVibeMarketingRun(env, request, runId);
+        const currentRun = await getVibeMarketingRun(env, request, runId, companyId);
         if (currentRun.workflow === "article_system_setup") setupRunId = runId;
       }
       if (!setupRunId) return { intent, error: "No setup build was available to cancel." };
@@ -497,6 +499,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       if (scanPurpose !== "inventory" && !articleSurfaceUrl) return { intent, error: "Enter the articles or blog URL before scanning." };
       const autoSetupPreview = scanPurpose === "setup";
       const result = await startVibeMarketingScan(env, request, {
+        companyId,
         githubRepo,
         github_repo: githubRepo,
         scanPurpose,
@@ -526,6 +529,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       if (!githubRepo) return { intent, error: "Choose a GitHub repository before continuing." };
       if (!articleSurfaceUrl) return { intent, error: "Choose or enter an article/blog route before continuing." };
       const result = await startVibeMarketingScan(env, request, {
+        companyId,
         githubRepo,
         github_repo: githubRepo,
         scanPurpose: "setup",
@@ -553,7 +557,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         defaultTimezone: stringFromForm(formData, "defaultTimezone"),
       });
     } else if (intent === "run-daily-discovery-now") {
-      const result = await replayVibeMarketingDaily(env, request, {});
+      const result = await replayVibeMarketingDaily(env, request, { companyId });
       if (result.runId) {
         throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
       }
@@ -584,7 +588,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
           : (intent === "resume" || intent === "restart") && targetRunId
             ? targetRunId
             : runId;
-      const payload: Record<string, unknown> = {};
+      const payload: Record<string, unknown> = { companyId };
       if (sourceRunId) payload.sourceRunId = sourceRunId;
       if (autoMerge) payload.autoMerge = true;
       const result = await controlVibeMarketingRun(env, request, controlRunId, intent, payload);
@@ -599,7 +603,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         deliveryMode: String(formData.get("deliveryMode") ?? ""),
       });
     } else if (intent === "start-article") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request);
+      const bootstrap = await getVibeMarketingBootstrap(env, request, companyId);
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return { intent, error: "Publish the articles setup before generating articles. If you've already published it, refresh status." };
       }
@@ -619,6 +623,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       }
       const deliveryModeExplicit = stringFromForm(formData, "deliveryModeExplicit") === "true";
       const result = await startVibeMarketingArticle(env, request, {
+        companyId,
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
         topic,

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -17,6 +17,7 @@ import {
 import {
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
+  resolveActiveCompanyId,
   saveVibeRaisingCompany,
 } from "~/lib/vibe-raising";
 
@@ -45,8 +46,10 @@ function founderNamesFromForm(formData: FormData) {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
-  return { bootstrap: await getVibeMarketingBootstrap(env, request) };
+  const { appUser } = await requireVibeRaisingFounder(env, request);
+  return {
+    bootstrap: await getVibeMarketingBootstrap(env, request, resolveActiveCompanyId(appUser)),
+  };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -113,6 +116,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       registered: true,
     });
     await saveVibeMarketingSettings(env, request, {
+      companyId: activeCompany?.id ?? null,
       domain: stringFromForm(formData, "domain"),
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
       company_linkedin_url: stringFromForm(formData, "companyLinkedInUrl"),

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -88,6 +88,9 @@ import {
   uploadVibeMarketingCompanyAvatar,
 } from "~/lib/vibe-marketing";
 import {
+  companyDomainConflictFromError,
+  detectCompanyDomainConflict,
+  domainConflictFromActionData,
   getActiveVibeRaisingCompany,
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
@@ -370,6 +373,10 @@ export async function action({ request, context }: Route.ActionArgs) {
   // Pin every read and mutation in this action to the company the page was
   // rendered for, instead of the backend's mutable active_company.
   const activeCompanyId = resolveActiveCompanyId(vibeContext.appUser);
+  // "create-new" | "update-existing" — the user's answer to a domain-conflict
+  // prompt from a previous submit of the startup-details form.
+  const domainDecision = stringFromForm(formData, "domainDecision");
+  const createAsNew = domainDecision === "create-new";
 
   try {
     if (intent === "save-company-avatar") {
@@ -407,8 +414,13 @@ export async function action({ request, context }: Route.ActionArgs) {
       }
 
       const activeCompany = vibeContext.appUser ? getActiveVibeRaisingCompany(vibeContext.appUser) : null;
+      if (!domainDecision) {
+        const conflict = detectCompanyDomainConflict(activeCompany, domain, intent);
+        if (conflict) return { intent, domainConflict: conflict };
+      }
       const companyId = await saveVibeRaisingCompany(env, request, {
-        companyId: activeCompany?.id ?? null,
+        companyId: createAsNew ? null : activeCompany?.id ?? null,
+        createNew: createAsNew,
         name,
         domain,
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
@@ -447,7 +459,16 @@ export async function action({ request, context }: Route.ActionArgs) {
         });
       }
 
+      if (!domainDecision) {
+        const activeCompany = vibeContext.appUser ? getActiveVibeRaisingCompany(vibeContext.appUser) : null;
+        const conflict = detectCompanyDomainConflict(activeCompany, stringFromForm(formData, "domain"), intent);
+        if (conflict) return { intent, domainConflict: conflict };
+      }
+
       const result = await startVibeMarketingAutofill(env, request, {
+        companyId: createAsNew ? null : activeCompanyId,
+        createNew: createAsNew || undefined,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         companyName: stringFromForm(formData, "companyName"),
         company_name: stringFromForm(formData, "companyName"),
         domain: stringFromForm(formData, "domain"),
@@ -776,6 +797,8 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
+    const conflict = companyDomainConflictFromError(error, intent);
+    if (conflict) return { intent, domainConflict: conflict };
     const fallback =
       intent === "start-autofill"
         ? "AI research could not start. Check the backend logs and try again."
@@ -4731,6 +4754,7 @@ export default function FounderToolsMarketing() {
   const location = useLocation();
   const error = actionError(actionData);
   const errorIntent = actionIntent(actionData);
+  const domainConflict = domainConflictFromActionData(actionData);
   const setupMergedNotice = new URLSearchParams(location.search).get("setupMerged") === "1";
   const shouldShowTopicPicker = shouldShowVibeMarketingTopicPicker(bootstrap);
 
@@ -4746,7 +4770,7 @@ export default function FounderToolsMarketing() {
           setupMergedNotice={setupMergedNotice}
         />
       ) : (
-        <VibeMarketingStartupBaselineSetup bootstrap={bootstrap} error={error} />
+        <VibeMarketingStartupBaselineSetup bootstrap={bootstrap} error={error} domainConflict={domainConflict} />
       )}
     </div>
   );

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -91,6 +91,7 @@ import {
   getActiveVibeRaisingCompany,
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
+  resolveActiveCompanyId,
   saveVibeRaisingCompany,
   saveVibeRaisingProfile,
   setVibeRaisingActiveCompany,
@@ -338,7 +339,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   }
 
   const [bootstrap, githubRepos] = await Promise.all([
-    getVibeMarketingBootstrap(env, request, null, "summary"),
+    getVibeMarketingBootstrap(env, request, resolveActiveCompanyId(vibeContext.appUser), "summary"),
     getVibeMarketingGithubRepos(env, request).catch(() => unavailableGithubRepos()),
   ]);
   return {
@@ -366,6 +367,9 @@ export async function action({ request, context }: Route.ActionArgs) {
 
   const formData = await request.formData();
   const intent = stringFromForm(formData, "intent");
+  // Pin every read and mutation in this action to the company the page was
+  // rendered for, instead of the backend's mutable active_company.
+  const activeCompanyId = resolveActiveCompanyId(vibeContext.appUser);
 
   try {
     if (intent === "save-company-avatar") {
@@ -376,7 +380,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (!(avatar instanceof File) || avatar.size === 0) {
         return { intent, error: "Choose an avatar image before saving." };
       }
-      const bootstrap = await uploadVibeMarketingCompanyAvatar(env, request, avatar);
+      const bootstrap = await uploadVibeMarketingCompanyAvatar(env, request, avatar, activeCompanyId);
       return { intent, avatarUrl: bootstrap.company.avatarUrl ?? null };
     }
 
@@ -503,29 +507,30 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-baseline") {
-      const result = await startVibeMarketingBaseline(env, request, {});
+      const result = await startVibeMarketingBaseline(env, request, { companyId: activeCompanyId });
       return { intent, baselineRunId: result.runId, status: result.status };
     }
 
     if (intent === "refresh-baseline-google") {
-      const websiteBaseline = await refreshVibeMarketingBaselineGoogle(env, request, {});
+      const websiteBaseline = await refreshVibeMarketingBaselineGoogle(env, request, { companyId: activeCompanyId });
       return { intent, websiteBaseline };
     }
 
     if (intent === "skip-baseline") {
       await skipVibeMarketingBaseline(env, request, {
+        companyId: activeCompanyId,
         reason: stringFromForm(formData, "reason") || "Skipped during marketing setup",
       });
       return redirect("/founder-tools/marketing/create?step=articleSystem");
     }
 
     if (intent === "scan") {
-      const run = await startVibeMarketingScan(env, request, {});
+      const run = await startVibeMarketingScan(env, request, { companyId: activeCompanyId });
       if (run.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}`);
     }
 
     if (intent === "start-content-island-discovery") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      const bootstrap = await getVibeMarketingBootstrap(env, request, activeCompanyId, "summary");
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return { intent, error: "Merge the articles setup PR before researching topics. If you merged it in GitHub, refresh merge status." };
       }
@@ -539,6 +544,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         pillar.topicCandidates.find((candidate) => candidate.pillarKeyword)?.pillarKeyword ||
         pillar.name;
       const run = await startVibeMarketingDiscovery(env, request, {
+        companyId: activeCompanyId,
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
         contentIslandSlug: pillar.slug,
@@ -570,7 +576,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "research-custom-topic") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      const bootstrap = await getVibeMarketingBootstrap(env, request, activeCompanyId, "summary");
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return { intent, error: "Merge the articles setup PR before researching topics. If you merged it in GitHub, refresh merge status." };
       }
@@ -581,6 +587,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         return { intent, error: "Add an article title/angle or a target keyword to research." };
       }
       const run = await startVibeMarketingDiscovery(env, request, {
+        companyId: activeCompanyId,
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
         customTopicTitle: customTitle,
@@ -608,11 +615,11 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-discovery" || intent === "discovery") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request, null, "summary");
+      const bootstrap = await getVibeMarketingBootstrap(env, request, activeCompanyId, "summary");
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return { intent, error: "Merge the articles setup PR before researching topics. If you merged it in GitHub, refresh merge status." };
       }
-      const run = await startVibeMarketingDiscovery(env, request, {});
+      const run = await startVibeMarketingDiscovery(env, request, { companyId: activeCompanyId });
       if (run.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}`);
     }
 
@@ -626,6 +633,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         request,
         runId,
         intent === "resume-draft" ? "resume" : "restart",
+        { companyId: activeCompanyId },
       );
       const nextRunId = run.runId || runId;
       throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(nextRunId)}`);
@@ -636,7 +644,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       if (!runId) {
         return { intent, error: "Choose a draft article to delete." };
       }
-      const run = await controlVibeMarketingRun(env, request, runId, "cancel", { cancel_group: true });
+      const run = await controlVibeMarketingRun(env, request, runId, "cancel", { cancel_group: true, companyId: activeCompanyId });
       return {
         intent,
         runId,
@@ -651,7 +659,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         return { intent, error: "Choose an article to discard." };
       }
       try {
-        const result = await discardVibeMarketingWrittenArticle(env, request, articleId);
+        const result = await discardVibeMarketingWrittenArticle(env, request, articleId, activeCompanyId);
         return {
           intent,
           articleId,
@@ -667,7 +675,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
 
     if (intent === "start-article") {
-      const bootstrap = await getVibeMarketingBootstrap(env, request);
+      const bootstrap = await getVibeMarketingBootstrap(env, request, activeCompanyId);
       if (isArticleSystemSetupBlocked(bootstrap)) {
         return { intent, error: "Merge the articles setup PR before generating articles. If you merged it in GitHub, refresh merge status." };
       }
@@ -701,6 +709,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
       const deliveryModeExplicit = stringFromForm(formData, "deliveryModeExplicit") === "true";
       const result = await startVibeMarketingArticle(env, request, {
+        companyId: activeCompanyId,
         clientRequestId: stringFromForm(formData, "clientRequestId"),
         client_request_id: stringFromForm(formData, "clientRequestId"),
         topic,
@@ -735,6 +744,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       }
 
       const feedback = await recordVibeMarketingTopicFeedback(env, request, {
+        companyId: activeCompanyId,
         keyword,
         sessionId: stringFromForm(formData, "sourceDiscoveryRunId"),
         feedbackType: "declined",
@@ -756,12 +766,12 @@ export async function action({ request, context }: Route.ActionArgs) {
         return { intent, error: "Choose a declined topic to restore." };
       }
 
-      const feedback = await restoreVibeMarketingTopicFeedback(env, request, feedbackId);
+      const feedback = await restoreVibeMarketingTopicFeedback(env, request, feedbackId, activeCompanyId);
       return { intent, topicFeedback: feedback };
     }
 
     if (intent === "daily-replay") {
-      const run = await replayVibeMarketingDaily(env, request, {});
+      const run = await replayVibeMarketingDaily(env, request, { companyId: activeCompanyId });
       if (run.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}`);
     }
   } catch (error: any) {

--- a/app/routes/founder-tools.switch-company.tsx
+++ b/app/routes/founder-tools.switch-company.tsx
@@ -1,0 +1,45 @@
+import type { Route } from "./+types/founder-tools.switch-company";
+import { redirect } from "react-router";
+
+import { getEnv } from "~/lib/env.server";
+import { requireVibeRaisingFounder, setVibeRaisingActiveCompany } from "~/lib/vibe-raising";
+
+/**
+ * Map the page a switch was initiated from to somewhere safe to land after the
+ * active company changes. List/dashboard pages re-render with the new
+ * company's data in place; pages pinned to a specific record of the OLD
+ * company (a run, an update, a mid-flight wizard) fall back to their section
+ * root instead of erroring.
+ */
+export function safeCompanySwitchPath(pathname: string): string {
+  if (!pathname.startsWith("/founder-tools")) return "/founder-tools";
+  const sectionRoots: Array<[RegExp, string]> = [
+    [/^\/founder-tools\/updates\/.+/, "/founder-tools/updates"],
+    [/^\/founder-tools\/drafts\/.+/, "/founder-tools/drafts"],
+    [/^\/founder-tools\/marketing\/(runs|run-status|autofill-runs|github-connect|create)(\/.*)?$/, "/founder-tools/marketing"],
+    [/^\/founder-tools\/company-setup(\/.*)?$/, "/founder-tools/companies"],
+  ];
+  for (const [pattern, root] of sectionRoots) {
+    if (pattern.test(pathname)) return root;
+  }
+  return pathname;
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  const env = getEnv(context);
+  const { appUser } = await requireVibeRaisingFounder(env, request);
+  const formData = await request.formData();
+  const companyId = String(formData.get("companyId") ?? "");
+  const returnTo = String(formData.get("returnTo") ?? "");
+
+  if (companyId && appUser.companies.some((company) => company.id === companyId) && companyId !== appUser.activeCompanyId) {
+    await setVibeRaisingActiveCompany(env, request, companyId);
+  }
+
+  throw redirect(safeCompanySwitchPath(returnTo));
+}
+
+export async function loader() {
+  // Resource route: nothing to render on GET.
+  throw redirect("/founder-tools/companies");
+}

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -11,6 +11,9 @@ import {
 } from "~/lib/vibe-marketing";
 import { combineCompanyContext } from "~/lib/vibe-marketing-startup-setup";
 import {
+  companyDomainConflictFromError,
+  detectCompanyDomainConflict,
+  domainConflictFromActionData,
   getActiveVibeRaisingCompany,
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
@@ -214,6 +217,15 @@ export async function action({ request, context }: Route.ActionArgs) {
   const formData = await request.formData();
   const intent = stringFromForm(formData, "intent");
   const companyContext = companyContextFromForm(formData);
+  // "create-new" | "update-existing" — the user's answer to a domain-conflict
+  // prompt from a previous submit of this same form.
+  const domainDecision = stringFromForm(formData, "domainDecision");
+  const activeCompany = vibeContext.appUser
+    ? getActiveVibeRaisingCompany(vibeContext.appUser)
+    : vibeContext.profile
+      ? getActiveVibeRaisingCompany(vibeContext.profile)
+      : null;
+  const createAsNew = isAddingNew || domainDecision === "create-new";
 
   try {
     if (intent === "start-autofill") {
@@ -224,7 +236,19 @@ export async function action({ request, context }: Route.ActionArgs) {
         });
       }
 
+      if (!createAsNew && !domainDecision) {
+        const conflict = detectCompanyDomainConflict(
+          activeCompany,
+          stringFromForm(formData, "domain"),
+          intent,
+        );
+        if (conflict) return { intent, domainConflict: conflict };
+      }
+
       const result = await startVibeMarketingAutofill(env, request, {
+        companyId: createAsNew ? null : activeCompany?.id ?? null,
+        createNew: createAsNew || undefined,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         companyName: stringFromForm(formData, "companyName"),
         company_name: stringFromForm(formData, "companyName"),
         domain: stringFromForm(formData, "domain"),
@@ -314,14 +338,15 @@ export async function action({ request, context }: Route.ActionArgs) {
       });
     }
 
-    const activeCompany = vibeContext.appUser
-      ? getActiveVibeRaisingCompany(vibeContext.appUser)
-      : vibeContext.profile
-        ? getActiveVibeRaisingCompany(vibeContext.profile)
-        : null;
+    if (!createAsNew && !domainDecision) {
+      const conflict = detectCompanyDomainConflict(activeCompany, domain, intent);
+      if (conflict) return { intent, domainConflict: conflict };
+    }
+
     const { founderProfiles, founderNames } = founderNamesFromForm(formData);
     const companyId = await saveVibeRaisingCompany(env, request, {
-      companyId: isAddingNew ? null : activeCompany?.id ?? null,
+      companyId: createAsNew ? null : activeCompany?.id ?? null,
+      createNew: createAsNew,
       name: companyName,
       domain,
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
@@ -352,6 +377,8 @@ export async function action({ request, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
+    const conflict = companyDomainConflictFromError(error, intent);
+    if (conflict) return { intent, domainConflict: conflict };
     return {
       intent,
       error: readableBackendError(error, {
@@ -364,19 +391,22 @@ export async function action({ request, context }: Route.ActionArgs) {
     };
   }
 
-  throw redirect("/founder-tools/updates");
+  const next = url.searchParams.get("next");
+  throw redirect(next && next.startsWith("/founder-tools") ? next : "/founder-tools/updates");
 }
 
 export default function CompanySetup() {
   const { bootstrap, audienceVisibility, isAddingNew, isEditingExisting } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const error = actionData && typeof actionData === "object" && "error" in actionData ? String(actionData.error ?? "") : null;
+  const domainConflict = domainConflictFromActionData(actionData);
   return (
     <div className="min-h-screen bg-[#f7f6f2] px-4 py-6 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl">
         <VibeMarketingStartupBaselineSetup
           bootstrap={bootstrap}
           error={error}
+          domainConflict={domainConflict}
           variant="workflow"
           includeBaseline={false}
           setupEyebrow=""

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -187,7 +187,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   let bootstrap = emptyBootstrap(vibeContext.profile, activeCompany);
   if (activeCompany && !isAddingNew) {
     try {
-      bootstrap = await getVibeMarketingBootstrap(env, request);
+      bootstrap = await getVibeMarketingBootstrap(env, request, activeCompany.id);
     } catch {
       bootstrap = emptyBootstrap(vibeContext.profile, activeCompany);
     }

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -11,6 +11,7 @@ import {
   ActiveDraftRunProvider,
 } from "~/components/ActiveDraftRunStatus";
 import AuthenticatedLayout from "~/components/AuthenticatedLayout";
+import CompanySwitcher from "~/components/CompanySwitcher";
 import VibeRaisingIntroPopup from "~/components/VibeRaisingIntroPopup";
 import { getEnv } from "~/lib/env.server";
 import { getCurrentRooPointsBalance } from "~/lib/roo-points";
@@ -115,7 +116,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 }
 
 export default function VibeRaisingApp() {
-  const { user, backendBaseUrl, rooPointsBalance } = useLoaderData<typeof loader>();
+  const { user, appUser, backendBaseUrl, rooPointsBalance } = useLoaderData<typeof loader>();
   const [showAnnouncement, setShowAnnouncement] = useState(false);
   const [onCompleteCallback, setOnCompleteCallback] =
     useState<(() => void) | undefined>();
@@ -125,6 +126,11 @@ export default function VibeRaisingApp() {
     setShowAnnouncement(true);
   };
 
+  const companySwitcher =
+    appUser && appUser.companies.length > 0 ? (
+      <CompanySwitcher companies={appUser.companies} activeCompanyId={appUser.activeCompanyId ?? null} />
+    ) : undefined;
+
   return (
     <AuthenticatedLayout
       user={user}
@@ -132,6 +138,7 @@ export default function VibeRaisingApp() {
       userNavigation={FOUNDER_USER_NAVIGATION}
       rooPointsBalance={rooPointsBalance}
       logoutAction="/founder-tools/logout"
+      companySwitcher={companySwitcher}
     >
       {showAnnouncement ? (
         <VibeRaisingIntroPopup


### PR DESCRIPTION
## Why

The app behaves as if a founder has exactly one startup. Worse, onboarding a **second** startup through the marketing wizard silently overwrote the first company's name/domain (backend name-match upsert + autofill binding to the active company) — which is why Manage Companies shows only one company for founders who created several. And nothing in the shell says which company's data is on screen.

Implements Wins 1–3 of the multi-company plan (audit 2026-07-02), in three commits:

## 1. `companyId` threading (761a375)

Every Vibe Marketing read AND mutation now pins the company explicitly instead of trusting the backend's mutable server-side `active_company` (which another tab can switch mid-flight):

- New `resolveActiveCompanyId(profile)` helper mirrors the backend fallback.
- Loaders/actions pass `companyId` to `getVibeMarketingBootstrap` / `getVibeMarketingRun` across the marketing, create, settings, run, run-status, autofill-run and company-setup routes (lands the previously-uncommitted P4 threading, untangled from the scaffold-panel work in the shared checkout).
- All mutations carry `companyId`: run starts (scan/discovery/article/setup/baseline/daily), run controls, settings & author saves, scaffold accept/disconnect/reset, topic feedback, article discard, avatar upload.

## 2. Create-vs-edit made explicit (eed27c1)

- "Register New Company" flows send `createNew`, so a name collision can never silently rewrite an existing company; autofill on `?new=true` binds to a **fresh** company.
- Editing flows pass the explicit `companyId` to autofill.
- Submitting a **different domain** than the active company's now shows a prompt — *"This looks like a different company"* — with **Add as a new company** / **Update <company> to this domain** actions (client-side detection + mapping of the backend's `company_domain_change_requires_confirmation` 409).
- The wizard names the company being edited, with a "Register a new company" escape hatch; `company-setup` honours a sanitized `?next=` redirect.

## 3. Company switcher in the shell (d2a2ee4)

- Header dropdown: active company name + favicon, one-click switch, Register-new-company and Manage-companies entries — visible on every founder-tools page.
- `POST /founder-tools/switch-company` validates ownership, pins the active company, and returns to the page you were on; detail pages pinned to the old company (runs, update detail, mid-flight wizards) land on their section root instead of erroring.

## Verification

`react-router typegen && tsc -b` clean.

## Pairs with

mlai-backend [#509](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/509) (`createNew` flag, autofill `create_new`/`confirm_domain_change` modes, settings/avatar `company_id`). Either PR can land first — the prompt actions degrade gracefully without the backend modes (the backend keeps legacy behaviour for flag-less requests), but full protection needs both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)