### PR TITLE
Show only measured topic demand trends

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -218,6 +218,10 @@
 - [x] Add Vibe Raising backend profile/auth helper layer and types
 - [x] Extract reusable Vibe Raising onboarding card component
 - [x] Refactor Vibe Raising routes off `vibe_raising_session` auth
+
+- [x] Preserve measured topic-trend provenance in the Vibe Marketing candidate contract
+- [x] Remove synthetic topic sparklines and render only measured demand history
+- [x] Add focused topic trend-card tests and run typecheck
 - [x] Extend shared login and verify-email flow for `app=vibe-raising`
 - [x] Add Vibe Raising CTA to `/hackathons`
 - [x] Run `bun run typecheck`

--- a/app/components/TopicDecisionCard.tsx
+++ b/app/components/TopicDecisionCard.tsx
@@ -139,6 +139,17 @@ function trendRecord(candidate: VibeMarketingTopicCandidate) {
   return recordValue(candidate.velocity);
 }
 
+const MEASURED_TREND_SOURCES = new Set(["glimpse", "google_trends", "dataforseo_ai"]);
+
+function trendSource(candidate: VibeMarketingTopicCandidate) {
+  const record = trendRecord(candidate);
+  return (
+    stringValue(candidate.trendSource) ||
+    stringValue(record?.source) ||
+    ""
+  ).toLowerCase();
+}
+
 function numberSeries(value: unknown) {
   if (!Array.isArray(value)) return [];
   return value
@@ -158,24 +169,13 @@ function numberSeries(value: unknown) {
 }
 
 function searchHistory(candidate: VibeMarketingTopicCandidate) {
+  if (candidate.trendIsEstimated || !MEASURED_TREND_SOURCES.has(trendSource(candidate))) return [];
   const explicit = numberSeries(candidate.monthlySearches);
   if (explicit.length >= 2) return explicit;
   const record = trendRecord(candidate);
   const velocityHistory = numberSeries(record?.dailyVolumes ?? record?.daily_volumes);
   if (velocityHistory.length >= 2) return velocityHistory;
   return [];
-}
-
-function placeholderHistory(candidate: VibeMarketingTopicCandidate) {
-  const volume = numericValue(candidate.volume);
-  const base = volume && volume > 0 ? volume : 100;
-  const multipliers = [0.52, 0.68, 0.61, 0.76, 0.72, 0.84, 0.91, 0.8];
-  return multipliers.map((multiplier) => Math.max(1, Math.round(base * multiplier)));
-}
-
-function chartValues(candidate: VibeMarketingTopicCandidate) {
-  const history = searchHistory(candidate);
-  return history.length >= 2 ? history : placeholderHistory(candidate);
 }
 
 function trendStatus(candidate: VibeMarketingTopicCandidate) {
@@ -260,7 +260,7 @@ function whyTopic(candidate: VibeMarketingTopicCandidate) {
   return metrics || reason || "Recommended from the latest topic discovery.";
 }
 
-function Sparkline({ values }: { values: number[] }) {
+function Sparkline({ values, basis }: { values: number[]; basis?: string | null }) {
   if (values.length < 2) {
     return (
       <div className="flex h-28 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 text-xs font-bold text-gray-400">
@@ -271,8 +271,8 @@ function Sparkline({ values }: { values: number[] }) {
   const width = 320;
   const height = 112;
   const padding = 10;
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = 0;
+  const max = basis === "relative_interest" ? 100 : Math.max(...values) * 1.08 || 1;
   const span = max - min || 1;
   const points = values.map((value, index) => {
     const x = padding + (index / Math.max(values.length - 1, 1)) * (width - padding * 2);
@@ -311,7 +311,8 @@ function trendPercentLabel(candidate: VibeMarketingTopicCandidate) {
   const score = numericValue(recordValue(candidate.velocity)?.velocityScore ?? recordValue(candidate.velocity)?.velocity_score);
   const value = trendPercent !== undefined ? trendPercent : score !== undefined ? score * 100 : undefined;
   if (value === undefined) return null;
-  return `${value > 0 ? "+" : ""}${Math.round(value)}% past 6 months`;
+  const period = stringValue(candidate.trendPeriodLabel) || "over the measured period";
+  return `${value > 0 ? "+" : ""}${Math.round(value)}% ${period}`;
 }
 
 function TrendPanel({ candidate }: { candidate: VibeMarketingTopicCandidate }) {
@@ -439,9 +440,8 @@ export function TopicDecisionCard({
 }) {
   const volume = numericValue(candidate.volume);
   const score = opportunityScore(candidate);
-  const history = searchHistory(candidate);
-  const trendValues = chartValues(candidate);
-  const hasTrend = history.length >= 2 || Boolean(trendStatus(candidate));
+  const trendValues = searchHistory(candidate);
+  const hasTrend = trendValues.length >= 2;
   const opportunity = score === undefined ? "Unavailable" : `${formatNumber(score)} / 2,000`;
   const relatedKeywords = candidate.relatedKeywords ?? [];
   const handleSelect = () => onChange();
@@ -500,13 +500,13 @@ export function TopicDecisionCard({
 
         <div className="rounded-xl border border-gray-100 bg-white px-4 py-3">
           <div className="mb-2 flex items-center justify-between gap-3">
-            <p className="text-xs font-black text-gray-950">Search Volume Over Time</p>
+            <p className="text-xs font-black text-gray-950">Search Demand Over Time</p>
             <p className="text-xs font-bold text-gray-500">
               {volume !== undefined ? `${formatNumber(volume)} searches/mo` : candidate.volumeDisplay ?? "Volume unavailable"}
             </p>
           </div>
-          <Sparkline values={trendValues} />
-          {!hasTrend ? <p className="mt-1 text-[11px] font-bold text-gray-400">Estimated shape until trend history is available.</p> : null}
+          <Sparkline values={trendValues} basis={candidate.trendBasis} />
+          {!hasTrend ? <p className="mt-1 text-[11px] font-bold text-gray-400">Measured trend history is not available for this topic.</p> : null}
         </div>
 
         <TrendPanel candidate={candidate} />

--- a/app/lib/vibe-marketing.ts
+++ b/app/lib/vibe-marketing.ts
@@ -667,13 +667,31 @@ function normalizeTopicCandidate(raw: unknown): VibeMarketingTopicCandidate {
     volume: payload.volume,
     volumeDisplay: asNullableString(payload.volumeDisplay) ?? asNullableString(payload.volume_display),
     tier: payload.tier,
-    velocity: payload.velocity ?? payload.latestVelocity ?? payload.latest_velocity,
+    velocity: payload.velocity ?? payload.velocity_data ?? payload.latestVelocity ?? payload.latest_velocity,
+    monthlySearches:
+      payload.monthlySearches ??
+      payload.monthly_searches ??
+      payload.trendPoints ??
+      payload.trend_points,
     aiSaturation:
       payload.aiSaturation ??
       payload.ai_saturation ??
       payload.latestSaturation ??
       payload.latest_saturation,
+    trendStatus: payload.trendStatus ?? payload.trend_status ?? payload.trending_status,
+    trendPercent: payload.trendPercent ?? payload.trend_percent,
+    trendDescription:
+      asNullableString(payload.trendDescription) ??
+      asNullableString(payload.trend_description) ??
+      asNullableString(payload.trend_summary),
     trendLabel: asNullableString(payload.trendLabel) ?? asNullableString(payload.trending_label),
+    trendSource: asNullableString(payload.trendSource) ?? asNullableString(payload.trend_source),
+    trendSourceLabel:
+      asNullableString(payload.trendSourceLabel) ?? asNullableString(payload.trend_source_label),
+    trendBasis: asNullableString(payload.trendBasis) ?? asNullableString(payload.trend_basis),
+    trendPeriodLabel:
+      asNullableString(payload.trendPeriodLabel) ?? asNullableString(payload.trend_period_label),
+    trendIsEstimated: asOptionalBoolean(payload.trendIsEstimated ?? payload.trend_is_estimated) ?? undefined,
     statsMeaning: asNullableString(payload.statsMeaning) ?? asNullableString(payload.stats_meaning),
     whyRecommended: asNullableString(payload.whyRecommended) ?? asNullableString(payload.why_recommended),
     recommendationReason: asNullableString(payload.recommendationReason) ?? asNullableString(payload.recommendation_reason),

--- a/app/types/vibe-marketing.ts
+++ b/app/types/vibe-marketing.ts
@@ -402,6 +402,11 @@ export interface VibeMarketingTopicCandidate {
   trendPercent?: unknown;
   trendDescription?: string | null;
   trendLabel?: string | null;
+  trendSource?: string | null;
+  trendSourceLabel?: string | null;
+  trendBasis?: string | null;
+  trendPeriodLabel?: string | null;
+  trendIsEstimated?: boolean;
   statsMeaning?: string | null;
   whyRecommended?: string | null;
   recommendationReason?: string | null;

--- a/tests/topic-decision-card-trends.test.ts
+++ b/tests/topic-decision-card-trends.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TopicDecisionCard } from "../app/components/TopicDecisionCard";
+import type { VibeMarketingTopicCandidate } from "../app/types/vibe-marketing";
+
+const baseCandidate: VibeMarketingTopicCandidate = {
+  id: "topic-1",
+  keyword: "founder marketing",
+  title: "Founder Marketing",
+  volume: 2900,
+  trendStatus: "rising",
+};
+
+function render(candidate: VibeMarketingTopicCandidate) {
+  return renderToStaticMarkup(
+    createElement(TopicDecisionCard, {
+      candidate,
+      checked: false,
+      onChange: () => undefined,
+    }),
+  );
+}
+
+describe("TopicDecisionCard measured trends", () => {
+  test("does not invent a chart when provenance is missing", () => {
+    const markup = render({
+      ...baseCandidate,
+      monthlySearches: [100, 500, 200, 900],
+    });
+
+    expect(markup).not.toContain('aria-label="Search trend chart"');
+    expect(markup).toContain("Trend unavailable");
+    expect(markup).toContain("Measured trend history is not available for this topic.");
+  });
+
+  test("renders a measured Google Trends series with the real period label", () => {
+    const markup = render({
+      ...baseCandidate,
+      monthlySearches: [22, 30, 37, 45],
+      trendSource: "google_trends",
+      trendBasis: "relative_interest",
+      trendPeriodLabel: "past 30 days",
+      trendIsEstimated: false,
+      trendPercent: 24,
+    });
+
+    expect(markup).toContain('aria-label="Search trend chart"');
+    expect(markup).toContain("+24% past 30 days");
+    expect(markup).not.toContain("Measured trend history is not available");
+  });
+
+  test("suppresses explicitly estimated series", () => {
+    const markup = render({
+      ...baseCandidate,
+      monthlySearches: [20, 80, 30, 90],
+      trendSource: "google_trends",
+      trendBasis: "relative_interest",
+      trendIsEstimated: true,
+    });
+
+    expect(markup).not.toContain('aria-label="Search trend chart"');
+    expect(markup).toContain("Trend unavailable");
+  });
+});


### PR DESCRIPTION
## What changed

- Normalizes trend provenance returned by the content-factory API.
- Removes the fixed synthetic sparkline fallback from article recommendations.
- Renders charts only for measured Glimpse, Google Trends, or DataForSEO AI history.
- Uses the actual measurement period and an honest zero or 0–100 baseline.

## Why

The choose-article screen could display a placeholder curve when no real history was available, making the visual appear measured when it was not.

## Impact

Users now see an honest chart when measured history exists and a clear unavailable state otherwise.

## Validation

- `3 tests passed` for measured, missing, and estimated trend states.
- TypeScript typecheck passed.
- Article internal-link validation passed.
- `git diff --check` passed.