### PR TITLE
Clarify article setup review and cancellation UX

### DIFF
--- a/app/components/ArticleSystemConnectionPanel.tsx
+++ b/app/components/ArticleSystemConnectionPanel.tsx
@@ -208,6 +208,17 @@ function articleSystemSetupString(run: VibeMarketingRunSummary | null | undefine
   return stringResultValue(run, ...keys);
 }
 
+function articleSystemSetupBoolean(run: VibeMarketingRunSummary | null | undefined, ...keys: string[]) {
+  if (!run) return false;
+  const setup = articleSystemSetupPayload(run);
+  for (const key of keys) {
+    if (setup[key] !== undefined) return Boolean(setup[key]);
+    const value = resultValue(run, key);
+    if (value !== undefined) return Boolean(value);
+  }
+  return false;
+}
+
 function setupPreviewUrlForRun(run: VibeMarketingRunSummary | null | undefined) {
   if (!run) return "";
   return (
@@ -1064,6 +1075,15 @@ export default function ArticleSystemConnectionPanel({
       articleSystemSetupString(effectiveSetupRun, "preview_unsupported_reason", "previewUnsupportedReason") ??
       "",
   ).trim();
+  const baselineBuildBlocked = Boolean(
+    articleSetupState?.baselineBuildBlocked ??
+      articleSystemSetupBoolean(effectiveSetupRun, "baseline_build_blocked", "baselineBuildBlocked"),
+  );
+  const codeReviewReason = String(
+    articleSetupState?.codeReviewReason ??
+      articleSystemSetupString(effectiveSetupRun, "code_review_reason", "codeReviewReason") ??
+      "",
+  ).trim();
   const scaffoldStatusContent =
     scaffoldStatus === "ready_to_build" && isAdoptingExisting
       ? {
@@ -1080,9 +1100,11 @@ export default function ArticleSystemConnectionPanel({
         : scaffoldStatus === "review_ready" && setupCodeReviewReady
           ? {
               title: "Articles setup is ready for code review",
-              body: previewUnsupportedReason
-                ? `${previewUnsupportedReason} Open the setup build to review the changed files and approve.`
-                : "A live preview isn't supported for this site's stack yet. Open the setup build to review the changed files and approve.",
+              body: baselineBuildBlocked
+                ? `No GitHub Action was dispatched because the unchanged repository baseline failed local build verification.${codeReviewReason ? ` ${codeReviewReason}` : ""} Open the setup build to review the changed files and approve.`
+                : previewUnsupportedReason
+                  ? `${previewUnsupportedReason} Open the setup build to review the changed files and approve.`
+                  : "A live preview isn't supported for this site's stack yet. Open the setup build to review the changed files and approve.",
               tone: "violet" as const,
             }
           : scaffoldStatusCopy[scaffoldStatus];

--- a/app/components/ArticlesSetupProgressCard.tsx
+++ b/app/components/ArticlesSetupProgressCard.tsx
@@ -78,6 +78,9 @@ function normalizedSteps(run: VibeMarketingRunSummary): VibeMarketingStepState[]
 }
 
 function activeStepLabel(run: VibeMarketingRunSummary, steps: VibeMarketingStepState[]) {
+  if (run.workflow === "article_system_setup" && setupStatus(run) === "code_review_ready") {
+    return "Awaiting setup code review";
+  }
   const active =
     steps.find((step) => RUNNING_STATUSES.has(step.status)) ??
     steps.find((step) => !COMPLETE_STEP_STATUSES.has(step.status)) ??
@@ -95,6 +98,37 @@ function setupPhase(run: VibeMarketingRunSummary) {
   const stale = Boolean(run.stale || run.staleReason);
   const approved = run.status === "completed" || run.approvalState === "approved";
   const ready = READY_STATUSES.has(run.status) || READY_STATUSES.has(status);
+
+  // `code_review_ready` is a stable approval gate, not an active build. Let the
+  // setup payload win even if an older mirrored run status still says `running`.
+  if (isSetupPreviewRun && status === "code_review_ready") {
+    const setup = setupPayload(run);
+    const result = nestedObject(run.result);
+    const baselineBuildBlocked = Boolean(
+      setup.baseline_build_blocked ??
+        setup.baselineBuildBlocked ??
+        result.baseline_build_blocked ??
+        result.baselineBuildBlocked,
+    );
+    const reason = String(
+      (baselineBuildBlocked
+        ? setup.code_review_reason ?? setup.codeReviewReason ?? result.code_review_reason ?? result.codeReviewReason
+        : setup.preview_unsupported_reason ??
+          setup.previewUnsupportedReason ??
+          result.preview_unsupported_reason ??
+          result.previewUnsupportedReason) ??
+        "",
+    ).trim();
+    return {
+      title: "Articles setup ready for code review",
+      description: baselineBuildBlocked
+        ? `No GitHub Action was dispatched because the unchanged repository baseline failed local build verification.${reason ? ` ${reason}` : ""} Review the setup branch, then approve setup PR creation.`
+        : reason
+          ? `${reason} Open the setup build to review the code changes, then approve setup PR creation.`
+          : "A live preview isn't supported for this site's stack. Open the setup build to review the code changes, then approve setup PR creation.",
+      tone: "ready" as const,
+    };
+  }
 
   if (active) {
     return {
@@ -138,24 +172,6 @@ function setupPhase(run: VibeMarketingRunSummary) {
     };
   }
   if (ready) {
-    // Server-rendered stacks get no hosted preview (code_review_ready): the
-    // reviewable surface is the setup branch diff on the run page.
-    if (isSetupPreviewRun && status === "code_review_ready") {
-      const setup = setupPayload(run);
-      const reason = String(
-        setup.preview_unsupported_reason ??
-          setup.previewUnsupportedReason ??
-          nestedObject(run.result).preview_unsupported_reason ??
-          "",
-      ).trim();
-      return {
-        title: "Articles setup ready for code review",
-        description: reason
-          ? `${reason} Open the setup build to review the code changes, then approve setup PR creation.`
-          : "A live preview isn't supported for this site's stack. Open the setup build to review the code changes, then approve setup PR creation.",
-        tone: "ready" as const,
-      };
-    }
     return {
       title: isSetupPreviewRun ? "Articles setup preview ready" : "Articles setup ready to build",
       description: isSetupPreviewRun
@@ -180,7 +196,13 @@ function progressPercent(run: VibeMarketingRunSummary, steps: VibeMarketingStepS
   const currentIndex = currentStep ? steps.findIndex((step) => step.key === currentStep) : -1;
   const completedUnits = Math.max(completedSteps, currentIndex > 0 ? currentIndex : 0);
 
-  if (run.status === "completed" || run.approvalState === "approved" || READY_STATUSES.has(run.status)) return 100;
+  if (
+    run.status === "completed" ||
+    run.approvalState === "approved" ||
+    READY_STATUSES.has(run.status) ||
+    setupStatus(run) === "code_review_ready"
+  )
+    return 100;
   if (FAILED_STATUSES.has(run.status)) return Math.max(12, Math.min(100, Math.round((completedUnits / totalSteps) * 100)));
   if (RUNNING_STATUSES.has(run.status) || RUNNING_STATUSES.has(setupStatus(run))) return Math.max(12, Math.min(95, Math.round((completedUnits / totalSteps) * 100)));
   return Math.max(5, Math.min(100, Math.round((completedUnits / totalSteps) * 100)));

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -330,6 +330,8 @@ function normalizeArticleSetupState(raw: unknown): VibeMarketingArticleSetupStat
     previewRuntimeUnsupported: asBoolean(payload.previewRuntimeUnsupported ?? payload.preview_runtime_unsupported),
     previewUnsupportedReason:
       asNullableString(payload.previewUnsupportedReason) ?? asNullableString(payload.preview_unsupported_reason),
+    baselineBuildBlocked: asBoolean(payload.baselineBuildBlocked ?? payload.baseline_build_blocked),
+    codeReviewReason: asNullableString(payload.codeReviewReason) ?? asNullableString(payload.code_review_reason),
     source: source ?? undefined,
     updatedAt: asNullableString(payload.updatedAt) ?? asNullableString(payload.updated_at),
     // The scan's verdict on the chosen route. Carried through so the wizard can

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -853,7 +853,7 @@ export async function action({ request, context }: Route.ActionArgs) {
         workflow: "article_system_setup",
         companyId: activeCompanyId,
       });
-      return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
+      return redirect("/founder-tools/marketing/create?step=articleSystem");
     }
 
     if (intent === "start-discovery") {

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -508,7 +508,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         cleanup: true,
         workflow: "article_system_setup",
       });
-      throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);
+      throw redirect("/founder-tools/marketing/create?step=articleSystem");
     } else if (intent === "retry-scan") {
       const result = await controlVibeMarketingRun(env, request, runId, "resume", { workflow: "repo_scan" });
       if (result.runId) throw redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
@@ -1233,6 +1233,15 @@ export function ArticleSystemSetupPreviewPanel({
   const previewUnsupportedReason =
     stringResultValue(run, "preview_unsupported_reason", "previewUnsupportedReason") ||
     String(setup.preview_unsupported_reason ?? setup.previewUnsupportedReason ?? "");
+  const baselineBuildBlocked = Boolean(
+    setup.baseline_build_blocked ??
+      setup.baselineBuildBlocked ??
+      run.result?.baseline_build_blocked ??
+      run.result?.baselineBuildBlocked,
+  );
+  const codeReviewReason =
+    stringResultValue(run, "code_review_reason", "codeReviewReason") ||
+    String(setup.code_review_reason ?? setup.codeReviewReason ?? "");
   const setupBranchName =
     stringResultValue(run, "branch_name", "branchName") || String(setup.branch_name ?? setup.branchName ?? "");
   const setupBranchUrl = repo && setupBranchName ? `https://github.com/${repo}/tree/${setupBranchName}` : "";
@@ -1399,8 +1408,10 @@ export function ArticleSystemSetupPreviewPanel({
           <div className="rounded-xl border border-violet-200 bg-violet-50 p-4">
             <p className="text-sm font-black text-violet-950">Review the code changes to approve this setup</p>
             <p className="mt-1 text-sm font-semibold leading-6 text-violet-900">
-              {previewUnsupportedReason ||
-                "A live preview isn't supported for this site's stack yet, so the setup is reviewed from its code changes instead."}
+              {baselineBuildBlocked
+                ? `No GitHub Action was dispatched because the unchanged repository baseline failed local build verification.${codeReviewReason ? ` ${codeReviewReason}` : ""}`
+                : previewUnsupportedReason ||
+                  "A live preview isn't supported for this site's stack yet, so the setup is reviewed from its code changes instead."}
             </p>
             {setupBranchUrl ? (
               <a

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -120,6 +120,8 @@ export interface VibeMarketingArticleSetupState {
   error?: string | null;
   previewRuntimeUnsupported?: boolean;
   previewUnsupportedReason?: string | null;
+  baselineBuildBlocked?: boolean;
+  codeReviewReason?: string | null;
   source?: "config" | "scan_run" | "setup_run" | "none" | string;
   updatedAt?: string | null;
   articleSurfaceMode?: string | null;

--- a/tests/article-system-connection-panel.test.ts
+++ b/tests/article-system-connection-panel.test.ts
@@ -218,4 +218,17 @@ describe("article system connection panel", () => {
     expect(markup).toContain("supported for this site");
     expect(markup).toContain("Open the setup build to review the changed files and approve.");
   });
+
+  test("explains why no GitHub Action exists when the unchanged baseline build failed", () => {
+    const state = codeReviewReadySetupState(null);
+    state.baselineBuildBlocked = true;
+    state.codeReviewReason = "Build error: Error: supabaseUrl is required.";
+
+    const markup = renderPanel({ articleSetupState: state, scanRun: null });
+
+    expect(markup).toContain("Articles setup is ready for code review");
+    expect(markup).toContain("No GitHub Action was dispatched");
+    expect(markup).toContain("supabaseUrl is required");
+    expect(markup).not.toContain("supported for this site");
+  });
 });

--- a/tests/articles-setup-progress-card.test.ts
+++ b/tests/articles-setup-progress-card.test.ts
@@ -50,4 +50,24 @@ describe("articles setup progress card", () => {
     expect(markup).toContain("supported for this site");
     expect(markup).toContain("Open the setup build to review the code changes, then approve setup PR creation.");
   });
+
+  test("explains a baseline build block and does not render it as an active build", () => {
+    const run = codeReviewReadyRun(null);
+    run.status = "running";
+    run.result = {
+      article_system_setup: {
+        status: "code_review_ready",
+        baseline_build_blocked: true,
+        code_review_reason: "Build error: Error: supabaseUrl is required.",
+      },
+    };
+
+    const markup = renderToStaticMarkup(createElement(ArticlesSetupProgressCard, { run }));
+
+    expect(markup).toContain("Articles setup ready for code review");
+    expect(markup).toContain("No GitHub Action was dispatched");
+    expect(markup).toContain("supabaseUrl is required");
+    expect(markup).not.toContain("Building articles setup preview");
+    expect(markup).not.toContain("supported for this site");
+  });
 });


### PR DESCRIPTION
## Summary

- render code_review_ready as an approval gate even if a stale mirrored status still says running
- explain that no GitHub Action was dispatched when the unchanged baseline failed local verification
- carry baseline-blocked and code-review-reason fields through the normalized setup state
- return successful cancellation to the clean articles setup entry point

## Root cause

The UI prioritized the outer running status over the terminal setup payload and used the unsupported-stack fallback for all code-review-ready runs. That made a deliberate branch-diff review state look like a silent build stall.

## Impact

Users see the concrete repository build failure, understand why no Action or preview exists, and land back at a clean setup screen after cancellation.

## Validation

- 8 focused Bun component tests
- React Router type generation and TypeScript build
- internal article link check across 129 files
- git diff --check