### PR TITLE
Pin Content Factory requests to company

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,7 @@
+- [x] Pin GitHub repository reads and mutations to the company shown in Founder Tools
+- [x] Surface scan/setup start failures instead of silently redirecting
+- [x] Run company-context frontend typecheck and build
+
 - [x] Move Article authors ahead of the article-system Danger zone
 - [x] Refresh empty author cards and fields so they look active and editable
 - [x] Add focused layout and author-form render tests

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -1791,7 +1791,11 @@ export async function connectVibeMarketingGithub(env: Env, request: Request, bod
   };
 }
 
-export async function getVibeMarketingGithubRepos(env: Env, request: Request): Promise<VibeMarketingGithubReposResponse> {
+export async function getVibeMarketingGithubRepos(
+  env: Env,
+  request: Request,
+  companyId?: string | null,
+): Promise<VibeMarketingGithubReposResponse> {
   if (shouldUseDevBackendStub()) {
     return normalizeGithubReposResponse({
       status: "connected",
@@ -1810,7 +1814,10 @@ export async function getVibeMarketingGithubRepos(env: Env, request: Request): P
     });
   }
   const client = createApiClient(env, request);
-  const response = await client.get(`${BASE_PATH}/github/repos`);
+  const params = new URLSearchParams();
+  if (companyId) params.set("company_id", companyId);
+  const query = params.toString() ? `?${params.toString()}` : "";
+  const response = await client.get(`${BASE_PATH}/github/repos${query}`);
   return normalizeGithubReposResponse(response.data);
 }
 

--- a/app/routes/founder-tools.marketing.create.tsx
+++ b/app/routes/founder-tools.marketing.create.tsx
@@ -513,7 +513,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   });
   if (activeStep === "articleSystem" || requestedStep === "articleSystem") {
     try {
-      githubRepos = await getVibeMarketingGithubRepos(env, request);
+      githubRepos = await getVibeMarketingGithubRepos(env, request, activeCompanyId);
     } catch (error) {
       githubRepos = {
         status: "unavailable",
@@ -684,6 +684,8 @@ export async function action({ request, context }: Route.ActionArgs) {
         env,
         request,
         {
+          companyId: activeCompanyId,
+          company_id: activeCompanyId,
           returnUrl,
           return_url: returnUrl,
           ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),
@@ -730,6 +732,9 @@ export async function action({ request, context }: Route.ActionArgs) {
         autoSetupPreview: false,
         auto_setup_preview: false,
       });
+      if (result.error) {
+        return { intent, error: result.error, errors: result.errors };
+      }
       if (result.runId) {
         return redirect(`/founder-tools/marketing/create?step=articleSystem&scanRunId=${encodeURIComponent(result.runId)}`);
       }
@@ -756,6 +761,9 @@ export async function action({ request, context }: Route.ActionArgs) {
         autoSetupPreview: true,
         auto_setup_preview: true,
       });
+      if (result.error) {
+        return { intent, error: result.error, errors: result.errors };
+      }
       const setupRunId = result.setupRunId || result.runId;
       if (setupRunId) {
         return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(setupRunId)}`);

--- a/app/routes/founder-tools.marketing.github-connect.tsx
+++ b/app/routes/founder-tools.marketing.github-connect.tsx
@@ -3,7 +3,7 @@ import { redirect } from "react-router";
 
 import { getEnv } from "~/lib/env.server";
 import { connectVibeMarketingGithub } from "~/lib/vibe-marketing";
-import { requireVibeRaisingFounder } from "~/lib/vibe-raising";
+import { requireVibeRaisingFounder, resolveActiveCompanyId } from "~/lib/vibe-raising";
 
 const DEFAULT_RETURN_TO = "/founder-tools/marketing/create?step=articleSystem";
 
@@ -61,7 +61,8 @@ function githubAuthErrorMessage(error: unknown) {
 
 export async function loader({ request, context }: Route.LoaderArgs) {
   const env = getEnv(context);
-  await requireVibeRaisingFounder(env, request);
+  const { appUser } = await requireVibeRaisingFounder(env, request);
+  const companyId = resolveActiveCompanyId(appUser);
 
   const url = new URL(request.url);
   const returnTo = safeReturnTo(url.searchParams.get("returnTo"));
@@ -75,6 +76,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   try {
     const response = await connectVibeMarketingGithub(env, request, {
+      companyId,
+      company_id: companyId,
       returnUrl,
       return_url: returnUrl,
       ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -373,7 +373,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const shouldLoadGithubRepos = ["repo_scan", "content_factory_scan"].includes(run.workflow) && !setupRunIdForRun(run);
   if (shouldLoadGithubRepos) {
     try {
-      githubRepos = await getVibeMarketingGithubRepos(env, request);
+      githubRepos = await getVibeMarketingGithubRepos(env, request, companyId);
     } catch {
       githubRepos = { status: "unavailable", repos: [], repositories: [], error: "Repository list is unavailable." };
     }
@@ -427,6 +427,8 @@ export async function action({ request, params, context }: Route.ActionArgs) {
         env,
         request,
         {
+          companyId,
+          company_id: companyId,
           ...(githubRepo && !forceReconnect ? { githubRepo, github_repo: githubRepo } : {}),
           ...(forceReconnect ? { forceReconnect: true, force_reconnect: true } : {}),
         },

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -341,9 +341,10 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     };
   }
 
+  const activeCompanyId = resolveActiveCompanyId(vibeContext.appUser);
   const [bootstrap, githubRepos] = await Promise.all([
-    getVibeMarketingBootstrap(env, request, resolveActiveCompanyId(vibeContext.appUser), "summary"),
-    getVibeMarketingGithubRepos(env, request).catch(() => unavailableGithubRepos()),
+    getVibeMarketingBootstrap(env, request, activeCompanyId, "summary"),
+    getVibeMarketingGithubRepos(env, request, activeCompanyId).catch(() => unavailableGithubRepos()),
   ]);
   return {
     bootstrap,


### PR DESCRIPTION
## What changed
- send the selected company ID with GitHub connect and repository-list requests
- pin all Founder Tools GitHub reads and mutations to the company shown in the UI
- preserve the company scope through the GitHub reconnect resource route
- surface scan and setup start errors instead of silently redirecting

## Root cause
GitHub scan/setup calls had company scoping, but GitHub connect and repository listing did not. For a multi-company founder, those requests fell back to the backend profile active-company record, allowing a Sheldon repo selection to be written into Inner Expert configuration.

## Validation
- `bun run typecheck`
- `bunx react-router build`
- internal article-link validation passed for 129 files