### PR TITLE
Baseline page: unified verdict, score-coverage disclosure, honest GSC connect states

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -625,6 +625,24 @@ function baselineSummaryText(summary: VibeMarketingWebsiteBaseline["summary"]) {
   return "Run a baseline to capture website health, search visibility, authority, AI visibility, and traffic before article generation starts.";
 }
 
+function baselineMeasuredCounts(baseline: VibeMarketingWebsiteBaseline) {
+  const entries = Object.values(baseline.metrics ?? {});
+  const measured = entries.filter((metric) => metric && typeof metric === "object" && metric.status === "measured").length;
+  return { measured, total: entries.length };
+}
+
+// Single narrative derived from the same bands as the scorecard legend, so the
+// status pill, the band label, and this text can never contradict each other.
+function baselineNarrative(baseline: VibeMarketingWebsiteBaseline) {
+  const score = clampScore(baseline.overallScore);
+  if (score === null) return baselineSummaryText(baseline.summary);
+  const band = baselineScoreBand(score);
+  const counts = baselineMeasuredCounts(baseline);
+  const coverageNote =
+    counts.total > 0 && counts.measured < counts.total ? ` Based on ${counts.measured} of ${counts.total} measured areas.` : "";
+  return `${band.label}: ${band.description}${coverageNote}`;
+}
+
 function metricStatus(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
   const message = typeof metric?.message === "string" ? metric.message : "";
   if (label === "Lighthouse" && /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message)) {
@@ -649,6 +667,9 @@ function metricMessage(label: string, metric?: VibeMarketingWebsiteBaselineMetri
   }
   if (label === "Lighthouse" && looksLikeTechnicalBaselineMessage(message)) {
     return "PageSpeed Insights could not load right now. You can keep going and retry later.";
+  }
+  if (label === "Traffic/users" && message && /accessnotconfigured|api has not been used/i.test(message)) {
+    return "Search Console is connected, but Google's Search Console API is currently disabled for this app. Retry once it is re-enabled — your connection is fine.";
   }
   if (label === "Traffic/users" && looksLikeTechnicalBaselineMessage(message)) {
     return "Search Console traffic lookup failed. You can keep going and retry it later.";
@@ -728,7 +749,9 @@ function baselineStatusLabel(baseline: VibeMarketingWebsiteBaseline, active: boo
   if (active) return "Collecting baseline";
   if (baseline.skipped) return "Skipped";
   if (baseline.stale) return "Baseline stale";
-  if (baseline.passed || baseline.status === "completed" || typeof baseline.overallScore === "number") return "Baseline ready";
+  // "Collected" is a collection status, not a quality verdict — the band label
+  // (Strong/Fair/Needs work) carries the verdict, so the two can't contradict.
+  if (baseline.passed || baseline.status === "completed" || typeof baseline.overallScore === "number") return "Baseline collected";
   return "Baseline needed";
 }
 
@@ -2041,7 +2064,9 @@ export default function VibeMarketingStartupBaselineSetup({
         ? baselineHasSnapshot
           ? trafficMetricMessage ?? "Search Console is connected. Traffic data will load automatically."
           : "Search Console is connected. Run a baseline snapshot first, then traffic can load."
-        : trafficMetricMessage ?? "Connect Search Console to include verified traffic data.";
+        : bootstrap.googleBaselineConnection?.connected
+          ? "Google is connected, but Search Console access wasn't granted. Reconnect and approve Search Console read-only access."
+          : trafficMetricMessage ?? "Connect Search Console to include verified traffic data.";
   const trafficDisplayMetric: VibeMarketingWebsiteBaselineMetric = {
     ...(trafficMetric ?? {}),
     status: trafficStatus ?? trafficMetric?.status,
@@ -2053,6 +2078,17 @@ export default function VibeMarketingStartupBaselineSetup({
   const baselineDomain = effectiveBaseline.domain || startupValues.domain || bootstrap.organization.domain || bootstrap.company.domain || "No domain saved yet";
   const baselineScore = clampScore(effectiveBaseline.overallScore);
   const baselineBand = baselineScoreBand(baselineScore);
+  const baselineMeasured = baselineMeasuredCounts(effectiveBaseline);
+  const baselineCoverage =
+    typeof effectiveBaseline.scoreCoverage === "number"
+      ? Math.min(100, Math.max(0, Math.round(effectiveBaseline.scoreCoverage)))
+      : null;
+  const baselineCoverageLabel =
+    baselineScore !== null && baselineMeasured.total > 0 && baselineMeasured.measured < baselineMeasured.total
+      ? `Measured ${baselineMeasured.measured} of ${baselineMeasured.total} areas${
+          baselineCoverage !== null ? ` (${baselineCoverage}% of score weight)` : ""
+        } — the score reflects measured areas only.`
+      : null;
   const baselineCollectedLabel = effectiveBaseline.collectedAt ? formatStableDate(effectiveBaseline.collectedAt) : "Not collected yet";
   const coreWebVitalsMetric = deriveCoreWebVitalsMetric(baselineMetrics);
   const baselineActionError = baselineStartData?.error ?? googleBaselineFetcher.data?.error ?? skipBaselineFetcher.data?.error ?? null;
@@ -3067,7 +3103,9 @@ export default function VibeMarketingStartupBaselineSetup({
                     className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-black text-gray-800 shadow-sm transition hover:bg-gray-50"
                   >
                     <GoogleIcon />
-                    Connect Google Search Console
+                    {bootstrap.googleBaselineConnection?.connected
+                      ? "Reconnect Google — add Search Console access"
+                      : "Connect Google Search Console"}
                     <ExternalLink className="h-3.5 w-3.5" />
                   </a>
                 ) : (
@@ -3088,7 +3126,7 @@ export default function VibeMarketingStartupBaselineSetup({
                     We&apos;ll collect the latest data and calculate your starting metrics across SEO, visibility, and traffic.
                   </p>
                   <p className="mt-4 text-sm font-black text-gray-950">{baselineDomain}</p>
-                  <p className="mt-1 text-sm font-semibold text-gray-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
+                  <p className="mt-1 text-sm font-semibold text-gray-600">{baselineNarrative(effectiveBaseline)}</p>
                   <p className="mt-2 text-xs font-semibold text-gray-500">
                     Last updated: {baselineCollectedLabel}
                     {effectiveBaseline.stale ? " · stale" : ""}
@@ -3134,9 +3172,9 @@ export default function VibeMarketingStartupBaselineSetup({
                 {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
                 <span>
                   {baselineRun?.status === "completed"
-                    ? "Baseline ready"
+                    ? "Baseline collected"
                     : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
-                      ? "Baseline needs attention"
+                      ? "Baseline collection failed"
                       : "Collecting baseline"}
                 </span>
               </div>
@@ -3150,15 +3188,20 @@ export default function VibeMarketingStartupBaselineSetup({
               <MetricInfoTooltip label="Baseline scorecard" body={metricHelpText("Baseline scorecard")} />
             </div>
             <div className="mt-4 grid gap-6 lg:grid-cols-[1.1fr_1fr_1.5fr] lg:items-center">
-              <div className="flex items-center gap-5">
-                <div>
-                  <p className="text-sm font-semibold text-gray-600">Overall baseline score</p>
-                  <div className="mt-2 flex items-end gap-2">
-                    <span className="text-5xl font-black text-gray-950">{baselineScore === null ? "-" : baselineScore}</span>
-                    <span className="pb-2 text-sm font-black text-gray-500">out of 100</span>
+              <div>
+                <div className="flex items-center gap-5">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-600">Overall baseline score</p>
+                    <div className="mt-2 flex items-end gap-2">
+                      <span className="text-5xl font-black text-gray-950">{baselineScore === null ? "-" : baselineScore}</span>
+                      <span className="pb-2 text-sm font-black text-gray-500">out of 100</span>
+                    </div>
                   </div>
+                  <BaselineScoreRing score={baselineScore} tone={baselineBand.tone} />
                 </div>
-                <BaselineScoreRing score={baselineScore} tone={baselineBand.tone} />
+                {baselineCoverageLabel ? (
+                  <p className="mt-3 text-xs font-bold leading-5 text-gray-500">{baselineCoverageLabel}</p>
+                ) : null}
               </div>
 
               <div className="border-gray-100 lg:border-l lg:pl-6">

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1173,6 +1173,12 @@ function normalizeWebsiteBaseline(raw: unknown): VibeMarketingWebsiteBaseline {
         : typeof payload.overall_score === "number"
           ? payload.overall_score
           : null,
+    scoreCoverage:
+      typeof payload.scoreCoverage === "number"
+        ? payload.scoreCoverage
+        : typeof payload.score_coverage === "number"
+          ? payload.score_coverage
+          : null,
     summary:
       typeof summary === "string" || (summary && typeof summary === "object")
         ? (summary as VibeMarketingWebsiteBaseline["summary"])

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -1634,6 +1634,23 @@ function baselineSummaryText(summary: VibeMarketingWebsiteBaseline["summary"]) {
   return "Run a baseline to capture website health, search visibility, authority, AI visibility, and traffic before article generation starts.";
 }
 
+// Same bands as the baseline scorecard legend (80+/50+), so the dashboard strip
+// can't contradict the score shown next to it.
+function baselineNarrative(baseline: VibeMarketingWebsiteBaseline) {
+  const score = typeof baseline.overallScore === "number" ? Math.min(100, Math.max(0, Math.round(baseline.overallScore))) : null;
+  if (score === null) return baselineSummaryText(baseline.summary);
+  const band =
+    score >= 80
+      ? { label: "Strong", description: "You're well positioned to rank." }
+      : score >= 50
+        ? { label: "Fair", description: "You're on the right track with room to grow." }
+        : { label: "Needs work", description: "Important areas need attention." };
+  const entries = Object.values(baseline.metrics ?? {});
+  const measured = entries.filter((metric) => metric && typeof metric === "object" && metric.status === "measured").length;
+  const coverageNote = entries.length > 0 && measured < entries.length ? ` Based on ${measured} of ${entries.length} measured areas.` : "";
+  return `${band.label}: ${band.description}${coverageNote}`;
+}
+
 function metricStatus(label: string, metric?: VibeMarketingWebsiteBaselineMetric) {
   const message = typeof metric?.message === "string" ? metric.message : "";
   if (label === "Lighthouse" && /429|too many requests|googleapis|pagespeedonline|runpagespeed/i.test(message)) {
@@ -2295,7 +2312,9 @@ function FirstArticleSetupPage({
                     className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-black text-slate-800 shadow-sm transition hover:bg-slate-50"
                   >
                     <GoogleIcon />
-                    Connect Google Search Console
+                    {bootstrap.googleBaselineConnection?.connected
+                      ? "Reconnect Google — add Search Console access"
+                      : "Connect Google Search Console"}
                     <ExternalLink className="h-3.5 w-3.5" />
                   </a>
                 ) : (
@@ -2317,7 +2336,7 @@ function FirstArticleSetupPage({
                     This can run without Search Console. Use it to compare future article growth against today&apos;s website state.
                   </p>
                   <p className="mt-3 text-sm font-black text-slate-950">{effectiveBaseline.domain || startupValues.domain || "No domain saved yet"}</p>
-                  <p className="mt-1 text-sm font-semibold text-slate-600">{baselineSummaryText(effectiveBaseline.summary)}</p>
+                  <p className="mt-1 text-sm font-semibold text-slate-600">{baselineNarrative(effectiveBaseline)}</p>
                   {effectiveBaseline.collectedAt ? (
                     <p className="mt-1 text-xs font-semibold text-slate-500">
                       Collected {formatStableDate(effectiveBaseline.collectedAt, "recently")}
@@ -2360,9 +2379,9 @@ function FirstArticleSetupPage({
                 {baselinePending || baselinePolling ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
                 <span>
                   {baselineRun?.status === "completed"
-                    ? "Baseline ready"
+                    ? "Baseline collected"
                     : baselineRun?.status === "failed" || baselineRun?.status === "blocked"
-                      ? "Baseline needs attention"
+                      ? "Baseline collection failed"
                       : "Collecting baseline"}
                 </span>
               </div>

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -759,6 +759,7 @@ export interface VibeMarketingWebsiteBaseline {
   skipReason?: string | null;
   collectedAt?: string | null;
   overallScore?: number | null;
+  scoreCoverage?: number | null;
   summary?: string | Record<string, unknown> | null;
   metrics?: Record<string, VibeMarketingWebsiteBaselineMetric>;
   sourceStatus?: Record<string, string>;


### PR DESCRIPTION
## Why

For scores 50–59 the baseline section showed three contradictory verdicts simultaneously: pill **"Baseline ready"**, band **"Fair"**, and step-2 text **"Website baseline needs attention."** (the producer's summary used different thresholds than the scorecard legend). The 59/100 ring also gave no hint that ~half its weight was unmeasured, and a Search Console failure looked identical to never having connected.

## Changes

- **One verdict source**: the pill/run box now report collection status ("Baseline collected" / "Baseline collection failed"), and the step-2 narrative derives from the same 80/50 bands as the scorecard legend via `baselineNarrative()` (both on the create page and the dashboard strip, which had its own drifted copy).
- **Coverage disclosure**: new caption under the score — "Measured N of M areas (X% of score weight) — the score reflects measured areas only." Backed by the new `scoreCoverage` field (normalized in `vibe-marketing.ts`, typed in `types/vibe-marketing.ts`; serialized by the mlai-backend companion PR).
- **Honest GSC states** (both surfaces): connected-but-missing-scope shows "Reconnect Google — add Search Console access" with matching helper text instead of the generic connect button; an `accessNotConfigured` traffic failure now says the Search Console API is disabled for the app and the user's connection is fine, instead of a generic "lookup failed".

Companion PRs: mlai-backend #518 (compact serializer + scoreCoverage + GSC error rollup), content-factory #591 (authority truthfulness + producer summary bands).

## Verification

`react-router typegen && tsc -b` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)