### PR TITLE
Show the review CTA on the setup wizard for code_review_ready runs

### DIFF
--- a/app/components/ArticlesSetupProgressCard.tsx
+++ b/app/components/ArticlesSetupProgressCard.tsx
@@ -137,6 +137,15 @@ function setupPhase(run: VibeMarketingRunSummary) {
     };
   }
   if (ready) {
+    // Server-rendered stacks get no hosted preview (code_review_ready): the
+    // reviewable surface is the setup branch diff on the run page.
+    if (isSetupPreviewRun && status === "code_review_ready") {
+      return {
+        title: "Articles setup ready for code review",
+        description: "A live preview isn't supported for this site's stack. Open the setup build to review the code changes, then approve setup PR creation.",
+        tone: "ready" as const,
+      };
+    }
     return {
       title: isSetupPreviewRun ? "Articles setup preview ready" : "Articles setup ready to build",
       description: isSetupPreviewRun

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -1429,12 +1429,23 @@ export default function FounderToolsMarketingCreate() {
       !pendingArticleSystemSetupRunId &&
       pendingArticleSystemScan.status === "completed",
   );
-  const setupPreviewReady = Boolean(
+  // Server-rendered stacks get no hosted preview; the run parks in
+  // code_review_ready and the reviewable surface is the branch diff on the run
+  // page, so the review CTA must not require a preview URL.
+  const setupCodeReviewReady = Boolean(
     setupStatusRun &&
       !setupPublished &&
       !setupVerifying &&
       !setupManualMergeRequired &&
-      hasExactArticleSystemSetupPreview(setupStatusRun),
+      setupChildStatus === "code_review_ready",
+  );
+  const setupPreviewReady = Boolean(
+    setupCodeReviewReady ||
+      (setupStatusRun &&
+        !setupPublished &&
+        !setupVerifying &&
+        !setupManualMergeRequired &&
+        hasExactArticleSystemSetupPreview(setupStatusRun)),
   );
   const setupLegacyNeedsPreview = Boolean(
     pendingArticleSystemScan && !pendingArticleSystemSetupRunId && SETUP_READY_STATUSES.has(pendingArticleSystemScan.status),
@@ -1478,7 +1489,7 @@ export default function FounderToolsMarketingCreate() {
       to={`/founder-tools/marketing/runs/${encodeURIComponent(setupPreviewRunId)}`}
       className="inline-flex items-center justify-center gap-2 rounded-xl bg-gray-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-black"
     >
-      Review articles setup preview
+      {setupCodeReviewReady ? "Review setup changes" : "Review articles setup preview"}
       <ArrowRightIcon className="h-4 w-4" />
     </Link>
   ) : setupLegacyNeedsPreview ? (


### PR DESCRIPTION
Companion to [mlai-backend#526](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/526), found live on arb-gen.com (run `ad1ea21b`): the run reached `code_review_ready` / awaiting approval, but the setup wizard showed only "Cancel setup build" with copy telling the founder to "Review the Cloudflare preview" that doesn't exist.

- `setupPreviewReady` (which drives the primary "Review…" CTA on the wizard card) now also passes for `code_review_ready` without requiring an exact preview URL; the link is labeled **"Review setup changes"** and goes to the run page, where the code-review approval panel (#1320) renders the reason, branch link, and approve/deny.
- `ArticlesSetupProgressCard` gets code-review-aware ready copy: "A live preview isn't supported for this site's stack. Open the setup build to review the code changes, then approve setup PR creation."

Typecheck + 94 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)