### PR TITLE
Add generated article performance analytics dashboard

### DIFF
--- a/app/components/VibeMarketingAnalyticsPerformance.tsx
+++ b/app/components/VibeMarketingAnalyticsPerformance.tsx
@@ -1,0 +1,586 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock3,
+  Eye,
+  Loader2,
+  MousePointerClick,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import { clsx } from "clsx";
+
+import {
+  AI_REFERRAL_CAVEAT,
+  getVibeMarketingAnalyticsStatus,
+  getVibeMarketingAnalyticsSummary,
+  getVibeMarketingArticleAnalytics,
+  isVibeMarketingAnalyticsEndpointUnavailable,
+  setVibeMarketingAnalyticsEnabled,
+  verifyVibeMarketingAnalyticsGsc,
+  vibeMarketingAnalyticsErrorMessage,
+} from "~/lib/vibe-marketing-analytics";
+import type {
+  VibeMarketingAnalyticsSource,
+  VibeMarketingAnalyticsStatus,
+  VibeMarketingAnalyticsSummary,
+  VibeMarketingAnalyticsTotals,
+  VibeMarketingArticleAnalytics,
+} from "~/lib/vibe-marketing-analytics";
+
+type LoadingState = "loading" | "ready" | "unavailable" | "error";
+
+function formatCount(value: number | null): string {
+  return value === null ? "—" : new Intl.NumberFormat("en-AU", { maximumFractionDigits: 0 }).format(value);
+}
+
+function rateAsPercent(value: number): number {
+  return Math.abs(value) <= 1 ? value * 100 : value;
+}
+
+function formatRate(value: number | null): string {
+  if (value === null) return "—";
+  const percent = rateAsPercent(value);
+  return `${new Intl.NumberFormat("en-AU", { maximumFractionDigits: percent < 10 ? 1 : 0 }).format(percent)}%`;
+}
+
+function formatPosition(value: number | null): string {
+  if (value === null) return "—";
+  return new Intl.NumberFormat("en-AU", { maximumFractionDigits: 1 }).format(value);
+}
+
+function formatDate(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function ratioLabel(value: number | null, visits: number | null): string | null {
+  if (value === null || visits === null || visits <= 0) return null;
+  return `${formatRate(value / visits)} of visits`;
+}
+
+function MetricCard({
+  label,
+  value,
+  detail,
+  tone = "slate",
+}: {
+  label: string;
+  value: string;
+  detail?: string | null;
+  tone?: "slate" | "violet" | "emerald" | "blue";
+}) {
+  const toneClasses = {
+    slate: "bg-slate-50 text-slate-950",
+    violet: "bg-violet-50 text-violet-950",
+    emerald: "bg-emerald-50 text-emerald-950",
+    blue: "bg-blue-50 text-blue-950",
+  } as const;
+  return (
+    <div className={clsx("min-w-0 rounded-xl px-4 py-3", toneClasses[tone])}>
+      <p className="text-[11px] font-black uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-2 truncate text-xl font-black">{value}</p>
+      {detail ? <p className="mt-1 text-[11px] font-bold text-slate-500">{detail}</p> : null}
+    </div>
+  );
+}
+
+function TotalsGrid({ totals, compact = false }: { totals: VibeMarketingAnalyticsTotals; compact?: boolean }) {
+  const cards = [
+    { label: "Search impressions", value: formatCount(totals.searchImpressions), tone: "blue" as const },
+    { label: "Search clicks", value: formatCount(totals.searchClicks), tone: "blue" as const },
+    { label: "Search CTR", value: formatRate(totals.searchCtr), tone: "blue" as const },
+    { label: "Avg. position", value: formatPosition(totals.averagePosition), tone: "blue" as const },
+    { label: "Visits", value: formatCount(totals.visits), tone: "slate" as const },
+    {
+      label: "Engaged 30s",
+      value: formatCount(totals.engaged30),
+      detail: ratioLabel(totals.engaged30, totals.visits),
+      tone: "violet" as const,
+    },
+    {
+      label: "Scrolled 50%",
+      value: formatCount(totals.scroll50),
+      detail: ratioLabel(totals.scroll50, totals.visits),
+      tone: "violet" as const,
+    },
+    {
+      label: "Scrolled 90%",
+      value: formatCount(totals.scroll90),
+      detail: ratioLabel(totals.scroll90, totals.visits),
+      tone: "violet" as const,
+    },
+    { label: "CTA impressions", value: formatCount(totals.ctaImpressions), tone: "emerald" as const },
+    { label: "CTA clicks", value: formatCount(totals.ctaClicks), tone: "emerald" as const },
+    { label: "CTA conversion", value: formatRate(totals.ctaConversionRate), tone: "emerald" as const },
+  ];
+
+  return (
+    <div className={clsx("grid grid-cols-2 gap-2", compact ? "sm:grid-cols-4" : "") }>
+      {cards.map((card) => (
+        <MetricCard key={card.label} {...card} />
+      ))}
+    </div>
+  );
+}
+
+function TrafficSources({ sources }: { sources: VibeMarketingAnalyticsSource[] }) {
+  const maxVisits = Math.max(1, ...sources.map((source) => source.visits));
+  if (!sources.length) {
+    return <p className="rounded-xl bg-slate-50 px-4 py-5 text-sm font-semibold text-slate-500">No source data has arrived yet.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {sources.slice(0, 6).map((source) => (
+        <div key={source.key}>
+          <div className="flex items-center justify-between gap-3 text-xs font-bold">
+            <span className="flex min-w-0 items-center gap-2 text-slate-700">
+              <span className="truncate">{source.label}</span>
+              {source.isAi ? (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-violet-50 px-2 py-0.5 text-[10px] font-black text-violet-700">
+                  <Bot className="h-3 w-3" /> AI
+                </span>
+              ) : null}
+            </span>
+            <span className="shrink-0 text-slate-500">
+              {formatCount(source.visits)} visits{source.share !== null ? ` · ${formatRate(source.share)}` : ""}
+              {source.ctaClicks > 0 ? ` · ${formatCount(source.ctaClicks)} CTA clicks` : ""}
+            </span>
+          </div>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-100">
+            <div
+              className={clsx("h-full rounded-full", source.isAi ? "bg-violet-500" : "bg-slate-700")}
+              style={{ width: `${Math.max(4, (source.visits / maxVisits) * 100)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SearchQueries({ queries }: { queries: VibeMarketingArticleAnalytics["queries"] }) {
+  if (!queries.length) return null;
+  return (
+    <div>
+      <p className="mb-2 text-xs font-black uppercase tracking-wide text-slate-500">Top Google queries (best effort)</p>
+      <div className="overflow-hidden rounded-lg border border-slate-100">
+        {queries.slice(0, 10).map((query) => (
+          <div key={query.query} className="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-3 border-b border-slate-100 px-3 py-2 text-xs last:border-b-0">
+            <span className="truncate font-bold text-slate-700">{query.query}</span>
+            <span className="font-semibold text-slate-500">{formatCount(query.clicks)} clicks</span>
+            <span className="font-semibold text-slate-500">{formatRate(query.ctr)} CTR</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FreshnessLine({ summary }: { summary: VibeMarketingAnalyticsSummary }) {
+  const analyticsThrough = formatDate(summary.freshness.analyticsDataThrough);
+  const searchThrough = formatDate(summary.freshness.searchDataThrough);
+  const updatedAt = formatDate(summary.freshness.updatedAt);
+  const parts = [
+    analyticsThrough ? `On-page data through ${analyticsThrough}` : null,
+    searchThrough ? `Search data through ${searchThrough}` : null,
+    !analyticsThrough && !searchThrough && updatedAt ? `Updated ${updatedAt}` : null,
+  ].filter(Boolean);
+
+  return (
+    <div
+      className={clsx(
+        "flex items-start gap-2 rounded-lg px-3 py-2 text-xs font-bold",
+        summary.freshness.stale ? "bg-amber-50 text-amber-800" : "bg-slate-50 text-slate-500",
+      )}
+    >
+      <Clock3 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>
+        {summary.freshness.message || parts.join(" · ") || "Waiting for the first analytics sync."}
+        {searchThrough ? " Search Console data is finalized later than on-page events." : ""}
+      </span>
+    </div>
+  );
+}
+
+function ArticleHeadlineMetrics({ totals }: { totals: VibeMarketingAnalyticsTotals }) {
+  return (
+    <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+      <div className="rounded-lg bg-blue-50 px-2 py-2">
+        <p className="text-[10px] font-black uppercase text-blue-700">Search clicks</p>
+        <p className="mt-1 text-sm font-black text-slate-950">{formatCount(totals.searchClicks)}</p>
+      </div>
+      <div className="rounded-lg bg-violet-50 px-2 py-2">
+        <p className="text-[10px] font-black uppercase text-violet-700">Visits</p>
+        <p className="mt-1 text-sm font-black text-slate-950">{formatCount(totals.visits)}</p>
+      </div>
+      <div className="rounded-lg bg-emerald-50 px-2 py-2">
+        <p className="text-[10px] font-black uppercase text-emerald-700">CTA rate</p>
+        <p className="mt-1 text-sm font-black text-slate-950">{formatRate(totals.ctaConversionRate)}</p>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="rounded-xl border border-rose-100 bg-rose-50 px-4 py-5">
+      <p className="text-sm font-black text-rose-800">Article performance is temporarily unavailable.</p>
+      <p className="mt-2 text-sm font-semibold leading-6 text-rose-700">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-4 inline-flex items-center gap-2 rounded-lg bg-white px-3 py-2 text-xs font-black text-rose-700 shadow-sm"
+      >
+        <RefreshCw className="h-3.5 w-3.5" /> Try again
+      </button>
+    </div>
+  );
+}
+
+export default function VibeMarketingAnalyticsPerformance({ companyId }: { companyId?: string | null }) {
+  const [loadingState, setLoadingState] = useState<LoadingState>("loading");
+  const [status, setStatus] = useState<VibeMarketingAnalyticsStatus | null>(null);
+  const [summary, setSummary] = useState<VibeMarketingAnalyticsSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [action, setAction] = useState<"enable" | "gsc" | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [expandedArticleId, setExpandedArticleId] = useState<string | null>(null);
+  const [articleDetails, setArticleDetails] = useState<Record<string, VibeMarketingArticleAnalytics>>({});
+  const [articleLoadingId, setArticleLoadingId] = useState<string | null>(null);
+  const [articleErrors, setArticleErrors] = useState<Record<string, string>>({});
+
+  const options = useMemo(() => ({ companyId }), [companyId]);
+
+  const load = useCallback(async () => {
+    setLoadingState("loading");
+    setError(null);
+    try {
+      const nextStatus = await getVibeMarketingAnalyticsStatus(options);
+      setStatus(nextStatus);
+      if (!nextStatus.available) {
+        setSummary(null);
+        setLoadingState("unavailable");
+        return;
+      }
+      if (!nextStatus.enabled) {
+        setSummary(null);
+        setLoadingState("ready");
+        return;
+      }
+      const nextSummary = await getVibeMarketingAnalyticsSummary("28d", options);
+      setSummary(nextSummary);
+      setLoadingState("ready");
+    } catch (loadError) {
+      if (isVibeMarketingAnalyticsEndpointUnavailable(loadError)) {
+        setLoadingState("unavailable");
+        setError(null);
+        return;
+      }
+      setError(vibeMarketingAnalyticsErrorMessage(loadError));
+      setLoadingState("error");
+    }
+  }, [options]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const enableAnalytics = useCallback(
+    async () => {
+      setAction("enable");
+      setActionMessage(null);
+      try {
+        await setVibeMarketingAnalyticsEnabled(true, options);
+        await load();
+      } catch (actionError) {
+        setActionMessage(vibeMarketingAnalyticsErrorMessage(actionError, "Analytics could not be enabled."));
+      } finally {
+        setAction(null);
+      }
+    },
+    [load, options],
+  );
+
+  const verifyGsc = useCallback(async () => {
+    setAction("gsc");
+    setActionMessage(null);
+    try {
+      const gsc = await verifyVibeMarketingAnalyticsGsc(options);
+      setStatus((current) => (current ? { ...current, gsc } : current));
+      setActionMessage(gsc.message || (gsc.connected ? "Search Console access verified." : "Search Console access is not available yet."));
+    } catch (verifyError) {
+      setActionMessage(vibeMarketingAnalyticsErrorMessage(verifyError, "Search Console access could not be verified."));
+    } finally {
+      setAction(null);
+    }
+  }, [options]);
+
+  const toggleArticle = useCallback(
+    async (articleId: string) => {
+      if (expandedArticleId === articleId) {
+        setExpandedArticleId(null);
+        return;
+      }
+      setExpandedArticleId(articleId);
+      if (articleDetails[articleId]) return;
+      setArticleLoadingId(articleId);
+      setArticleErrors((current) => {
+        const next = { ...current };
+        delete next[articleId];
+        return next;
+      });
+      try {
+        const detail = await getVibeMarketingArticleAnalytics(articleId, "90d", options);
+        setArticleDetails((current) => ({ ...current, [articleId]: detail }));
+      } catch (detailError) {
+        setArticleErrors((current) => ({
+          ...current,
+          [articleId]: vibeMarketingAnalyticsErrorMessage(detailError, "The 90-day article detail could not be loaded."),
+        }));
+      } finally {
+        setArticleLoadingId((current) => (current === articleId ? null : current));
+      }
+    },
+    [articleDetails, expandedArticleId, options],
+  );
+
+  if (loadingState === "loading") {
+    return (
+      <div className="flex items-center gap-3 rounded-xl bg-slate-50 px-4 py-5 text-sm font-bold text-slate-600">
+        <Loader2 className="h-4 w-4 animate-spin text-violet-600" />
+        Checking analytics status…
+      </div>
+    );
+  }
+
+  if (loadingState === "unavailable") {
+    return (
+      <div className="rounded-xl bg-slate-50 px-4 py-5">
+        <p className="text-sm font-black text-slate-950">Performance analytics is being prepared.</p>
+        <p className="mt-2 text-sm font-semibold leading-6 text-slate-500">
+          This dashboard will appear here as soon as analytics support is enabled for your Content Factory site. Your articles and the rest of this page still work normally.
+        </p>
+      </div>
+    );
+  }
+
+  if (loadingState === "error") {
+    return <ErrorState message={error || "The analytics service did not respond."} onRetry={() => void load()} />;
+  }
+
+  const statusName = status?.status.toLowerCase() || "";
+  const provisioning = statusName === "provisioning" || statusName === "pending";
+  const provisioningFailed = statusName === "error";
+  if (!status?.enabled || provisioning || provisioningFailed) {
+    return (
+      <div className="rounded-xl border border-violet-100 bg-violet-50 px-4 py-5">
+        <p className="text-sm font-black text-violet-950">
+          {provisioning
+            ? "Analytics setup is in progress."
+            : provisioningFailed
+              ? "Analytics setup needs another attempt."
+              : "Measure how your published articles perform."}
+        </p>
+        <p className="mt-2 text-sm font-semibold leading-6 text-violet-800">
+          {status?.message ||
+            (provisioning
+              ? "Provisioning can take a few minutes. Refresh to check again."
+              : provisioningFailed
+                ? "The analytics service could not finish provisioning. Retry after checking its configuration."
+                : "Turn on anonymous article analytics to see search visibility, reading depth, and CTA clicks. No visitor profiles are shown here.")}
+        </p>
+        <button
+          type="button"
+          disabled={action !== null}
+          onClick={() => (provisioning ? void load() : void enableAnalytics())}
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-violet-700 px-4 py-2.5 text-xs font-black text-white disabled:opacity-50"
+        >
+          {action === "enable" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : provisioning ? <RefreshCw className="h-3.5 w-3.5" /> : <Activity className="h-3.5 w-3.5" />}
+          {provisioning
+            ? "Check setup"
+            : action === "enable"
+              ? provisioningFailed
+                ? "Retrying…"
+                : "Enabling…"
+              : provisioningFailed
+                ? "Retry analytics setup"
+                : "Enable article analytics"}
+        </button>
+        {actionMessage ? <p className="mt-3 text-xs font-bold text-rose-700">{actionMessage}</p> : null}
+      </div>
+    );
+  }
+
+  if (!summary) {
+    return <ErrorState message="Analytics is enabled, but no summary was returned." onRetry={() => void load()} />;
+  }
+
+  const hasAnyData = Object.values(summary.totals).some((value) => value !== null && value > 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-black uppercase tracking-wide text-violet-700">Last 28 days</p>
+          <p className="mt-1 text-sm font-semibold text-slate-500">
+            Anonymous, aggregate results from Content Factory article pages only.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="inline-flex shrink-0 items-center gap-2 self-start rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-black text-slate-600 hover:bg-slate-50"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refresh
+        </button>
+      </div>
+
+      <FreshnessLine summary={summary} />
+
+      {!status.collecting ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-4">
+          <p className="text-sm font-black text-amber-950">The article scaffold still needs its analytics update.</p>
+          <p className="mt-1 text-xs font-semibold leading-5 text-amber-800">
+            {status.message ||
+              "Analytics is provisioned, but visits will not be reported reliably until the existing Content Factory article scaffold is rebuilt and published."}
+          </p>
+        </div>
+      ) : null}
+
+      {!hasAnyData ? (
+        <div className="rounded-xl bg-slate-50 px-4 py-5 text-sm font-semibold leading-6 text-slate-500">
+          Analytics is enabled and waiting for the first published-article visit. Search Console figures can take two to three days to finalize.
+        </div>
+      ) : null}
+
+      <div>
+        <div className="mb-3 flex items-center gap-2">
+          <Search className="h-4 w-4 text-blue-600" />
+          <h3 className="text-sm font-black text-slate-950">Search, engagement, and calls to action</h3>
+        </div>
+        <TotalsGrid totals={summary.totals} />
+      </div>
+
+      <div>
+        <div className="mb-3 flex items-center gap-2">
+          <Eye className="h-4 w-4 text-violet-600" />
+          <h3 className="text-sm font-black text-slate-950">Where article visits came from</h3>
+        </div>
+        <TrafficSources sources={summary.sources} />
+        <p className="mt-4 rounded-lg border border-violet-100 bg-violet-50 px-3 py-3 text-xs font-semibold leading-5 text-violet-800">
+          {AI_REFERRAL_CAVEAT}
+        </p>
+      </div>
+
+      <div>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <MousePointerClick className="h-4 w-4 text-emerald-600" />
+            <h3 className="text-sm font-black text-slate-950">Published article results</h3>
+          </div>
+          <span className="text-xs font-bold text-slate-400">{summary.articles.length} tracked</span>
+        </div>
+        {summary.articles.length ? (
+          <div className="space-y-3">
+            {summary.articles.map((article) => {
+              const expanded = expandedArticleId === article.id;
+              const detail = articleDetails[article.id];
+              const detailError = articleErrors[article.id];
+              return (
+                <article key={article.id} className="rounded-xl border border-slate-200 bg-white p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="line-clamp-2 text-sm font-black leading-5 text-slate-950">{article.title}</p>
+                      {article.url ? (
+                        <a
+                          href={article.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="mt-1 block truncate text-xs font-bold text-violet-700 hover:underline"
+                        >
+                          {article.slug || article.url}
+                        </a>
+                      ) : article.slug ? (
+                        <p className="mt-1 truncate text-xs font-bold text-slate-400">{article.slug}</p>
+                      ) : null}
+                    </div>
+                    <button
+                      type="button"
+                      aria-expanded={expanded}
+                      onClick={() => void toggleArticle(article.id)}
+                      className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-slate-50 px-2.5 py-2 text-[11px] font-black text-slate-600 hover:bg-slate-100"
+                    >
+                      90 days
+                      {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                    </button>
+                  </div>
+                  <ArticleHeadlineMetrics totals={article.totals} />
+                  {expanded ? (
+                    <div className="mt-4 border-t border-slate-100 pt-4">
+                      {articleLoadingId === article.id ? (
+                        <p className="flex items-center gap-2 text-xs font-bold text-slate-500">
+                          <Loader2 className="h-3.5 w-3.5 animate-spin text-violet-600" /> Loading 90-day results…
+                        </p>
+                      ) : detailError ? (
+                        <p className="text-xs font-bold text-rose-700">{detailError}</p>
+                      ) : detail ? (
+                        <div className="space-y-4">
+                          <TotalsGrid totals={detail.totals} compact />
+                          {detail.sources.length ? <TrafficSources sources={detail.sources} /> : null}
+                          <SearchQueries queries={detail.queries} />
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="rounded-xl bg-slate-50 px-4 py-5 text-sm font-semibold text-slate-500">
+            No published article has reported performance data yet.
+          </p>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4">
+        <div className="flex items-start gap-3">
+          <span className={clsx("mt-0.5", status.gsc.connected ? "text-emerald-600" : "text-slate-400")}>
+            {status.gsc.connected ? <CheckCircle2 className="h-5 w-5" /> : <Search className="h-5 w-5" />}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-black text-slate-950">
+              {status.gsc.connected ? "Search Console connected" : "Check Search Console access"}
+            </p>
+            <p className="mt-1 text-xs font-semibold leading-5 text-slate-500">
+              {status.gsc.property || status.gsc.message || "Verify that MLAI's service account can read this website's Search Console property."}
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={action !== null}
+            onClick={() => void verifyGsc()}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-[11px] font-black text-slate-700 disabled:opacity-50"
+          >
+            {action === "gsc" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Verify
+          </button>
+        </div>
+        {actionMessage ? <p className="mt-3 text-xs font-bold text-slate-600">{actionMessage}</p> : null}
+      </div>
+
+    </div>
+  );
+}

--- a/app/components/VibeMarketingAnalyticsSection.tsx
+++ b/app/components/VibeMarketingAnalyticsSection.tsx
@@ -1,0 +1,55 @@
+import { lazy, Suspense, useState } from "react";
+import { BarChart3, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+
+const VibeMarketingAnalyticsPerformance = lazy(
+  () => import("~/components/VibeMarketingAnalyticsPerformance"),
+);
+
+export default function VibeMarketingAnalyticsSection({
+  companyId,
+}: {
+  companyId?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-start justify-between gap-4 text-left"
+      >
+        <span className="flex min-w-0 gap-4">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-violet-50 text-violet-700">
+            <BarChart3 className="h-5 w-5" />
+          </span>
+          <span className="min-w-0">
+            <span className="block text-lg font-black text-slate-950">Article performance</span>
+            <span className="mt-1 block text-sm font-semibold leading-6 text-slate-500">
+              Search visibility, reader engagement, and CTA results for your published articles.
+            </span>
+          </span>
+        </span>
+        <span className="mt-1 shrink-0 text-slate-400" aria-hidden="true">
+          {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+        </span>
+      </button>
+
+      {open ? (
+        <div className="mt-6 border-t border-slate-100 pt-6">
+          <Suspense
+            fallback={
+              <div className="flex items-center gap-3 rounded-xl bg-slate-50 px-4 py-5 text-sm font-bold text-slate-600">
+                <Loader2 className="h-4 w-4 animate-spin text-violet-600" />
+                Loading article performance…
+              </div>
+            }
+          >
+            <VibeMarketingAnalyticsPerformance companyId={companyId} />
+          </Suspense>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/lib/vibe-marketing-analytics.ts
+++ b/app/lib/vibe-marketing-analytics.ts
@@ -1,0 +1,457 @@
+import { apiErrorDetail, axiosInstance } from "~/lib/api";
+
+const ANALYTICS_BASE_PATH = "/api/v1/vibe-marketing/analytics";
+
+export const AI_REFERRAL_CAVEAT =
+  "AI referrals are a detectable lower bound. Some assistants strip referrers or open links as direct traffic, so unattributed visits may include additional AI traffic.";
+
+export type VibeMarketingAnalyticsRange = "7d" | "28d" | "90d" | "16m";
+
+export interface VibeMarketingAnalyticsTotals {
+  searchImpressions: number | null;
+  searchClicks: number | null;
+  searchCtr: number | null;
+  averagePosition: number | null;
+  visits: number | null;
+  engaged30: number | null;
+  scroll50: number | null;
+  scroll90: number | null;
+  ctaImpressions: number | null;
+  ctaClicks: number | null;
+  ctaConversionRate: number | null;
+}
+
+export interface VibeMarketingAnalyticsFreshness {
+  status: string | null;
+  updatedAt: string | null;
+  analyticsDataThrough: string | null;
+  searchDataThrough: string | null;
+  stale: boolean;
+  delayDays: number | null;
+  message: string | null;
+}
+
+export interface VibeMarketingAnalyticsSource {
+  key: string;
+  label: string;
+  visits: number;
+  ctaClicks: number;
+  share: number | null;
+  isAi: boolean;
+}
+
+export interface VibeMarketingAnalyticsQuery {
+  query: string;
+  clicks: number;
+  impressions: number;
+  ctr: number | null;
+}
+
+export interface VibeMarketingArticleAnalytics {
+  id: string;
+  title: string;
+  slug: string | null;
+  url: string | null;
+  totals: VibeMarketingAnalyticsTotals;
+  sources: VibeMarketingAnalyticsSource[];
+  queries: VibeMarketingAnalyticsQuery[];
+  freshness: VibeMarketingAnalyticsFreshness;
+}
+
+export interface VibeMarketingAnalyticsSummary {
+  range: VibeMarketingAnalyticsRange;
+  startDate: string | null;
+  endDate: string | null;
+  totals: VibeMarketingAnalyticsTotals;
+  sources: VibeMarketingAnalyticsSource[];
+  articles: VibeMarketingArticleAnalytics[];
+  freshness: VibeMarketingAnalyticsFreshness;
+}
+
+export interface VibeMarketingGscConnection {
+  status: string;
+  connected: boolean;
+  property: string | null;
+  message: string | null;
+  lastVerifiedAt: string | null;
+}
+
+export interface VibeMarketingAnalyticsStatus {
+  status: string;
+  available: boolean;
+  enabled: boolean;
+  collecting: boolean;
+  provider: string | null;
+  lastEventAt: string | null;
+  lastSyncedAt: string | null;
+  message: string | null;
+  gsc: VibeMarketingGscConnection;
+}
+
+export interface VibeMarketingAnalyticsHttpClient {
+  get(url: string): Promise<{ data: unknown }>;
+  post(url: string, body?: unknown): Promise<{ data: unknown }>;
+}
+
+export interface VibeMarketingAnalyticsRequestOptions {
+  companyId?: string | null;
+  client?: VibeMarketingAnalyticsHttpClient;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on", "enabled", "active", "collecting", "connected"].includes(normalized)) return true;
+    if (["0", "false", "no", "off", "disabled", "inactive", "disconnected"].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function firstString(records: Record<string, unknown>[], keys: string[]): string | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = asString(record[key]);
+      if (value !== null) return value;
+    }
+  }
+  return null;
+}
+
+function firstNumber(records: Record<string, unknown>[], keys: string[]): number | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = asNumber(record[key]);
+      if (value !== null) return value;
+    }
+  }
+  return null;
+}
+
+function metricRecords(raw: unknown): Record<string, unknown>[] {
+  const payload = asRecord(raw);
+  const totals = asRecord(payload.totals ?? payload.metrics);
+  return [
+    totals,
+    asRecord(totals.search ?? totals.searchConsole ?? totals.search_console ?? totals.gsc),
+    asRecord(totals.engagement ?? totals.behaviour ?? totals.behavior ?? totals.umami),
+    asRecord(totals.cta ?? totals.conversions),
+    payload,
+    asRecord(payload.search ?? payload.searchConsole ?? payload.search_console ?? payload.gsc),
+    asRecord(payload.engagement ?? payload.behaviour ?? payload.behavior ?? payload.umami),
+    asRecord(payload.cta ?? payload.conversions),
+  ];
+}
+
+export function normalizeVibeMarketingAnalyticsTotals(raw: unknown): VibeMarketingAnalyticsTotals {
+  const records = metricRecords(raw);
+  const searchImpressions = firstNumber(records, ["searchImpressions", "search_impressions", "gscImpressions", "gsc_impressions", "impressions"]);
+  const searchClicks = firstNumber(records, ["searchClicks", "search_clicks", "gscClicks", "gsc_clicks", "clicks"]);
+  const visits = firstNumber(records, ["visits", "articleVisits", "article_visits", "pageViews", "page_views", "pageviews"]);
+  const ctaClicks = firstNumber(records, ["ctaClicks", "cta_clicks", "ctaClickCount", "cta_click_count"]);
+  const suppliedSearchCtr = firstNumber(records, ["searchCtr", "search_ctr", "gscCtr", "gsc_ctr", "ctr"]);
+  const suppliedCtaConversion = firstNumber(records, [
+    "ctaConversionRate",
+    "cta_conversion_rate",
+    "ctaConversion",
+    "cta_conversion",
+    "conversionRate",
+    "conversion_rate",
+  ]);
+
+  return {
+    searchImpressions,
+    searchClicks,
+    searchCtr:
+      suppliedSearchCtr ??
+      (searchImpressions !== null && searchImpressions > 0 && searchClicks !== null
+        ? searchClicks / searchImpressions
+        : null),
+    averagePosition: firstNumber(records, [
+      "averagePosition",
+      "average_position",
+      "searchPosition",
+      "search_position",
+      "position",
+    ]),
+    visits,
+    engaged30: firstNumber(records, ["engaged30", "engaged_30", "engaged30Count", "engaged_30_count"]),
+    scroll50: firstNumber(records, ["scroll50", "scroll_50", "scroll50Count", "scroll_50_count"]),
+    scroll90: firstNumber(records, ["scroll90", "scroll_90", "scroll90Count", "scroll_90_count"]),
+    ctaImpressions: firstNumber(records, ["ctaImpressions", "cta_impressions", "ctaImpressionCount", "cta_impression_count"]),
+    ctaClicks,
+    ctaConversionRate:
+      suppliedCtaConversion ??
+      (visits !== null && visits > 0 && ctaClicks !== null ? ctaClicks / visits : null),
+  };
+}
+
+export function normalizeVibeMarketingAnalyticsFreshness(raw: unknown): VibeMarketingAnalyticsFreshness {
+  const payload = asRecord(raw);
+  const nested = asRecord(payload.freshness);
+  const records = [nested, payload];
+  return {
+    status: firstString(records, ["status", "freshnessStatus", "freshness_status"]),
+    updatedAt: firstString(records, ["updatedAt", "updated_at", "lastUpdatedAt", "last_updated_at", "lastSyncedAt", "last_synced_at"]),
+    analyticsDataThrough: firstString(records, [
+      "analyticsDataThrough",
+      "analytics_data_through",
+      "eventsDataThrough",
+      "events_data_through",
+    ]),
+    searchDataThrough: firstString(records, [
+      "searchDataThrough",
+      "search_data_through",
+      "gscDataThrough",
+      "gsc_data_through",
+    ]),
+    stale: asBoolean(nested.stale ?? payload.stale),
+    delayDays: firstNumber(records, ["delayDays", "delay_days"]),
+    message: firstString(records, ["message", "detail"]),
+  };
+}
+
+function sourceItems(raw: unknown): unknown[] {
+  if (Array.isArray(raw)) return raw;
+  const payload = asRecord(raw);
+  return Object.entries(payload).map(([key, value]) => ({ key, ...asRecord(value) }));
+}
+
+function looksLikeAiSource(key: string, label: string): boolean {
+  const value = `${key} ${label}`.toLowerCase();
+  return ["ai assistant", "chatgpt", "perplexity", "claude", "copilot", "gemini", "grok", "openai"].some((token) =>
+    value.includes(token),
+  );
+}
+
+export function normalizeVibeMarketingAnalyticsSources(raw: unknown, totalVisits: number | null = null): VibeMarketingAnalyticsSource[] {
+  return sourceItems(raw)
+    .map((item, index) => {
+      const payload = asRecord(item);
+      const key =
+        asString(payload.key ?? payload.id ?? payload.source ?? payload.channel) ??
+        `source-${index + 1}`;
+      const label = asString(payload.label ?? payload.name ?? payload.sourceLabel ?? payload.source_label) ?? key;
+      const visits = asNumber(payload.visits ?? payload.views ?? payload.pageViews ?? payload.page_views) ?? 0;
+      const suppliedShare = asNumber(payload.share ?? payload.visitShare ?? payload.visit_share);
+      return {
+        key,
+        label,
+        visits,
+        ctaClicks: asNumber(payload.ctaClicks ?? payload.cta_clicks ?? payload.conversions) ?? 0,
+        share: suppliedShare ?? (totalVisits !== null && totalVisits > 0 ? visits / totalVisits : null),
+        isAi: asBoolean(payload.isAi ?? payload.is_ai, looksLikeAiSource(key, label)),
+      };
+    })
+    .filter((source) => source.visits > 0 || source.ctaClicks > 0)
+    .sort((left, right) => right.visits - left.visits);
+}
+
+function normalizeVibeMarketingAnalyticsQueries(raw: unknown): VibeMarketingAnalyticsQuery[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item) => {
+      const payload = asRecord(item);
+      const query = asString(payload.query ?? payload.keyword) ?? "";
+      const clicks = asNumber(payload.clicks) ?? 0;
+      const impressions = asNumber(payload.impressions) ?? 0;
+      return {
+        query,
+        clicks,
+        impressions,
+        ctr: asNumber(payload.ctr) ?? (impressions > 0 ? clicks / impressions : null),
+      };
+    })
+    .filter((item) => Boolean(item.query));
+}
+
+function articlePayload(raw: unknown): Record<string, unknown> {
+  const payload = asRecord(raw);
+  const nested = asRecord(payload.article);
+  return Object.keys(nested).length ? { ...payload, ...nested } : payload;
+}
+
+export function normalizeVibeMarketingArticleAnalytics(raw: unknown): VibeMarketingArticleAnalytics {
+  const payload = articlePayload(raw);
+  const totals = normalizeVibeMarketingAnalyticsTotals(payload);
+  return {
+    id: asString(payload.id ?? payload.articleId ?? payload.article_id ?? payload.key) ?? "",
+    title: asString(payload.title ?? payload.articleTitle ?? payload.article_title) ?? "Untitled article",
+    slug: asString(payload.slug),
+    url: asString(payload.url ?? payload.liveUrl ?? payload.live_url ?? payload.canonicalUrl ?? payload.canonical_url),
+    totals,
+    sources: normalizeVibeMarketingAnalyticsSources(
+      payload.sources ?? payload.trafficSources ?? payload.traffic_sources ?? payload.channels,
+      totals.visits,
+    ),
+    queries: normalizeVibeMarketingAnalyticsQueries(payload.queries ?? payload.searchQueries ?? payload.search_queries),
+    freshness: normalizeVibeMarketingAnalyticsFreshness(payload),
+  };
+}
+
+export function normalizeVibeMarketingAnalyticsSummary(
+  raw: unknown,
+  fallbackRange: VibeMarketingAnalyticsRange = "28d",
+): VibeMarketingAnalyticsSummary {
+  const payload = asRecord(raw);
+  const totals = normalizeVibeMarketingAnalyticsTotals(payload);
+  const rawArticles = Array.isArray(payload.articles)
+    ? payload.articles
+    : Array.isArray(payload.items)
+      ? payload.items
+      : [];
+  const range = asString(payload.range);
+  const normalizedRange: VibeMarketingAnalyticsRange =
+    range === "7d" || range === "28d" || range === "90d" || range === "16m" ? range : fallbackRange;
+  return {
+    range: normalizedRange,
+    startDate: asString(payload.startDate ?? payload.start_date),
+    endDate: asString(payload.endDate ?? payload.end_date),
+    totals,
+    sources: normalizeVibeMarketingAnalyticsSources(
+      payload.sources ?? payload.trafficSources ?? payload.traffic_sources ?? payload.channels,
+      totals.visits,
+    ),
+    articles: rawArticles
+      .map(normalizeVibeMarketingArticleAnalytics)
+      .filter((article) => Boolean(article.id)),
+    freshness: normalizeVibeMarketingAnalyticsFreshness(payload),
+  };
+}
+
+function normalizeGscConnection(raw: unknown): VibeMarketingGscConnection {
+  const payload = asRecord(raw);
+  const status = asString(payload.status ?? payload.connectionStatus ?? payload.connection_status) ?? "not_connected";
+  return {
+    status,
+    connected: asBoolean(payload.connected, ["connected", "verified", "active"].includes(status.toLowerCase())),
+    property: asString(payload.property ?? payload.propertyUrl ?? payload.property_url ?? payload.siteUrl ?? payload.site_url),
+    message: asString(payload.message ?? payload.detail),
+    lastVerifiedAt: asString(payload.lastVerifiedAt ?? payload.last_verified_at ?? payload.verifiedAt ?? payload.verified_at),
+  };
+}
+
+export function normalizeVibeMarketingAnalyticsStatus(raw: unknown): VibeMarketingAnalyticsStatus {
+  const payload = asRecord(raw);
+  const status = asString(payload.status) ?? "disabled";
+  const normalizedStatus = status.toLowerCase();
+  const enabled = asBoolean(payload.enabled ?? payload.isEnabled ?? payload.is_enabled, ["enabled", "active", "collecting"].includes(normalizedStatus));
+  return {
+    status,
+    available: asBoolean(
+      payload.available,
+      !["unavailable", "not_available", "not_implemented", "unsupported"].includes(normalizedStatus),
+    ),
+    enabled,
+    collecting: asBoolean(payload.collecting ?? payload.isCollecting ?? payload.is_collecting, enabled && normalizedStatus !== "provisioning"),
+    provider: asString(payload.provider),
+    lastEventAt: asString(payload.lastEventAt ?? payload.last_event_at),
+    lastSyncedAt: asString(payload.lastSyncedAt ?? payload.last_synced_at),
+    message: asString(payload.message ?? payload.detail),
+    gsc: normalizeGscConnection(payload.gsc ?? payload.searchConsole ?? payload.search_console),
+  };
+}
+
+function clientFor(options: VibeMarketingAnalyticsRequestOptions): VibeMarketingAnalyticsHttpClient {
+  return options.client ?? (axiosInstance as VibeMarketingAnalyticsHttpClient);
+}
+
+function queryPath(path: string, values: Record<string, string | null | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value) params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+export async function getVibeMarketingAnalyticsStatus(
+  options: VibeMarketingAnalyticsRequestOptions = {},
+): Promise<VibeMarketingAnalyticsStatus> {
+  const response = await clientFor(options).get(
+    queryPath(`${ANALYTICS_BASE_PATH}/status`, { company_id: options.companyId }),
+  );
+  return normalizeVibeMarketingAnalyticsStatus(response.data);
+}
+
+export async function setVibeMarketingAnalyticsEnabled(
+  enabled: boolean,
+  options: VibeMarketingAnalyticsRequestOptions = {},
+): Promise<VibeMarketingAnalyticsStatus> {
+  const response = await clientFor(options).post(
+    `${ANALYTICS_BASE_PATH}/${enabled ? "enable" : "disable"}`,
+    options.companyId ? { companyId: options.companyId, company_id: options.companyId } : {},
+  );
+  return normalizeVibeMarketingAnalyticsStatus(response.data);
+}
+
+export async function getVibeMarketingAnalyticsSummary(
+  range: VibeMarketingAnalyticsRange = "28d",
+  options: VibeMarketingAnalyticsRequestOptions = {},
+): Promise<VibeMarketingAnalyticsSummary> {
+  const response = await clientFor(options).get(
+    queryPath(`${ANALYTICS_BASE_PATH}/summary`, { range, company_id: options.companyId }),
+  );
+  return normalizeVibeMarketingAnalyticsSummary(response.data, range);
+}
+
+export async function getVibeMarketingArticleAnalytics(
+  articleId: string,
+  range: VibeMarketingAnalyticsRange = "90d",
+  options: VibeMarketingAnalyticsRequestOptions = {},
+): Promise<VibeMarketingArticleAnalytics> {
+  const response = await clientFor(options).get(
+    queryPath(`${ANALYTICS_BASE_PATH}/articles/${encodeURIComponent(articleId)}`, {
+      range,
+      company_id: options.companyId,
+    }),
+  );
+  return normalizeVibeMarketingArticleAnalytics(response.data);
+}
+
+export async function verifyVibeMarketingAnalyticsGsc(
+  options: VibeMarketingAnalyticsRequestOptions = {},
+): Promise<VibeMarketingGscConnection> {
+  const response = await clientFor(options).post(
+    `${ANALYTICS_BASE_PATH}/gsc/verify`,
+    options.companyId ? { companyId: options.companyId, company_id: options.companyId } : {},
+  );
+  const payload = asRecord(response.data);
+  return normalizeGscConnection(payload.gsc ?? payload.searchConsole ?? payload.search_console ?? payload);
+}
+
+export function isVibeMarketingAnalyticsEndpointUnavailable(error: unknown): boolean {
+  const status =
+    (error as { response?: { status?: number } } | null)?.response?.status ??
+    (error as { status?: number } | null)?.status;
+  return status === 404 || status === 405 || status === 501;
+}
+
+export function vibeMarketingAnalyticsErrorMessage(
+  error: unknown,
+  fallback = "Article performance could not be loaded. Try again in a moment.",
+): string {
+  return apiErrorDetail(error, fallback);
+}

--- a/app/routes/founder-tools.marketing.tsx
+++ b/app/routes/founder-tools.marketing.tsx
@@ -41,6 +41,7 @@ import MarketingRunProgressCard from "~/components/MarketingRunProgressCard";
 import type { MarketingRunProgressTheme } from "~/components/MarketingRunProgressCard";
 import AvatarModal from "~/components/AvatarModal";
 import { RooPointCost } from "~/components/RooPointCost";
+import VibeMarketingAnalyticsSection from "~/components/VibeMarketingAnalyticsSection";
 import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartupBaselineSetup";
 import { readableBackendError, readableBackendErrors } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
@@ -4713,6 +4714,10 @@ function ReturningTopicPickerPage({
               )}
             </div>
           </section>
+
+          {publishedArticles.length ? (
+            <VibeMarketingAnalyticsSection companyId={bootstrap.company.id} />
+          ) : null}
 
           <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/tests/vibe-marketing-analytics.test.ts
+++ b/tests/vibe-marketing-analytics.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import VibeMarketingAnalyticsSection from "../app/components/VibeMarketingAnalyticsSection";
+import {
+  AI_REFERRAL_CAVEAT,
+  getVibeMarketingAnalyticsStatus,
+  getVibeMarketingAnalyticsSummary,
+  getVibeMarketingArticleAnalytics,
+  isVibeMarketingAnalyticsEndpointUnavailable,
+  normalizeVibeMarketingAnalyticsStatus,
+  normalizeVibeMarketingAnalyticsSummary,
+  setVibeMarketingAnalyticsEnabled,
+  verifyVibeMarketingAnalyticsGsc,
+} from "../app/lib/vibe-marketing-analytics";
+import type { VibeMarketingAnalyticsHttpClient } from "../app/lib/vibe-marketing-analytics";
+
+describe("vibe marketing analytics normalization", () => {
+  test("normalizes snake-case provider data and derives honest aggregate rates", () => {
+    const summary = normalizeVibeMarketingAnalyticsSummary({
+      range: "28d",
+      start_date: "2026-06-01",
+      end_date: "2026-06-28",
+      totals: {
+        search: {
+          impressions: 2000,
+          clicks: 100,
+          average_position: 7.4,
+        },
+        engagement: {
+          visits: 80,
+          engaged_30: 40,
+          scroll_50: 36,
+          scroll_90: 18,
+        },
+        cta: {
+          cta_impressions: 50,
+          cta_clicks: 8,
+        },
+      },
+      traffic_sources: [
+        { source: "google", label: "Google organic", visits: 50 },
+        { source: "chatgpt.com", label: "ChatGPT", visits: 10, cta_clicks: 2 },
+      ],
+      freshness: {
+        analytics_data_through: "2026-06-28",
+        gsc_data_through: "2026-06-26",
+        stale: false,
+      },
+      articles: [
+        {
+          article_id: "article-1",
+          article_title: "Anonymous analytics for SEO pages",
+          live_url: "https://example.com/articles/analytics",
+          totals: { visits: 20, cta_clicks: 3 },
+          queries: [{ query: "anonymous seo analytics", clicks: 4, impressions: 80 }],
+        },
+      ],
+    });
+
+    expect(summary.totals.searchImpressions).toBe(2000);
+    expect(summary.totals.searchClicks).toBe(100);
+    expect(summary.totals.searchCtr).toBe(0.05);
+    expect(summary.totals.averagePosition).toBe(7.4);
+    expect(summary.totals.engaged30).toBe(40);
+    expect(summary.totals.ctaConversionRate).toBe(0.1);
+    expect(summary.sources[1]?.isAi).toBe(true);
+    expect(summary.sources[1]?.share).toBe(0.125);
+    expect(summary.articles[0]?.id).toBe("article-1");
+    expect(summary.articles[0]?.queries[0]).toEqual({
+      query: "anonymous seo analytics",
+      clicks: 4,
+      impressions: 80,
+      ctr: 0.05,
+    });
+    expect(summary.freshness.searchDataThrough).toBe("2026-06-26");
+  });
+
+  test("normalizes enabled and Search Console status without requiring one response casing", () => {
+    const status = normalizeVibeMarketingAnalyticsStatus({
+      status: "enabled",
+      is_collecting: true,
+      provider: "umami",
+      last_event_at: "2026-07-11T03:00:00Z",
+      search_console: {
+        connection_status: "verified",
+        property_url: "sc-domain:example.com",
+      },
+    });
+
+    expect(status.available).toBe(true);
+    expect(status.enabled).toBe(true);
+    expect(status.collecting).toBe(true);
+    expect(status.gsc.connected).toBe(true);
+    expect(status.gsc.property).toBe("sc-domain:example.com");
+  });
+});
+
+describe("vibe marketing analytics client contract", () => {
+  test("uses the scoped status, summary, article, toggle, and GSC endpoints", async () => {
+    const calls: Array<{ method: "GET" | "POST"; url: string; body?: unknown }> = [];
+    const client: VibeMarketingAnalyticsHttpClient = {
+      async get(url) {
+        calls.push({ method: "GET", url });
+        if (url.includes("/summary")) return { data: { range: "28d", totals: {}, articles: [] } };
+        if (url.includes("/articles/")) return { data: { article_id: "article/with spaces", title: "Article" } };
+        return { data: { status: "enabled" } };
+      },
+      async post(url, body) {
+        calls.push({ method: "POST", url, body });
+        if (url.endsWith("/gsc/verify")) return { data: { status: "verified", property: "sc-domain:example.com" } };
+        return { data: { status: url.endsWith("/enable") ? "enabled" : "disabled" } };
+      },
+    };
+    const options = { companyId: "company-1", client };
+
+    await getVibeMarketingAnalyticsStatus(options);
+    await getVibeMarketingAnalyticsSummary("28d", options);
+    await getVibeMarketingArticleAnalytics("article/with spaces", "90d", options);
+    await setVibeMarketingAnalyticsEnabled(true, options);
+    await setVibeMarketingAnalyticsEnabled(false, options);
+    const gsc = await verifyVibeMarketingAnalyticsGsc(options);
+
+    expect(calls).toEqual([
+      {
+        method: "GET",
+        url: "/api/v1/vibe-marketing/analytics/status?company_id=company-1",
+      },
+      {
+        method: "GET",
+        url: "/api/v1/vibe-marketing/analytics/summary?range=28d&company_id=company-1",
+      },
+      {
+        method: "GET",
+        url: "/api/v1/vibe-marketing/analytics/articles/article%2Fwith%20spaces?range=90d&company_id=company-1",
+      },
+      {
+        method: "POST",
+        url: "/api/v1/vibe-marketing/analytics/enable",
+        body: { companyId: "company-1", company_id: "company-1" },
+      },
+      {
+        method: "POST",
+        url: "/api/v1/vibe-marketing/analytics/disable",
+        body: { companyId: "company-1", company_id: "company-1" },
+      },
+      {
+        method: "POST",
+        url: "/api/v1/vibe-marketing/analytics/gsc/verify",
+        body: { companyId: "company-1", company_id: "company-1" },
+      },
+    ]);
+    expect(gsc.connected).toBe(true);
+  });
+
+  test("recognizes endpoints that have not shipped without treating every outage as unsupported", () => {
+    expect(isVibeMarketingAnalyticsEndpointUnavailable({ response: { status: 404 } })).toBe(true);
+    expect(isVibeMarketingAnalyticsEndpointUnavailable({ status: 501 })).toBe(true);
+    expect(isVibeMarketingAnalyticsEndpointUnavailable({ response: { status: 503 } })).toBe(false);
+  });
+});
+
+describe("vibe marketing analytics dashboard boundary", () => {
+  test("renders a collapsed launcher without loading performance content into the dashboard bootstrap", () => {
+    const markup = renderToStaticMarkup(
+      createElement(VibeMarketingAnalyticsSection, { companyId: "company-1" }),
+    );
+
+    expect(markup).toContain("Article performance");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).not.toContain("Search impressions");
+    expect(markup).not.toContain(AI_REFERRAL_CAVEAT);
+  });
+
+  test("keeps the AI attribution warning explicit", () => {
+    expect(AI_REFERRAL_CAVEAT).toContain("detectable lower bound");
+    expect(AI_REFERRAL_CAVEAT).toContain("unattributed visits");
+  });
+});


### PR DESCRIPTION
## Summary
- add an Article performance dashboard for published Content Factory pages
- report search impressions, clicks, CTR, visits, engagement, scroll depth, CTA performance, and detectable AI/search sources
- support analytics enable/disable and Google Search Console verification states
- keep the dashboard lazy-loaded and explicit about incomplete AI-referral attribution

Backend contract: https://github.com/MLAI-AUS-Inc/mlai-backend/pull/585

## Validation
- 6 Bun tests passed
- TypeScript and route typecheck passed
- production React Router build passed