### PR TITLE
Founder tools: surface the real backend failure reason on run actions

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,4 +1,5 @@
 import axios, { type InternalAxiosRequestConfig, AxiosHeaders, type AxiosAdapter } from 'axios';
+import { looksLikeHtml } from "~/lib/backend-error";
 
 export function shouldUseDevBackendStub() {
     return import.meta.env.DEV && import.meta.env.VITE_STUB_BACKEND === "true";
@@ -46,6 +47,32 @@ export function isApiNotFoundError(error: unknown): boolean {
         (error as { response?: { status?: number } } | null)?.response?.status ??
         (error as { status?: number } | null)?.status;
     return status === 404;
+}
+
+// Extract the human-readable failure reason a backend returned, across every thrown shape:
+// the axios shape (`error.response.data`), the top-level-status Worker shape (`error.data`, see
+// the note above), a string body, and DRF bodies keyed on `detail`/`error`/`message`/
+// `non_field_errors` (string or list). Falls back to the error message, then a generic string.
+// Used so a real server reason (e.g. a 409 detail) surfaces in the UI instead of axios's opaque
+// "Request failed with status code 409".
+export function apiErrorDetail(error: unknown, fallback = "Run action failed."): string {
+    const body =
+        (error as { response?: { data?: unknown } } | null)?.response?.data ??
+        (error as { data?: unknown } | null)?.data;
+    // A string body is the real reason UNLESS it's an HTML error page (Cloudflare/nginx gateway
+    // 5xx, or a Django DEBUG-off 500) — dumping that whole document into the banner is worse than
+    // the axios status message, so let those fall through to `error.message`.
+    if (typeof body === "string" && body.trim() && !looksLikeHtml(body)) return body.trim();
+    if (body && typeof body === "object") {
+        const rec = body as Record<string, unknown>;
+        const candidate = rec.detail ?? rec.error ?? rec.message ?? rec.non_field_errors;
+        if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+        if (Array.isArray(candidate) && typeof candidate[0] === "string" && candidate[0].trim()) {
+            return candidate[0].trim();
+        }
+    }
+    const message = (error as { message?: string } | null)?.message;
+    return typeof message === "string" && message.trim() ? message.trim() : fallback;
 }
 
 // Catch-all stub adapter for local development only. When

--- a/app/lib/backend-error.ts
+++ b/app/lib/backend-error.ts
@@ -9,7 +9,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function looksLikeHtml(value: string) {
+export function looksLikeHtml(value: string) {
   const normalized = value.trim().toLowerCase();
   return (
     normalized.startsWith("<!doctype html") ||

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -31,7 +31,7 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import MarketingWorkflowShell from "~/components/MarketingWorkflowShell";
 import { RooPointCost } from "~/components/RooPointCost";
 import { TopicDecisionCard } from "~/components/TopicDecisionCard";
-import { isApiNotFoundError } from "~/lib/api";
+import { apiErrorDetail, isApiNotFoundError } from "~/lib/api";
 import { getEnv } from "~/lib/env.server";
 import {
   VIBE_MARKETING_ARTICLE_JOB_COST_POINTS,
@@ -684,14 +684,9 @@ export async function action({ request, params, context }: Route.ActionArgs) {
     }
   } catch (error: any) {
     if (error instanceof Response) throw error;
-    return {
-      intent,
-      error:
-        error?.data?.detail ??
-        error?.response?.data?.detail ??
-        error?.message ??
-        "Run action failed.",
-    };
+    // Surface the real backend reason (e.g. a revision 409 detail) across every thrown shape,
+    // instead of genericizing to axios's opaque "Request failed with status code 409".
+    return { intent, error: apiErrorDetail(error) };
   }
 
   throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(runId)}`);

--- a/tests/api-error-detail.test.ts
+++ b/tests/api-error-detail.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { apiErrorDetail } from "../app/lib/api";
+
+describe("apiErrorDetail", () => {
+  test("extracts the axios response.data.detail (the common 409 shape)", () => {
+    const error = {
+      response: { status: 409, data: { detail: "not accepting review comments (status=failed)" } },
+      message: "Request failed with status code 409",
+    };
+    expect(apiErrorDetail(error)).toBe("not accepting review comments (status=failed)");
+  });
+
+  test("extracts a top-level-status Worker-shape data.detail", () => {
+    const error = { status: 409, data: { detail: "missing GitHub branch context (missing: branch)" } };
+    expect(apiErrorDetail(error)).toBe("missing GitHub branch context (missing: branch)");
+  });
+
+  test("falls back to alternate DRF body keys (error / message / non_field_errors)", () => {
+    expect(apiErrorDetail({ response: { data: { error: "boom" } } })).toBe("boom");
+    expect(apiErrorDetail({ response: { data: { message: "nope" } } })).toBe("nope");
+    expect(apiErrorDetail({ response: { data: { non_field_errors: ["first problem", "second"] } } })).toBe(
+      "first problem",
+    );
+  });
+
+  test("handles a plain string body", () => {
+    expect(apiErrorDetail({ response: { data: "plain reason" } })).toBe("plain reason");
+  });
+
+  test("does not dump an HTML gateway/500 error page — falls through to the status message", () => {
+    const html = "<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>";
+    const error = { response: { status: 502, data: html }, message: "Request failed with status code 502" };
+    expect(apiErrorDetail(error)).toBe("Request failed with status code 502");
+  });
+
+  test("never renders [object Object] for a non-string detail — uses the message fallback", () => {
+    const error = { response: { data: { detail: { code: 1 } } }, message: "Request failed with status code 409" };
+    expect(apiErrorDetail(error)).toBe("Request failed with status code 409");
+  });
+
+  test("falls back to the error message, then the generic/ custom fallback", () => {
+    expect(apiErrorDetail({ message: "Network Error" })).toBe("Network Error");
+    expect(apiErrorDetail({})).toBe("Run action failed.");
+    expect(apiErrorDetail(null)).toBe("Run action failed.");
+    expect(apiErrorDetail(undefined, "custom fallback")).toBe("custom fallback");
+  });
+});


### PR DESCRIPTION
## Problem
When "Send revision comments" (and other run actions) failed, the shared action catch genericized the error — a revision **409 with a real `detail`** (e.g. "not accepting review comments (status=failed)") could fall through to axios's opaque *"Request failed with status code 409"*, so the wizard showed no reason.

## Fix
Add a robust `apiErrorDetail()` that extracts the backend reason across every thrown shape — axios (`error.response.data`), the top-level-status Worker shape (`error.data`), string bodies, and DRF `detail`/`error`/`message`/`non_field_errors` (string or list) — while **guarding against dumping an HTML gateway/500 page** (reuses the existing `looksLikeHtml`) and never rendering `[object Object]`. Wired into the shared action catch, so every intent (approve/deny/scan/revise) surfaces the real reason.

## Tests
- `apiErrorDetail` across all body shapes, incl. the HTML-page fall-through to the status message
- full suite (105) + typecheck green

Part of the three-repo revision-comments fix (mlai-backend restores the pins; content-factory logs rejections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)