### PR TITLE
Multi-company Win 5 (frontend): domain-change data guard — confirm plumbing + moves-data prompt

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -2360,13 +2360,20 @@ export default function VibeMarketingStartupBaselineSetup({
       <input type="hidden" name="companyContext" value={companyContext} />
       {activeDomainConflict ? (
         <div className="border-b border-amber-200 bg-amber-50 px-6 py-4">
-          <p className="text-sm font-bold leading-6 text-amber-900">
-            This looks like a different company.{" "}
-            <span className="font-black">{activeDomainConflict.activeCompanyName || "Your current company"}</span> is set
-            up on <span className="font-black">{activeDomainConflict.activeCompanyDomain}</span>, but these details are
-            for <span className="font-black">{activeDomainConflict.submittedDomain}</span>. Adding it as a new company
-            keeps each startup's articles, updates and integrations separate.
-          </p>
+          {activeDomainConflict.kind === "moves_data" ? (
+            <p className="text-sm font-bold leading-6 text-amber-900">
+              {activeDomainConflict.detail ||
+                `Moving ${activeDomainConflict.activeCompanyName || "your current company"} from ${activeDomainConflict.activeCompanyDomain} to ${activeDomainConflict.submittedDomain} disconnects its existing integrations, article runs and updates.`}
+            </p>
+          ) : (
+            <p className="text-sm font-bold leading-6 text-amber-900">
+              This looks like a different company.{" "}
+              <span className="font-black">{activeDomainConflict.activeCompanyName || "Your current company"}</span> is set
+              up on <span className="font-black">{activeDomainConflict.activeCompanyDomain}</span>, but these details are
+              for <span className="font-black">{activeDomainConflict.submittedDomain}</span>. Adding it as a new company
+              keeps each startup's articles, updates and integrations separate.
+            </p>
+          )}
           <div className="mt-3 flex flex-wrap gap-2">
             {activeDomainConflict.sourceIntent === "start-autofill" ? (
               <>
@@ -2382,7 +2389,9 @@ export default function VibeMarketingStartupBaselineSetup({
                   onClick={() => startAutofill("update-existing")}
                   className="rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
                 >
-                  Update {activeDomainConflict.activeCompanyName || "the existing company"} to this domain
+                  {activeDomainConflict.kind === "moves_data"
+                    ? `Move ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain anyway`
+                    : `Update ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain`}
                 </button>
               </>
             ) : (
@@ -2401,7 +2410,9 @@ export default function VibeMarketingStartupBaselineSetup({
                   value="update-existing"
                   className="rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
                 >
-                  Update {activeDomainConflict.activeCompanyName || "the existing company"} to this domain
+                  {activeDomainConflict.kind === "moves_data"
+                    ? `Move ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain anyway`
+                    : `Update ${activeDomainConflict.activeCompanyName || "the existing company"} to this domain`}
                 </button>
               </>
             )}

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -1762,6 +1762,14 @@ export type CompanyDomainConflict = {
   submittedDomain: string;
   activeCompanyName: string;
   activeCompanyDomain: string;
+  /**
+   * "different_company": the submitted domain looks like another startup —
+   * offer add-as-new vs update. "moves_data": the backend refused a domain
+   * change because re-pointing the company would strand its organization's
+   * data (connections/runs/updates) until explicitly confirmed.
+   */
+  kind: "different_company" | "moves_data";
+  detail?: string | null;
 };
 
 /**
@@ -1801,6 +1809,7 @@ export function detectCompanyDomainConflict(
     submittedDomain: submitted,
     activeCompanyName: activeCompany.name,
     activeCompanyDomain: existing,
+    kind: "different_company",
   };
 }
 
@@ -1814,13 +1823,28 @@ export function companyDomainConflictFromError(
     response?: { data?: Record<string, unknown> };
   } | null;
   const data = payload?.response?.data ?? payload?.data;
-  if (!data || data.code !== "company_domain_change_requires_confirmation") return null;
-  return {
-    sourceIntent,
-    submittedDomain: String(data.submittedDomain ?? ""),
-    activeCompanyName: String(data.companyName ?? "your current company"),
-    activeCompanyDomain: String(data.existingDomain ?? ""),
-  };
+  if (!data) return null;
+  if (data.code === "company_domain_change_requires_confirmation") {
+    return {
+      sourceIntent,
+      submittedDomain: String(data.submittedDomain ?? ""),
+      activeCompanyName: String(data.companyName ?? "your current company"),
+      activeCompanyDomain: String(data.existingDomain ?? ""),
+      kind: "different_company",
+      detail: typeof data.detail === "string" ? data.detail : null,
+    };
+  }
+  if (data.code === "company_domain_change_moves_data") {
+    return {
+      sourceIntent,
+      submittedDomain: String(data.newDomain ?? ""),
+      activeCompanyName: String(data.companyName ?? "your current company"),
+      activeCompanyDomain: String(data.currentDomain ?? ""),
+      kind: "moves_data",
+      detail: typeof data.detail === "string" ? data.detail : null,
+    };
+  }
+  return null;
 }
 
 export function domainConflictFromActionData(actionData: unknown): CompanyDomainConflict | null {
@@ -1834,6 +1858,8 @@ export function domainConflictFromActionData(actionData: unknown): CompanyDomain
     submittedDomain: String(payload.submittedDomain),
     activeCompanyName: String(payload.activeCompanyName ?? "your current company"),
     activeCompanyDomain: String(payload.activeCompanyDomain),
+    kind: payload.kind === "moves_data" ? "moves_data" : "different_company",
+    detail: typeof payload.detail === "string" ? payload.detail : null,
   };
 }
 
@@ -2055,6 +2081,7 @@ export async function saveVibeRaisingCompany(
   body: {
     companyId?: string | null;
     createNew?: boolean;
+    confirmDomainChange?: boolean;
     name: string;
     domain?: string | null;
     companyLinkedInUrl?: string | null;

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -568,6 +568,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       const companyId = await saveVibeRaisingCompany(env, request, {
         companyId: createAsNew ? null : activeCompany?.id ?? null,
         createNew: createAsNew,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         name: stringFromForm(formData, "companyName"),
         domain: stringFromForm(formData, "domain"),
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -15,6 +15,8 @@ import {
   verifyNotificationChannelOtp,
 } from "~/lib/vibe-marketing";
 import {
+  companyDomainConflictFromError,
+  domainConflictFromActionData,
   getActiveVibeRaisingCompany,
   requireVibeRaisingFounder,
   resolveActiveCompanyId,
@@ -89,10 +91,15 @@ export async function action({ request, context }: Route.ActionArgs) {
   }
 
   const { founderProfiles, founderNames } = founderNamesFromForm(formData);
+  // Set by the inline confirm banner after a company_domain_change_moves_data
+  // 409: the founder has acknowledged that moving domains strands the old
+  // organization's data.
+  const confirmDomainChange = stringFromForm(formData, "confirmDomainChange") === "true";
 
   try {
     await saveVibeRaisingCompany(env, request, {
       companyId: activeCompany?.id ?? null,
+      confirmDomainChange: confirmDomainChange || undefined,
       name: stringFromForm(formData, "companyName"),
       domain: stringFromForm(formData, "domain"),
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
@@ -117,6 +124,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     });
     await saveVibeMarketingSettings(env, request, {
       companyId: activeCompany?.id ?? null,
+      confirmDomainChange: confirmDomainChange || undefined,
       domain: stringFromForm(formData, "domain"),
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),
       company_linkedin_url: stringFromForm(formData, "companyLinkedInUrl"),
@@ -132,6 +140,8 @@ export async function action({ request, context }: Route.ActionArgs) {
       defaultTimezone: stringFromForm(formData, "defaultTimezone"),
     });
   } catch (error: any) {
+    const domainConflict = companyDomainConflictFromError(error, "save-settings");
+    if (domainConflict) return { domainConflict };
     return {
       error:
         error?.data?.detail ??
@@ -163,6 +173,7 @@ export default function FounderToolsMarketingSettings() {
     (CHANNEL_INTENTS as readonly string[]).includes(String(actionData.intent))
       ? actionData.error
       : null;
+  const domainConflict = domainConflictFromActionData(actionData);
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
@@ -188,13 +199,29 @@ export default function FounderToolsMarketingSettings() {
         </div>
       ) : null}
 
-      {actionData?.error && !channelError ? (
+      {actionData && "error" in actionData && actionData.error && !channelError ? (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
           {actionData.error}
         </div>
       ) : null}
 
       <Form method="POST" className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        {domainConflict ? (
+          <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+            <p className="text-sm font-bold leading-6 text-amber-900">
+              {domainConflict.detail ||
+                `Moving ${domainConflict.activeCompanyName || "this company"} from ${domainConflict.activeCompanyDomain} to ${domainConflict.submittedDomain} disconnects its existing integrations, article runs and updates.`}
+            </p>
+            <button
+              type="submit"
+              name="confirmDomainChange"
+              value="true"
+              className="mt-3 rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm font-black text-amber-900 transition hover:bg-amber-100"
+            >
+              Move to {domainConflict.submittedDomain} anyway
+            </button>
+          </div>
+        ) : null}
         <FounderStartupDetailsStep
           defaults={{
             companyName: bootstrap.company.name,

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -421,6 +421,7 @@ export async function action({ request, context }: Route.ActionArgs) {
       const companyId = await saveVibeRaisingCompany(env, request, {
         companyId: createAsNew ? null : activeCompany?.id ?? null,
         createNew: createAsNew,
+        confirmDomainChange: domainDecision === "update-existing" || undefined,
         name,
         domain,
         companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -347,6 +347,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     const companyId = await saveVibeRaisingCompany(env, request, {
       companyId: createAsNew ? null : activeCompany?.id ?? null,
       createNew: createAsNew,
+      confirmDomainChange: domainDecision === "update-existing" || undefined,
       name: companyName,
       domain,
       companyLinkedInUrl: stringFromForm(formData, "companyLinkedInUrl"),


### PR DESCRIPTION
Re-lands the Win 5 frontend commit onto `main`. The original PR #1310 was merged into its stacked base branch (`claude/multi-company-win4-frontend`) rather than `main` because its PR base was never retargeted after #1309 merged — so the changes weren't actually on `main`. This is the identical, already-reviewed diff as a single clean commit on `main`.

Surfaces the backend domain-change data guard ([mlai-backend #512](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/512)):
- `CompanyDomainConflict` gains `kind` (`different_company` | `moves_data`) + `detail`; both 409 codes mapped.
- Wizard conflict panel shows the stranding explanation and a "Move … anyway" action for moves-data conflicts; "Add as a new company" stays the safe out.
- The update-existing decision now sends `confirmDomainChange` on the save path (parity with autofill).
- Marketing settings gets an inline confirm banner + resubmit.

`tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)