### PR TITLE
Marketing settings: surface and retract learned editorial rules

### DIFF
--- a/app/components/LearnedEditorialRules.tsx
+++ b/app/components/LearnedEditorialRules.tsx
@@ -1,0 +1,126 @@
+import { Form } from "react-router";
+import { CheckCircleIcon } from "@heroicons/react/24/outline";
+import { Sparkles, Trash2 } from "lucide-react";
+import { clsx } from "clsx";
+
+import type { VibeMarketingLearnedRule } from "~/types/vibe-marketing";
+
+export const LEARNED_RULE_INTENTS = ["retract-learned-rule"] as const;
+
+function ScopeChip({ scope }: { scope: string }) {
+  const isDurable = scope !== "one_off";
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-black uppercase tracking-wide",
+        isDurable
+          ? "border-violet-200 bg-violet-50 text-violet-700"
+          : "border-gray-200 bg-gray-100 text-gray-500",
+      )}
+    >
+      {isDurable ? "Every article" : "One-off"}
+    </span>
+  );
+}
+
+function RetractButton({ ruleId, disabled }: { ruleId: string; disabled: boolean }) {
+  return (
+    <Form method="POST" className="inline">
+      <input type="hidden" name="ruleId" value={ruleId} />
+      <button
+        type="submit"
+        name="intent"
+        value="retract-learned-rule"
+        disabled={disabled}
+        className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-black text-gray-600 shadow-sm transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+        Retract
+      </button>
+    </Form>
+  );
+}
+
+function LearnedRuleRow({
+  rule,
+  isSubmitting,
+}: {
+  rule: VibeMarketingLearnedRule;
+  isSubmitting: boolean;
+}) {
+  const target = rule.componentLabel || rule.componentType || null;
+  return (
+    <div className="grid gap-3 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+      <div className="min-w-0 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <ScopeChip scope={rule.scope} />
+          {target ? (
+            <span className="inline-flex items-center rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[11px] font-bold text-gray-600">
+              {target}
+            </span>
+          ) : null}
+          {rule.foldedToSpec ? (
+            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-bold text-emerald-700">
+              <CheckCircleIcon className="h-3 w-3" />
+              In the design specs
+            </span>
+          ) : null}
+        </div>
+        <p className="text-sm font-bold leading-6 text-gray-950">{rule.rule}</p>
+        {rule.specAmendment ? (
+          <p className="text-xs font-medium leading-5 text-gray-600">
+            <span className="font-black text-gray-700">Spec change:</span> {rule.specAmendment}
+          </p>
+        ) : null}
+        {rule.sourceComment ? (
+          <p className="truncate text-xs italic text-gray-400" title={rule.sourceComment}>
+            From your comment: “{rule.sourceComment}”
+          </p>
+        ) : null}
+      </div>
+      <div className="sm:pt-0.5">
+        <RetractButton ruleId={rule.id} disabled={isSubmitting} />
+      </div>
+    </div>
+  );
+}
+
+export default function LearnedEditorialRules({
+  rules,
+  isSubmitting,
+  error,
+}: {
+  rules: VibeMarketingLearnedRule[];
+  isSubmitting: boolean;
+  error?: string | null;
+}) {
+  return (
+    <div>
+      {error ? (
+        <div className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {rules.length === 0 ? (
+        <div className="flex items-start gap-3 rounded-xl border border-dashed border-gray-200 bg-gray-50/60 px-4 py-5">
+          <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-violet-400" />
+          <div>
+            <p className="text-sm font-black text-gray-900">Nothing learned yet</p>
+            <p className="mt-1 text-sm text-gray-600">
+              When you comment on a draft article and accept the AI revision, the durable
+              preferences behind your feedback show up here — and every future article applies
+              them automatically.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100">
+          {rules.map((rule) => (
+            <LearnedRuleRow key={rule.id} rule={rule} isSubmitting={isSubmitting} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -30,6 +30,7 @@ import type {
   VibeMarketingArticlePublishStatus,
   VibeMarketingPublishAttempt,
   VibeMarketingPublishAttemptState,
+  VibeMarketingLearnedRule,
   VibeMarketingTopicCandidate,
   VibeMarketingTopicFeedback,
   VibeMarketingTopicPillar,
@@ -746,6 +747,50 @@ function normalizeTopicFeedback(raw: unknown): VibeMarketingTopicFeedback | null
     restoredAt:
       asNullableString(payload.restoredAt) ??
       asNullableString(payload.restored_at),
+  };
+}
+
+function normalizeLearnedRule(raw: unknown): VibeMarketingLearnedRule | null {
+  const payload = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
+  if (!payload) return null;
+  const id = asNullableString(payload.id);
+  const rule = asNullableString(payload.rule);
+  if (!id || !rule) return null;
+  return {
+    id,
+    rule,
+    scope:
+      asNullableString(payload.scope) ??
+      "durable_preference",
+    status:
+      asNullableString(payload.status) ??
+      asNullableString(payload.promotion_state) ??
+      "promoted",
+    componentId:
+      asNullableString(payload.componentId) ??
+      asNullableString(payload.component_id),
+    componentType:
+      asNullableString(payload.componentType) ??
+      asNullableString(payload.component_type),
+    componentLabel:
+      asNullableString(payload.componentLabel) ??
+      asNullableString(payload.component_label),
+    sourceComment:
+      asNullableString(payload.sourceComment) ??
+      asNullableString(payload.source_comment),
+    specAmendment:
+      asNullableString(payload.specAmendment) ??
+      asNullableString(payload.spec_amendment),
+    appliesToComponentTypes: asStringList(
+      payload.appliesToComponentTypes ?? payload.applies_to_component_types,
+    ),
+    foldedToSpec: asBoolean(payload.foldedToSpec ?? payload.folded_to_spec),
+    createdAt:
+      asNullableString(payload.createdAt) ??
+      asNullableString(payload.created_at),
+    updatedAt:
+      asNullableString(payload.updatedAt) ??
+      asNullableString(payload.updated_at),
   };
 }
 
@@ -1790,6 +1835,43 @@ export async function restoreVibeMarketingTopicFeedback(
     companyId ? { companyId } : {},
   );
   return normalizeTopicFeedback(response.data);
+}
+
+export async function getVibeMarketingLearnedRules(
+  env: Env,
+  request: Request,
+  companyId?: string | null,
+  includeArchived = false,
+) {
+  const client = createApiClient(env, request);
+  const params = new URLSearchParams();
+  if (companyId) params.set("company_id", companyId);
+  if (includeArchived) params.set("include_archived", "1");
+  const query = params.toString() ? `?${params.toString()}` : "";
+  const response = await client.get(`${BASE_PATH}/learned-rules/${query}`);
+  const rawRules = (response.data as { rules?: unknown } | null)?.rules;
+  return Array.isArray(rawRules)
+    ? rawRules
+        .map(normalizeLearnedRule)
+        .filter((rule): rule is VibeMarketingLearnedRule => Boolean(rule))
+    : [];
+}
+
+export async function retractVibeMarketingLearnedRule(
+  env: Env,
+  request: Request,
+  ruleId: string,
+  companyId?: string | null,
+) {
+  const client = createApiClient(env, request);
+  const params = new URLSearchParams();
+  if (companyId) params.set("company_id", companyId);
+  const query = params.toString() ? `?${params.toString()}` : "";
+  const response = await client.delete(
+    `${BASE_PATH}/learned-rules/${encodeURIComponent(ruleId)}/${query}`,
+  );
+  const rawRule = (response.data as { rule?: unknown } | null)?.rule ?? response.data;
+  return normalizeLearnedRule(rawRule);
 }
 
 export async function discardVibeMarketingWrittenArticle(

--- a/app/routes/founder-tools.marketing.settings.tsx
+++ b/app/routes/founder-tools.marketing.settings.tsx
@@ -4,13 +4,16 @@ import { ArrowLeftIcon, ArrowPathIcon, CheckCircleIcon } from "@heroicons/react/
 
 import DailyReminderChannels, { CHANNEL_INTENTS } from "~/components/DailyReminderChannels";
 import FounderStartupDetailsStep from "~/components/FounderStartupDetailsStep";
+import LearnedEditorialRules, { LEARNED_RULE_INTENTS } from "~/components/LearnedEditorialRules";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import {
   createNotificationChannel,
   getVibeMarketingBootstrap,
+  getVibeMarketingLearnedRules,
   removeNotificationChannel,
   resendNotificationChannelCode,
+  retractVibeMarketingLearnedRule,
   saveVibeMarketingSettings,
   verifyNotificationChannelOtp,
 } from "~/lib/vibe-marketing";
@@ -49,9 +52,13 @@ function founderNamesFromForm(formData: FormData) {
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
   const { appUser } = await requireVibeRaisingFounder(env, request);
-  return {
-    bootstrap: await getVibeMarketingBootstrap(env, request, resolveActiveCompanyId(appUser)),
-  };
+  const companyId = resolveActiveCompanyId(appUser);
+  const [bootstrap, learnedRules] = await Promise.all([
+    getVibeMarketingBootstrap(env, request, companyId),
+    // Never let a learned-rules fetch failure take down the whole settings page.
+    getVibeMarketingLearnedRules(env, request, companyId).catch(() => []),
+  ]);
+  return { bootstrap, learnedRules };
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
@@ -85,6 +92,29 @@ export async function action({ request, context }: Route.ActionArgs) {
           error?.response?.data?.detail ??
           error?.message ??
           "That channel action could not be completed.",
+      };
+    }
+    return { intent };
+  }
+
+  if ((LEARNED_RULE_INTENTS as readonly string[]).includes(intent)) {
+    try {
+      if (intent === "retract-learned-rule") {
+        await retractVibeMarketingLearnedRule(
+          env,
+          request,
+          stringFromForm(formData, "ruleId"),
+          activeCompany?.id ?? null,
+        );
+      }
+    } catch (error: any) {
+      return {
+        intent,
+        error:
+          error?.data?.detail ??
+          error?.response?.data?.detail ??
+          error?.message ??
+          "That rule could not be retracted.",
       };
     }
     return { intent };
@@ -161,7 +191,7 @@ const EMAIL_CHANNEL_BANNERS: Record<string, { tone: "success" | "error"; message
 };
 
 export default function FounderToolsMarketingSettings() {
-  const { bootstrap } = useLoaderData<typeof loader>();
+  const { bootstrap, learnedRules } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
@@ -171,6 +201,11 @@ export default function FounderToolsMarketingSettings() {
   const channelError =
     actionData && "intent" in actionData && actionData.error &&
     (CHANNEL_INTENTS as readonly string[]).includes(String(actionData.intent))
+      ? actionData.error
+      : null;
+  const learnedRuleError =
+    actionData && "intent" in actionData && actionData.error &&
+    (LEARNED_RULE_INTENTS as readonly string[]).includes(String(actionData.intent))
       ? actionData.error
       : null;
   const domainConflict = domainConflictFromActionData(actionData);
@@ -199,7 +234,7 @@ export default function FounderToolsMarketingSettings() {
         </div>
       ) : null}
 
-      {actionData && "error" in actionData && actionData.error && !channelError ? (
+      {actionData && "error" in actionData && actionData.error && !channelError && !learnedRuleError ? (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
           {actionData.error}
         </div>
@@ -287,6 +322,21 @@ export default function FounderToolsMarketingSettings() {
             isSubmitting={isSubmitting}
             error={channelError}
             errorIntent={actionData && "intent" in actionData ? String(actionData.intent) : null}
+          />
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-black text-gray-950">Learned editorial rules</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Preferences the content factory picked up from the article revisions you accepted. Every
+          future article applies these automatically — retract any you no longer want.
+        </p>
+        <div className="mt-4">
+          <LearnedEditorialRules
+            rules={learnedRules}
+            isSubmitting={isSubmitting}
+            error={learnedRuleError}
           />
         </div>
       </section>

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -437,6 +437,28 @@ export interface VibeMarketingTopicFeedback {
   restoredAt?: string | null;
 }
 
+/**
+ * A durable editorial preference the content factory learned from a founder's
+ * accepted article-revision comments. `scope` is "durable_preference" (feeds every
+ * future article) or "one_off"; `status` is candidate/promoted/archived. Promoted rules
+ * with component targets get `foldedToSpec` once merged into the article-kit specs.
+ */
+export interface VibeMarketingLearnedRule {
+  id: string;
+  rule: string;
+  scope: string;
+  status: string;
+  componentId?: string | null;
+  componentType?: string | null;
+  componentLabel?: string | null;
+  sourceComment?: string | null;
+  specAmendment?: string | null;
+  appliesToComponentTypes: string[];
+  foldedToSpec: boolean;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
 export type VibeMarketingArticlePublishStatus =
   | "written"
   | "pr_open"


### PR DESCRIPTION
## Why

The content factory now learns durable editorial preferences from a founder's accepted article revisions (backend: MLAI-AUS-Inc/mlai-backend#511) and exposes them at `GET`/`DELETE /api/v1/vibe-marketing/learned-rules/`. This is the founder-facing UI for that data — visibility into what the factory has learned, and the ability to retract a rule so future articles stop applying it.

## What

A **"Learned editorial rules"** panel on the marketing settings page (`/founder-tools/marketing/settings`), placed alongside notification channels since learned rules are per-site config. Each rule shows its text, a scope chip (*Every article* vs *One-off*), the target component, an *In the design specs* badge when it's been folded into the article-kit specs, the spec amendment, and the source comment — with a **Retract** button. Friendly empty state before anything is learned.

Files:
- `app/types/vibe-marketing.ts` — `VibeMarketingLearnedRule` type.
- `app/lib/vibe-marketing.ts` — `normalizeLearnedRule`, `getVibeMarketingLearnedRules` (GET), `retractVibeMarketingLearnedRule` (DELETE); `company_id` threaded through both for multi-startup correctness.
- `app/components/LearnedEditorialRules.tsx` — the panel (new).
- `app/routes/founder-tools.marketing.settings.tsx` — parallel loader fetch (resilient: a learned-rules failure can't take down settings), a `retract-learned-rule` action intent, and the rendered section.

Mirrors the existing `DailyReminderChannels` settings pattern (dedicated component + intent-based action) rather than inventing a new one.

## Verification

`tsc -b` clean and a full `react-router build` succeeds (whole module graph including the new component compiles). No live visual render — that needs a founder session + backend, which isn't set up in this environment; worth a look during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)