### PR TITLE
Fall back to default palettes for unknown article component variants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,6 @@
+- [x] Fall back to default palettes for unknown variant keys in QuoteBlock, ArticleCallout, ArticleResourceCTA, Badge, and ArticleHeroHeader (mirrors the AudienceGrid SSR fix in PR 1448)
+- [x] Run `react-router typegen` + `tsc -b` and SSR fallback render checks for the hardened article components
+
 - [x] Replace the HealthHack resources schedule with the supplied Saturday and Sunday run sheets
 - [x] Remove Subtopics, Venue, and Mentor Schedules from HealthHack resources and navigation
 - [x] Add the Large Tract semifinal/final pathway and prominently feature the pitching guide

--- a/app/components/articles/ArticleCallout.tsx
+++ b/app/components/articles/ArticleCallout.tsx
@@ -44,7 +44,9 @@ export function ArticleCallout({
     children,
     className = '',
 }: ArticleCalloutProps) {
-    const styles = VARIANT_STYLES[variant]
+    // Article content is cast past these prop types, so an unknown
+    // variant can reach us at runtime and must not crash SSR.
+    const styles = VARIANT_STYLES[variant] ?? VARIANT_STYLES.info
 
     return (
         <div className={`my-8 border-l-4 ${styles.border} ${styles.background} pl-6 py-4 pr-4 rounded-r-lg ${className}`}>

--- a/app/components/articles/ArticleHeroHeader.tsx
+++ b/app/components/articles/ArticleHeroHeader.tsx
@@ -68,7 +68,11 @@ export function ArticleHeroHeader({
         orange: 'text-white/70 hover:text-white',
     }
 
-    const highlightColor = headerBgColor === 'cyan' ? 'text-[#ff3d00]' : 'text-[#ff3d00]'
+    // Article content is cast past these prop types, so an unknown color
+    // can reach us at runtime and must not render "undefined" classes.
+    const heroColor: keyof typeof bgColorMap = bgColorMap[headerBgColor] ? headerBgColor : 'cyan'
+
+    const highlightColor = heroColor === 'cyan' ? 'text-[#ff3d00]' : 'text-[#ff3d00]'
 
     return (
         <div
@@ -78,7 +82,7 @@ export function ArticleHeroHeader({
             data-cf-component-label="Hero header"
         >
             {/* Hero Banner */}
-            <div className={`${bgColorMap[headerBgColor]} rounded-2xl px-6 py-8 sm:px-10 sm:py-12 lg:px-14 lg:py-16`}>
+            <div className={`${bgColorMap[heroColor]} rounded-2xl px-6 py-8 sm:px-10 sm:py-12 lg:px-14 lg:py-16`}>
                 {/* Breadcrumbs */}
                 {breadcrumbs && breadcrumbs.length > 0 && (
                     <nav
@@ -92,17 +96,17 @@ export function ArticleHeroHeader({
                             {breadcrumbs.map((item, index) => (
                                 <li key={index} className="flex items-center gap-2">
                                     {index > 0 && (
-                                        <span className={`${textColorMap[headerBgColor]} opacity-50`}>/</span>
+                                        <span className={`${textColorMap[heroColor]} opacity-50`}>/</span>
                                     )}
                                     {item.href && !item.current ? (
                                         <Link
                                             to={item.href}
-                                            className={`${breadcrumbLinkColor[headerBgColor]} transition-colors underline-offset-4 hover:underline flex items-center gap-1`}
+                                            className={`${breadcrumbLinkColor[heroColor]} transition-colors underline-offset-4 hover:underline flex items-center gap-1`}
                                         >
                                             {item.icon ? <item.icon className="h-4 w-4" /> : item.label}
                                         </Link>
                                     ) : (
-                                        <span className={`${textColorMap[headerBgColor]} ${item.current ? 'font-semibold' : ''} flex items-center gap-1`}>
+                                        <span className={`${textColorMap[heroColor]} ${item.current ? 'font-semibold' : ''} flex items-center gap-1`}>
                                             {item.icon ? <item.icon className="h-4 w-4" /> : item.label}
                                         </span>
                                     )}
@@ -114,7 +118,7 @@ export function ArticleHeroHeader({
 
                 {/* Title */}
                 <h1
-                    className={`text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight tracking-tight ${textColorMap[headerBgColor]}`}
+                    className={`text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight tracking-tight ${textColorMap[heroColor]}`}
                     style={{ fontFamily: "'Georgia', 'Times New Roman', serif" }}
                     data-cf-component-id="title"
                     data-cf-component-type="title"

--- a/app/components/articles/ArticleResourceCTA.tsx
+++ b/app/components/articles/ArticleResourceCTA.tsx
@@ -65,7 +65,9 @@ export function ArticleResourceCTA({
     accent = 'purple',
     previewCards = DEFAULT_PREVIEW_CARDS,
 }: ArticleResourceCTAProps) {
-    const styles = ACCENT_STYLES[accent]
+    // Article content is cast past these prop types, so an unknown
+    // accent can reach us at runtime and must not crash SSR.
+    const styles = ACCENT_STYLES[accent] ?? ACCENT_STYLES.purple
 
     return (
         <div className="my-12 relative overflow-hidden rounded-[36px] p-8 sm:p-12 shadow-[0_25px_80px_-30px_rgba(0,0,0,0.55)] not-prose">

--- a/app/components/articles/Badge.tsx
+++ b/app/components/articles/Badge.tsx
@@ -31,7 +31,9 @@ export function Badge({ variant = "slate", children, className }: BadgeProps) {
     <span
       className={clsx(
         "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
-        BADGE_VARIANTS[variant],
+        // Article content is cast past these prop types, so an unknown
+        // variant can reach us at runtime and must not drop the badge styling.
+        BADGE_VARIANTS[variant] ?? BADGE_VARIANTS.slate,
         className,
       )}
     >

--- a/app/components/articles/QuoteBlock.tsx
+++ b/app/components/articles/QuoteBlock.tsx
@@ -29,7 +29,9 @@ export function QuoteBlock({
     },
   } as const
 
-  const palette = variants[variant]
+  // Article content is cast past these prop types, so an unknown
+  // variant can reach us at runtime and must not crash SSR.
+  const palette = variants[variant] ?? variants.purple
 
   return (
     <div


### PR DESCRIPTION
## Summary

Article content files cast components past their prop types (`as unknown as ArticleComponent`), so an invalid variant string in content reaches the palette maps at runtime without TypeScript catching it. This is the same failure mode as the AudienceGrid 500 fixed in #1448 — an unknown key crashes SSR with `Cannot read properties of undefined (reading 'bg')`.

This PR hardens every remaining unguarded variant/palette map lookup in `app/components/articles/` with a fallback to the component's default palette, mirroring the #1448 fix:

- **QuoteBlock** — `variants[variant] ?? variants.purple` (was an SSR crash on unknown variant)
- **ArticleCallout** — `VARIANT_STYLES[variant] ?? VARIANT_STYLES.info` (was an SSR crash)
- **ArticleResourceCTA** — `ACCENT_STYLES[accent] ?? ACCENT_STYLES.purple` (was an SSR crash)
- **Badge** — `BADGE_VARIANTS[variant] ?? BADGE_VARIANTS.slate` (no crash, but an unknown variant silently rendered an unstyled badge; this also backstops ArticleResourceList's `TONE_TO_VARIANT[badge.tone] || badge.tone` passthrough)
- **ArticleHeroHeader** — normalizes `headerBgColor` to a known key once (`heroColor`, default `cyan`) before the `bgColorMap`/`textColorMap`/`breadcrumbLinkColor` lookups (no crash, but an unknown color rendered literal `undefined` classes and lost the hero background)

Intentionally not touched:
- **AudienceGrid** — already fixed by open PR #1448
- **ArticleReferences** — already safe (`variant?.indicator ?? defaultIndicator` etc.)
- **ArticleListCard / UpcomingEventsCTA** — indexed by `idx % array.length`, can't be out of range

## Verification

- `./node_modules/.bin/react-router typegen && ./node_modules/.bin/tsc -b` — clean
- SSR render check (`react-dom/server` `renderToString`) for all five components: unknown variant keys render with the default palette and no `undefined` classes instead of throwing; valid variants render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)