### PR TITLE
Interactive channel checkboxes on the daily-reminder card

### DIFF
--- a/app/components/DailyReminderChannels.tsx
+++ b/app/components/DailyReminderChannels.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Form } from "react-router";
+import { Form, useFetcher } from "react-router";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import { Check, Mail } from "lucide-react";
 import { clsx } from "clsx";
@@ -143,6 +143,60 @@ function PublishChannelStatusBadge({ tone }: { tone: PublishChannelTone }) {
     <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-violet-600 text-white shadow-sm">
       <Check className="h-4 w-4" strokeWidth={3} />
     </span>
+  );
+}
+
+// Checkbox that toggles whether a connected channel receives the daily reminder.
+// Submits inline via a fetcher (no page nav), reflects the sent value optimistically,
+// and reverts + shows the reason if the server rejects (e.g. the last channel).
+function DeliveryToggle({
+  channel,
+  type,
+  isSubmitting,
+}: {
+  channel: VibeMarketingNotificationChannel;
+  type: VibeMarketingNotificationChannelType;
+  isSubmitting: boolean;
+}) {
+  const fetcher = useFetcher<{ intent?: string; ok?: boolean; error?: string }>();
+  const busy = fetcher.state !== "idle";
+  const sent = fetcher.formData?.get("enabled");
+  const checked = sent != null ? sent === "true" : channel.deliveryEnabled;
+  const error = !busy && fetcher.data?.error ? fetcher.data.error : null;
+  const next = !checked;
+  return (
+    <div className="flex shrink-0 flex-col items-end gap-1">
+      <fetcher.Form method="POST" className="inline">
+        <input type="hidden" name="intent" value="set-channel-delivery" />
+        <input type="hidden" name="channelId" value={channel.id} />
+        <input type="hidden" name="enabled" value={next ? "true" : "false"} />
+        <button
+          type="submit"
+          role="switch"
+          aria-checked={checked}
+          aria-label={`Send the daily research reminder via ${CHANNEL_LABELS[type]}`}
+          title={
+            checked
+              ? `Sending via ${CHANNEL_LABELS[type]} — click to stop`
+              : `Not sending via ${CHANNEL_LABELS[type]} — click to enable`
+          }
+          disabled={isSubmitting || busy}
+          className={clsx(
+            "flex h-6 w-6 shrink-0 items-center justify-center rounded-md border shadow-sm outline-none transition focus-visible:ring-2 focus-visible:ring-violet-500/40 disabled:opacity-60",
+            checked
+              ? "border-violet-600 bg-violet-600 text-white hover:bg-violet-700"
+              : "border-gray-300 bg-white text-transparent hover:border-violet-400",
+          )}
+        >
+          <Check className="h-4 w-4" strokeWidth={3} />
+        </button>
+      </fetcher.Form>
+      {error ? (
+        <span className="max-w-[9.5rem] text-right text-[10px] font-semibold leading-tight text-red-600">
+          {error}
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -298,6 +352,8 @@ function ChannelRow({
             >
               {whatsappSetupOpen ? "Cancel" : "Set up"}
             </button>
+          ) : isActive && channel ? (
+            <DeliveryToggle channel={channel} type={type} isSubmitting={isSubmitting} />
           ) : (
             <PublishChannelStatusBadge tone={publishTone} />
           )}

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -2047,6 +2047,8 @@ export function normalizeNotificationChannel(payload: unknown): VibeMarketingNot
     consentState: String(
       data.consentState ?? data.consent_state ?? "pending",
     ) as VibeMarketingNotificationChannel["consentState"],
+    // Absent on legacy payloads → treat as enabled (matches the backend default).
+    deliveryEnabled: Boolean(data.deliveryEnabled ?? data.delivery_enabled ?? true),
     verifiedAt: asNullableString(data.verifiedAt ?? data.verified_at),
     isPrimary: Boolean(data.isPrimary ?? data.is_primary),
     pendingVerification: pending
@@ -2149,6 +2151,20 @@ export async function saveResearchAutomation(
 ) {
   const client = createApiClient(env, request);
   const response = await client.post(`${BASE_PATH}/notifications/automation`, body);
+  return normalizeNotificationChannelsPayload(response.data);
+}
+
+export async function setNotificationChannelDelivery(
+  env: Env,
+  request: Request,
+  channelId: string,
+  enabled: boolean,
+) {
+  const client = createApiClient(env, request);
+  const response = await client.patch(
+    `${BASE_PATH}/notifications/channels/${encodeURIComponent(channelId)}`,
+    { deliveryEnabled: enabled },
+  );
   return normalizeNotificationChannelsPayload(response.data);
 }
 

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -63,6 +63,7 @@ import {
   removeNotificationChannel,
   replayVibeMarketingDaily,
   resendNotificationChannelCode,
+  setNotificationChannelDelivery,
   submitVibeMarketingArticleSystemComments,
   submitVibeMarketingComponentComments,
   startVibeMarketingScan,
@@ -589,6 +590,14 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       await resendNotificationChannelCode(env, request, stringFromForm(formData, "channelId"));
     } else if (intent === "remove-channel") {
       await removeNotificationChannel(env, request, stringFromForm(formData, "channelId"));
+    } else if (intent === "set-channel-delivery") {
+      const channelId = stringFromForm(formData, "channelId");
+      if (!channelId) return { intent, error: "Missing channel." };
+      const enabled = stringFromForm(formData, "enabled") === "true";
+      await setNotificationChannelDelivery(env, request, channelId, enabled);
+      // Return (rather than fall through to the redirect below) so the toggle's
+      // fetcher stays inline; loader revalidation refreshes the checkbox state.
+      return { intent, ok: true };
     } else if (["approve", "deny", "resume", "restart", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
       const sourceRunId = stringFromForm(formData, "sourceRunId");
       const targetRunId = stringFromForm(formData, "targetRunId");

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -340,6 +340,8 @@ export interface VibeMarketingNotificationChannel {
   routeId: string;
   displayName: string;
   consentState: VibeMarketingNotificationConsentState;
+  /** Whether this channel receives the daily research reminder + topics. */
+  deliveryEnabled: boolean;
   verifiedAt: string | null;
   isPrimary: boolean;
   pendingVerification: VibeMarketingNotificationChannelVerification | null;


### PR DESCRIPTION
## What

Makes the Slack / Email / WhatsApp checkboxes on the **"Trigger article research daily"** card interactive. Checking/unchecking a connected channel controls whether it receives the daily reminder and the researched topic buttons.

## Why

The checkboxes were a static `PublishChannelStatusBadge` (a violet check icon) with no click handler — clicking did nothing.

## Changes

- `deliveryEnabled` on `VibeMarketingNotificationChannel` + `normalizeNotificationChannel` (defaults `true` when absent).
- `setNotificationChannelDelivery()` → `PATCH /notifications/channels/<id>`.
- `set-channel-delivery` route intent that **returns inline** instead of the connect/verify full-page redirect, so the toggle's fetcher stays inline; React Router loader revalidation then refreshes the checkbox from the server.
- `DeliveryToggle`: a `useFetcher` checkbox with optimistic state, `role="switch"` + `aria-checked` + keyboard focus ring, disabled while submitting, that reverts and shows the reason inline on the `409 last_delivery_channel`.
- Only connected/active channels get the toggle; pending / not-set-up channels keep their existing connect/verify affordances.

## Verification

`react-router typegen && tsc -b`: clean.

**Requires** the mlai-backend PR (adds `deliveryEnabled` to the payload and the `PATCH` route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
