### PR TITLE
Recognize projected scaffold quality stalls

### DIFF
--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -1274,15 +1274,28 @@ export function ArticleSystemSetupPreviewPanel({
   const setupBranchUrl = repo && setupBranchName ? `https://github.com/${repo}/tree/${setupBranchName}` : "";
   const setupTerminalFailure = ["blocked", "failed"].includes(run.status) || ARTICLE_SETUP_FAILED_STATUSES.has(setupStatus);
   const terminalQualityErrorCode = (
+    run.errorCode ||
     stringResultValue(run, "error_code", "errorCode") ||
     String(setup.error_code ?? setup.errorCode ?? "")
   ).trim().toUpperCase();
-  const terminalQualityStep = (
-    run.currentStep ||
-    stringResultValue(run, "failed_step", "failedStep") ||
-    String(setup.failed_step ?? setup.failedStep ?? "") ||
-    articleSystemSetupCurrentStep(run)
-  ).trim().toLowerCase();
+  // MLAI exposes the remote error code canonically at the top level, while
+  // callback state can leave `currentStep` on a generic local failure label.
+  // Check every preserved step signal instead of allowing the first stale value
+  // to hide the actual browser/style repair step.
+  const terminalQualitySteps = new Set(
+    [
+      run.currentStep,
+      articleSystemSetupCurrentStep(run),
+      articleSystemSetupFailureStep(run),
+      stringResultValue(run, "failed_step", "failedStep"),
+      String(setup.failed_step ?? setup.failedStep ?? ""),
+    ]
+      .map((value) => String(value ?? "").trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const terminalQualityStepPresent = Array.from(terminalQualitySteps).some((step) =>
+    ARTICLE_SETUP_MANUAL_QUALITY_OVERRIDE_STEPS.has(step),
+  );
   const manualQualityOverrideAvailable = Boolean(
     !setupAlreadyApproved &&
       setupExactPreviewReady &&
@@ -1291,7 +1304,7 @@ export function ArticleSystemSetupPreviewPanel({
         ARTICLE_SETUP_MANUAL_QUALITY_OVERRIDE_ERROR_CODES.has(terminalQualityErrorCode) ||
         (
           terminalQualityErrorCode === "SETUP_STEP_STALLED" &&
-          ARTICLE_SETUP_MANUAL_QUALITY_OVERRIDE_STEPS.has(terminalQualityStep)
+          terminalQualityStepPresent
         )
       ),
   );

--- a/tests/article-system-setup-preview-panel.test.ts
+++ b/tests/article-system-setup-preview-panel.test.ts
@@ -138,4 +138,32 @@ describe("article system setup preview panel", () => {
     expect(markup).toContain("Approval records your reviewed-preview override.");
     expect(markup).not.toContain("Approval unavailable");
   });
+
+  test("recognizes a projected stall code when the local current step is stale", () => {
+    const markup = renderPanel(
+      exactPreviewRun({
+        status: "blocked",
+        currentStep: "article_system_setup_preview_failed",
+        approvalState: "not_required",
+        errorCode: "SETUP_STEP_STALLED",
+        livePreview: {
+          available: true,
+          status: "failed",
+          platformStatus: "ready",
+          previewUrl: "https://preview.example/articles",
+          exactRender: true,
+        },
+        result: {
+          status: "blocked",
+          setup_status: "preview_verifying",
+          failed_step: "repair_directory_visual_style",
+          article_system_setup: { status: "preview_verifying" },
+        },
+      }),
+    );
+
+    expect(markup).toContain("Approve preview and create PR");
+    expect(markup).toContain('value="approve"');
+    expect(markup).not.toContain("Approval unavailable");
+  });
 });


### PR DESCRIPTION
## What changed

- Read the canonical top-level `errorCode` emitted by the MLAI run serializer when deciding whether a terminal exact-preview override is available.
- Evaluate every preserved setup and failure step instead of letting a stale local `currentStep` hide the underlying browser or visual repair step.
- Add a regression test matching Tala Thrive's projected run shape.

## Root cause

Content Factory correctly stored Tala's terminal `SETUP_STEP_STALLED` state and exact hosted preview, and the backend approval endpoint already supports the audited human override. MLAI projected the error code at the top level while its local callback step could remain on a generic failure label. The frontend only searched nested result fields and selected the first step value, so it rendered the green control but left it disabled.

## Validation

- `bun test tests/article-system-setup-preview-panel.test.ts tests/vibe-marketing-run-view.test.ts` (10 passed)
- `bun run typecheck`
- `git diff --check`
