### PR TITLE
Simplify mobile article review

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -534,3 +534,7 @@
 - [~] root.tsx pathname-based canonical (line 141): RECONSIDERED — it is load-bearing (strips query params, correctly consolidating /?trk= and /?utm_source= -> /). The only downside is a cosmetic /articles?page=N conflict that is harmless (deep pagination is fine not-indexed). Recommend LEAVING it as-is; vibe-raising dupes were already fixed at the worker.
 - [x] GSC "Crawled - currently not indexed" (18): diagnosed, NOT a code bug. Real articles are live 200 + index,follow + clean self-canonical (Google indexing discretion, same as Discovered). /how-to-pitch-your-idea, /?trk=, /?utm_source=chatgpt.com, /hackathon?trk= all correctly 301 -> 200 (will reclassify). /members is a dead 404 with no internal links (correct to leave, or 301 if a target chosen). /articles?page=3 = normal pagination non-indexing. Lever is request-indexing + internal linking + content differentiation + time.
 - [x] GSC "Discovered - currently not indexed" (18 articles): diagnosed as crawl-prioritization, NOT a code bug — all in sitemap with lastmod, IndexNow pinging, crawlable paginated internal links, live 200, no noindex. Lever is request-indexing + internal linking + time, not code.
+- [x] Simplify the review-ready article screen for mobile
+- [x] Remove duplicate progress and preview messaging once an article is ready
+- [x] Show one context-aware review action at a time
+- [x] Run focused tests, typecheck, and 390px browser verification

--- a/app/components/MarketingWorkflowShell.tsx
+++ b/app/components/MarketingWorkflowShell.tsx
@@ -36,6 +36,12 @@ interface MarketingWorkflowShellProps {
   activeDetailSlot?: ReactNode;
   activeDetailLabel?: string;
   activeDetailDefaultExpanded?: boolean;
+  mobileSummary?: {
+    eyebrow: string;
+    title: string;
+    status: string;
+    description?: string;
+  };
   showPrimaryAction?: boolean;
   className?: string;
 }
