### PR TITLE
Wizard cards: render the real preview-unsupported reason, not the generic sentence

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -1056,6 +1056,14 @@ export default function ArticleSystemConnectionPanel({
   // Adopting an existing page (the scan found a working articles surface and the
   // user picked an existing detected route) publishes into it without rebuilding.
   const isAdoptingExisting = surfaceExists && selectedMode === "existing";
+  // The specific reason a code-review-ready park has no hosted preview (server-rendered
+  // stack, worker runtime crash, manual scaffold, …). Prefer the normalized setup state,
+  // fall back to reading it off the setup run payload; empty when unknown.
+  const previewUnsupportedReason = String(
+    articleSetupState?.previewUnsupportedReason ??
+      articleSystemSetupString(effectiveSetupRun, "preview_unsupported_reason", "previewUnsupportedReason") ??
+      "",
+  ).trim();
   const scaffoldStatusContent =
     scaffoldStatus === "ready_to_build" && isAdoptingExisting
       ? {
@@ -1072,7 +1080,9 @@ export default function ArticleSystemConnectionPanel({
         : scaffoldStatus === "review_ready" && setupCodeReviewReady
           ? {
               title: "Articles setup is ready for code review",
-              body: "A live preview isn't supported for this site's stack yet. Open the setup build to review the changed files and approve.",
+              body: previewUnsupportedReason
+                ? `${previewUnsupportedReason} Open the setup build to review the changed files and approve.`
+                : "A live preview isn't supported for this site's stack yet. Open the setup build to review the changed files and approve.",
               tone: "violet" as const,
             }
           : scaffoldStatusCopy[scaffoldStatus];

--- a/app/components/ArticlesSetupProgressCard.tsx
+++ b/app/components/ArticlesSetupProgressCard.tsx
@@ -141,9 +141,18 @@ function setupPhase(run: VibeMarketingRunSummary) {
     // Server-rendered stacks get no hosted preview (code_review_ready): the
     // reviewable surface is the setup branch diff on the run page.
     if (isSetupPreviewRun && status === "code_review_ready") {
+      const setup = setupPayload(run);
+      const reason = String(
+        setup.preview_unsupported_reason ??
+          setup.previewUnsupportedReason ??
+          nestedObject(run.result).preview_unsupported_reason ??
+          "",
+      ).trim();
       return {
         title: "Articles setup ready for code review",
-        description: "A live preview isn't supported for this site's stack. Open the setup build to review the code changes, then approve setup PR creation.",
+        description: reason
+          ? `${reason} Open the setup build to review the code changes, then approve setup PR creation.`
+          : "A live preview isn't supported for this site's stack. Open the setup build to review the code changes, then approve setup PR creation.",
         tone: "ready" as const,
       };
     }

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -327,6 +327,9 @@ function normalizeArticleSetupState(raw: unknown): VibeMarketingArticleSetupStat
     livePreview: normalizeLivePreview(payload.livePreview ?? payload.live_preview),
     retryAvailable: asBoolean(payload.retryAvailable ?? payload.retry_available),
     error: asNullableString(payload.error),
+    previewRuntimeUnsupported: asBoolean(payload.previewRuntimeUnsupported ?? payload.preview_runtime_unsupported),
+    previewUnsupportedReason:
+      asNullableString(payload.previewUnsupportedReason) ?? asNullableString(payload.preview_unsupported_reason),
     source: source ?? undefined,
     updatedAt: asNullableString(payload.updatedAt) ?? asNullableString(payload.updated_at),
     // The scan's verdict on the chosen route. Carried through so the wizard can

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -118,6 +118,8 @@ export interface VibeMarketingArticleSetupState {
   livePreview?: VibeMarketingLivePreview | null;
   retryAvailable?: boolean;
   error?: string | null;
+  previewRuntimeUnsupported?: boolean;
+  previewUnsupportedReason?: string | null;
   source?: "config" | "scan_run" | "setup_run" | "none" | string;
   updatedAt?: string | null;
   articleSurfaceMode?: string | null;

--- a/tests/article-system-connection-panel.test.ts
+++ b/tests/article-system-connection-panel.test.ts
@@ -116,6 +116,19 @@ function staleArticleSetupState(): VibeMarketingArticleSetupState {
   };
 }
 
+function codeReviewReadySetupState(reason: string | null): VibeMarketingArticleSetupState {
+  return {
+    repo: "DrAnuG1995/website",
+    githubRepo: "DrAnuG1995/website",
+    setupRunId: "setup-code-review-1",
+    setupStatus: "code_review_ready",
+    setupRunStatus: "code_review_ready",
+    routePath: "/articles",
+    previewUnsupportedReason: reason,
+    source: "config",
+  };
+}
+
 function renderPanel({
   bootstrap = baseBootstrap(),
   articleSetupState = staleArticleSetupState(),
@@ -179,5 +192,30 @@ describe("article system connection panel", () => {
     expect(markup).toContain("value=\"reset-article-setup\"");
     expect(markup).not.toContain(">Continue<");
     expect(markup).not.toContain("/founder-tools/marketing/create?step=research");
+  });
+
+  test("renders the specific preview-unsupported reason on a code_review_ready park", () => {
+    const reason = "The hosted preview deployed, but the app server crashed on boot because it requires production secrets.";
+    const markup = renderPanel({
+      articleSetupState: codeReviewReadySetupState(reason),
+      scanRun: null,
+    });
+
+    expect(markup).toContain("Articles setup is ready for code review");
+    expect(markup).toContain("The hosted preview deployed, but the app server crashed on boot");
+    expect(markup).toContain("Open the setup build to review the changed files and approve.");
+    // The generic stack fallback must NOT appear when a real reason is known.
+    expect(markup).not.toContain("supported for this site");
+  });
+
+  test("falls back to the generic stack sentence when no preview-unsupported reason is present", () => {
+    const markup = renderPanel({
+      articleSetupState: codeReviewReadySetupState(null),
+      scanRun: null,
+    });
+
+    expect(markup).toContain("Articles setup is ready for code review");
+    expect(markup).toContain("supported for this site");
+    expect(markup).toContain("Open the setup build to review the changed files and approve.");
   });
 });

--- a/tests/articles-setup-progress-card.test.ts
+++ b/tests/articles-setup-progress-card.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import ArticlesSetupProgressCard from "../app/components/ArticlesSetupProgressCard";
+import type { VibeMarketingRunSummary } from "../app/types/vibe-marketing";
+
+function codeReviewReadyRun(reason: string | null): VibeMarketingRunSummary {
+  const setup: Record<string, unknown> = { status: "code_review_ready" };
+  if (reason !== null) setup.preview_unsupported_reason = reason;
+  return {
+    runId: "setup-code-review-1",
+    workflow: "article_system_setup",
+    domain: "statdoctor.app",
+    githubRepo: "DrAnuG1995/website",
+    // A code-review-ready park sits at the setup approval gate; the setup payload
+    // carries the terminal "code_review_ready" status the card branches on.
+    status: "awaiting_approval",
+    currentStep: "build_preview",
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: [],
+    artifacts: [],
+    diagnostics: {},
+    result: { article_system_setup: setup },
+  };
+}
+
+describe("articles setup progress card", () => {
+  test("renders the specific preview-unsupported reason on a code_review_ready park", () => {
+    const reason = "The hosted preview deployed, but the app server crashed on boot because it requires production secrets.";
+    const markup = renderToStaticMarkup(
+      createElement(ArticlesSetupProgressCard, { run: codeReviewReadyRun(reason) }),
+    );
+
+    expect(markup).toContain("Articles setup ready for code review");
+    expect(markup).toContain("The hosted preview deployed, but the app server crashed on boot");
+    expect(markup).toContain("Open the setup build to review the code changes, then approve setup PR creation.");
+    // The generic stack fallback must NOT appear when a real reason is known.
+    expect(markup).not.toContain("supported for this site");
+  });
+
+  test("falls back to the generic stack sentence when no preview-unsupported reason is present", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ArticlesSetupProgressCard, { run: codeReviewReadyRun(null) }),
+    );
+
+    expect(markup).toContain("Articles setup ready for code review");
+    expect(markup).toContain("supported for this site");
+    expect(markup).toContain("Open the setup build to review the code changes, then approve setup PR creation.");
+  });
+});


### PR DESCRIPTION
## Problem

When an articles-setup run parks at **code_review_ready** (no hosted live preview — server-rendered stack, worker runtime crash, or a manual/routeless scaffold), Content Factory sends a **specific reason** for the missing preview, and the **run page** (`founder-tools.marketing.run.tsx:1388`) already renders it. But the two **wizard** surfaces hardcoded the generic *"A live preview isn't supported for this site's stack yet…"* regardless of the real cause.

## Fix

- **types + normalizer** (`app/types/vibe-marketing.ts`, `app/lib/vibe-marketing.ts`): thread `previewUnsupportedReason` (+ the paired `previewRuntimeUnsupported` flag, mirroring the backend contract) off the `article_setup_state` payload, accepting camelCase or snake_case.
- **`ArticleSystemConnectionPanel.tsx`**: the `review_ready` + `setupCodeReviewReady` branch prefers `articleSetupState.previewUnsupportedReason` (falling back to the setup-run payload via `articleSystemSetupString`), else the existing generic sentence.
- **`ArticlesSetupProgressCard.tsx`**: the `code_review_ready` branch prefers the reason off `run.result.article_system_setup`, else the existing generic sentence.

Each card keeps its original CTA and falls back cleanly when no reason is known.

## Tests (bun:test + `renderToStaticMarkup`)

Both cards, both halves: renders the specific reason **and not** the generic fallback when a reason is present; renders the generic fallback when it is absent. 6 pass across the two files; `bun run typecheck` clean.

Pairs with mlai-backend (emits `previewUnsupportedReason` in the wizard state payload) and content-factory (composes/sends the reason — already live). Depends on the mlai-backend PR for the wizard-panel path; the progress card also reads the run payload directly, so it improves even before the backend deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)