### PR TITLE
Baseline: real snapshot-history trends replace fabricated sparklines

### DIFF
--- a/app/components/VibeMarketingStartupBaselineSetup.tsx
+++ b/app/components/VibeMarketingStartupBaselineSetup.tsx
@@ -47,6 +47,7 @@ import AbnAutocomplete from "~/components/AbnAutocomplete";
 import type {
   VibeMarketingAutofillCompetitor,
   VibeMarketingAutofillResult,
+  VibeMarketingBaselineHistoryPoint,
   VibeMarketingBootstrap,
   VibeMarketingRunSummary,
   VibeMarketingWebsiteBaseline,
@@ -116,6 +117,7 @@ type SetupVariant = "landing" | "workflow";
 
 type VibeMarketingStartupBaselineSetupProps = {
   bootstrap: VibeMarketingBootstrap;
+  baselineHistory?: VibeMarketingBaselineHistoryPoint[];
   error?: string | null;
   domainConflict?: CompanyDomainConflict | null;
   variant?: SetupVariant;
@@ -713,7 +715,6 @@ function sourceStatusLabel(status?: string | null) {
 }
 
 type BaselineTone = "violet" | "emerald" | "amber" | "rose" | "sky" | "slate";
-type BaselineTrendShape = "rise" | "steady" | "flat";
 
 const baselineToneClasses: Record<
   BaselineTone,
@@ -783,19 +784,23 @@ function numberListFromUnknown(value: unknown): number[] {
     .filter((item): item is number => typeof item === "number" && Number.isFinite(item));
 }
 
-function fallbackTrendValues(score: number | null, shape: BaselineTrendShape) {
-  if (score === null) return [];
-  if (shape === "flat") return Array.from({ length: 9 }, () => score);
-  const start = shape === "rise" ? Math.max(0, score - 15) : Math.max(0, score - 5);
-  const end = shape === "rise" ? score : Math.min(100, score + 3);
-  return Array.from({ length: 9 }, (_, index) => {
-    const progress = index / 8;
-    const wave = shape === "rise" ? Math.sin(index * 1.15) * 3 : Math.sin(index * 1.7) * 2;
-    return Math.min(100, Math.max(0, start + (end - start) * progress + wave));
-  });
+function historySeriesForMetric(history: VibeMarketingBaselineHistoryPoint[], metricKey?: string): number[] {
+  if (!metricKey) return [];
+  return history
+    .map((point) => point.metricScores?.[metricKey])
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
 }
 
-function trendValuesFromMetric(metric: VibeMarketingWebsiteBaselineMetric | undefined, fallbackScore: number | null, shape: BaselineTrendShape) {
+// Only real measurements chart: cross-snapshot history first, then any series
+// the metric payload itself carries. No data means no line — a single snapshot
+// must not be dressed up as a trend.
+function trendValuesForMetric(
+  metric: VibeMarketingWebsiteBaselineMetric | undefined,
+  history: VibeMarketingBaselineHistoryPoint[],
+  metricKey?: string,
+) {
+  const historyValues = historySeriesForMetric(history, metricKey);
+  if (historyValues.length >= 2) return historyValues;
   const directKeys = ["trend", "series", "history", "values", "daily", "dailyScores", "data", "points"];
   for (const key of directKeys) {
     const values = numberListFromUnknown(metric?.[key]);
@@ -804,7 +809,7 @@ function trendValuesFromMetric(metric: VibeMarketingWebsiteBaselineMetric | unde
   const searchConsole = plainObject(metric?.googleSearchConsole);
   const searchConsoleDaily = numberListFromUnknown(searchConsole?.daily);
   if (searchConsoleDaily.length >= 2) return searchConsoleDaily;
-  return fallbackTrendValues(fallbackScore, shape);
+  return [];
 }
 
 function sparklinePoints(values: number[], width = 240, height = 74) {
@@ -1506,13 +1511,63 @@ function MiniSparkline({ values, tone }: { values: number[]; tone: BaselineTone 
   );
 }
 
-function BaselineComparisonChart() {
+function BaselineComparisonChart({ history }: { history: VibeMarketingBaselineHistoryPoint[] }) {
+  const scored = history.filter((point): point is VibeMarketingBaselineHistoryPoint & { overallScore: number } =>
+    typeof point.overallScore === "number" && Number.isFinite(point.overallScore),
+  );
+  if (scored.length >= 2) {
+    const values = scored.map((point) => point.overallScore);
+    const points = sparklinePoints(values, 236, 72);
+    const first = scored[0];
+    const last = scored[scored.length - 1];
+    const delta = Math.round(last.overallScore - first.overallScore);
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+        <div className="flex items-center justify-between border-b border-gray-100 pb-2">
+          <p className="text-xs font-black text-gray-950">Overall score across {scored.length} snapshots</p>
+          <span
+            className={clsx(
+              "rounded-full px-2 py-0.5 text-[11px] font-black",
+              delta > 0 ? "bg-emerald-50 text-emerald-700" : delta < 0 ? "bg-rose-50 text-rose-700" : "bg-slate-100 text-slate-600",
+            )}
+          >
+            {delta > 0 ? `+${delta}` : delta}
+          </span>
+        </div>
+        <svg viewBox="0 0 260 92" className="mt-2 h-28 w-full overflow-visible" role="img" aria-label="Overall baseline score over time">
+          <polyline
+            points={points
+              .split(" ")
+              .map((point) => {
+                const [x, y] = point.split(",");
+                return `${Number(x) + 12},${Number(y) + 4}`;
+              })
+              .join(" ")}
+            fill="none"
+            stroke="#5b21b6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="4"
+          />
+          <text x="12" y="90" fill="#111827" fontSize="12" fontWeight="800">
+            {formatStableDate(first.collectedAt ?? "", "First")} · {Math.round(first.overallScore)}
+          </text>
+          <text x="150" y="90" fill="#111827" fontSize="12" fontWeight="800">
+            {formatStableDate(last.collectedAt ?? "", "Latest")} · {Math.round(last.overallScore)}
+          </text>
+        </svg>
+      </div>
+    );
+  }
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
-      <div className="flex gap-1.5 border-b border-gray-100 pb-2">
-        <span className="h-2 w-2 rounded-full bg-violet-200" />
-        <span className="h-2 w-2 rounded-full bg-violet-200" />
-        <span className="h-2 w-2 rounded-full bg-violet-200" />
+      <div className="flex items-center justify-between border-b border-gray-100 pb-2">
+        <div className="flex gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-violet-200" />
+          <span className="h-2 w-2 rounded-full bg-violet-200" />
+          <span className="h-2 w-2 rounded-full bg-violet-200" />
+        </div>
+        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-black text-slate-500">Example preview</span>
       </div>
       <svg viewBox="0 0 260 108" className="mt-2 h-28 w-full" role="img" aria-label="Baseline comparison illustration">
         <line x1="125" y1="0" x2="125" y2="108" stroke="#c4b5fd" strokeDasharray="5 5" strokeWidth="2" />
@@ -1538,18 +1593,18 @@ function BaselineComparisonChart() {
 
 function MetricVisual({
   metric,
-  score,
+  metricKey,
+  history,
   status,
   tone,
   visual,
-  trendShape = "rise",
 }: {
   metric?: VibeMarketingWebsiteBaselineMetric;
-  score: number | null;
+  metricKey?: string;
+  history: VibeMarketingBaselineHistoryPoint[];
   status?: string | null;
   tone: BaselineTone;
   visual: "sparkline" | "ai-sources" | "none";
-  trendShape?: BaselineTrendShape;
 }) {
   if (visual === "ai-sources") {
     const rows = aiVisibilityPlatformRows(metric);
@@ -1581,27 +1636,37 @@ function MetricVisual({
     );
   }
   if (visual === "none") return null;
-  return <MiniSparkline values={trendValuesFromMetric(metric, score, trendShape)} tone={tone} />;
+  const values = trendValuesForMetric(metric, history, metricKey);
+  if (values.length < 2) {
+    return (
+      <div className="mt-5 flex h-[74px] items-center rounded-xl bg-slate-50 px-4 text-xs font-bold leading-5 text-slate-500">
+        No trend yet — rerun the baseline after publishing to chart change over time.
+      </div>
+    );
+  }
+  return <MiniSparkline values={values} tone={tone} />;
 }
 
 function BaselineMetricCard({
   label,
   metric,
+  metricKey,
+  history = [],
   icon: Icon,
   tone,
   description,
   visual = "sparkline",
-  trendShape,
   action,
   compact = false,
 }: {
   label: string;
   metric?: VibeMarketingWebsiteBaselineMetric;
+  metricKey?: string;
+  history?: VibeMarketingBaselineHistoryPoint[];
   icon: LucideIcon;
   tone: BaselineTone;
   description: string;
   visual?: "sparkline" | "ai-sources" | "none";
-  trendShape?: BaselineTrendShape;
   action?: ReactNode;
   compact?: boolean;
 }) {
@@ -1627,7 +1692,7 @@ function BaselineMetricCard({
       </div>
       <p className={clsx("mt-2 text-sm font-semibold leading-6 text-gray-600", !compact && "line-clamp-3")}>{message ?? description}</p>
       {action ? <div className="mt-4">{action}</div> : null}
-      {!compact ? <MetricVisual metric={metric} score={score} status={status} tone={tone} visual={visual} trendShape={trendShape} /> : null}
+      {!compact ? <MetricVisual metric={metric} metricKey={metricKey} history={history} status={status} tone={tone} visual={visual} /> : null}
     </div>
   );
 }
@@ -1907,6 +1972,7 @@ function ProfileResearchProgressCard({
 
 export default function VibeMarketingStartupBaselineSetup({
   bootstrap,
+  baselineHistory = [],
   error,
   domainConflict = null,
   variant = "landing",
@@ -3155,7 +3221,7 @@ export default function VibeMarketingStartupBaselineSetup({
             </div>
 
             <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-              <BaselineComparisonChart />
+              <BaselineComparisonChart history={baselineHistory} />
               <p className="mt-3 text-sm font-semibold leading-6 text-gray-600">We compare future results to this baseline.</p>
             </div>
           </div>
@@ -3233,6 +3299,8 @@ export default function VibeMarketingStartupBaselineSetup({
             <BaselineMetricCard
               label="Technical health"
               metric={baselineMetrics.technicalHealth}
+              metricKey="technicalHealth"
+              history={baselineHistory}
               icon={Search}
               tone="violet"
               description="How healthy and easy your site is for search engines to crawl."
@@ -3240,6 +3308,8 @@ export default function VibeMarketingStartupBaselineSetup({
             <BaselineMetricCard
               label="AI visibility"
               metric={baselineMetrics.aiVisibility}
+              metricKey="aiVisibility"
+              history={baselineHistory}
               icon={Sparkles}
               tone="sky"
               description="How often AI platforms reference your website as a source."
@@ -3248,6 +3318,8 @@ export default function VibeMarketingStartupBaselineSetup({
             <BaselineMetricCard
               label="Organic search"
               metric={baselineMetrics.organicSearch}
+              metricKey="organicSearch"
+              history={baselineHistory}
               icon={TrendingUp}
               tone="emerald"
               description="How your site performs in organic search results."
@@ -3255,10 +3327,11 @@ export default function VibeMarketingStartupBaselineSetup({
             <BaselineMetricCard
               label="Authority"
               metric={baselineMetrics.authority}
+              metricKey="authority"
+              history={baselineHistory}
               icon={Link2}
               tone="amber"
               description="How trusted your site is based on backlinks and brand signals."
-              trendShape="flat"
             />
           </div>
 

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -24,6 +24,7 @@ import type {
   VibeMarketingScanProgress,
   VibeMarketingStepState,
   VibeMarketingStartupProfile,
+  VibeMarketingBaselineHistoryPoint,
   VibeMarketingWebsiteBaseline,
   VibeMarketingGoogleBaselineConnection,
   VibeMarketingArticleBucket,
@@ -1585,6 +1586,46 @@ export async function getVibeMarketingBootstrap(
   } catch (error) {
     if (shouldUseDevBackendFallback(error)) return DEV_BOOTSTRAP;
     throw error;
+  }
+}
+
+function normalizeBaselineHistoryPoint(raw: unknown): VibeMarketingBaselineHistoryPoint {
+  const payload = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const metricScores: Record<string, number | null> = {};
+  if (payload.metricScores && typeof payload.metricScores === "object") {
+    for (const [key, value] of Object.entries(payload.metricScores as Record<string, unknown>)) {
+      metricScores[key] = typeof value === "number" && Number.isFinite(value) ? value : null;
+    }
+  }
+  return {
+    id: typeof payload.id === "number" ? payload.id : null,
+    runId: typeof payload.runId === "string" ? payload.runId : null,
+    status: typeof payload.status === "string" ? payload.status : null,
+    collectedAt: typeof payload.collectedAt === "string" ? payload.collectedAt : null,
+    overallScore: typeof payload.overallScore === "number" ? payload.overallScore : null,
+    scoreCoverage: typeof payload.scoreCoverage === "number" ? payload.scoreCoverage : null,
+    metricScores,
+  };
+}
+
+// Trends are progressive enhancement: never let a history failure break the
+// baseline page, just render without sparklines.
+export async function getVibeMarketingBaselineHistory(
+  env: Env,
+  request: Request,
+  companyId?: string | null,
+): Promise<VibeMarketingBaselineHistoryPoint[]> {
+  if (shouldUseDevBackendStub()) return [];
+  try {
+    const client = createApiClient(env, request);
+    const params = new URLSearchParams();
+    if (companyId) params.set("company_id", companyId);
+    const query = params.toString() ? `?${params.toString()}` : "";
+    const response = await client.get(`${BASE_PATH}/baseline/history${query}`);
+    const raw = response.data?.snapshots;
+    return Array.isArray(raw) ? raw.map(normalizeBaselineHistoryPoint) : [];
+  } catch {
+    return [];
   }
 }
 

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -42,6 +42,7 @@ import { combineCompanyContext as combineStartupCompanyContext } from "~/lib/vib
 import {
   connectVibeMarketingGithub,
   controlVibeMarketingRun,
+  getVibeMarketingBaselineHistory,
   getVibeMarketingGithubRepos,
   getVibeMarketingBootstrap,
   replayVibeMarketingDaily,
@@ -492,12 +493,11 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   }
 
   const vibeContext = await getOptionalVibeRaisingContext(env, request);
-  const bootstrap = await getVibeMarketingBootstrap(
-    env,
-    request,
-    resolveActiveCompanyId(vibeContext.appUser),
-    "summary",
-  );
+  const activeCompanyId = resolveActiveCompanyId(vibeContext.appUser);
+  const [bootstrap, baselineHistory] = await Promise.all([
+    getVibeMarketingBootstrap(env, request, activeCompanyId, "summary"),
+    getVibeMarketingBaselineHistory(env, request, activeCompanyId),
+  ]);
   const requestedStep = normalizeStep(url.searchParams.get("step"), "startupDetails");
   if (isArticleSystemSetupBlocked(bootstrap) && ["research", "chooseArticle"].includes(requestedStep)) {
     url.searchParams.set("step", "articleSystem");
@@ -525,6 +525,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   }
   return {
     bootstrap,
+    baselineHistory,
     githubRepos,
     billingRequestIds: {
       articleJob: createVibeMarketingClientRequestId("vibe-article-job"),
@@ -1056,7 +1057,7 @@ function PanelHeader({
 }
 
 export default function FounderToolsMarketingCreate() {
-  const { bootstrap, githubRepos, billingRequestIds } = useLoaderData<typeof loader>();
+  const { bootstrap, baselineHistory, githubRepos, billingRequestIds } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
   const activeStep = resolveActiveStep(searchParams.get("step"), bootstrap, {
     hasResearchRun: Boolean(searchParams.get("researchRunId")?.trim()),
@@ -1544,6 +1545,7 @@ export default function FounderToolsMarketingCreate() {
         {setupStepActive ? (
           <VibeMarketingStartupBaselineSetup
             bootstrap={bootstrap}
+            baselineHistory={baselineHistory}
             error={topActionError}
             domainConflict={domainConflict}
             variant="workflow"

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -774,6 +774,16 @@ export interface VibeMarketingGoogleBaselineConnection {
   connectUrl?: string | null;
 }
 
+export interface VibeMarketingBaselineHistoryPoint {
+  id?: number | null;
+  runId?: string | null;
+  status?: string | null;
+  collectedAt?: string | null;
+  overallScore?: number | null;
+  scoreCoverage?: number | null;
+  metricScores?: Record<string, number | null>;
+}
+
 export interface VibeMarketingGithubRepo {
   fullName: string;
   full_name?: string;


### PR DESCRIPTION
## Why

The baseline page fabricated its visuals: `fallbackTrendValues` synthesized a 9-point sine-wave series from the single current score (default shape "rise" — a single measurement rendered as historical growth), and the Before/After growth chart was a hardcoded SVG. Snapshots accumulate per collection run in the backend, so real trends are available — nothing was reading them.

## Changes

- Create-page loader fetches `GET /content-factory/vibe-marketing/baseline/history` (new endpoint from mlai-backend #520) in parallel with the bootstrap; failures degrade to an empty list so trends can never break page load.
- `trendValuesForMetric` replaces the fabrication: cross-snapshot per-metric scores first (≥2 points), then any real series inside the metric payload (e.g. Search Console daily clicks), otherwise nothing — the card shows "No trend yet — rerun the baseline after publishing to chart change over time."
- `fallbackTrendValues`, `BaselineTrendShape`, and the `trendShape` prop plumbing are deleted.
- `BaselineComparisonChart` now plots the real overall score across up to 24 snapshots with first/latest date·score labels and a +/- delta chip once two snapshots exist; the illustrative SVG remains for first-time users but is explicitly badged "Example preview".

Stacked on `claude/baseline-score-honesty` (#1316); companion backend PR: mlai-backend #520.

## Verification

`react-router typegen && tsc -b` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)