### PR TITLE
Scaffold revision preview: reload the iframe on rebuild + show an 'applying comments' state

### DIFF
--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1022,6 +1022,30 @@ function normalizeLivePreview(raw: unknown): VibeMarketingLivePreview | null {
   };
 }
 
+// Revision rebuilds redeploy the preview to the SAME URL, so an iframe whose src
+// never changes silently keeps showing the stale deployment. Appending the
+// deployed revision (commit sha) as a cfRev query param gives the iframe a new
+// src per deployment; with an empty revision key the url passes through unchanged
+// so non-revision flows render byte-identical markup.
+export function previewIframeSrc(previewUrl: string | null | undefined, revisionKey: string | null | undefined): string {
+  const rawUrl = String(previewUrl ?? "");
+  if (!rawUrl.trim()) return "";
+  const key = String(revisionKey ?? "").trim();
+  if (!key) return rawUrl;
+  const url = rawUrl.trim();
+  const hashIndex = url.indexOf("#");
+  const hash = hashIndex >= 0 ? url.slice(hashIndex) : "";
+  const base = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const queryIndex = base.indexOf("?");
+  const path = queryIndex >= 0 ? base.slice(0, queryIndex) : base;
+  const query = queryIndex >= 0 ? base.slice(queryIndex + 1) : "";
+  const params = query
+    .split("&")
+    .filter((param) => param && param.split("=", 1)[0] !== "cfRev");
+  params.push(`cfRev=${encodeURIComponent(key)}`);
+  return `${path}?${params.join("&")}${hash}`;
+}
+
 function normalizeComponentFeedbackComment(raw: unknown): VibeMarketingComponentFeedbackComment | null {
   const payload = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
   if (!payload) return null;

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -61,6 +61,7 @@ import {
   getVibeMarketingGithubRepos,
   getVibeMarketingRun,
   getDailyRunStatus,
+  previewIframeSrc,
   removeNotificationChannel,
   replayVibeMarketingDaily,
   runDailyResearchNow,
@@ -101,14 +102,15 @@ const POLLING_STATUSES = new Set([
   "preview_building",
   "preview_verifying",
   "repair_preview_building",
+  "revision_preview_building",
   "awaiting_confirmation",
   "awaiting_delivery_mode",
   "awaiting_approval",
   "approval_required",
 ]);
-const LIVE_PREVIEW_ACTIVE_STATUSES = new Set(["queued", "pending", "preparing", "starting", "building", "running", "preview_verifying", "repair_preview_building"]);
+const LIVE_PREVIEW_ACTIVE_STATUSES = new Set(["queued", "pending", "preparing", "starting", "building", "running", "preview_verifying", "repair_preview_building", "revision_preview_building"]);
 const LIVE_PREVIEW_FAILURE_STATUSES = new Set(["failed", "blocked", "expired", "cancelled", "canceled", "timeout", "timed_out"]);
-const ARTICLE_SETUP_ACTIVE_STATUSES = new Set(["queued", "pending", "processing", "running", "in_progress", "preview_building", "preview_verifying", "repair_preview_building"]);
+const ARTICLE_SETUP_ACTIVE_STATUSES = new Set(["queued", "pending", "processing", "running", "in_progress", "preview_building", "preview_verifying", "repair_preview_building", "revision_preview_building"]);
 const ARTICLE_SETUP_FAILED_STATUSES = new Set(["failed", "blocked", "preview_failed"]);
 const ARTICLE_SETUP_FALLBACK_STATUSES = new Set(["fallback_ready"]);
 const ARTICLE_SETUP_PUBLISH_STATUSES = new Set(["pr_created", "setup_pr_created", "manual_merge_required", "merged", "merged_verifying", "verifying"]);
@@ -1159,7 +1161,7 @@ function setupBuildCancelActionSlot(
   );
 }
 
-function ArticleSystemSetupPreviewPanel({
+export function ArticleSystemSetupPreviewPanel({
   run,
   sourceRun,
   selectedComponent,
@@ -1246,6 +1248,12 @@ function ArticleSystemSetupPreviewPanel({
     Boolean(fallbackPreviewUrl) ||
     ARTICLE_SETUP_FALLBACK_STATUSES.has(setupStatus) ||
     isFailedArticlePreview(run.livePreview);
+  // A revision rebuild redeploys the preview in place; without a visible state the
+  // user just stares at the stale preview and concludes their comments were lost.
+  const revisionRebuildInFlight =
+    run.currentStep === "revision_preview_building" ||
+    setupStatus === "revision_preview_building" ||
+    articleSystemSetupCurrentStep(run).toLowerCase() === "revision_preview_building";
 
   return (
     <section className="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
@@ -1277,6 +1285,15 @@ function ArticleSystemSetupPreviewPanel({
               </span>
             ))}
           </div>
+        </div>
+      ) : null}
+
+      {revisionRebuildInFlight ? (
+        <div role="status" className="rounded-xl border border-violet-200 bg-violet-50 p-4">
+          <p className="text-sm font-black text-violet-950">Applying your revision comments</p>
+          <p className="mt-1 text-sm font-semibold leading-6 text-violet-900">
+            The preview rebuilds in about 3–5 minutes and refreshes here automatically. Your pinned comments stay saved.
+          </p>
         </div>
       ) : null}
 
@@ -2248,6 +2265,15 @@ function LivePreviewCommentInspectorPanel({
   }, [selectedComponent, sendInspectorCommand]);
 
   const displayPreviewUrl = previewDisplayUrl(preview?.previewUrl);
+  // Revision rebuilds redeploy to the SAME preview URL, so the iframe would never
+  // reload on its own. Key the src by the deployed commit so a fresh deployment
+  // remounts the iframe and the user sees the revised page instead of the stale one.
+  const proofRecord = preview?.proof && typeof preview.proof === "object" ? (preview.proof as Record<string, unknown>) : {};
+  const previewRevisionKey =
+    [proofRecord.commitSha, proofRecord.commit_sha, preview?.commitSha, run.result?.["branch_commit_sha"]]
+      .map((value) => (typeof value === "string" || typeof value === "number" ? String(value).trim() : ""))
+      .find(Boolean) ?? "";
+  const previewSrc = previewIframeSrc(preview?.previewUrl, previewRevisionKey);
 
   return (
     <div className="space-y-4">
@@ -2313,8 +2339,9 @@ function LivePreviewCommentInspectorPanel({
                 ) : null}
                 <iframe
                   ref={iframeRef}
+                  key={previewSrc}
                   title={previewTitle}
-                  src={preview?.previewUrl ?? ""}
+                  src={previewSrc}
                   className="h-[820px] w-full bg-white"
                   sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
                   onLoad={() => {

--- a/tests/article-system-setup-preview-panel.test.ts
+++ b/tests/article-system-setup-preview-panel.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+import { ArticleSystemSetupPreviewPanel } from "../app/routes/founder-tools.marketing.run";
+import type { VibeMarketingRunSummary } from "../app/types/vibe-marketing";
+
+function setupRun(overrides: Partial<VibeMarketingRunSummary> = {}): VibeMarketingRunSummary {
+  return {
+    runId: "setup-revision-1",
+    workflow: "article_system_setup",
+    domain: "statdoctor.app",
+    githubRepo: "DrAnuG1995/website",
+    status: "running",
+    currentStep: "build_preview",
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: [],
+    artifacts: [],
+    diagnostics: {},
+    result: {},
+    ...overrides,
+  };
+}
+
+function renderPanel(run: VibeMarketingRunSummary) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/founder-tools/marketing/runs/:runId",
+        element: createElement(ArticleSystemSetupPreviewPanel, {
+          run,
+          selectedComponent: null,
+          onSelectComponent: () => {},
+          isSubmitting: false,
+          isActionPending: () => false,
+        }),
+      },
+    ],
+    { initialEntries: [`/founder-tools/marketing/runs/${run.runId}`] },
+  );
+  return renderToStaticMarkup(createElement(RouterProvider, { router }));
+}
+
+describe("article system setup preview panel", () => {
+  test("shows the applying-revision-comments banner while a revision rebuild is in flight", () => {
+    const markup = renderPanel(setupRun({ currentStep: "revision_preview_building" }));
+
+    expect(markup).toContain("Applying your revision comments");
+    expect(markup).toContain("Your pinned comments stay saved.");
+  });
+
+  test("shows the banner when the setup payload carries the revision rebuild status", () => {
+    const markup = renderPanel(
+      setupRun({ result: { article_system_setup: { status: "revision_preview_building" } } }),
+    );
+
+    expect(markup).toContain("Applying your revision comments");
+  });
+
+  test("does not show the revision banner outside a revision rebuild", () => {
+    const markup = renderPanel(setupRun());
+
+    expect(markup).not.toContain("Applying your revision comments");
+  });
+});

--- a/tests/preview-iframe-src.test.ts
+++ b/tests/preview-iframe-src.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { previewIframeSrc } from "../app/lib/vibe-marketing";
+
+const URL = "https://cf-articles-run1.pages.dev/articles";
+
+describe("previewIframeSrc", () => {
+  test("returns an empty string for an empty preview url", () => {
+    expect(previewIframeSrc("", "abc123")).toBe("");
+    expect(previewIframeSrc(null, "abc123")).toBe("");
+    expect(previewIframeSrc(undefined, "abc123")).toBe("");
+    expect(previewIframeSrc("   ", "abc123")).toBe("");
+  });
+
+  test("returns the url unchanged when the revision key is empty", () => {
+    expect(previewIframeSrc(URL, "")).toBe(URL);
+    expect(previewIframeSrc(URL, null)).toBe(URL);
+    expect(previewIframeSrc(URL, undefined)).toBe(URL);
+    expect(previewIframeSrc(URL, "   ")).toBe(URL);
+    expect(previewIframeSrc(`${URL}?tab=preview`, "")).toBe(`${URL}?tab=preview`);
+  });
+
+  test("appends cfRev with ? when the url has no query", () => {
+    expect(previewIframeSrc(URL, "abc123")).toBe(`${URL}?cfRev=abc123`);
+  });
+
+  test("appends cfRev with & when the url already has a query", () => {
+    expect(previewIframeSrc(`${URL}?tab=preview`, "abc123")).toBe(`${URL}?tab=preview&cfRev=abc123`);
+  });
+
+  test("replaces an existing cfRev instead of duplicating it", () => {
+    expect(previewIframeSrc(`${URL}?cfRev=oldsha`, "newsha")).toBe(`${URL}?cfRev=newsha`);
+    expect(previewIframeSrc(`${URL}?tab=preview&cfRev=oldsha`, "newsha")).toBe(`${URL}?tab=preview&cfRev=newsha`);
+    expect(previewIframeSrc(`${URL}?cfRev=oldsha&tab=preview`, "newsha")).toBe(`${URL}?tab=preview&cfRev=newsha`);
+  });
+
+  test("encodes the revision key", () => {
+    expect(previewIframeSrc(URL, "sha/with spaces+chars")).toBe(`${URL}?cfRev=sha%2Fwith%20spaces%2Bchars`);
+  });
+
+  test("keeps a hash fragment after the appended query", () => {
+    expect(previewIframeSrc(`${URL}#top`, "abc123")).toBe(`${URL}?cfRev=abc123#top`);
+  });
+});


### PR DESCRIPTION
## Problem

When a user sends revision comments on the **articles-scaffold** preview, content-factory edits the setup branch and **redeploys the preview to the same pages.dev URL**. The run page's iframe `src` was that unchanged URL string, so React never re-navigated it — the user watched a *stale* preview for ~14 minutes and concluded **"nothing happens"** (prod run `f79e588a`; the revised page was in fact deployed). Compounding it, `revision_preview_building` wasn't a polling status, so the page didn't refresh during the rebuild, and there was no "we're working on it" state.

## Fix

1. **Cache-busted, remounting iframe** — new pure helper `previewIframeSrc(previewUrl, revisionKey)` appends `cfRev=<commitSha>` (replacing any prior `cfRev`, preserving `#fragments`). The iframe uses `src={previewSrc}` **and** `key={previewSrc}`, so React remounts it whenever the deployment's commit sha changes. Revision key chain: `livePreview.proof.commitSha → proof.commit_sha → livePreview.commitSha → run.result.branch_commit_sha`. When the key is empty the src is **byte-identical to today**, so the article-generation flow is unaffected.
2. **Poll through the rebuild** — `"revision_preview_building"` added to `POLLING_STATUSES`, `LIVE_PREVIEW_ACTIVE_STATUSES`, and `ARTICLE_SETUP_ACTIVE_STATUSES` (each means "a preview build is in flight for this run"), so the page keeps polling and picks up the new sha automatically. (Terminal/failed/publish sets deliberately untouched.)
3. **Visible progress** — `ArticleSystemSetupPreviewPanel` shows a violet *"Applying your revision comments — the preview rebuilds in about 3–5 minutes and refreshes here automatically. Your pinned comments stay saved."* banner while the run is in `revision_preview_building`; the existing preview/iframe stays mounted below it.

## Tests

`tests/preview-iframe-src.test.ts` (join `?`/`&`, replace existing `cfRev`, encode, preserve fragment, empty url/key) and `tests/article-system-setup-preview-panel.test.ts` (banner shown only during a revision rebuild). **bun test 115 pass; `bun run typecheck` clean.**

Pairs with the content-factory PR that makes the revision itself idempotent + serialized. This is the frontend half of the "revision comments do nothing" fix (prod run f79e588a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)