### PR TITLE
Add article preview quality retry controls

### DIFF
--- a/app/lib/vibe-marketing-run-view.ts
+++ b/app/lib/vibe-marketing-run-view.ts
@@ -118,6 +118,26 @@ function boolResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
   return false;
 }
 
+function objectResultValue(run: VibeMarketingRunSummary, ...keys: string[]) {
+  for (const key of keys) {
+    const values = [
+      run.result?.[key],
+      run.result?.["result"] && typeof run.result["result"] === "object"
+        ? (run.result["result"] as Record<string, unknown>)[key]
+        : undefined,
+      run.result?.["latest_control_response"] && typeof run.result["latest_control_response"] === "object"
+        ? (run.result["latest_control_response"] as Record<string, unknown>)[key]
+        : undefined,
+    ];
+    for (const value of values) {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        return value as Record<string, unknown>;
+      }
+    }
+  }
+  return {} as Record<string, unknown>;
+}
+
 function optionalBoolResultValue(run: VibeMarketingRunSummary, ...keys: string[]): boolean | null {
   for (const key of keys) {
     const values = [
@@ -156,6 +176,72 @@ export interface ArticlePreconditionRepairState {
   message: string;
   actionHref: string;
   actionLabel: string;
+}
+
+export interface ArticlePreviewQualityState {
+  status: string;
+  checking: boolean;
+  blocksApproval: boolean;
+  advisory: boolean;
+  canRetry: boolean;
+  message: string;
+  findings: string[];
+  repairInstructions: string[];
+  mismatchSummaries: string[];
+}
+
+export function articlePreviewQualityStateForRun(run: VibeMarketingRunSummary): ArticlePreviewQualityState {
+  const quality = objectResultValue(run, "article_preview_quality", "articlePreviewQuality");
+  const blocker = objectResultValue(run, "approval_blocker", "approvalBlocker");
+  const status = normalized(typeof quality.status === "string" ? quality.status : "");
+  const findings = Array.isArray(quality.findings)
+    ? quality.findings.map((item) => String(item ?? "").trim()).filter(Boolean)
+    : [];
+  const repairInstructions = Array.isArray(quality.repair_instructions)
+    ? quality.repair_instructions.map((item) => String(item ?? "").trim()).filter(Boolean)
+    : Array.isArray(quality.repairInstructions)
+      ? quality.repairInstructions.map((item) => String(item ?? "").trim()).filter(Boolean)
+      : [];
+  const style = quality.style && typeof quality.style === "object"
+    ? (quality.style as Record<string, unknown>)
+    : {};
+  const mismatchSummaries = Array.isArray(style.mismatches)
+    ? style.mismatches
+        .map((item) =>
+          item && typeof item === "object"
+            ? String((item as Record<string, unknown>).summary ?? "").trim()
+            : String(item ?? "").trim(),
+        )
+        .filter(Boolean)
+    : [];
+  const checking = status === "queued" || status === "running" || status === "transient_findings";
+  const blocksApproval = checking || status === "blocking_findings";
+  const advisory = status === "advisory_findings";
+  const editorialScoreMissing = findings.includes("editorial:score_missing");
+  const blockerMessage = String(blocker.message ?? blocker.detail ?? "").trim();
+  const message = blockerMessage || (checking
+    ? "The hosted article quality check is running. Publishing will unlock automatically when it finishes."
+    : editorialScoreMissing
+      ? "The editorial reviewer did not return the required score. The article content rendered successfully; retry this quality check without regenerating the draft."
+      : status === "blocking_findings"
+        ? "The hosted preview has a blocking quality finding that must be resolved before publishing."
+        : advisory
+          ? "The preview passed its publishing gate with advisory style feedback. You can publish it as-is or send a revision comment."
+          : "");
+  return {
+    status,
+    checking,
+    blocksApproval,
+    advisory,
+    canRetry: Boolean(
+      !checking &&
+        (editorialScoreMissing || status === "review_error" || status === "queue_failed"),
+    ),
+    message,
+    findings,
+    repairInstructions,
+    mismatchSummaries,
+  };
 }
 
 export function isArticleGenerationActivelyRunning(run: VibeMarketingRunSummary) {

--- a/app/routes/founder-tools.marketing.run.tsx
+++ b/app/routes/founder-tools.marketing.run.tsx
@@ -42,6 +42,7 @@ import {
 import { useMarketingActionPending } from "~/lib/vibe-marketing-pending-actions";
 import {
   articlePreconditionRepairStateForRun,
+  articlePreviewQualityStateForRun,
   articleReviewApproveIntentForRun,
   articleReviewApproveLabelForRun,
   articleWorkflowProgressForRunPage,
@@ -648,7 +649,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
       // Type-based: connects Slack/Email on first enable (email → verification sent).
       const result = await setChannelTypeDelivery(env, request, channelType, enabled);
       return { intent, ok: true, status: result.status };
-    } else if (["approve", "deny", "resume", "restart", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
+    } else if (["approve", "deny", "resume", "restart", "retry-preview-quality", "promote-bundle", "publish-pr", "merge-publish-pr", "merge-setup-pr", "refresh-setup-pr-status"].includes(intent)) {
       const sourceRunId = stringFromForm(formData, "sourceRunId");
       const targetRunId = stringFromForm(formData, "targetRunId");
       const autoMerge =
@@ -2666,9 +2667,75 @@ function LiveArticlePreviewPanel({
   const acceptArticleIntent = articleReviewApproveIntentForRun(run, publishStep?.primaryAction?.intent);
   const acceptArticleLabel = articleReviewApproveLabelForRun(run);
   const reviewApprovalReady = isArticleReviewPreviewReady(run);
+  const previewQuality = articlePreviewQualityStateForRun(run);
+  const retryQualityPending = isActionPending?.("retry-preview-quality") ?? isSubmitting;
+  const showQualityNotice = Boolean(
+    previewQuality.checking ||
+      previewQuality.blocksApproval ||
+      previewQuality.advisory ||
+      previewQuality.status === "review_error" ||
+      previewQuality.status === "queue_failed",
+  );
 
   return (
-    <section>
+    <section className="space-y-4">
+      {showQualityNotice ? (
+        <div
+          role={previewQuality.blocksApproval && !previewQuality.checking ? "alert" : "status"}
+          className={clsx(
+            "rounded-xl border p-4",
+            previewQuality.checking
+              ? "border-violet-200 bg-violet-50 text-violet-950"
+              : previewQuality.blocksApproval
+                ? "border-red-200 bg-red-50 text-red-950"
+                : "border-amber-200 bg-amber-50 text-amber-950",
+          )}
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-3">
+              {previewQuality.checking ? (
+                <ArrowPathIcon className="mt-0.5 h-5 w-5 flex-shrink-0 animate-spin" aria-hidden="true" />
+              ) : (
+                <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
+              )}
+              <div>
+                <p className="text-sm font-black">
+                  {previewQuality.checking
+                    ? "Checking hosted article quality"
+                    : previewQuality.blocksApproval
+                      ? "Publishing is waiting on a quality check"
+                      : "Advisory preview feedback"}
+                </p>
+                {previewQuality.message ? (
+                  <p className="mt-1 max-w-3xl text-sm font-semibold leading-6">{previewQuality.message}</p>
+                ) : null}
+                {previewQuality.mismatchSummaries.length ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-xs font-semibold">
+                    {previewQuality.mismatchSummaries.map((summary) => <li key={summary}>{summary}</li>)}
+                  </ul>
+                ) : null}
+                {previewQuality.repairInstructions.length ? (
+                  <p className="mt-2 text-xs font-semibold">Suggested repair: {previewQuality.repairInstructions[0]}</p>
+                ) : null}
+              </div>
+            </div>
+            {previewQuality.canRetry ? (
+              <Form method="POST">
+                <button
+                  type="submit"
+                  name="intent"
+                  value="retry-preview-quality"
+                  disabled={isSubmitting}
+                  className="inline-flex w-full flex-shrink-0 items-center justify-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2.5 text-sm font-black text-red-800 shadow-sm transition hover:bg-red-100 disabled:opacity-50 sm:w-auto"
+                >
+                  {retryQualityPending ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : <ArrowPathIcon className="h-4 w-4" />}
+                  {retryQualityPending ? "Retrying..." : "Retry quality check"}
+                </button>
+              </Form>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
       <LivePreviewCommentInspectorPanel
         run={run}
         selectedComponent={selectedComponent}
@@ -2694,6 +2761,7 @@ function LiveArticlePreviewPanel({
               !canAcceptRevision &&
               !reviewState.hasPendingRevisionBatch &&
               (reviewApprovalReady || publishStep?.status === "ready") &&
+              !previewQuality.blocksApproval &&
               acceptArticleIntent,
           );
           const acceptArticlePending = isActionPending?.(acceptArticleIntent) ?? isSubmitting;
@@ -4813,6 +4881,7 @@ export default function FounderToolsMarketingRun() {
     articleRepairState.autoRecovering ||
     setupPreviewActive ||
     hasPendingArticlePreview(run) ||
+    articlePreviewQualityStateForRun(run).checking ||
     (hasPublishHandoffEvidence(run) && !isPublishFlowSettled(run));
   const hasArticlePreview = hasReadyArticlePreview(run);
   const setupBlocked = isArticleSystemSetupBlocked(bootstrap);

--- a/tests/vibe-marketing-run-view.test.ts
+++ b/tests/vibe-marketing-run-view.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   articlePreconditionRepairStateForRun,
+  articlePreviewQualityStateForRun,
   articleReviewApproveIntentForRun,
   articleReviewApproveLabelForRun,
   articleRunPathAfterStart,
@@ -81,6 +82,55 @@ describe("vibe marketing run view state", () => {
     expect(articleReviewApproveLabelForRun(run)).toEqual({
       idle: "Approve article and create PR",
       pending: "Approving...",
+    });
+  });
+
+  test("blocks approval while required editorial quality evidence is missing", () => {
+    const run = articleRun({
+      result: {
+        status: "preview_ready",
+        review_surface_kind: "component_live_preview",
+        preview_url: "https://preview.example/articles/generated",
+        approval_blocker: {
+          message: "The editorial reviewer did not produce the required score.",
+        },
+        article_preview_quality: {
+          status: "blocking_findings",
+          findings: ["editorial:score_missing", "style:1_mismatches"],
+          repair_instructions: ["Use the captured heading font."],
+          style: {
+            mismatches: [{ summary: "Heading font does not match the captured baseline." }],
+          },
+        },
+      },
+    });
+
+    expect(articlePreviewQualityStateForRun(run)).toMatchObject({
+      status: "blocking_findings",
+      blocksApproval: true,
+      canRetry: true,
+      message: "The editorial reviewer did not produce the required score.",
+      repairInstructions: ["Use the captured heading font."],
+      mismatchSummaries: ["Heading font does not match the captured baseline."],
+    });
+  });
+
+  test("treats style-only findings as advisory and keeps publishing available", () => {
+    const run = articleRun({
+      result: {
+        status: "preview_ready",
+        article_preview_quality: {
+          status: "advisory_findings",
+          findings: ["style:1_mismatches"],
+        },
+      },
+    });
+
+    expect(articlePreviewQualityStateForRun(run)).toMatchObject({
+      status: "advisory_findings",
+      blocksApproval: false,
+      advisory: true,
+      canRetry: false,
     });
   });
 


### PR DESCRIPTION
## What changed

- derives a typed preview-quality state from article run results
- disables approval only for active or genuinely blocking quality checks
- shows inline checking, blocking, and advisory feedback beside the article preview
- adds a retry button for transient editorial review failures
- keeps polling while a quality recheck is active

## Root cause

The review UI enabled approval based only on preview readiness and surfaced the server conflict in a transient page-level error. It had no representation of the quality gate or a way to retry it.

## Impact

Users can see why publishing is waiting, retry the exact preview's quality check, and publish when the gate becomes advisory or passes.

## Validation

- `bun test tests/vibe-marketing-run-view.test.ts` — 11 passed
- `bun run typecheck`
- `bun run build`