### PR TITLE
Multi-company Win 5: surface the domain-change data guard (confirm plumbing + moves-data prompt)

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -2360,13 +2360,20 @@ export default function VibeMarketingStartupBaselineSetup({
       <input type="hidden" name="companyContext" value={companyContext} />
       {activeDomainConflict ? (
         <div className="border-b border-amber-200 bg-amber-50 px-6 py-4">
-          <p className="text-sm font-bold leading-6 text-amber-900">
-            This looks like a different company.{" "}
-            <span className="font-black">{activeDomainConflict.activeCompanyName || "Your current company"}</span> is set
-            up on <span className="font-black">{activeDomainConflict.activeCompanyDomain}</span>, but these details are
-            for <span className="font-black">{activeDomainConflict.submittedDomain}</span>. Adding it as a new company
-            keeps each startup's articles, updates and integrations separate.
-          </p>
+          {activeDomainConflict.kind === "moves_data" ? (
+            <p className="text-sm font-bold leading-6 text-amber-900">
+              {activeDomainConflict.detail ||
+                `Moving ${activeDomainConflict.activeCompanyName || "your current company"} from ${activeDomainConflict.activeCompanyDomain} to ${activeDomainConflict.submittedDomain} disconnects its existing integrations, article runs and updates.`}
+            </p>
+          ) : (
+            <p className="text-sm font-bold leading-6 text-amber-900">
+              This looks like a different company.{" "}
+              <span className="font-black">{activeDomainConflict.activeCompanyName || "Your current company"}</span> is set
+              up on <span className="font-black">{activeDomainConflict.activeCompanyDomain}</span>, but these details are
+              for <span className="font-black">{activeDomainConflict.submittedDomain}</span>. Adding it as a new company
+              keeps each startup's articles, updates and integrations separate.
+            </p>
+          )}
           <div className="mt-3 flex flex-wrap gap-2">
             {activeDomainConflict.sourceIntent === "start-autofill" ? (
               <>
@@ -2382,7 +2389,9 @@ export default function VibeMarketingStartupBaselineSetup({
                   onClick={() => startAutofill("update-existing")}
                   className="rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
                 >
-                  Update {activeDomainConflict.activeCompanyName || "the existing company"} to this domain
+                  {activeDomainConflict.kind === "moves_data"
+                    ? `Move ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain anyway`
+                    : `Update ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain`}
                 </button>
               </>
             ) : (
@@ -2401,7 +2410,9 @@ export default function VibeMarketingStartupBaselineSetup({
                   value="update-existing"
                   className="rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
                 >
-                  Update {activeDomainConflict.activeCompanyName || "the existing company"} to this domain
+                  {activeDomainConflict.kind === "moves_data"
+                    ? `Move ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain anyway`
+                    : `Update ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain`}
                 </button>
               </>
             )}

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1295,6 +1295,25 @@ function readableBrowserError(data: unknown, status: number): string {
   return `Request failed with status ${status}`;
 }
 
+// Which company this tab's browser-side API calls target. Set from loader data
+// by the founder-tools shell, so a company switch in ANOTHER tab (which
+// mutates the backend's shared active_company) can't redirect this tab's
+// previews, selections, uploads and email-draft calls to the wrong startup.
+// Client-only: never set during SSR, where module scope is shared across
+// requests.
+let browserCompanyScopeId: string | null = null;
+
+export function setVibeRaisingBrowserCompanyScope(companyId: string | null) {
+  if (typeof window === "undefined") return;
+  browserCompanyScopeId = companyId;
+}
+
+function withBrowserCompanyScope(path: string): string {
+  if (typeof window === "undefined" || !browserCompanyScopeId) return path;
+  if (path.includes("company_id=") || path.includes("companyId=")) return path;
+  return `${path}${path.includes("?") ? "&" : "?"}company_id=${encodeURIComponent(browserCompanyScopeId)}`;
+}
+
 async function requestBrowserJson<T>(
   backendBaseUrl: string,
   path: string,
@@ -1314,7 +1333,7 @@ async function requestBrowserJson<T>(
     headers.set("Content-Type", "application/json");
   }
 
-  const targetUrl = buildAbsoluteBackendUrl(backendBaseUrl, path);
+  const targetUrl = buildAbsoluteBackendUrl(backendBaseUrl, withBrowserCompanyScope(path));
   let response: Response;
   try {
     response = await fetch(targetUrl, {
@@ -2292,6 +2311,7 @@ const DEV_MONTHLY_UPDATES_BUNDLE_STUB: VibeRaisingMonthlyUpdatesBundle = {
 export async function getVibeRaisingMonthlyUpdatesBundle(
   env: Env,
   request: Request,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdatesBundle> {
   if (shouldUseDevBackendStub()) {
     return mergeLocalPublishedUpdate(DEV_MONTHLY_UPDATES_BUNDLE_STUB, request);
@@ -2299,7 +2319,9 @@ export async function getVibeRaisingMonthlyUpdatesBundle(
   const client = createApiClient(env, request);
 
   try {
-    const response = await client.get(UPDATES_PATH);
+    const response = await client.get(
+      companyId ? `${UPDATES_PATH}?company_id=${encodeURIComponent(companyId)}` : UPDATES_PATH,
+    );
     const updates: unknown[] = Array.isArray(response.data?.updates) ? response.data.updates : [];
     return mergeLocalPublishedUpdate({
       updates: updates
@@ -2336,13 +2358,15 @@ export async function getVibeRaisingMonthlyUpdatesBundle(
 export async function getVibeRaisingMonthlyUpdates(
   env: Env,
   request: Request,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdate[]> {
-  return (await getVibeRaisingMonthlyUpdatesBundle(env, request)).updates;
+  return (await getVibeRaisingMonthlyUpdatesBundle(env, request, companyId)).updates;
 }
 
 export async function getVibeRaisingDrafts(
   env: Env,
   request: Request,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdate[]> {
   if (shouldUseDevBackendStub()) {
     return mergeLocalDraftUpdate(DEV_MONTHLY_DRAFTS_STUB, request);
@@ -2350,7 +2374,9 @@ export async function getVibeRaisingDrafts(
 
   const client = createApiClient(env, request);
   try {
-    const response = await client.get(DRAFTS_PATH);
+    const response = await client.get(
+      companyId ? `${DRAFTS_PATH}?company_id=${encodeURIComponent(companyId)}` : DRAFTS_PATH,
+    );
     const drafts: unknown[] = Array.isArray(response.data?.drafts) ? response.data.drafts : [];
     return mergeLocalDraftUpdate(
       drafts
@@ -2386,10 +2412,11 @@ export async function getVibeRaisingMonthlyUpdateById(
   env: Env,
   request: Request,
   updateId: string,
+  companyId?: string | null,
 ): Promise<VibeRaisingMonthlyUpdate | null> {
   const [draftsResult, updatesResult] = await Promise.allSettled([
-    getVibeRaisingDrafts(env, request),
-    getVibeRaisingMonthlyUpdates(env, request),
+    getVibeRaisingDrafts(env, request, companyId),
+    getVibeRaisingMonthlyUpdates(env, request, companyId),
   ]);
   const drafts = draftsResult.status === "fulfilled" ? draftsResult.value : [];
   const updates = updatesResult.status === "fulfilled" ? updatesResult.value : [];
@@ -2410,6 +2437,7 @@ export async function saveVibeRaisingMonthlyUpdate(
   env: Env,
   request: Request,
   body: {
+    companyId?: string | null;
     month: string;
     year: number;
     highlights: string;

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1762,6 +1762,14 @@ export type CompanyDomainConflict = {
   submittedDomain: string;
   activeCompanyName: string;
   activeCompanyDomain: string;
+  /**
+   * "different_company": the submitted domain looks like another startup —
+   * offer add-as-new vs update. "moves_data": the backend refused a domain
+   * change because re-pointing the company would strand its organization's
+   * data (connections/runs/updates) until explicitly confirmed.
+   */
+  kind: "different_company" | "moves_data";
+  detail?: string | null;
 };
 
 /**
@@ -1801,6 +1809,7 @@ export function detectCompanyDomainConflict(
     submittedDomain: submitted,
     activeCompanyName: activeCompany.name,
     activeCompanyDomain: existing,
+    kind: "different_company",
   };
 }
 
@@ -1814,13 +1823,28 @@ export function companyDomainConflictFromError(
     response?: { data?: Record<string, unknown> };
   } | null;
   const data = payload?.response?.data ?? payload?.data;
-  if (!data || data.code !== "company_domain_change_requires_confirmation") return null;
-  return {
-    sourceIntent,
-    submittedDomain: String(data.submittedDomain ?? ""),
-    activeCompanyName: String(data.companyName ?? "your current company"),
-    activeCompanyDomain: String(data.existingDomain ?? ""),
-  };
+  if (!data) return null;
+  if (data.code === "company_domain_change_requires_confirmation") {
+    return {
+      sourceIntent,
+      submittedDomain: String(data.submittedDomain ?? ""),
+      activeCompanyName: String(data.companyName ?? "your current company"),
+      activeCompanyDomain: String(data.existingDomain ?? ""),
+      kind: "different_company",
+      detail: typeof data.detail === "string" ? data.detail : null,
+    };
+  }
+  if (data.code === "company_domain_change_moves_data") {
+    return {
+      sourceIntent,
+      submittedDomain: String(data.newDomain ?? ""),
+      activeCompanyName: String(data.companyName ?? "your current company"),
+      activeCompanyDomain: String(data.currentDomain ?? ""),
+      kind: "moves_data",
+      detail: typeof data.detail === "string" ? data.detail : null,
+    };
+  }
+  return null;
 }
 
 export function domainConflictFromActionData(actionData: unknown): CompanyDomainConflict | null {
@@ -1834,6 +1858,8 @@ export function domainConflictFromActionData(actionData: unknown): CompanyDomain
     submittedDomain: String(payload.submittedDomain),
     activeCompanyName: String(payload.activeCompanyName ?? "your current company"),
     activeCompanyDomain: String(payload.activeCompanyDomain),
+    kind: payload.kind === "moves_data" ? "moves_data" : "different_company",
+    detail: typeof payload.detail === "string" ? payload.detail : null,
   };
 }
 
@@ -2055,6 +2081,7 @@ export async function saveVibeRaisingCompany(
   body: {
     companyId?: string | null;
     createNew?: boolean;
+    confirmDomainChange?: boolean;
     name: string;
     domain?: string | null;
     companyLinkedInUrl?: string | null;

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -568,6 +568,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       const companyId = await saveVibeRaisingCompany(env, request, {
         companyId: createAsNew ? null : activeCompany?.id ?? null,
         createNew: createAsNew,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         name: stringFromForm(formData, "companyName"),
         domain: stringFromForm(formData, "domain"),
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -15,6 +15,8 @@ import {
   verifyNotificationChannelOtp,
 } from "~/lib/vibe-marketing";
 import {
+  companyDomainConflictFromError,
+  domainConflictFromActionData,
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
   resolveActiveCompanyId,
@@ -89,10 +91,15 @@ export async function action({ request, context }: Route.ActionArgs) {
   }
 
   const { founderProfiles, founderNames } = founderNamesFromForm(formData);
+  // Set by the inline confirm banner after a company_domain_change_moves_data
+  // 409: the founder has acknowledged that moving domains strands the old
+  // organization's data.
+  const confirmDomainChange = stringFromForm(formData, "confirmDomainChange") === "true";
 
   try {
     await saveVibeRaisingCompany(env, request, {
       companyId: activeCompany?.id ?? null,
+      confirmDomainChange: confirmDomainChange || undefined,
       name: stringFromForm(formData, "companyName"),
       domain: stringFromForm(formData, "domain"),
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
@@ -117,6 +124,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     });
     await saveVibeMarketingSettings(env, request, {
       companyId: activeCompany?.id ?? null,
+      confirmDomainChange: confirmDomainChange || undefined,
       domain: stringFromForm(formData, "domain"),
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
       company_linkedin_url: stringFromForm(formData, "companyLinkedInUrl"),
@@ -132,6 +140,8 @@ export async function action({ request, context }: Route.ActionArgs) {
       defaultTimezone: stringFromForm(formData, "defaultTimezone"),
     });
   } catch (error: any) {
+    const domainConflict = companyDomainConflictFromError(error, "save-settings");
+    if (domainConflict) return { domainConflict };
     return {
       error:
         error?.data?.detail ??
@@ -163,6 +173,7 @@ export default function FounderToolsMarketingSettings() {
     (CHANNEL_INTENTS as readonly string[]).includes(String(actionData.intent))
       ? actionData.error
       : null;
+  const domainConflict = domainConflictFromActionData(actionData);
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
@@ -188,13 +199,29 @@ export default function FounderToolsMarketingSettings() {
         </div>
       ) : null}
 
-      {actionData?.error && !channelError ? (
+      {actionData && "error" in actionData && actionData.error && !channelError ? (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
           {actionData.error}
         </div>
       ) : null}
 
       <Form method="POST" className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        {domainConflict ? (
+          <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+            <p className="text-sm font-bold leading-6 text-amber-900">
+              {domainConflict.detail ||
+                `Moving ${domainConflict.activeCompanyName || "this company"} from ${domainConflict.activeCompanyDomain} to ${domainConflict.submittedDomain} disconnects its existing integrations, article runs and updates.`}
+            </p>
+            <button
+              type="submit"
+              name="confirmDomainChange"
+              value="true"
+              className="mt-3 rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
+            >
+              Move to {domainConflict.submittedDomain} anyway
+            </button>
+          </div>
+        ) : null}
         <FounderStartupDetailsStep
           defaults={{
             companyName: bootstrap.company.name,

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -421,6 +421,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       const companyId = await saveVibeRaisingCompany(env, request, {
         companyId: createAsNew ? null : activeCompany?.id ?? null,
         createNew: createAsNew,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         name,
         domain,
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),

--- a/app/routes/vibe-raising-app._index.tsx
+++ b/app/routes/vibe-raising-app._index.tsx
@@ -6,6 +6,7 @@ import {
     getVibeRaisingMonthlyUpdatesBundle,
     getOptionalVibeRaisingContext,
     getVibeRaisingLoginHref,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import type { VibeRaisingMetricHistory } from "~/types/vibe-raising";
 import { isFounderToolsDiscoverEnabled } from "~/lib/founder-tools-preview";
@@ -62,7 +63,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
     const user = vibeContext.appUser;
     const updatesBundle = user.role === "founder"
-        ? await getVibeRaisingMonthlyUpdatesBundle(env, request)
+        ? await getVibeRaisingMonthlyUpdatesBundle(env, request, resolveActiveCompanyId(user))
         : { updates: [], metricHistory: {} };
     const metricHistory = updatesBundle.metricHistory;
     const updates = updatesBundle.updates.map((update, index) => ({

--- a/app/routes/vibe-raising-app.companies.tsx
+++ b/app/routes/vibe-raising-app.companies.tsx
@@ -28,7 +28,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         Boolean(activeCompany?.id) &&
         (
             hasSubmittedVibeRaisingUpdate(request, activeCompany?.id) ||
-            (await getVibeRaisingMonthlyUpdates(env, request)).length > 0
+            (await getVibeRaisingMonthlyUpdates(env, request, activeCompany?.id ?? null)).length > 0
         );
 
     return { user, activeCompanyId: activeCompany?.id ?? null, activeCompanyHasUpdates };
@@ -49,7 +49,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
         const hasExistingUpdate =
             hasSubmittedVibeRaisingUpdate(request, companyId) ||
-            (await getVibeRaisingMonthlyUpdates(env, request)).length > 0;
+            (await getVibeRaisingMonthlyUpdates(env, request, companyId)).length > 0;
 
         return redirect(hasExistingUpdate ? "/founder-tools/updates" : "/founder-tools/updates/create");
     }

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -347,6 +347,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     const companyId = await saveVibeRaisingCompany(env, request, {
       companyId: createAsNew ? null : activeCompany?.id ?? null,
       createNew: createAsNew,
+      confirmDomainChange: domainDecision === "update-existing" || undefined,
       name: companyName,
       domain,
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -21,6 +21,7 @@ import {
     saveVibeRaisingMonthlyUpdate,
     uploadVibeRaisingPitchDeck,
     uploadVibeRaisingUpdateVideo,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import {
@@ -449,14 +450,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
     let existingData = null;
     if (editId) {
-        const existingUpdate = await getVibeRaisingMonthlyUpdateById(env, request, editId).catch((error) => {
+        const existingUpdate = await getVibeRaisingMonthlyUpdateById(env, request, editId, resolveActiveCompanyId(user)).catch((error) => {
             console.warn("Unable to load Vibe Raising update for editing.", error);
             return null;
         });
         existingData = existingUpdate ? buildExistingUpdateFormData(existingUpdate) : null;
     }
 
-    const existingMonthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request).catch((error) => {
+    const existingMonthlyUpdates = await getVibeRaisingMonthlyUpdates(env, request, resolveActiveCompanyId(user)).catch((error) => {
         console.warn("Unable to load existing Vibe Raising monthly updates for create flow.", error);
         return [];
     });
@@ -557,6 +558,9 @@ function extractVibeRaisingActionError(error: unknown, fallback: string) {
 export async function action({ request, context }: Route.ActionArgs) {
     const env = getEnv(context);
     const { appUser } = await requireVibeRaisingFounder(env, request);
+    // Pin every read and save in this action to the company the page was
+    // rendered for, instead of the backend's mutable active_company.
+    const activeCompanyId = resolveActiveCompanyId(appUser);
     const formData = await request.formData();
     const intent = formData.get("intent");
     const updates = Object.fromEntries(formData);
@@ -577,7 +581,7 @@ export async function action({ request, context }: Route.ActionArgs) {
                 return redirect("/founder-tools/updates");
             }
 
-            const drafts = await getVibeRaisingDrafts(env, request);
+            const drafts = await getVibeRaisingDrafts(env, request, activeCompanyId);
             console.log("[monthly-update:publish-action] loaded drafts for fallback", JSON.stringify({
                 draftCount: drafts.length,
                 publishableDrafts: drafts
@@ -616,6 +620,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 
             const savedUpdate = await saveVibeRaisingMonthlyUpdate(env, request, {
                 ...savePayload,
+                companyId: activeCompanyId,
                 saveMode: "ready",
             });
             if (savedUpdate?.id && BACKEND_DRAFT_ID_PATTERN.test(savedUpdate.id)) {
@@ -701,6 +706,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         try {
             savedUpdate = await saveVibeRaisingMonthlyUpdate(env, request, {
                 ...savePayload,
+                companyId: activeCompanyId,
                 saveMode: "ready",
             });
         } catch (error) {
@@ -738,6 +744,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         try {
             update = await saveVibeRaisingMonthlyUpdate(env, request, {
                 ...savePayload,
+                companyId: activeCompanyId,
                 saveMode: "draft",
             });
         } catch (error) {

--- a/app/routes/vibe-raising-app.drafts.tsx
+++ b/app/routes/vibe-raising-app.drafts.tsx
@@ -14,6 +14,7 @@ import { getEnv } from "~/lib/env.server";
 import {
     getVibeRaisingDrafts,
     requireVibeRaisingFounder,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import {
     ArrowRightIcon,
@@ -93,7 +94,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         throw redirect("/founder-tools/company-setup");
     }
 
-    const drafts = await getVibeRaisingDrafts(env, request);
+    const drafts = await getVibeRaisingDrafts(env, request, resolveActiveCompanyId(appUser));
 
     return {
         drafts,

--- a/app/routes/vibe-raising-app.tsx
+++ b/app/routes/vibe-raising-app.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/vibe-raising-app";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Outlet,
   redirect,
@@ -18,6 +18,8 @@ import { getCurrentRooPointsBalance } from "~/lib/roo-points";
 import {
   getOptionalVibeRaisingContext,
   getVibeRaisingLoginHref,
+  resolveActiveCompanyId,
+  setVibeRaisingBrowserCompanyScope,
 } from "~/lib/vibe-raising";
 import { shouldSkipVibeMarketingCreateRevalidation } from "~/lib/vibe-marketing-step-revalidation";
 import {
@@ -130,6 +132,14 @@ export default function VibeRaisingApp() {
     appUser && appUser.companies.length > 0 ? (
       <CompanySwitcher companies={appUser.companies} activeCompanyId={appUser.activeCompanyId ?? null} />
     ) : undefined;
+
+  // Pin this tab's browser-side API calls (previews, selections, uploads,
+  // email-draft polling) to the company this render is for, so a switch in
+  // another tab can't redirect them to a sibling startup.
+  const scopedCompanyId = resolveActiveCompanyId(appUser);
+  useEffect(() => {
+    setVibeRaisingBrowserCompanyScope(scopedCompanyId);
+  }, [scopedCompanyId]);
 
   return (
     <AuthenticatedLayout

--- a/app/routes/vibe-raising-app.update-detail.tsx
+++ b/app/routes/vibe-raising-app.update-detail.tsx
@@ -6,6 +6,7 @@ import {
     getOptionalVibeRaisingContext,
     getVibeRaisingLoginHref,
     getVibeRaisingMonthlyUpdatesBundle,
+    resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import VRPreviewUpdateCard from "~/components/vibe-raising/VRPreviewUpdateCard";
 import TrendsSection from "~/components/vibe-raising/TrendsSection";
@@ -22,7 +23,7 @@ export async function loader({ request, context, params }: Route.LoaderArgs) {
         throw redirect("/founder-tools/updates");
     }
 
-    const { updates, metricHistory } = await getVibeRaisingMonthlyUpdatesBundle(env, request);
+    const { updates, metricHistory } = await getVibeRaisingMonthlyUpdatesBundle(env, request, resolveActiveCompanyId(vibeContext.appUser));
     const update = updates.find((item) => String(item.id) === String(params.id));
     if (!update) {
         throw new Response("Update not found", { status: 404 });


### PR DESCRIPTION
## Why

Backend Win 5 ([mlai-backend #512](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/512)) stops a domain edit from silently stranding a company's data: it renames the Organization in place when safe, and returns a structured **409 `company_domain_change_moves_data`** when a re-point would detach the company from its integrations, article runs and updates. This PR gives that 409 a real UI.

**Stacked on** `claude/multi-company-win4-frontend` (#1309) → retarget after it merges. Chain: #1308 → #1309 → this.

## What

- `CompanyDomainConflict` gains `kind` (`different_company` | `moves_data`) and `detail`; `companyDomainConflictFromError` maps **both** 409 codes into the existing prompt pipeline.
- The wizard conflict panel (marketing wizard, create wizard, company-setup) shows the backend's stranding explanation for moves-data conflicts and relabels the confirm action to **"Move … to this domain anyway"**; **"Add as a new company"** remains the safe way out.
- Choosing "update existing" now sends `confirmDomainChange` on the **save** path too (it previously only did on autofill), so one prompt covers both intent and data-move confirmation — no double-prompting.
- **Marketing settings** (which has no wizard panel): a blocked domain edit renders an inline amber banner with the explanation and a "Move anyway" resubmit button that threads `confirmDomainChange` through both settings saves.

## Verification

`react-router typegen && tsc -b` clean.

Note: in the common case (typo fix / rebrand to an unused domain) users see **no prompt at all** — the backend renames the org and all data follows. The prompt only appears when the move genuinely detaches data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)