### PR TITLE
Multi-company Win 4: companyId on the Vibe Raising surface + per-tab browser scope

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1295,6 +1295,25 @@ function readableBrowserError(data: unknown, status: number): string {
   return `Request failed with status ${status}`;
 }
 
+// Which company this tab's browser-side API calls target. Set from loader data
+// by the founder-tools shell, so a company switch in ANOTHER tab (which
+// mutates the backend's shared active_company) can't redirect this tab's
+// previews, selections, uploads and email-draft calls to the wrong startup.
+// Client-only: never set during SSR, where module scope is shared across
+// requests.
+let browserCompanyScopeId: string | null = null;
+
+export function setVibeRaisingBrowserCompanyScope(companyId: string | null) {
+  if (typeof window === "undefined") return;
+  browserCompanyScopeId = companyId;
+}
+
+function withBrowserCompanyScope(path: string): string {
+  if (typeof window === "undefined" || !browserCompanyScopeId) return path;
+  if (path.includes("company_id=") || path.includes("companyId=")) return path;
+  return `${path}${path.includes("?") ? "&" : "?"}company_id=${encodeURIComponent(browserCompanyScopeId)}`;
+}
+
 async function requestBrowserJson<T>(
   backendBaseUrl: string,
   path: string,
@@ -1314,7 +1333,7 @@ async function requestBrowserJson<T>(
     headers.set("Content-Type", "application/json");
   }
 
-  const targetUrl = buildAbsoluteBackendUrl(backendBaseUrl, path);
+  const targetUrl = buildAbsoluteBackendUrl(backendBaseUrl, withBrowserCompanyScope(path));
   let response: Response;
   try {
     response = await fetch(targetUrl, {
@@ -2292,6 +2311,7 @@ const DEV_MONTHLY_UPDATES_BUNDLE_STUB: VibeRaisingMonthlyUpdatesBundle = {
 export async function getVibeRaisingMonthlyUpdatesBundle(
   env: Env,
   request: Request,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdatesBundle> {
   if (shouldUseDevBackendStub()) {
     return mergeLocalPublishedUpdate(DEV_MONTHLY_UPDATES_BUNDLE_STUB, request);
@@ -2299,7 +2319,9 @@ export async function getVibeRaisingMonthlyUpdatesBundle(
   const client = createApiClient(env, request);
 
   try {
-    const response = await client.get(UPDATES_PATH);
+    const response = await client.get(
+      companyId ? `${UPDATES_PATH}?company_id=${encodeURIComponent(companyId)}` : UPDATES_PATH,
+    );
     const updates: unknown[] = Array.isArray(response.data?.updates) ? response.data.updates : [];
     return mergeLocalPublishedUpdate({
       updates: updates
@@ -2336,13 +2358,15 @@ export async function getVibeRaisingMonthlyUpdatesBundle(
 export async function getVibeRaisingMonthlyUpdates(
   env: Env,
   request: Request,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdate[]> {
-  return (await getVibeRaisingMonthlyUpdatesBundle(env, request)).updates;
+  return (await getVibeRaisingMonthlyUpdatesBundle(env, request, companyId)).updates;
 }
 
 export async function getVibeRaisingDrafts(
   env: Env,
   request: Request,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdate[]> {
   if (shouldUseDevBackendStub()) {
     return mergeLocalDraftUpdate(DEV_MONTHLY_DRAFTS_STUB, request);
@@ -2350,7 +2374,9 @@ export async function getVibeRaisingDrafts(
 
   const client = createApiClient(env, request);
   try {
-    const response = await client.get(DRAFTS_PATH);
+    const response = await client.get(
+      companyId ? `${DRAFTS_PATH}?company_id=${encodeURIComponent(companyId)}` : DRAFTS_PATH,
+    );
     const drafts: unknown[] = Array.isArray(response.data?.drafts) ? response.data.drafts : [];
     return mergeLocalDraftUpdate(
       drafts
@@ -2386,10 +2412,11 @@ export async function getVibeRaisingMonthlyUpdateById(
   env: Env,
   request: Request,
   updateId: string,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdate | null> {
   const [draftsResult, updatesResult] = await Promise.allSettled([
-    getVibeRaisingDrafts(env, request),
-    getVibeRaisingMonthlyUpdates(env, request),
+    getVibeRaisingDrafts(env, request, companyId),
+    getVibeRaisingMonthlyUpdates(env, request, companyId),
   ]);
   const drafts = draftsResult.status === "fulfilled" ? draftsResult.value : [];
   const updates = updatesResult.status === "fulfilled" ? updatesResult.value : [];
@@ -2410,6 +2437,7 @@ export async function saveVibeRaisingMonthlyUpdate(
   env: Env,
   request: Request,
   body: {
+    companyId?: string | null;
     month: string;
     year: number;
     highlights: string;

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -6,6 +6,7 @@ import {
     getVibeRaisingMonthlyUpdatesBundle,
     getOptionalVibeRaisingContext,
     getVibeRaisingLoginHref,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import type { VibeRaisingMetricHistory } from "~/types/vibe-raising";
 import { isFounderToolsDiscoverEnabled } from "~/lib/founder-tools-preview";
@@ -62,7 +63,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
     const user = vibeContext.appUser;
     const updatesBundle = user.role === "founder"
-        ? await getVibeRaisingMonthlyUpdatesBundle(env, request)
+        ? await getVibeRaisingMonthlyUpdatesBundle(env, request, resolveActiveCompanyId(user))
         : { updates: [], metricHistory: {} };
     const metricHistory = updatesBundle.metricHistory;
     const updates = updatesBundle.updates.map((update, index) => ({

--- a/app/routes/vibe-raising-app.companies.tsx
+++ b/app/routes/vibe-raising-app.companies.tsx
@@ -28,7 +28,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         Boolean(activeCompany?.id) &&
         (
             hasSubmittedVibeRaisingUpdate(request, activeCompany?.id) ||
-            (await getVibeRaisingMonthlyUpdates(env, request)).length > 0
+            (await getVibeRaisingMonthlyUpdates(env, request, activeCompany?.id ?? null)).length > 0
         );
 
     return { user, activeCompanyId: activeCompany?.id ?? null, activeCompanyHasUpdates };
@@ -49,7 +49,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
         const hasExistingUpdate =
             hasSubmittedVibeRaisingUpdate(request, companyId) ||
-            (await getVibeRaisingMonthlyUpdates(env, request)).length > 0;
+            (await getVibeRaisingMonthlyUpdates(env, request, companyId)).length > 0;
 
         return redirect(hasExistingUpdate ? "/founder-tools/updates" : "/founder-tools/updates/create");
     }

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -21,6 +21,7 @@ import {
     saveVibeRaisingMonthlyUpdate,
     uploadVibeRaisingPitchDeck,
     uploadVibeRaisingUpdateVideo,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import {
@@ -449,14 +450,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
     let existingData = null;
     if (editId) {
-        const existingUpdate = await getVibeRaisingMonthlyUpdateById(env, request, editId).catch((error) => {
+        const existingUpdate = await getVibeRaisingMonthlyUpdateById(env, request, editId, resolveActiveCompanyId(user)).catch((error) => {
             console.warn("Unable to load Vibe Raising update for editing.", error);
             return null;
         });
         existingData = existingUpdate ? buildExistingUpdateFormData(existingUpdate) : null;
     }
 
-    const existingMonthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request).catch((error) => {
+    const existingMonthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request, resolveActiveCompanyId(user)).catch((error) => {
         console.warn("Unable to load existing Vibe Raising monthly updates for create flow.", error);
         return [];
     });
@@ -557,6 +558,9 @@ function extractVibeRaisingActionError(error: unknown, fallback: string) {
 export async function action({ request, context }: Route.ActionArgs) {
     const env = getEnv(context);
     const { appUser } = await requireVibeRaisingFounder(env, request);
+    // Pin every read and save in this action to the company the page was
+    // rendered for, instead of the backend's mutable active_company.
+    const activeCompanyId = resolveActiveCompanyId(appUser);
     const formData = await request.formData();
     const intent = formData.get("intent");
     const updates = Object.fromEntries(formData);
@@ -577,7 +581,7 @@ export async function action({ request, context }: Route.ActionArgs) {
                 return redirect("/founder-tools/updates");
             }
 
-            const drafts = await getVibeRaisingDrafts(env, request);
+            const drafts = await getVibeRaisingDrafts(env, request, activeCompanyId);
             console.log("[monthly-update:publish-action] loaded drafts for fallback", JSON.stringify({
                 draftCount: drafts.length,
                 publishableDrafts: drafts
@@ -616,6 +620,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
             const savedUpdate = await saveVibeRaisingMonthlyUpdate(env, request, {
                 ...savePayload,
+                companyId: activeCompanyId,
                 saveMode: "ready",
             });
             if (savedUpdate?.id && BACKEND_DRAFT_ID_PATTERN.test(savedUpdate.id)) {
@@ -701,6 +706,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         try {
             savedUpdate = await saveVibeRaisingMonthlyUpdate(env, request, {
                 ...savePayload,
+                companyId: activeCompanyId,
                 saveMode: "ready",
             });
         } catch (error) {
@@ -738,6 +744,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         try {
             update = await saveVibeRaisingMonthlyUpdate(env, request, {
                 ...savePayload,
+                companyId: activeCompanyId,
                 saveMode: "draft",
             });
         } catch (error) {

--- a/app/routes/vibe-raising-app.drafts.tsx
+++ b/app/routes/vibe-raising-app.drafts.tsx
@@ -14,6 +14,7 @@ import { getEnv } from "~/lib/env.server";
 import {
     getVibeRaisingDrafts,
     requireVibeRaisingFounder,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import {
     ArrowRightIcon,
@@ -93,7 +94,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         throw redirect("/founder-tools/company-setup");
     }
 
-    const drafts = await getVibeRaisingDrafts(env, request);
+    const drafts = await getVibeRaisingDrafts(env, request, resolveActiveCompanyId(appUser));
 
     return {
         drafts,

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/vibe-raising-app";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Outlet,
   redirect,
@@ -18,6 +18,8 @@ import { getCurrentRooPointsBalance } from "~/lib/roo-points";
 import {
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
+  resolveActiveCompanyId,
+  setVibeRaisingBrowserCompanyScope,
 } from "~/lib/vibe-raising";
 import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import {
@@ -130,6 +132,14 @@ export default function VibeRaisingApp() {
     appUser && appUser.companies.length > 0 ? (
       <CompanySwitcher companies={appUser.companies} activeCompanyId={appUser.activeCompanyId ?? null} />
     ) : undefined;
+
+  // Pin this tab's browser-side API calls (previews, selections, uploads,
+  // email-draft polling) to the company this render is for, so a switch in
+  // another tab can't redirect them to a sibling startup.
+  const scopedCompanyId = resolveActiveCompanyId(appUser);
+  useEffect(() => {
+    setVibeRaisingBrowserCompanyScope(scopedCompanyId);
+  }, [scopedCompanyId]);
 
   return (
     <AuthenticatedLayout

--- a/app/routes/vibe-raising-app.update-detail.tsx
+++ b/app/routes/vibe-raising-app.update-detail.tsx
@@ -6,6 +6,7 @@ import {
     getOptionalVibeRaisingContext,
     getVibeRaisingLoginHref,
     getVibeRaisingMonthlyUpdatesBundle,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import VRPreviewUpdateCard from "~/components/vibe-raising/VRPreviewUpdateCard";
 import TrendsSection from "~/components/vibe-raising/TrendsSection";
@@ -22,7 +23,7 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
         throw redirect("/founder-tools/updates");
     }
 
-    const { updates, metricHistory } = await getVibeRaisingMonthlyUpdatesBundle(env, request);
+    const { updates, metricHistory } = await getVibeRaisingMonthlyUpdatesBundle(env, request, resolveActiveCompanyId(vibeContext.appUser));
     const update = updates.find((item) => String(item.id) === String(params.id));
     if (!update) {
         throw new Response("Update not found", { status: 404 });


### PR DESCRIPTION
## Why

Wins 1–3 (#1308) scoped the vibe-marketing surface, but the Vibe Raising side — monthly updates, drafts, uploads, email drafts, and every Data Sources browser call — still trusted the backend's mutable server-side `active_company`. A company switch in another tab mid-create-update wrote the update, metrics and source selections to the **wrong company** with no error.

**Stacked on** `claude/multi-company-wins-1-3` (#1308) — retarget to `main` after it merges.

## What

**Server-side fetchers + loaders (explicit `companyId`):**
- `getVibeRaisingMonthlyUpdatesBundle` / `MonthlyUpdates` / `Drafts` / `MonthlyUpdateById` gain optional `companyId`; `saveVibeRaisingMonthlyUpdate` carries it in the body.
- Threaded via `resolveActiveCompanyId` through the updates list, drafts, update-detail, create-update (loader + all save intents) and companies routes.
- The companies-page switch action now checks the **switched-to** company's updates when picking its landing page.

**Browser-side calls (per-tab company scope):**
- All ~25 browser helpers funnel through `requestBrowserJson`; a client-only module scope — set by the founder-tools shell from loader data — appends `company_id` to every call: integration previews, channel/project/property/event selections, video/pitch-deck/manual-document uploads, email-draft start/status and the active-run banner poll.
- SSR never sets the scope (module state is shared across requests on Workers); paths that already carry an explicit `company_id` are left untouched; signed-URL uploads bypass the helper and are unaffected.

## Verification

`react-router typegen && tsc -b` clean.

## Pairs with

mlai-backend [#510](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/510), which resolves `company_id` on all 16 Vibe Raising founder endpoints and the connector status/sync/preview/selection/OAuth-start/Gmail-disconnect surfaces. This PR degrades gracefully without it (backends ignore the extra param until #510 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)