### PR TITLE
Keep revision comments pinned when the article-system submit fails

### DIFF
--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1179,6 +1179,7 @@ function ArticleSystemSetupPreviewPanel({
   isSubmitting: boolean;
   isActionPending?: (...keys: string[]) => boolean;
 }) {
+  const submitCommentsFetcher = useFetcher<typeof action>();
   const setup = articleSystemSetupPayload(run);
   const source = sourceRun ?? run;
   const repo = run.githubRepo || source.githubRepo || stringResultValue(run, "github_repo", "githubRepo") || stringResultValue(source, "github_repo", "githubRepo");
@@ -1312,52 +1313,68 @@ function ArticleSystemSetupPreviewPanel({
             if (setupAlreadyApproved) return null;
             const needsCommentSubmitFirst = reviewState.draftComments.length > 0 || reviewState.hasPendingRevisionBatch;
             const approveDisabled = isSubmitting || needsCommentSubmitFirst || !previewUrl;
-            const submitCommentsPending = isActionPending?.("submit-article-system-comments") ?? isSubmitting;
+            // Submit revision comments through a dedicated fetcher: a failed POST
+            // (e.g. a content-factory 500) then leaves the pinned draft comments in
+            // place and surfaces the error inline for retry, while only a successful
+            // submit redirects to the revision run (which clears the composer).
+            const submitCommentsPending = submitCommentsFetcher.state !== "idle";
+            const submitCommentsError =
+              submitCommentsFetcher.state === "idle" ? submitCommentsFetcher.data?.error ?? null : null;
             const denyPending = isActionPending?.("deny") ?? isSubmitting;
             const approvePending = isActionPending?.("approve") ?? isSubmitting;
             return (
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <Form method="POST">
-                  <input type="hidden" name="setupRunId" value={setupRunId} />
-                  <button
-                    type="submit"
-                    name="intent"
-                    value="submit-article-system-comments"
-                    disabled={isSubmitting || !reviewState.canSendRevisionRequest}
-                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
+              <div className="flex w-full flex-col gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <submitCommentsFetcher.Form method="POST">
+                    <input type="hidden" name="setupRunId" value={setupRunId} />
+                    <button
+                      type="submit"
+                      name="intent"
+                      value="submit-article-system-comments"
+                      disabled={submitCommentsPending || isSubmitting || !reviewState.canSendRevisionRequest}
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
+                    >
+                      {submitCommentsPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
+                      {submitCommentsPending ? "Sending..." : reviewState.canRetrySubmittedBatch ? "Retry revision comments" : "Send revision comments"}
+                    </button>
+                  </submitCommentsFetcher.Form>
+                  {canApprove ? (
+                    <>
+                      <Form method="POST">
+                        <button
+                          type="submit"
+                          name="intent"
+                          value="deny"
+                          disabled={isSubmitting}
+                          className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50 sm:w-auto"
+                        >
+                          {denyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <XCircleIcon className="h-4 w-4" />}
+                          {denyPending ? "Rejecting..." : "Reject setup"}
+                        </button>
+                      </Form>
+                      <Form method="POST">
+                        <button
+                          type="submit"
+                          name="intent"
+                          value="approve"
+                          disabled={approveDisabled}
+                          title={needsCommentSubmitFirst ? "Send or clear draft revision comments before approving." : undefined}
+                          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
+                        >
+                          {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
+                          {approvePending ? "Approving..." : "Approve setup and create PR"}
+                        </button>
+                      </Form>
+                    </>
+                  ) : null}
+                </div>
+                {submitCommentsError ? (
+                  <p
+                    role="alert"
+                    className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs font-semibold text-red-700"
                   >
-                    {submitCommentsPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <PaperAirplaneIcon className="h-4 w-4" />}
-                    {submitCommentsPending ? "Sending..." : reviewState.canRetrySubmittedBatch ? "Retry revision comments" : "Send revision comments"}
-                  </button>
-                </Form>
-                {canApprove ? (
-                  <>
-                    <Form method="POST">
-                      <button
-                        type="submit"
-                        name="intent"
-                        value="deny"
-                        disabled={isSubmitting}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-bold text-red-700 shadow-sm transition hover:bg-red-50 disabled:opacity-50 sm:w-auto"
-                      >
-                        {denyPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <XCircleIcon className="h-4 w-4" />}
-                        {denyPending ? "Rejecting..." : "Reject setup"}
-                      </button>
-                    </Form>
-                    <Form method="POST">
-                      <button
-                        type="submit"
-                        name="intent"
-                        value="approve"
-                        disabled={approveDisabled}
-                        title={needsCommentSubmitFirst ? "Send or clear draft revision comments before approving." : undefined}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 sm:w-auto"
-                      >
-                        {approvePending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <CheckCircleIcon className="h-4 w-4" />}
-                        {approvePending ? "Approving..." : "Approve setup and create PR"}
-                      </button>
-                    </Form>
-                  </>
+                    {submitCommentsError} Your revision comments are still pinned — try sending them again.
+                  </p>
                 ) : null}
               </div>
             );


### PR DESCRIPTION
## Problem

On `article_system_setup` runs, the live-preview inspector's **"Send revision comments"** batch submit (`submit-article-system-comments` → content-factory `/api/runs/<run_id>/article-system-revisions`) was a plain React Router `<Form method="POST">`.

When that POST returns a non-2xx, the server action correctly returns `{ intent, error }` (no redirect) — but:
- the only place the error rendered was the banner at the **top of the page**, far from the composer the user is working in; and
- the `<Form>` still performed a **navigation + scroll-reset** on failure, bouncing the user back to the preview.

Net effect: the user got no visible error and it looked like their pinned revision comments were silently lost. Observed in prod 2026-07-08 — content-factory returned 500 (`No active attempt for step 'await_review'`) three times for arb-gen.com run `8568a3c9`, and the composer state appeared to vanish each time.

The backend 500 itself is fixed separately by **content-factory#645**; this PR is the client-side hardening so the UI degrades gracefully regardless of what the backend returns.

## Fix

Submit through a dedicated `useFetcher` instead of a navigating `<Form>`:

- A failed POST **no longer navigates**, so the pinned draft comments (and the rest of the inspector) stay put.
- The error renders **inline** next to the button (`role="alert"`) with a note that the comments are still pinned, and the button stays enabled for **retry**.
- Only the server's success `redirect` clears the composer — clearing is now conditional on success.

Success UX is unchanged: a fetcher follows the action's redirect to the revision run exactly as the `<Form>` did. Deny/Approve remain plain `<Form>` navigations (they *should* navigate on completion).

## Testing

- `react-router typegen && tsc -b` passes (exit 0).
- Not driven end-to-end: reproducing the failure needs a live setup run parked at `awaiting_approval` with a hosted preview, pinned comments, and a 500ing backend. The change is a contained swap to the fetcher pattern already used elsewhere in this file (`previewStartFetcher`, `runStatusFetcher`, the per-pin fetcher in `ArticleCommentCanvas`).

## Follow-up (not in this PR)

The sibling AI-revision submit (`submit-component-comments` in `LiveArticlePreviewPanel`) has the same fragility against a failed POST, but hits a different endpoint (`submitVibeMarketingComponentComments`). Worth the same treatment in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
