### PR TITLE
Render the code-review approval panel for previewless setup runs

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -812,6 +812,9 @@ export default function ArticleSystemConnectionPanel({
     surfaceExists ||
     (scanScaffoldStatus !== "not_needed" &&
       !["ambiguous", "unmatched", "missing"].includes(scanArticleSurfaceState));
+  // Server-rendered stacks get no hosted preview; Content Factory parks the run in
+  // "code_review_ready" and the reviewable surface is the setup branch diff.
+  const setupCodeReviewReady = setupStatus === "code_review_ready";
   const scaffoldStatus: ArticleSystemScaffoldStatus = !setupTargetReady && !selectedSurfaceUrl
     ? "not_ready"
     : scaffoldExplicitReady
@@ -822,7 +825,7 @@ export default function ArticleSystemConnectionPanel({
           ? "verifying"
           : scaffoldPublishReady
             ? "publish_ready"
-            : setupPreviewUrl
+            : setupPreviewUrl || setupCodeReviewReady
               ? "review_ready"
               : scaffoldLegacyReady
                 ? "legacy_ready"
@@ -1033,7 +1036,13 @@ export default function ArticleSystemConnectionPanel({
             body: "The latest scan could not confirm the saved articles route in this repository. Re-scan, choose a different route, or create a new articles folder.",
             tone: "amber" as const,
           }
-        : scaffoldStatusCopy[scaffoldStatus];
+        : scaffoldStatus === "review_ready" && setupCodeReviewReady
+          ? {
+              title: "Articles setup is ready for code review",
+              body: "A live preview isn't supported for this site's stack yet. Open the setup build to review the changed files and approve.",
+              tone: "violet" as const,
+            }
+          : scaffoldStatusCopy[scaffoldStatus];
   const scaffoldIconTone = {
     emerald: "bg-emerald-100 text-emerald-700",
     violet: "bg-violet-100 text-violet-700",

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeftIcon,
   ArrowPathIcon,
   ArrowRightIcon,
+  ArrowTopRightOnSquareIcon,
   CalendarDaysIcon,
   CheckCircleIcon,
   ChevronDownIcon,
@@ -1191,7 +1192,25 @@ function ArticleSystemSetupPreviewPanel({
         source.livePreview?.exactRender === true
       ),
   );
-  const canApprove = Boolean(!setupAlreadyApproved && setupExactPreviewReady && (run.status === "awaiting_approval" || run.status === "approval_required"));
+  // Server-rendered stacks (FastAPI/Django/Rails/...) get no hosted preview shape;
+  // Content Factory parks the run in "code_review_ready" and the reviewable surface
+  // is the setup branch diff, so approval proceeds without a preview URL.
+  const setupCodeReviewReady = Boolean(
+    !setupAlreadyApproved &&
+      setupStatus === "code_review_ready" &&
+      (run.status === "awaiting_approval" || run.status === "approval_required"),
+  );
+  const previewUnsupportedReason =
+    stringResultValue(run, "preview_unsupported_reason", "previewUnsupportedReason") ||
+    String(setup.preview_unsupported_reason ?? setup.previewUnsupportedReason ?? "");
+  const setupBranchName =
+    stringResultValue(run, "branch_name", "branchName") || String(setup.branch_name ?? setup.branchName ?? "");
+  const setupBranchUrl = repo && setupBranchName ? `https://github.com/${repo}/tree/${setupBranchName}` : "";
+  const canApprove = Boolean(
+    !setupAlreadyApproved &&
+      (setupExactPreviewReady || setupCodeReviewReady) &&
+      (run.status === "awaiting_approval" || run.status === "approval_required"),
+  );
   const setupCompleted = setupMerged;
   const previewReady = setupExactPreviewReady;
   const setupTerminalFailure = ["blocked", "failed"].includes(run.status) || ARTICLE_SETUP_FAILED_STATUSES.has(setupStatus);
@@ -1314,6 +1333,55 @@ function ArticleSystemSetupPreviewPanel({
             );
           }}
         />
+      ) : setupCodeReviewReady ? (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-violet-200 bg-violet-50 p-4">
+            <p className="text-sm font-black text-violet-950">Review the code changes to approve this setup</p>
+            <p className="mt-1 text-sm font-semibold leading-6 text-violet-900">
+              {previewUnsupportedReason ||
+                "A live preview isn't supported for this site's stack yet, so the setup is reviewed from its code changes instead."}
+            </p>
+            {setupBranchUrl ? (
+              <a
+                href={setupBranchUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-3 inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2.5 text-sm font-bold text-violet-800 shadow-sm transition hover:bg-violet-100"
+              >
+                Review the branch on GitHub
+                <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+              </a>
+            ) : null}
+          </div>
+          {canApprove ? (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Form method="POST">
+                <button
+                  type="submit"
+                  name="intent"
+                  value="deny"
+                  disabled={isSubmitting}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50 sm:w-auto"
+                >
+                  {(isActionPending?.("deny") ?? isSubmitting) ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <XCircleIcon className="h-4 w-4" />}
+                  {(isActionPending?.("deny") ?? isSubmitting) ? "Rejecting..." : "Reject setup"}
+                </button>
+              </Form>
+              <Form method="POST">
+                <button
+                  type="submit"
+                  name="intent"
+                  value="approve"
+                  disabled={isSubmitting}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
+                >
+                  {(isActionPending?.("approve") ?? isSubmitting) ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                  {(isActionPending?.("approve") ?? isSubmitting) ? "Approving..." : "Approve setup and create PR"}
+                </button>
+              </Form>
+            </div>
+          ) : null}
+        </div>
       ) : !setupCompleted ? (
         <div className="space-y-4">
           {previewFailed ? (


### PR DESCRIPTION
Companion to [content-factory#599](https://github.com/MLAI-AUS-Inc/content-factory/pull/599) and [mlai-backend#525](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/525).

Server-rendered stacks (like arb-gen.com's FastAPI app) get no hosted preview; Content Factory now parks those setup runs in **`code_review_ready`** with the setup branch diff as the reviewable surface. Before this change the state fell through to the "building" spinner forever and approve/deny never rendered (both were gated on a preview URL).

- **Wizard panel**: `code_review_ready` resolves to the `review_ready` step with copy directing the founder to review the changed files from the setup build.
- **Run page**: a dedicated code-review branch renders the platform's unsupported-runtime reason, the planned-files list (already shown above it), a "Review the branch on GitHub" link, and Reject / "Approve setup and create PR" actions. `canApprove` accepts code-review mode without a preview URL; the exact-preview requirement is unchanged for every previewable stack, and the CF backend independently enforces the gate.

Typecheck + all 94 tests pass. (No new component test: the panel/run-page assertions live in the CF + mlai-backend suites, which enforce the actual gate; the UI derivation here is copy + conditional rendering.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)