### PR TITLE
Hide automatic article scaffold repair warning

### DIFF
--- a/app/components/ArticleRunStageProgress.tsx
+++ b/app/components/ArticleRunStageProgress.tsx
@@ -342,9 +342,16 @@ export function articleRunTechnicalProgressLabel(run: VibeMarketingRunSummary) {
   return `${completed} of ${total} checks complete`;
 }
 
+export function articleRunVisibleError(run: VibeMarketingRunSummary) {
+  const repair = articlePreconditionRepairStateForRun(run);
+  if (repair.autoRecovering) return "";
+  return run.errors[0] ?? "";
+}
+
 export default function ArticleRunStageProgress({ run, variant = "standalone", reviewHref }: ArticleRunStageProgressProps) {
   const stages = deriveArticleProgressStages(run);
   const repair = articlePreconditionRepairStateForRun(run);
+  const visibleError = articleRunVisibleError(run);
   const embedded = variant === "embedded";
   const activeStage =
     stages.find((stage) => stage.status === "attention") ??
@@ -379,7 +386,7 @@ export default function ArticleRunStageProgress({ run, variant = "standalone", r
             Step {Math.min(activeStageIndex + 1, stages.length)} of {stages.length}
           </span>
           <span className="rounded-full bg-white px-3 py-1.5 text-xs font-black uppercase tracking-wide text-violet-700 shadow-sm">
-            {run.status.replace(/_/g, " ")}
+            {repair.autoRecovering ? "checking" : run.status.replace(/_/g, " ")}
           </span>
         </div>
       </div>
@@ -452,9 +459,9 @@ export default function ArticleRunStageProgress({ run, variant = "standalone", r
         })}
       </div>
 
-      {run.errors.length > 0 ? (
+      {visibleError ? (
         <div className={clsx("rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700", !embedded && "mt-3")}>
-          {run.errors[0]}
+          {visibleError}
         </div>
       ) : null}
     </section>

--- a/tests/article-run-stage-progress.test.ts
+++ b/tests/article-run-stage-progress.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { deriveArticleProgressStages } from "../app/components/ArticleRunStageProgress";
+import {
+  articleRunVisibleError,
+  deriveArticleProgressStages,
+} from "../app/components/ArticleRunStageProgress";
 import type { VibeMarketingRunSummary } from "../app/types/vibe-marketing";
 
 function repairingArticle(overrides: Partial<VibeMarketingRunSummary> = {}): VibeMarketingRunSummary {
@@ -27,27 +30,34 @@ function repairingArticle(overrides: Partial<VibeMarketingRunSummary> = {}): Vib
 
 describe("article generation stage progress during setup repair", () => {
   test("shows automatic repair as an in-progress article-system check", () => {
-    const stages = deriveArticleProgressStages(repairingArticle());
+    const run = repairingArticle({
+      errors: [
+        "The existing article scaffold only proves a listing page. Content Factory must repair it before generation.",
+      ],
+    });
+    const stages = deriveArticleProgressStages(run);
 
     expect(stages.find((stage) => stage.id === "article_system")).toMatchObject({
       status: "running",
       detail: "Refreshing the repository article setup before topic research starts automatically.",
     });
     expect(stages.some((stage) => stage.status === "attention")).toBe(false);
+    expect(articleRunVisibleError(run)).toBe("");
   });
 
   test("shows a genuine setup blocker as needing attention", () => {
-    const stages = deriveArticleProgressStages(
-      repairingArticle({
-        repairStatus: "awaiting_approval",
-        requiresUserAction: true,
-        result: { message: "Approve the generated article setup before continuing." },
-      }),
-    );
+    const run = repairingArticle({
+      repairStatus: "awaiting_approval",
+      requiresUserAction: true,
+      errors: ["Approve the generated article setup before continuing."],
+      result: { message: "Approve the generated article setup before continuing." },
+    });
+    const stages = deriveArticleProgressStages(run);
 
     expect(stages.find((stage) => stage.id === "article_system")).toMatchObject({
       status: "attention",
       detail: "Approve the generated article setup before continuing.",
     });
+    expect(articleRunVisibleError(run)).toBe("Approve the generated article setup before continuing.");
   });
 });


### PR DESCRIPTION
## Summary
- suppress the stale listing-only scaffold error while Content Factory is automatically repairing and resuming the article run
- present the transient blocked status as a neutral `checking` state
- continue showing genuine setup failures that require user approval or action

## Production evidence
Cowork Adelaide run `56e4750a-4acd-4138-8514-03165bdaea4f` automatically recovered and resumed, while the old precondition message remained in the initial error list. The fresh scan now proves the direct `src/articles/{category}/{slug}.tsx` target.

## Verification
- 13 focused article-repair and run-view tests passed
- React Router type generation, TypeScript build, and article internal-link checks passed