### PR TITLE
Multi-company Win 6: danger-zone remove-company on Manage Companies

### DIFF
--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -2123,6 +2123,35 @@ export async function setVibeRaisingActiveCompany(
   await client.post(ACTIVE_COMPANY_PATH, { companyId });
 }
 
+export type VibeRaisingCompanyOffboarding = {
+  companyId: string;
+  gmailDisconnected: boolean;
+  connectionsRemoved: number;
+  orgShared: boolean;
+  orgDataPurged: boolean;
+  newActiveCompanyId?: string | null;
+  warnings: string[];
+};
+
+/**
+ * Delete (offboard) a company: the backend revokes its integrations, purges its
+ * data, re-points the active company, and frees the domain. Returns the
+ * offboarding summary and the refreshed profile's new active company id.
+ */
+export async function deleteVibeRaisingCompany(
+  env: Env,
+  request: Request,
+  companyId: string,
+): Promise<{ offboarding: VibeRaisingCompanyOffboarding | null; newActiveCompanyId: string | null }> {
+  const client = createApiClient(env, request);
+  const response = await client.delete(`${COMPANIES_PATH}${encodeURIComponent(companyId)}/`);
+  const data = (response.data ?? {}) as Record<string, any>;
+  const offboarding = (data.offboarding ?? null) as VibeRaisingCompanyOffboarding | null;
+  const newActiveCompanyId =
+    (data.profile?.activeCompanyId ?? offboarding?.newActiveCompanyId ?? null) || null;
+  return { offboarding, newActiveCompanyId };
+}
+
 // Local dev only: seeded monthly updates so the founder's "My Updates" page
 // shows realistic content without the backend.
 const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [

--- a/app/routes/vibe-raising-app.companies.tsx
+++ b/app/routes/vibe-raising-app.companies.tsx
@@ -1,7 +1,10 @@
 import type { Route } from "./+types/vibe-raising-app.companies";
-import { Link, Form, redirect, useNavigation } from "react-router";
+import { useState } from "react";
+import { Link, Form, redirect, useActionData, useNavigation } from "react-router";
 import { getEnv } from "~/lib/env.server";
+import { readableBackendError } from "~/lib/backend-error";
 import {
+    deleteVibeRaisingCompany,
     getActiveVibeRaisingCompany,
     getVibeRaisingMonthlyUpdates,
     hasSubmittedVibeRaisingUpdate,
@@ -16,6 +19,8 @@ import {
     GlobeAltIcon,
     IdentificationIcon,
     CheckBadgeIcon,
+    TrashIcon,
+    ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import StartupRegionBadge from "~/components/StartupRegionBadge";
 import { clsx } from "clsx";
@@ -53,7 +58,37 @@ export async function action({ request, context }: Route.ActionArgs) {
 
         return redirect(hasExistingUpdate ? "/founder-tools/updates" : "/founder-tools/updates/create");
     }
-    
+
+    if (intent === "delete-company") {
+        const env = getEnv(context);
+        const { appUser: user } = await requireVibeRaisingFounder(env, request);
+        const companyId = formData.get("companyId")?.toString() || "";
+        const target = user.companies.find((company) => company.id === companyId);
+
+        // Ownership is re-checked server-side; this just avoids a pointless call.
+        if (!target) {
+            return { intent, error: "That company could not be found." };
+        }
+        // Guard against a stale form where the typed confirmation no longer matches.
+        const confirmName = formData.get("confirmName")?.toString().trim() ?? "";
+        if (confirmName !== target.name.trim()) {
+            return { intent, error: "Type the company name exactly to confirm removal." };
+        }
+
+        try {
+            await deleteVibeRaisingCompany(env, request, companyId);
+        } catch (error) {
+            return {
+                intent,
+                error: readableBackendError(error, { fallback: "That company could not be removed." }),
+            };
+        }
+
+        // A founder with no companies left onboards again; otherwise back to the list.
+        const remaining = user.companies.filter((company) => company.id !== companyId);
+        return redirect(remaining.length ? "/founder-tools/companies" : "/founder-tools/company-setup");
+    }
+
     return null;
 }
 
@@ -61,7 +96,20 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
     const { user, activeCompanyId, activeCompanyHasUpdates } = loaderData;
     const companies = user.companies || [];
     const navigation = useNavigation();
+    const actionData = useActionData<typeof action>();
     const isSwitching = navigation.state === "submitting" && navigation.formData?.get("intent") === "switch-company";
+    const deletingCompanyId =
+        navigation.state === "submitting" && navigation.formData?.get("intent") === "delete-company"
+            ? navigation.formData?.get("companyId")?.toString() ?? null
+            : null;
+    const deleteError =
+        actionData && "intent" in actionData && actionData.intent === "delete-company"
+            ? (actionData as { error?: string }).error ?? null
+            : null;
+
+    // Which company's danger-zone confirmation is expanded, and the typed name.
+    const [pendingRemovalId, setPendingRemovalId] = useState<string | null>(null);
+    const [confirmName, setConfirmName] = useState("");
 
     const activeCompany = companies.find((c) => c.id === activeCompanyId) || companies[0];
     const otherCompanies = companies.filter((c) => c.id !== activeCompany?.id);
@@ -322,6 +370,102 @@ export default function ManageCompanies({ loaderData }: Route.ComponentProps) {
                     <span className="hidden sm:inline">Register another company</span>
                 </span>
             </Link>
+
+            {/* Danger zone — remove a company (revokes its integrations + deletes its data) */}
+            {companies.length > 0 && (
+                <div
+                    className="rounded-2xl border p-5 sm:p-6"
+                    style={{ borderColor: "rgba(220, 38, 38, 0.25)", background: "rgba(254, 242, 242, 0.5)" }}
+                >
+                    <div className="flex items-center gap-2">
+                        <ExclamationTriangleIcon className="h-5 w-5 text-red-600" />
+                        <h3 className="text-sm font-black uppercase tracking-wide text-red-700">Danger zone</h3>
+                    </div>
+                    <p className="mt-1.5 text-sm font-semibold text-red-900/80">
+                        Removing a company disconnects its integrations (Gmail, Stripe, Notion, Slack, and the rest) and
+                        permanently deletes its updates and articles. This cannot be undone.
+                    </p>
+
+                    <div className="mt-4 space-y-2.5">
+                        {companies.map((company) => {
+                            const isConfirming = pendingRemovalId === company.id;
+                            const isDeleting = deletingCompanyId === company.id;
+                            const confirmMatches = confirmName.trim() === company.name.trim();
+                            return (
+                                <div
+                                    key={company.id}
+                                    className="rounded-xl border bg-white p-4"
+                                    style={{ borderColor: "rgba(220, 38, 38, 0.18)" }}
+                                >
+                                    <div className="flex items-center justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <div className="truncate text-sm font-black text-gray-950">{company.name}</div>
+                                            {company.domain && (
+                                                <div className="truncate text-xs font-semibold text-gray-500">{company.domain}</div>
+                                            )}
+                                        </div>
+                                        {!isConfirming ? (
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    setPendingRemovalId(company.id);
+                                                    setConfirmName("");
+                                                }}
+                                                className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-2 text-xs font-black text-red-700 transition hover:bg-red-50"
+                                            >
+                                                <TrashIcon className="h-4 w-4" />
+                                                Remove
+                                            </button>
+                                        ) : (
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    setPendingRemovalId(null);
+                                                    setConfirmName("");
+                                                }}
+                                                className="shrink-0 rounded-lg px-3 py-2 text-xs font-black text-gray-500 transition hover:text-gray-800"
+                                            >
+                                                Cancel
+                                            </button>
+                                        )}
+                                    </div>
+
+                                    {isConfirming && (
+                                        <Form method="POST" className="mt-3 border-t border-red-100 pt-3">
+                                            <input type="hidden" name="intent" value="delete-company" />
+                                            <input type="hidden" name="companyId" value={company.id} />
+                                            <label className="block text-xs font-bold text-gray-700">
+                                                Type <span className="font-black text-gray-950">{company.name}</span> to confirm
+                                            </label>
+                                            <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                                                <input
+                                                    name="confirmName"
+                                                    value={confirmName}
+                                                    onChange={(event) => setConfirmName(event.target.value)}
+                                                    autoComplete="off"
+                                                    placeholder={company.name}
+                                                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium outline-none focus:border-red-400 focus:ring-4 focus:ring-red-500/10"
+                                                />
+                                                <button
+                                                    type="submit"
+                                                    disabled={!confirmMatches || isDeleting}
+                                                    className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-red-600 px-4 py-2 text-sm font-black text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                                >
+                                                    <TrashIcon className="h-4 w-4" />
+                                                    {isDeleting ? "Removing…" : "Remove company"}
+                                                </button>
+                                            </div>
+                                            {deleteError && (
+                                                <p className="mt-2 text-xs font-bold text-red-700">{deleteError}</p>
+                                            )}
+                                        </Form>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Why

Founders had no way to remove a company created by mistake (e.g. a duplicate) or a startup they shut down — the Manage Companies page only offered switch, edit, and add. Adds a GitHub-style danger zone that offboards a company via the new backend DELETE endpoint ([mlai-backend #513](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/513)), which revokes its integrations and purges its data.

Based on current `main` (includes Wins 1–5).

## What

- `deleteVibeRaisingCompany` fetcher → `DELETE /api/v1/founder-tools/companies/<id>/`, returning the offboarding summary + new active company id.
- **Danger zone** listing every company with a **type-to-confirm** removal: the Remove button reveals an input that must match the company name exactly before the submit enables. The action re-validates the typed name, and ownership is re-checked server-side.
- After removal, a founder with companies left returns to the list; one with none is routed to onboarding. The backend re-points the active company.

## Verification

`react-router typegen && tsc -b` clean.

## Pairs with

mlai-backend [#513](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/513).

🤖 Generated with [Claude Code](https://claude.com/claude-code)