### PR TITLE
Keep article generation on durable run state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -542,3 +542,6 @@
 - [x] Remove duplicate progress and preview messaging once an article is ready
 - [x] Show one context-aware review action at a time
 - [x] Run focused tests, typecheck, and 390px browser verification
+- [x] Keep new and self-healing article runs on Generate until their own review evidence exists
+- [x] Surface automatic article-setup repair and actionable setup blockers on the durable article run page
+- [x] Add focused repair-state, progress, normalization, and start-route tests; run `bun run typecheck`

--- a/app/components/ArticleRunStageProgress.tsx
+++ b/app/components/ArticleRunStageProgress.tsx
@@ -7,6 +7,10 @@ import {
 import { clsx } from "clsx";
 import { Link } from "react-router";
 
+import {
+  articlePreconditionRepairStateForRun,
+  isArticleGenerationActivelyRunning,
+} from "~/lib/vibe-marketing-run-view";
 import type { VibeMarketingRunSummary, VibeMarketingStepState } from "~/types/vibe-marketing";
 
 type StageId =
@@ -281,12 +285,22 @@ function StageIcon({ status }: { status: StageStatus }) {
 
 export function deriveArticleProgressStages(run: VibeMarketingRunSummary): StageView[] {
   const total = Math.max(run.stepOrder.length, run.steps.length, 1);
+  const repair = articlePreconditionRepairStateForRun(run);
   const activeStep = currentInternalStep(run);
-  const activeStage = stageForStep(activeStep ?? run.currentStep, activeStep ? run.steps.indexOf(activeStep) : 0, total);
+  const activeStage = repair.isPrecondition
+    ? "article_system"
+    : stageForStep(activeStep ?? run.currentStep, activeStep ? run.steps.indexOf(activeStep) : 0, total);
   const failingStep = run.steps.find((step) => FAILED_STEP_STATUSES.has(step.status)) ?? null;
-  const failingStage = failingStep ? stageForStep(failingStep, run.steps.indexOf(failingStep), total) : null;
-  const runFailed = FAILED_RUN_STATUSES.has(run.status);
-  const runRunning = RUNNING_RUN_STATUSES.has(run.status);
+  const failingStage = repair.requiresUserAction
+    ? "article_system"
+    : repair.autoRecovering
+      ? null
+      : failingStep
+      ? stageForStep(failingStep, run.steps.indexOf(failingStep), total)
+      : null;
+  const activeArticle = isArticleGenerationActivelyRunning(run);
+  const runFailed = FAILED_RUN_STATUSES.has(run.status) && !repair.autoRecovering && !activeArticle;
+  const runRunning = RUNNING_RUN_STATUSES.has(run.status) || repair.autoRecovering || activeArticle;
   const runComplete = run.status === "completed";
   const activeStageIndex = STAGE_INDEX.get(activeStage) ?? 0;
 
@@ -295,7 +309,10 @@ export function deriveArticleProgressStages(run: VibeMarketingRunSummary): Stage
     const stageSteps = run.steps.filter((step, index) => stageForStep(step, index, total) === stage.id);
     const allStageStepsComplete =
       stageSteps.length > 0 && stageSteps.every((step) => COMPLETE_STEP_STATUSES.has(step.status));
-    const attention = failingStage === stage.id || (runFailed && stage.id === activeStage);
+    const attention =
+      (repair.requiresUserAction && stage.id === "article_system") ||
+      failingStage === stage.id ||
+      (runFailed && stage.id === activeStage);
     const running = runRunning && stage.id === activeStage && !attention;
     const complete = runComplete || allStageStepsComplete || (runRunning && stageIndex < activeStageIndex && !attention);
     const status: StageStatus = attention ? "attention" : running ? "running" : complete ? "complete" : "up_next";
@@ -304,7 +321,11 @@ export function deriveArticleProgressStages(run: VibeMarketingRunSummary): Stage
       ...stage,
       status,
       detail:
-        status === "complete"
+        repair.isPrecondition && stage.id === "article_system" && status === "running"
+          ? "Refreshing the repository article setup before topic research starts automatically."
+          : repair.requiresUserAction && stage.id === "article_system" && status === "attention"
+            ? repair.message
+            : status === "complete"
           ? stage.completeText
           : status === "running"
             ? stage.activeText
@@ -323,6 +344,7 @@ export function articleRunTechnicalProgressLabel(run: VibeMarketingRunSummary) {
 
 export default function ArticleRunStageProgress({ run, variant = "standalone", reviewHref }: ArticleRunStageProgressProps) {
   const stages = deriveArticleProgressStages(run);
+  const repair = articlePreconditionRepairStateForRun(run);
   const embedded = variant === "embedded";
   const activeStage =
     stages.find((stage) => stage.status === "attention") ??
@@ -332,7 +354,11 @@ export default function ArticleRunStageProgress({ run, variant = "standalone", r
   const activeStageIndex = Math.max(0, stages.findIndex((stage) => stage.id === activeStage?.id));
   const completedStageCount = stages.filter((stage) => stage.status === "complete").length;
   const headline =
-    activeStage?.status === "attention"
+    repair.autoRecovering
+      ? "Checking article setup before research"
+      : repair.requiresUserAction
+        ? "Article setup needs attention"
+        : activeStage?.status === "attention"
       ? "This article run needs attention"
       : run.status === "completed"
         ? "Article ready for review"

--- a/app/lib/vibe-marketing-run-view.ts
+++ b/app/lib/vibe-marketing-run-view.ts
@@ -1,4 +1,4 @@
-import type { VibeMarketingRunSummary } from "~/types/vibe-marketing";
+import type { VibeMarketingRunSummary, VibeMarketingWorkflowProgress } from "~/types/vibe-marketing";
 
 const ARTICLE_WORKFLOWS = new Set([
   "article_generation",
@@ -13,6 +13,12 @@ const ARTICLE_GENERATION_WORKFLOWS = new Set([
   "direct_generate",
   "confirmed_topic",
   "article_revision",
+]);
+const ARTICLE_CREATION_WORKFLOWS = new Set([
+  "article_generation",
+  "content_factory_article",
+  "direct_generate",
+  "confirmed_topic",
 ]);
 const DISCOVERY_WORKFLOWS = new Set(["auto_discovery", "content_factory_discovery", "daily_discovery"]);
 const SCAN_WORKFLOWS = new Set(["repo_scan", "content_factory_scan"]);
@@ -32,6 +38,42 @@ const POLLING_STATUSES = new Set([
   "approval_required",
 ]);
 const APPROVAL_GATE_STATUSES = new Set(["awaiting_approval", "approval_required"]);
+const ACTIVE_ARTICLE_STATUSES = new Set([
+  "queued",
+  "pending",
+  "starting",
+  "processing",
+  "running",
+  "in_progress",
+  "preview_building",
+  "preview_verifying",
+  "repair_preview_building",
+]);
+const ACTIVE_REPAIR_STATUSES = new Set([
+  "queued",
+  "pending",
+  "starting",
+  "processing",
+  "running",
+  "in_progress",
+  "scanning",
+  "rescanning",
+  "completed",
+  "ready",
+  "verified",
+  "repaired",
+]);
+const USER_ACTION_REPAIR_STATUSES = new Set([
+  "awaiting_approval",
+  "awaiting_confirmation",
+  "awaiting_merge",
+  "auth_required",
+  "not_started",
+  "failed",
+  "blocked",
+  "resume_failed",
+]);
+const POST_GENERATE_STEP_IDS = new Set(["review", "revise", "package", "publish", "automation"]);
 
 export type ArticleSetupStepViewForRun = "generate" | "review" | "publish";
 export type ArticleStepViewForRun = "generate" | "review" | "publish";
@@ -76,8 +118,211 @@ function boolResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
   return false;
 }
 
+function optionalBoolResultValue(run: VibeMarketingRunSummary, ...keys: string[]): boolean | null {
+  for (const key of keys) {
+    const values = [
+      run.result?.[key],
+      run.result?.["result"] && typeof run.result["result"] === "object"
+        ? (run.result["result"] as Record<string, unknown>)[key]
+        : undefined,
+      run.result?.["latest_control_response"] && typeof run.result["latest_control_response"] === "object"
+        ? (run.result["latest_control_response"] as Record<string, unknown>)[key]
+        : undefined,
+    ];
+    for (const value of values) {
+      if (typeof value === "boolean") return value;
+      if (typeof value === "number") return value !== 0;
+      if (typeof value === "string") {
+        const normalizedValue = normalized(value);
+        if (["true", "1", "yes", "on"].includes(normalizedValue)) return true;
+        if (["false", "0", "no", "off"].includes(normalizedValue)) return false;
+      }
+    }
+  }
+  return null;
+}
+
 function normalized(value: string | null | undefined) {
   return String(value ?? "").trim().toLowerCase();
+}
+
+export interface ArticlePreconditionRepairState {
+  isPrecondition: boolean;
+  autoRecovering: boolean;
+  requiresUserAction: boolean;
+  repairStatus: string;
+  repairRunId: string;
+  nextAction: string;
+  message: string;
+  actionHref: string;
+  actionLabel: string;
+}
+
+export function isArticleGenerationActivelyRunning(run: VibeMarketingRunSummary) {
+  return Boolean(
+    ARTICLE_CREATION_WORKFLOWS.has(String(run.workflow ?? "")) &&
+      ACTIVE_ARTICLE_STATUSES.has(normalized(run.status)),
+  );
+}
+
+export function articlePreconditionRepairStateForRun(run: VibeMarketingRunSummary): ArticlePreconditionRepairState {
+  const repairStatus = normalized(
+    run.repairStatus || stringResultValue(run, "repair_status", "repairStatus"),
+  );
+  const preconditionStatus = normalized(
+    run.preconditionStatus ||
+      stringResultValue(run, "precondition_status", "preconditionStatus", "status", "final_status", "finalStatus"),
+  );
+  const errorCode = normalized(run.errorCode || stringResultValue(run, "error_code", "errorCode"));
+  const currentStep = normalized(run.currentStep);
+  const articleWorkHasStarted = [
+    "load_context",
+    "research",
+    "source_bundle",
+    "topic_explanation",
+    "plan_article",
+    "title_policy",
+    "draft_section",
+    "ground_section",
+    "assemble_article",
+    "generate_content_images",
+    "package_content_delivery",
+    "package_publish_bundle",
+    "render_article",
+    "validate_render",
+    "publish_preview",
+    "await_review",
+    "await_publish_approval",
+    "finalize",
+  ].some((marker) => currentStep.includes(marker));
+  const hasResolvedArticlePreview = Boolean(
+    run.componentManifest && run.livePreview?.available && String(run.livePreview.previewUrl ?? "").trim(),
+  );
+  const rawPrecondition = Boolean(
+    ARTICLE_CREATION_WORKFLOWS.has(String(run.workflow ?? "")) &&
+      (normalized(run.status) === "precondition_failed" ||
+        preconditionStatus === "precondition_failed" ||
+        errorCode === "article_system_setup_required"),
+  );
+  const isPrecondition =
+    rawPrecondition && normalized(run.status) !== "completed" && !hasResolvedArticlePreview && !articleWorkHasStarted;
+  const activeArticle = isArticleGenerationActivelyRunning(run);
+  const explicitRequiresUserAction =
+    run.requiresUserAction ?? optionalBoolResultValue(run, "requires_user_action", "requiresUserAction");
+  const repairIsActive = ACTIVE_REPAIR_STATUSES.has(repairStatus);
+  const repairNeedsUser = USER_ACTION_REPAIR_STATUSES.has(repairStatus);
+  const autoRecovering = Boolean(
+    isPrecondition &&
+      (activeArticle || (!repairNeedsUser && explicitRequiresUserAction !== true && repairIsActive)),
+  );
+  const requiresUserAction = Boolean(
+    isPrecondition &&
+      !activeArticle &&
+      (explicitRequiresUserAction === true || repairNeedsUser || !repairIsActive),
+  );
+  const repairRunId =
+    run.setupRunId?.trim() ||
+    run.repairRunId?.trim() ||
+    stringResultValue(
+      run,
+      "setup_run_id",
+      "setupRunId",
+      "repair_run_id",
+      "repairRunId",
+      "scan_run_id",
+      "scanRunId",
+      "pending_setup_run_id",
+    );
+  const nextAction = normalized(run.nextAction || stringResultValue(run, "next_action", "nextAction"));
+  const message =
+    stringResultValue(run, "repair_error", "message", "error", "hint") ||
+    run.blockingReason ||
+    run.errors[0] ||
+    "The website's article setup must be checked before research can continue.";
+  const actionHref = repairRunId && repairRunId !== run.runId
+    ? `/founder-tools/marketing/runs/${encodeURIComponent(repairRunId)}`
+    : "/founder-tools/marketing/create?step=articleSystem";
+  const actionLabel =
+    nextAction === "resume_article"
+      ? "Resume article"
+      : nextAction === "reconnect_github" || repairStatus === "auth_required"
+      ? "Reconnect GitHub"
+      : nextAction === "merge_scaffold_pr" || repairStatus === "awaiting_merge"
+        ? "Publish article setup"
+        : "Review article setup";
+
+  return {
+    isPrecondition,
+    autoRecovering,
+    requiresUserAction,
+    repairStatus,
+    repairRunId,
+    nextAction,
+    message,
+    actionHref,
+    actionLabel,
+  };
+}
+
+export function articleRunPathAfterStart(result: { runId?: string | null }) {
+  const runId = String(result.runId ?? "").trim();
+  return runId ? `/founder-tools/marketing/runs/${encodeURIComponent(runId)}` : null;
+}
+
+export function articleWorkflowProgressForRunPage(
+  run: VibeMarketingRunSummary,
+  fallbackProgress: VibeMarketingWorkflowProgress | null | undefined,
+): VibeMarketingWorkflowProgress | null {
+  const progress = run.workflowProgress ?? fallbackProgress ?? null;
+  if (!progress || !ARTICLE_CREATION_WORKFLOWS.has(String(run.workflow ?? ""))) return progress;
+
+  const repair = articlePreconditionRepairStateForRun(run);
+  const forceGenerate = isArticleGenerationActivelyRunning(run) || repair.isPrecondition;
+  if (!forceGenerate) return progress;
+
+  const normalizedSteps = progress.steps.map((step) => {
+    if (step.id === "generate") {
+      return {
+        ...step,
+        href: `/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}?articleStep=generate`,
+        status: repair.requiresUserAction ? "needs_action" : "running",
+        summary: repair.autoRecovering
+          ? "Checking the website article setup before research starts automatically."
+          : repair.requiresUserAction
+            ? "Finish the required article setup before research can continue."
+            : "Researching, drafting, and preparing this article for review.",
+        primaryAction: null,
+      };
+    }
+    if (POST_GENERATE_STEP_IDS.has(step.id)) {
+      return { ...step, status: "locked", primaryAction: null };
+    }
+    return step;
+  });
+  if (!normalizedSteps.some((step) => step.id === "generate")) {
+    const insertAt = normalizedSteps.findIndex((step) => POST_GENERATE_STEP_IDS.has(step.id));
+    const generateStep = {
+      id: "generate",
+      label: "Generate article",
+      phase: "article",
+      status: repair.requiresUserAction ? "needs_action" : "running",
+      href: `/founder-tools/marketing/runs/${encodeURIComponent(run.runId)}?articleStep=generate`,
+      summary: repair.autoRecovering
+        ? "Checking the website article setup before research starts automatically."
+        : repair.requiresUserAction
+          ? "Finish the required article setup before research can continue."
+          : "Researching, drafting, and preparing this article for review.",
+      primaryAction: null,
+    };
+    normalizedSteps.splice(insertAt >= 0 ? insertAt : normalizedSteps.length, 0, generateStep);
+  }
+
+  return {
+    ...progress,
+    currentStepId: "generate",
+    nextStepId: repair.requiresUserAction ? null : "review",
+    steps: normalizedSteps,
+  };
 }
 
 export function publishPrUrlForRun(run: VibeMarketingRunSummary) {
@@ -139,6 +384,8 @@ export function publishPreviewUrlForRun(run: VibeMarketingRunSummary) {
 
 export function hasPublishHandoffEvidence(run: VibeMarketingRunSummary) {
   if (isArticleReviewPreviewReady(run)) return false;
+  const repair = articlePreconditionRepairStateForRun(run);
+  if (isArticleGenerationActivelyRunning(run) || repair.autoRecovering) return false;
   return Boolean(
     publishPrUrlForRun(run) ||
       publishPreviewUrlForRun(run) ||
@@ -190,6 +437,13 @@ export function viewedWorkflowStepIdForRun(
   if (SCAN_WORKFLOWS.has(workflow)) return "article_system";
   if (workflow === "article_system_setup") return requestedSetupStep ?? setupWorkflowStepId ?? "generate";
   if (workflow === "website_baseline") return "baseline";
+  if (ARTICLE_CREATION_WORKFLOWS.has(workflow)) {
+    const repair = articlePreconditionRepairStateForRun(run);
+    // A newly-started or self-healing article always belongs on Generate. The
+    // organisation-level workflow progress can still point at the previous
+    // article's Review/Publish step while this run is only checking its repo.
+    if (isArticleGenerationActivelyRunning(run) || repair.isPrecondition) return "generate";
+  }
   // Explicit user override (e.g. ?articleStep=review) lets the user jump back to
   // the article preview at any point, even after the run has moved to publish.
   if (requestedArticleStep && ARTICLE_GENERATION_WORKFLOWS.has(workflow)) return requestedArticleStep;

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -137,6 +137,11 @@ function asBoolean(value: unknown): boolean {
   return Boolean(value);
 }
 
+function asOptionalBoolean(value: unknown): boolean | null {
+  if (value === null || value === undefined) return null;
+  return asBoolean(value);
+}
+
 function asNumberOrString(value: unknown): number | string | null {
   return asNumber(value) ?? asNullableString(value);
 }
@@ -355,6 +360,25 @@ export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
     payload.result && typeof payload.result === "object" && !Array.isArray(payload.result)
       ? (payload.result as Record<string, unknown>)
       : {};
+  const resultSources = [
+    result,
+    result.result && typeof result.result === "object" && !Array.isArray(result.result)
+      ? (result.result as Record<string, unknown>)
+      : null,
+    result.latest_control_response &&
+    typeof result.latest_control_response === "object" &&
+    !Array.isArray(result.latest_control_response)
+      ? (result.latest_control_response as Record<string, unknown>)
+      : null,
+  ].filter((source): source is Record<string, unknown> => Boolean(source));
+  const resultValue = (...keys: string[]) => {
+    for (const source of resultSources) {
+      for (const key of keys) {
+        if (source[key] !== null && source[key] !== undefined) return source[key];
+      }
+    }
+    return undefined;
+  };
   return {
     runId: asNullableString(payload.runId) ?? asNullableString(payload.run_id) ?? "",
     workflow: asNullableString(payload.workflow) ?? "",
@@ -379,6 +403,29 @@ export function normalizeMarketingRun(raw: unknown): VibeMarketingRunSummary {
       asNullableString(payload.blockingCode) ??
       asNullableString(payload.blocking_code) ??
       blockingCodeFromPayload(result),
+    preconditionStatus:
+      asNullableString(payload.preconditionStatus) ??
+      asNullableString(payload.precondition_status) ??
+      asNullableString(resultValue("preconditionStatus", "precondition_status")),
+    repairStatus:
+      asNullableString(payload.repairStatus) ??
+      asNullableString(payload.repair_status) ??
+      asNullableString(resultValue("repairStatus", "repair_status")),
+    repairRunId:
+      asNullableString(payload.repairRunId) ??
+      asNullableString(payload.repair_run_id) ??
+      asNullableString(resultValue("repairRunId", "repair_run_id", "scanRunId", "scan_run_id")),
+    setupRunId:
+      asNullableString(payload.setupRunId) ??
+      asNullableString(payload.setup_run_id) ??
+      asNullableString(resultValue("setupRunId", "setup_run_id", "scaffoldJobId", "scaffold_job_id")),
+    nextAction:
+      asNullableString(payload.nextAction) ??
+      asNullableString(payload.next_action) ??
+      asNullableString(resultValue("nextAction", "next_action")),
+    requiresUserAction:
+      asOptionalBoolean(payload.requiresUserAction ?? payload.requires_user_action) ??
+      asOptionalBoolean(resultValue("requiresUserAction", "requires_user_action")),
     cancelledRunIds: asStringList(payload.cancelledRunIds ?? payload.cancelled_run_ids),
     protectedRunIds: asStringList(payload.protectedRunIds ?? payload.protected_run_ids),
     artifacts: Array.isArray(payload.artifacts) ? payload.artifacts : [],
@@ -912,7 +959,10 @@ function normalizeContentPackage(raw: unknown): VibeMarketingContentPackage | nu
   const payload = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
   if (!payload) return null;
   const artifactPaths = asStringRecord(payload.artifactPaths ?? payload.artifact_paths);
-  const contentPackaged = Boolean(payload.contentPackaged ?? payload.content_packaged ?? Object.keys(artifactPaths).length);
+  // Generic run artifacts (repository scans, org-config snapshots, research
+  // bundles) are not proof that an article package exists. Only the explicit
+  // package-completion contract may unlock Review/Publish in the UI.
+  const contentPackaged = asBoolean(payload.contentPackaged ?? payload.content_packaged ?? false);
   if (!contentPackaged && !asNullableString(payload.title) && !asNullableString(payload.slug)) return null;
   return {
     title: asNullableString(payload.title),

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -41,9 +41,12 @@ import {
 } from "~/lib/vibe-marketing-billing";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
+  articlePreconditionRepairStateForRun,
   articleReviewApproveIntentForRun,
   articleReviewApproveLabelForRun,
+  articleWorkflowProgressForRunPage,
   hasPublishHandoffEvidence,
+  isArticleGenerationActivelyRunning,
   isArticleReviewPreviewReady,
   isPublishApprovalGate,
   isPublishFlowSettled,
@@ -321,6 +324,7 @@ function statusPollNeedsFullRefresh(run: VibeMarketingRunSummary) {
   if (run.workflow === "article_system_setup" && isActiveArticleSystemSetupRun(run)) {
     return false;
   }
+  if (articlePreconditionRepairStateForRun(run).autoRecovering) return false;
   if (run.status === "awaiting_confirmation" || run.status === "awaiting_approval" || run.status === "approval_required") {
     return true;
   }
@@ -393,7 +397,10 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       githubRepos = { status: "unavailable", repos: [], repositories: [], error: "Repository list is unavailable." };
     }
   }
-  const setupRunId = setupRunIdForRun(run);
+  // Article runs keep their own stable page while an associated scan/setup
+  // repairs the publish target. Loading that child as this page's setup run
+  // would incorrectly replace Generate with the separate setup workflow UI.
+  const setupRunId = isArticleGenerationWorkflow(run.workflow) ? "" : setupRunIdForRun(run);
   let setupRun: VibeMarketingRunSummary | null = null;
   if (setupRunId && setupRunId !== run.runId) {
     try {
@@ -2963,6 +2970,7 @@ function ArticleGenerationReviewDetail({
   const hasArticlePreview = hasReadyArticlePreview(run);
   return (
     <div className="space-y-5">
+      <ArticlePreconditionRepairNotice run={run} />
       {hasArticlePreview ? (
         <LiveArticlePreviewPanel
           run={run}
@@ -2979,6 +2987,74 @@ function ArticleGenerationReviewDetail({
         </>
       )}
     </div>
+  );
+}
+
+function ArticlePreconditionRepairNotice({ run }: { run: VibeMarketingRunSummary }) {
+  const repair = articlePreconditionRepairStateForRun(run);
+  if (!repair.isPrecondition) return null;
+
+  const recovering = repair.autoRecovering || isArticleGenerationActivelyRunning(run);
+  if (recovering) {
+    return (
+      <section role="status" className="rounded-xl border border-violet-200 bg-violet-50 p-5 text-violet-950">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white text-violet-700 shadow-sm">
+            <ArrowPathIcon className="h-5 w-5 animate-spin" aria-hidden="true" />
+          </span>
+          <div>
+            <h2 className="text-base font-black">Checking article setup before research</h2>
+            <p className="mt-1 max-w-2xl text-sm font-semibold leading-6 text-violet-900">
+              Content Factory is refreshing the repository&apos;s article location. This article will continue into research and writing automatically when that check is ready.
+            </p>
+            {repair.repairStatus ? (
+              <p className="mt-2 text-xs font-black uppercase tracking-wide text-violet-700">
+                Setup check: {repair.repairStatus.replace(/_/g, " ")}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!repair.requiresUserAction) return null;
+  return (
+    <section role="alert" className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-amber-950">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
+          <div>
+            <h2 className="text-base font-black">Article setup needs one action</h2>
+            <p className="mt-1 max-w-2xl text-sm font-semibold leading-6">{repair.message}</p>
+            <p className="mt-2 text-xs font-black uppercase tracking-wide text-amber-700">
+              This article run is saved and will continue after setup is ready.
+            </p>
+          </div>
+        </div>
+        {repair.nextAction === "resume_article" ? (
+          <Form method="POST">
+            <button
+              type="submit"
+              name="intent"
+              value="resume"
+              className="inline-flex w-full flex-shrink-0 items-center justify-center gap-2 rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm font-black text-amber-900 shadow-sm transition hover:bg-amber-100 sm:w-auto"
+            >
+              {repair.actionLabel}
+              <PlayIcon className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </Form>
+        ) : (
+          <Link
+            to={repair.actionHref}
+            className="inline-flex w-full flex-shrink-0 items-center justify-center gap-2 rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm font-black text-amber-900 shadow-sm transition hover:bg-amber-100 sm:w-auto"
+          >
+            {repair.actionLabel}
+            <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -4653,26 +4729,7 @@ function workflowProgressForRunPage(
       }),
     };
   }
-  if (!progress || !isArticleGenerationWorkflow(run.workflow) || !POLLING_STATUSES.has(run.status)) {
-    return progress;
-  }
-  if (progress.currentStepId === "publish" || progress.currentStepId === "automation" || hasPublishHandoffEvidence(run)) {
-    return progress;
-  }
-
-  return {
-    ...progress,
-    currentStepId: "generate",
-    nextStepId: progress.nextStepId === "generate" ? null : progress.nextStepId,
-    steps: progress.steps.map((step) =>
-      step.id === "generate"
-        ? {
-            ...step,
-            status: "running",
-          }
-        : step,
-    ),
-  };
+  return articleWorkflowProgressForRunPage(run, progress);
 }
 
 export default function FounderToolsMarketingRun() {
@@ -4700,6 +4757,9 @@ export default function FounderToolsMarketingRun() {
   const run = polledRun ?? loaderRun;
   const [selectedComponent, setSelectedComponent] = useState<VibeMarketingComponentManifestItem | null>(null);
   const workflow = String(run.workflow ?? "");
+  const isArticleWorkflowRun = isArticleWorkflow(workflow);
+  const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
+  const articleRepairState = articlePreconditionRepairStateForRun(run);
   const isScanRun = SCAN_WORKFLOWS.has(workflow);
   const isSetupScanContext = isScanRun && isSetupScanRun(run);
   const isStaleScan = isScanRun && Boolean(run.stale || run.staleReason === "scan_queue_not_started");
@@ -4718,11 +4778,10 @@ export default function FounderToolsMarketingRun() {
   const shouldPoll =
     setupRunActive ||
     (POLLING_STATUSES.has(run.status) && !isRunActionNeeded && !isScanCompleted && !isStaleScan && !setupPreviewFailed) ||
+    articleRepairState.autoRecovering ||
     setupPreviewActive ||
     hasPendingArticlePreview(run) ||
     (hasPublishHandoffEvidence(run) && !isPublishFlowSettled(run));
-  const isArticleWorkflowRun = isArticleWorkflow(workflow);
-  const isArticleGenerationRun = isArticleGenerationWorkflow(workflow);
   const hasArticlePreview = hasReadyArticlePreview(run);
   const setupBlocked = isArticleSystemSetupBlocked(bootstrap);
   const isDiscoveryConfirmation =
@@ -4731,7 +4790,7 @@ export default function FounderToolsMarketingRun() {
     !setupBlocked;
   const isPublishApproval = isPublishApprovalGate(run);
   const effectiveSetupPreviewRun = setupRun ?? (isScanRun && setupRunIdForRun(run) ? run : null);
-  const showRunAttentionBanner = RESUMABLE_ATTENTION_STATUSES.has(run.status);
+  const showRunAttentionBanner = RESUMABLE_ATTENTION_STATUSES.has(run.status) && !articleRepairState.isPrecondition;
   const canResume = Boolean(run.resumeAvailable && RESUMABLE_ATTENTION_STATUSES.has(run.status));
   const discoveryCandidates = useMemo(
     () => (isDiscoveryConfirmation ? topicCandidatesFromRun(run) : []),

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -70,6 +70,7 @@ import {
   restoreHiddenArticleId,
 } from "~/lib/vibe-marketing-article-discard";
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
+import { articleRunPathAfterStart } from "~/lib/vibe-marketing-run-view";
 import {
   controlVibeMarketingRun,
   discardVibeMarketingWrittenArticle,
@@ -747,8 +748,12 @@ export async function action({ request, context }: Route.ActionArgs) {
         sourceRunId: isCustomTopic ? "" : selectedCandidate?.sourceRunId || stringFromForm(formData, "sourceDiscoveryRunId"),
       });
 
-      if (result.runId) {
-        return redirect(`/founder-tools/marketing/runs/${encodeURIComponent(result.runId)}`);
+      const runPath = articleRunPathAfterStart(result);
+      if (runPath) {
+        // Precondition-repair runs are durable article runs too. Their run page
+        // now owns the setup-check/action state and continues polling until
+        // research begins, so keep one stable URL for the entire attempt.
+        return redirect(runPath);
       }
 
       return {

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -56,6 +56,12 @@ export interface VibeMarketingRunSummary {
   errorCode?: string | null;
   blockingReason?: string | null;
   blockingCode?: string | null;
+  preconditionStatus?: string | null;
+  repairStatus?: string | null;
+  repairRunId?: string | null;
+  setupRunId?: string | null;
+  nextAction?: string | null;
+  requiresUserAction?: boolean | null;
   cancelledRunIds?: string[];
   protectedRunIds?: string[];
   artifacts: unknown[];

--- a/tests/article-run-stage-progress.test.ts
+++ b/tests/article-run-stage-progress.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveArticleProgressStages } from "../app/components/ArticleRunStageProgress";
+import type { VibeMarketingRunSummary } from "../app/types/vibe-marketing";
+
+function repairingArticle(overrides: Partial<VibeMarketingRunSummary> = {}): VibeMarketingRunSummary {
+  return {
+    runId: "article-repair-1",
+    workflow: "confirmed_topic",
+    domain: "example.com",
+    status: "blocked",
+    currentStep: "blocked",
+    stepOrder: ["fetch_org_config", "scan_repository", "load_context", "discover_research"],
+    steps: [],
+    warnings: [],
+    errors: [],
+    artifacts: [],
+    diagnostics: {},
+    errorCode: "ARTICLE_SYSTEM_SETUP_REQUIRED",
+    preconditionStatus: "precondition_failed",
+    repairStatus: "queued",
+    requiresUserAction: false,
+    result: {},
+    ...overrides,
+  };
+}
+
+describe("article generation stage progress during setup repair", () => {
+  test("shows automatic repair as an in-progress article-system check", () => {
+    const stages = deriveArticleProgressStages(repairingArticle());
+
+    expect(stages.find((stage) => stage.id === "article_system")).toMatchObject({
+      status: "running",
+      detail: "Refreshing the repository article setup before topic research starts automatically.",
+    });
+    expect(stages.some((stage) => stage.status === "attention")).toBe(false);
+  });
+
+  test("shows a genuine setup blocker as needing attention", () => {
+    const stages = deriveArticleProgressStages(
+      repairingArticle({
+        repairStatus: "awaiting_approval",
+        requiresUserAction: true,
+        result: { message: "Approve the generated article setup before continuing." },
+      }),
+    );
+
+    expect(stages.find((stage) => stage.id === "article_system")).toMatchObject({
+      status: "attention",
+      detail: "Approve the generated article setup before continuing.",
+    });
+  });
+});

--- a/tests/vibe-marketing-run-repair-normalization.test.ts
+++ b/tests/vibe-marketing-run-repair-normalization.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeMarketingRun } from "../app/lib/vibe-marketing";
+
+describe("article repair run normalization", () => {
+  test("preserves nested precondition repair fields for the run page", () => {
+    const run = normalizeMarketingRun({
+      run_id: "article-1",
+      workflow: "confirmed_topic",
+      status: "blocked",
+      result: {
+        result: {
+          precondition_status: "precondition_failed",
+          repair_status: "queued",
+          scan_run_id: "scan-1",
+          next_action: "monitor_repair",
+          requires_user_action: false,
+        },
+      },
+    });
+
+    expect(run).toMatchObject({
+      preconditionStatus: "precondition_failed",
+      repairStatus: "queued",
+      repairRunId: "scan-1",
+      nextAction: "monitor_repair",
+      requiresUserAction: false,
+    });
+  });
+
+  test("does not treat unrelated JSON artifacts as a completed content package", () => {
+    const run = normalizeMarketingRun({
+      run_id: "article-2",
+      workflow: "confirmed_topic",
+      status: "running",
+      content_package: {
+        artifact_paths: {
+          org_config_snapshot: "fetch_org_config/org_config_snapshot.json",
+        },
+      },
+    });
+
+    expect(run.contentPackage).toBeNull();
+  });
+});

--- a/tests/vibe-marketing-run-view.test.ts
+++ b/tests/vibe-marketing-run-view.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  articlePreconditionRepairStateForRun,
   articleReviewApproveIntentForRun,
   articleReviewApproveLabelForRun,
+  articleRunPathAfterStart,
+  articleWorkflowProgressForRunPage,
   hasPublishHandoffEvidence,
   isArticleReviewPreviewReady,
   isPublishApprovalGate,
@@ -107,5 +110,172 @@ describe("vibe marketing run view state", () => {
         }),
       ),
     ).toBe("publish");
+  });
+
+  test("keeps a newly-running article on Generate despite stale publish progress", () => {
+    const run = articleRun({
+      status: "running",
+      currentStep: "fetch_org_config",
+      approvalState: null,
+      previewUrl: null,
+      componentManifest: null,
+      livePreview: null,
+      workflowProgress: {
+        currentStepId: "publish",
+        steps: [
+          { id: "generate", label: "Generate", phase: "article", status: "complete", href: "/generate" },
+          { id: "review", label: "Review", phase: "article", status: "complete", href: "/review" },
+          { id: "publish", label: "Publish", phase: "article", status: "ready", href: "/publish" },
+        ],
+      },
+      result: {},
+    });
+
+    expect(hasPublishHandoffEvidence(run)).toBe(false);
+    expect(viewedWorkflowStepIdForRun(run, null, null, "publish")).toBe("generate");
+    expect(articleWorkflowProgressForRunPage(run, null)).toMatchObject({
+      currentStepId: "generate",
+      steps: [
+        { id: "generate", status: "running" },
+        { id: "review", status: "locked" },
+        { id: "publish", status: "locked" },
+      ],
+    });
+  });
+
+  test("shows an automatic setup repair as Generate and keeps polling on the article run", () => {
+    const run = articleRun({
+      status: "blocked",
+      currentStep: "blocked",
+      approvalState: null,
+      previewUrl: null,
+      componentManifest: null,
+      contentPackage: null,
+      livePreview: null,
+      errorCode: "ARTICLE_SYSTEM_SETUP_REQUIRED",
+      preconditionStatus: "precondition_failed",
+      repairStatus: "queued",
+      repairRunId: "scan-repair-1",
+      requiresUserAction: false,
+      result: {
+        precondition_status: "precondition_failed",
+        repair_status: "queued",
+        repair_run_id: "scan-repair-1",
+        requires_user_action: false,
+      },
+    });
+
+    expect(articlePreconditionRepairStateForRun(run)).toMatchObject({
+      isPrecondition: true,
+      autoRecovering: true,
+      requiresUserAction: false,
+      repairRunId: "scan-repair-1",
+    });
+    expect(viewedWorkflowStepIdForRun(run)).toBe("generate");
+  });
+
+  test("links genuine setup blockers to their repair run", () => {
+    const run = articleRun({
+      status: "blocked",
+      currentStep: "blocked",
+      approvalState: null,
+      previewUrl: null,
+      componentManifest: null,
+      contentPackage: null,
+      livePreview: null,
+      errorCode: "ARTICLE_SYSTEM_SETUP_REQUIRED",
+      preconditionStatus: "precondition_failed",
+      repairStatus: "awaiting_approval",
+      setupRunId: "setup-review-1",
+      nextAction: "approve_scaffold",
+      requiresUserAction: true,
+      result: {},
+    });
+
+    expect(articlePreconditionRepairStateForRun(run)).toMatchObject({
+      isPrecondition: true,
+      autoRecovering: false,
+      requiresUserAction: true,
+      actionHref: "/founder-tools/marketing/runs/setup-review-1",
+      actionLabel: "Review article setup",
+    });
+    expect(viewedWorkflowStepIdForRun(run)).toBe("generate");
+    expect(articleWorkflowProgressForRunPage(run, null)?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "generate", status: "needs_action" }),
+        expect.objectContaining({ id: "publish", status: "locked" }),
+      ]),
+    );
+  });
+
+  test("turns a queued setup child into an actionable link instead of an endless repair spinner", () => {
+    const run = articleRun({
+      status: "blocked",
+      currentStep: "blocked",
+      approvalState: null,
+      previewUrl: null,
+      componentManifest: null,
+      contentPackage: null,
+      livePreview: null,
+      errorCode: "ARTICLE_SYSTEM_SETUP_REQUIRED",
+      preconditionStatus: "precondition_failed",
+      repairStatus: "setup_queued",
+      repairRunId: "setup-preview-queued-1",
+      setupRunId: "setup-preview-queued-1",
+      nextAction: "review_setup",
+      requiresUserAction: true,
+      result: {
+        precondition_status: "precondition_failed",
+        repair_status: "setup_queued",
+        repair_run_id: "setup-preview-queued-1",
+        setup_run_id: "setup-preview-queued-1",
+        next_action: "review_setup",
+        requires_user_action: true,
+      },
+    });
+
+    expect(articlePreconditionRepairStateForRun(run)).toMatchObject({
+      isPrecondition: true,
+      autoRecovering: false,
+      requiresUserAction: true,
+      repairRunId: "setup-preview-queued-1",
+      actionHref: "/founder-tools/marketing/runs/setup-preview-queued-1",
+      actionLabel: "Review article setup",
+    });
+  });
+
+  test("keeps every accepted article start on its durable run URL", () => {
+    expect(articleRunPathAfterStart({ runId: "queued-article" })).toBe(
+      "/founder-tools/marketing/runs/queued-article",
+    );
+    expect(articleRunPathAfterStart({ runId: "repairing article" })).toBe(
+      "/founder-tools/marketing/runs/repairing%20article",
+    );
+    expect(articleRunPathAfterStart({ runId: null })).toBeNull();
+  });
+
+  test("turns an exhausted automatic resume into an actionable article retry", () => {
+    const run = articleRun({
+      status: "blocked",
+      currentStep: "blocked",
+      approvalState: null,
+      previewUrl: null,
+      componentManifest: null,
+      contentPackage: null,
+      livePreview: null,
+      errorCode: "ARTICLE_SYSTEM_SETUP_REQUIRED",
+      preconditionStatus: "precondition_failed",
+      repairStatus: "resume_failed",
+      nextAction: "resume_article",
+      requiresUserAction: true,
+      result: {},
+    });
+
+    expect(articlePreconditionRepairStateForRun(run)).toMatchObject({
+      isPrecondition: true,
+      autoRecovering: false,
+      requiresUserAction: true,
+      actionLabel: "Resume article",
+    });
   });
 });


### PR DESCRIPTION
Keeps new and self-healing article runs on their durable Generate state and surfaces setup repair progress without stale Review or Publish transitions.