### PR TITLE
Label the compose_article_kit setup step in the progress wizard

### DIFF
--- a/app/components/ArticlesSetupProgressCard.tsx
+++ b/app/components/ArticlesSetupProgressCard.tsx
@@ -56,6 +56,7 @@ function setupStepLabel(stepKey: string) {
     fetch_org_config: "Loading setup context",
     synthesize_repository_contract: "Preparing setup instructions",
     draft_article_system_setup: "Drafting articles setup changes",
+    compose_article_kit: "Generating article components",
     build_preview: "Building articles setup preview",
     render_preview: "Rendering articles setup preview",
     package_preview: "Preparing review assets",


### PR DESCRIPTION
Companion to content-factory [#624](https://github.com/MLAI-AUS-Inc/content-factory/pull/624).

Content-factory now emits a first-class `compose_article_kit` durable step for the article-system-setup flow — the visual-capture → design-snapshot → kit-plan → component-generation phase that previously ran untracked, leaving the setup wizard sitting on the prior step for minutes while it appeared stuck.

The wizard renders step labels via `setupStepLabel()`, which already falls back gracefully to a humanized id, so the new step works without this change (it would show "Compose article kit"). This adds the curated label so founders see **"Generating article components"**.

- One entry in the `setupStepLabel` map (`app/components/ArticlesSetupProgressCard.tsx`).
- Non-blocking on merge order: the backend step functions regardless; this is polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)