@@ -278,6 +284,7 @@ export default function MarketingWorkflowShell({
   activeDetailSlot,
   activeDetailLabel = "Progress details",
   activeDetailDefaultExpanded = true,
+  mobileSummary,
   showPrimaryAction = false,
   className,
 }: MarketingWorkflowShellProps) {
@@ -317,6 +324,29 @@ export default function MarketingWorkflowShell({
 
   return (
     <section className={clsx("min-w-0 lg:rounded-2xl lg:border lg:border-gray-200 lg:bg-white lg:px-8 lg:py-9 lg:shadow-md lg:shadow-gray-200/60", className)}>
+      {mobileSummary ? (
+        <div className="lg:hidden">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-black uppercase tracking-wide text-violet-600">
+                {mobileSummary.eyebrow}
+              </p>
+              <HeadingTag className="mt-1.5 text-2xl font-black leading-tight tracking-tight text-gray-950">
+                {mobileSummary.title}
+              </HeadingTag>
+            </div>
+            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-black text-amber-800">
+              <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+              {mobileSummary.status}
+            </span>
+          </div>
+          {mobileSummary.description ? (
+            <p className="mt-2 max-w-xl text-sm font-semibold leading-5 text-gray-600">
+              {mobileSummary.description}
+            </p>
+          ) : null}
+        </div>
+      ) : (
       <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm lg:hidden">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
@@ -432,6 +462,7 @@ export default function MarketingWorkflowShell({
           </ol>
         ) : null}
       </div>
+      )}
 
       <div className="hidden lg:block">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -2054,11 +2054,13 @@ function LivePreviewCommentInspectorPanel({
   emptyDraftText = "0 draft pins ready for revision.",
   submittedRetryText = "Submitted comments are ready to retry.",
   waitingBridgeText = "Waiting for comment bridge",
+  commentModeReadyText = "Comment mode active",
   actionSlot,
   unavailableSlot,
   requiresExactPreview = false,
   readOnly = false,
   initiallyExpanded = false,
+  compactMobileControls = false,
 }: {
   run: VibeMarketingRunSummary;
   targetRunId?: string | null;
@@ -2071,11 +2073,13 @@ function LivePreviewCommentInspectorPanel({
   emptyDraftText?: string;
   submittedRetryText?: string;
   waitingBridgeText?: string;
+  commentModeReadyText?: string;
   actionSlot: (state: LivePreviewCommentInspectorState) => ReactNode;
   unavailableSlot?: ReactNode;
   requiresExactPreview?: boolean;
   readOnly?: boolean;
   initiallyExpanded?: boolean;
+  compactMobileControls?: boolean;
 }) {
   const manifest = run.componentManifest;
   const components = useMemo(() => manifest?.components ?? [], [manifest]);
@@ -2336,10 +2340,15 @@ function LivePreviewCommentInspectorPanel({
   const previewSrc = previewIframeSrc(preview?.previewUrl, previewRevisionKey);
 
   return (
-    <div className="space-y-4">
+    <div className={clsx("space-y-4", compactMobileControls && "pb-20 sm:pb-0")}>
       <div className="space-y-4">
         {!previewExpanded ? (
-          <div className="sticky top-[4.75rem] z-20 flex flex-col gap-3 rounded-xl border border-gray-200 bg-white/95 p-3 shadow-sm backdrop-blur sm:top-3 sm:flex-row sm:items-center sm:justify-between">
+          <div
+            className={clsx(
+              "sticky top-[4.75rem] z-20 flex flex-col gap-3 rounded-xl border border-gray-200 bg-white/95 p-3 shadow-sm backdrop-blur sm:top-3 sm:flex-row sm:items-center sm:justify-between",
+              compactMobileControls && "hidden sm:flex",
+            )}
+          >
             <div>
               <p className="text-sm font-black text-gray-950">{reviewTitle}</p>
               <p className="text-xs font-semibold text-gray-500">
@@ -2350,7 +2359,7 @@ function LivePreviewCommentInspectorPanel({
                     : emptyDraftText}
               </p>
               <p className={clsx("mt-1 text-xs font-black", commentModeActive ? "text-emerald-700" : "text-amber-700")}>
-                {commentModeActive ? "Comment mode active" : waitingBridgeText}
+                {commentModeActive ? commentModeReadyText : waitingBridgeText}
               </p>
               {previewWarnings.length ? (
                 <details className="mt-2 text-xs font-semibold text-amber-800">
@@ -2408,13 +2417,15 @@ function LivePreviewCommentInspectorPanel({
                     )}
                   </button>
                 </div>
-                {previewExpanded ? (
+                {previewExpanded || compactMobileControls ? (
                   <div className="mt-2 flex items-center justify-between gap-3 text-[11px] font-black">
                     <span className={commentModeActive ? "text-emerald-700" : "text-amber-700"}>
-                      {commentModeActive ? "Comment mode active" : waitingBridgeText}
+                      {commentModeActive ? commentModeReadyText : waitingBridgeText}
                     </span>
                     <span className="text-gray-500">
-                      {draftComments.length} {draftNoun}{draftComments.length === 1 ? "" : "s"}
+                      {draftComments.length > 0
+                        ? `${draftComments.length} ${draftNoun}${draftComments.length === 1 ? "" : "s"}`
+                        : emptyDraftText}
                     </span>
                   </div>
                 ) : null}
@@ -2518,6 +2529,14 @@ function LivePreviewCommentInspectorPanel({
           )}
         </div>
       </div>
+      {compactMobileControls && !previewExpanded && canRenderPreview ? (
+        <div
+          className="fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white/95 px-3 pt-3 shadow-[0_-8px_24px_rgba(15,23,42,0.10)] backdrop-blur sm:hidden"
+          style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+        >
+          {actionSlot(reviewState)}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -2543,22 +2562,18 @@ function LiveArticlePreviewPanel({
   const reviewApprovalReady = isArticleReviewPreviewReady(run);
 
   return (
-    <section className="space-y-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-lg font-black text-gray-950">Live article preview</h2>
-          <p className="mt-1 text-sm font-semibold text-gray-500">
-            Review the generated article and pin comments directly on sections that need changes.
-          </p>
-        </div>
-      </div>
-
+    <section>
       <LivePreviewCommentInspectorPanel
         run={run}
         selectedComponent={selectedComponent}
         onSelectComponent={onSelectComponent}
         previewTitle="Live generated article preview"
+        reviewTitle="Review article"
+        draftNoun="comment"
+        emptyDraftText="No comments yet"
+        commentModeReadyText="Ready for comments"
         initiallyExpanded={initiallyExpanded}
+        compactMobileControls
         actionSlot={(reviewState) => {
           const canAcceptRevision =
             run.workflow === "article_revision" &&
@@ -2582,6 +2597,7 @@ function LiveArticlePreviewPanel({
             reviewState.hasPendingRevisionBatch &&
             reviewState.latestBatchStatus !== "failed" &&
             reviewState.draftComments.length === 0;
+          const showRevisionAction = reviewState.canSendRevisionRequest || revisionInProgress;
           const revisionActionLabel = submitCommentsPending
             ? "Sending comments..."
             : revisionInProgress
@@ -2623,24 +2639,26 @@ function LiveArticlePreviewPanel({
                   </button>
                 </Form>
               ) : null}
-              <Form method="POST">
-                <button
-                  type="submit"
-                  name="intent"
-                  value="submit-component-comments"
-                  disabled={isSubmitting || !reviewState.canSendRevisionRequest}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
-                >
-                  {submitCommentsPending ? (
-                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                  ) : revisionInProgress ? (
-                    <ClockIcon className="h-4 w-4" />
-                  ) : (
-                    <PaperAirplaneIcon className="h-4 w-4" />
-                  )}
-                  {revisionActionLabel}
-                </button>
-              </Form>
+              {showRevisionAction ? (
+                <Form method="POST">
+                  <button
+                    type="submit"
+                    name="intent"
+                    value="submit-component-comments"
+                    disabled={isSubmitting || !reviewState.canSendRevisionRequest}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gray-950 px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-black disabled:opacity-40 sm:w-auto"
+                  >
+                    {submitCommentsPending ? (
+                      <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                    ) : revisionInProgress ? (
+                      <ClockIcon className="h-4 w-4" />
+                    ) : (
+                      <PaperAirplaneIcon className="h-4 w-4" />
+                    )}
+                    {revisionActionLabel}
+                  </button>
+                </Form>
+              ) : null}
             </div>
           );
         }}
@@ -2846,7 +2864,6 @@ function ArticleGenerationReviewDetail({
   const hasArticlePreview = hasReadyArticlePreview(run);
   return (
     <div className="space-y-5">
-      <ArticleRunStageProgress run={run} variant="embedded" />
       {hasArticlePreview ? (
         <LiveArticlePreviewPanel
           run={run}
@@ -2857,7 +2874,10 @@ function ArticleGenerationReviewDetail({
           initiallyExpanded={initiallyExpanded}
         />
       ) : (
-        <ArticlePreviewEmptyState run={run} isSubmitting={isSubmitting} isActionPending={isActionPending} />
+        <>
+          <ArticleRunStageProgress run={run} variant="embedded" />
+          <ArticlePreviewEmptyState run={run} isSubmitting={isSubmitting} isActionPending={isActionPending} />
+        </>
       )}
     </div>
   );
@@ -4834,6 +4854,16 @@ export default function FounderToolsMarketingRun() {
           ) : undefined
         }
         activeDetailLabel={isSetupPublishView ? "Publish" : isSetupGenerateView ? "Build setup page" : isSetupReviewView ? "Review setup preview" : isArticleSetupContext ? "Articles setup progress" : isPublishAutomateView ? "Publish & automate progress" : "Generating article progress"}
+        mobileSummary={
+          isArticleGenerationRun && hasArticlePreview && !isPublishAutomateView
+            ? {
+                eyebrow: "Article review",
+                title: "Ready for review",
+                status: "Needs review",
+                description: "Tap any section to comment, or approve the draft as-is.",
+              }
+            : undefined
+        }
       />
 
       {isPublishApproval && directPublishMode ? <PublishApprovalPanel run={run} isSubmitting={isSubmitting} isActionPending={pendingActions.isPending} /> : null}

--- a/tests/article-review-boundaries.test.ts
+++ b/tests/article-review-boundaries.test.ts
@@ -37,4 +37,32 @@ describe("article review component boundaries", () => {
     expect(content).toContain("event.stopPropagation();");
     expect(content).toContain("<ArticleCommentCanvas");
   });
+
+  test("ready article reviews use the compact mobile review state", () => {
+    const route = source("app/routes/founder-tools.marketing.run.tsx");
+    const shell = source("app/components/MarketingWorkflowShell.tsx");
+    const reviewDetail = route.slice(
+      route.indexOf("function ArticleGenerationReviewDetail"),
+      route.indexOf("function ArticleSetupPublishDetail"),
+    );
+
+    expect(shell).toContain("{mobileSummary ? (");
+    expect(route).toContain('eyebrow: "Article review"');
+    expect(route).toContain('title: "Ready for review"');
+    expect(route).toContain('status: "Needs review"');
+    expect(route).toContain("compactMobileControls");
+    expect(route).toContain('compactMobileControls && "hidden sm:flex"');
+    expect(route).toContain('className="fixed inset-x-0 bottom-0 z-40');
+    expect(reviewDetail.indexOf("<LiveArticlePreviewPanel")).toBeLessThan(reviewDetail.indexOf("<ArticleRunStageProgress"));
+    expect(route).not.toContain('>Live article preview</h2>');
+  });
+
+  test("article review only shows the action relevant to the current state", () => {
+    const content = source("app/routes/founder-tools.marketing.run.tsx");
+
+    expect(content).toContain("const showRevisionAction = reviewState.canSendRevisionRequest || revisionInProgress;");
+    expect(content).toContain("{showRevisionAction ? (");
+    expect(content).toContain('emptyDraftText="No comments yet"');
+    expect(content).toContain('commentModeReadyText="Ready for comments"');
+  });
 });


### PR DESCRIPTION
## What changed

- Replaced the duplicate ready-for-review progress surfaces with a compact mobile review header.
- Moved the review action into a mobile bottom tray and show only the action relevant to the current review state.
- Kept the expanded article preview and inline comment workflow available.

## Validation

- `bun test tests/article-review-boundaries.test.ts`
- `bun run typecheck`
- Reviewed embedded and expanded layouts at 390×844.