### PR TITLE
Fix SSR crash on unknown AudienceGrid variant

### DIFF
--- a/app/articles/content/featured/why-australian-startups-need-stronger-ai-communities.tsx
+++ b/app/articles/content/featured/why-australian-startups-need-stronger-ai-communities.tsx
@@ -302,8 +302,8 @@ export default function ArticleContent() {
             cards={[
               { title: 'AI founders', description: 'Bring a clear product, data or market question so community feedback can sharpen validation before decisions become fixed.', variant: 'orange' },
               { title: 'Technical builders', description: 'Use the community to find real workflows, domain constraints and customer problems that need more than tool experimentation.', variant: 'purple' },
-              { title: 'Researchers and domain experts', description: 'Connect research knowledge and practical workflow insight with founders who need stronger evidence and better product judgement.', variant: 'teal' },
-              { title: 'Investors and ecosystem supporters', description: 'Look for credible signals of capability, sharper validation and useful weak ties between teams, customers and support pathways.', variant: 'teal' },
+              { title: 'Researchers and domain experts', description: 'Connect research knowledge and practical workflow insight with founders who need stronger evidence and better product judgement.', variant: 'yellow' },
+              { title: 'Investors and ecosystem supporters', description: 'Look for credible signals of capability, sharper validation and useful weak ties between teams, customers and support pathways.', variant: 'yellow' },
             ]}
           />
         </div>

--- a/app/components/articles/AudienceGrid.tsx
+++ b/app/components/articles/AudienceGrid.tsx
@@ -47,7 +47,9 @@ export function AudienceGrid({ heading, cards, className }: AudienceGridProps) {
       ) : null}
       <div className="grid gap-4 sm:gap-6 md:grid-cols-3">
         {cards.map((card, idx) => {
-          const styles = variantStyles[card.variant ?? 'orange']
+          // Article content is cast past these prop types, so an unknown
+          // variant can reach us at runtime and must not crash SSR.
+          const styles = variantStyles[card.variant ?? 'orange'] ?? variantStyles.orange
           return (
             <div
               key={`${card.title}-${idx}`}


### PR DESCRIPTION
## Summary

https://mlai.au/articles/featured/why-australian-startups-need-stronger-ai-communities returns HTTP 500: the SSR render crashes with `TypeError: Cannot read properties of undefined (reading 'bg')` in `AudienceGrid`, and the client shows the "Oops! An unexpected error occurred." boundary.

**Root cause:** the article content (from #1134) passes `variant: 'teal'` on two audience cards, but `variantStyles` in `app/components/articles/AudienceGrid.tsx` only defines `orange | purple | yellow`. Article content files cast components via `as unknown as ArticleComponent`, so TypeScript never caught the invalid key, and the `undefined` map lookup crashed on `styles.bg`.

## Changes

- **`AudienceGrid.tsx`** — the variant lookup now falls back to the orange style for unknown keys, so bad content data can never take down SSR again.
- **`why-australian-startups-need-stronger-ai-communities.tsx`** — the two invalid `'teal'` cards now use the valid `'yellow'` variant (keeping the author's intent of the last two cards sharing a colour). These were the only invalid variant keys in the whole content tree.

## Verification

- `./node_modules/.bin/react-router typegen && ./node_modules/.bin/tsc -b` passes.
- Local dev SSR of `/articles/featured/why-australian-startups-need-stronger-ai-communities` returns **200**, no error boundary, and the grid renders with the two corrected yellow cards.
- All 9 other AudienceGrid consumers (`/articles/community/weekly-deep-dive-*`) still SSR **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)