### PR TITLE
Support multi-audience Vibe Raising visibility

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,8 @@
+- [x] Preserve multi-audience visibility arrays from the Vibe Raising backend
+- [x] Make community and investor visibility independently selectable
+- [x] Preserve numeric backend draft IDs during frontend normalization
+- [x] Add focused audience visibility tests and run typecheck/build
+
 - [x] Fall back to default palettes for unknown variant keys in QuoteBlock, ArticleCallout, ArticleResourceCTA, Badge, and ArticleHeroHeader (mirrors the AudienceGrid SSR fix in PR 1448)
 - [x] Run `react-router typegen` + `tsc -b` and SSR fallback render checks for the hardened article components
 

--- a/app/components/VibeRaisingAudienceVisibilityField.tsx
+++ b/app/components/VibeRaisingAudienceVisibilityField.tsx
@@ -1,7 +1,14 @@
 import { clsx } from "clsx";
 import { EyeIcon, UserGroupIcon, UserIcon } from "@heroicons/react/24/outline";
 import { useState, type ReactNode } from "react";
-import type { VibeRaisingAudienceVisibility } from "~/types/vibe-raising";
+import {
+  normalizeVibeRaisingAudienceVisibility,
+  toggleVibeRaisingAudienceVisibility,
+} from "~/lib/vibe-raising-audience-visibility";
+import type {
+  VibeRaisingAudienceVisibility,
+  VibeRaisingAudienceVisibilitySelection,
+} from "~/types/vibe-raising";
 
 export const VIBE_RAISING_AUDIENCE_VISIBILITY_OPTIONS: Array<{
   value: VibeRaisingAudienceVisibility;
@@ -29,9 +36,9 @@ const optionIconMap = {
 
 type Props = {
   name: string;
-  value?: VibeRaisingAudienceVisibility | null;
-  defaultValue?: VibeRaisingAudienceVisibility | null;
-  onChange?: (value: VibeRaisingAudienceVisibility) => void;
+  value?: VibeRaisingAudienceVisibilitySelection | null;
+  defaultValue?: VibeRaisingAudienceVisibilitySelection | null;
+  onChange?: (value: VibeRaisingAudienceVisibilitySelection) => void;
   title?: ReactNode;
   description?: string;
   className?: string;
@@ -40,14 +47,16 @@ type Props = {
 export default function VibeRaisingAudienceVisibilityField({
   name,
   value,
-  defaultValue = "just_me",
+  defaultValue = ["just_me"],
   onChange,
   title = "Who should see this?",
-  description = "Choose whether this stays private, shows to the community, or is visible to investors.",
+  description = "Keep this private, or select one or both public audiences.",
   className,
 }: Props) {
-  const [localValue, setLocalValue] = useState<VibeRaisingAudienceVisibility>(defaultValue ?? "just_me");
-  const selectedValue = value ?? localValue;
+  const [localValue, setLocalValue] = useState<VibeRaisingAudienceVisibilitySelection>(() =>
+    normalizeVibeRaisingAudienceVisibility(defaultValue),
+  );
+  const selectedValue = normalizeVibeRaisingAudienceVisibility(value ?? localValue);
 
   return (
     <section className={clsx("rounded-2xl border border-[var(--vr-color-border)] bg-white p-4 shadow-sm", className)}>
@@ -55,13 +64,14 @@ export default function VibeRaisingAudienceVisibilityField({
         <p className="text-base font-black text-gray-950">{title}</p>
         {description ? <p className="text-sm font-semibold text-slate-500">{description}</p> : null}
       </div>
-      <div className="mt-3 grid grid-cols-3 gap-2" role="radiogroup" aria-label={typeof title === "string" ? title : "Update visibility"}>
+      <div className="mt-3 grid grid-cols-3 gap-2" role="group" aria-label={typeof title === "string" ? title : "Update visibility"}>
         {VIBE_RAISING_AUDIENCE_VISIBILITY_OPTIONS.map((option) => {
           const Icon = optionIconMap[option.value];
-          const checked = selectedValue === option.value;
+          const checked = selectedValue.includes(option.value);
           const handleSelect = () => {
-            setLocalValue(option.value);
-            onChange?.(option.value);
+            const nextValue = toggleVibeRaisingAudienceVisibility(selectedValue, option.value);
+            setLocalValue(nextValue);
+            onChange?.(nextValue);
           };
           return (
             <label
@@ -74,7 +84,7 @@ export default function VibeRaisingAudienceVisibilityField({
               )}
             >
               <input
-                type="radio"
+                type="checkbox"
                 name={name}
                 value={option.value}
                 checked={checked}

--- a/app/lib/vibe-raising-audience-visibility.ts
+++ b/app/lib/vibe-raising-audience-visibility.ts
@@ -1,0 +1,55 @@
+import type {
+  VibeRaisingAudienceVisibility,
+  VibeRaisingAudienceVisibilitySelection,
+} from "~/types/vibe-raising";
+
+export const DEFAULT_VIBE_RAISING_AUDIENCE_VISIBILITY: VibeRaisingAudienceVisibilitySelection = [
+  "just_me",
+];
+
+function normalizeAudience(value: unknown): VibeRaisingAudienceVisibility | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (normalized === "just_me" || normalized === "private") return "just_me";
+  if (normalized === "community") return "community";
+  if (normalized === "investors" || normalized === "investor") return "investors";
+  return null;
+}
+
+export function parseVibeRaisingAudienceVisibility(
+  value: unknown,
+): VibeRaisingAudienceVisibilitySelection | null {
+  const rawValues = Array.isArray(value) ? value : [value];
+  const normalized = rawValues
+    .map(normalizeAudience)
+    .filter((audience): audience is VibeRaisingAudienceVisibility => audience !== null);
+
+  if (normalized.includes("just_me")) {
+    return ["just_me"];
+  }
+
+  const selection: VibeRaisingAudienceVisibilitySelection = [];
+  if (normalized.includes("community")) selection.push("community");
+  if (normalized.includes("investors")) selection.push("investors");
+  return selection.length > 0 ? selection : null;
+}
+
+export function normalizeVibeRaisingAudienceVisibility(
+  value: unknown,
+): VibeRaisingAudienceVisibilitySelection {
+  return parseVibeRaisingAudienceVisibility(value) ?? [...DEFAULT_VIBE_RAISING_AUDIENCE_VISIBILITY];
+}
+
+export function toggleVibeRaisingAudienceVisibility(
+  value: unknown,
+  audience: VibeRaisingAudienceVisibility,
+): VibeRaisingAudienceVisibilitySelection {
+  const current = normalizeVibeRaisingAudienceVisibility(value);
+  if (audience === "just_me") return ["just_me"];
+
+  const publicAudiences = current.filter((item) => item !== "just_me");
+  const next = publicAudiences.includes(audience)
+    ? publicAudiences.filter((item) => item !== audience)
+    : [...publicAudiences, audience];
+  return normalizeVibeRaisingAudienceVisibility(next);
+}

--- a/app/lib/vibe-raising.ts
+++ b/app/lib/vibe-raising.ts
@@ -3,8 +3,9 @@ import { normalizeAuthNextForApp } from "~/lib/auth-return";
 import type { User } from "~/types/user";
 import { createApiClient, shouldUseDevAuthBypass, shouldUseDevBackendFallback, shouldUseDevBackendStub } from "~/lib/api";
 import { getCurrentUser } from "~/lib/auth";
+import { parseVibeRaisingAudienceVisibility } from "~/lib/vibe-raising-audience-visibility";
 import type {
-  VibeRaisingAudienceVisibility,
+  VibeRaisingAudienceVisibilitySelection,
   VibeRaisingDraftResultsResponse,
   VibeRaisingAppUser,
   VibeRaisingBankFeedAccount,
@@ -172,14 +173,8 @@ type OptionalContext = {
 
 type VibeRaisingSaveMode = "draft" | "ready";
 
-function normalizeAudienceVisibility(value: unknown): VibeRaisingAudienceVisibility | null {
-  const text = asNullableString(value);
-  if (!text) return null;
-  const normalized = text.toLowerCase().replace(/[\s-]+/g, "_");
-  if (normalized === "just_me" || normalized === "private") return "just_me";
-  if (normalized === "community") return "community";
-  if (normalized === "investors" || normalized === "investor") return "investors";
-  return null;
+function normalizeAudienceVisibility(value: unknown): VibeRaisingAudienceVisibilitySelection | null {
+  return parseVibeRaisingAudienceVisibility(value);
 }
 
 export function isVibeRaisingProfileComplete(profile: VibeRaisingProfile): boolean {
@@ -200,6 +195,11 @@ function asNullableString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function asNullableIdentifier(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return asNullableString(value);
 }
 
 function asRevenueStatus(value: unknown): string | null {
@@ -898,7 +898,7 @@ export function normalizeMetricHistory(raw: unknown): VibeRaisingMetricHistory {
   return history;
 }
 
-function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
+export function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
   if (!raw || typeof raw !== "object") return null;
 
   const payload = unwrapPayload(raw) as Record<string, unknown>;
@@ -921,11 +921,11 @@ function normalizeMonthlyUpdate(raw: unknown): VibeRaisingMonthlyUpdate | null {
     (monthName && yearValue ? `${monthName} ${yearValue}` : monthName) ??
     "Update";
   const id =
-    asNullableString(payload.id) ??
-    asNullableString(payload.draftId) ??
-    asNullableString(payload.draft_id) ??
-    asNullableString(payload.updateId) ??
-    asNullableString(payload.update_id) ??
+    asNullableIdentifier(payload.id) ??
+    asNullableIdentifier(payload.draftId) ??
+    asNullableIdentifier(payload.draft_id) ??
+    asNullableIdentifier(payload.updateId) ??
+    asNullableIdentifier(payload.update_id) ??
     monthLabel;
 
   return {
@@ -2103,7 +2103,7 @@ export async function saveVibeRaisingCompany(
     stage?: string | null;
     organizationKind?: string | null;
     hasRevenue?: string | null;
-    audienceVisibility?: VibeRaisingAudienceVisibility | null;
+    audienceVisibility?: VibeRaisingAudienceVisibilitySelection | null;
     shortDescription?: string | null;
     problemSolved?: string | null;
     targetAudience?: string | null;
@@ -2184,7 +2184,7 @@ const DEV_MONTHLY_UPDATES_STUB: VibeRaisingMonthlyUpdate[] = [
     date: "2026-01-30T00:00:00.000Z",
     status: "ready",
     visibility: "published",
-    audienceVisibility: "investors",
+    audienceVisibility: ["investors"],
     publishedAt: "2026-01-30T00:00:00.000Z",
     summary:
       "SupportSorted (SuSo) is an AI-powered referral and matching platform for disability support professionals, allied-health clinics, and care coordinators. We are seeing early product-market resonance, active pilots, and MAP accelerator backing while we focus this quarter on shipping and tightening the core matching loop.",
@@ -2222,7 +2222,7 @@ const DEV_MONTHLY_DRAFTS_STUB: VibeRaisingMonthlyUpdate[] = [
     date: "2026-05-02T00:00:00.000Z",
     status: "draft",
     visibility: "private",
-    audienceVisibility: "just_me",
+    audienceVisibility: ["just_me"],
     publishedAt: null,
     summary: "Saved privately while the founder refines MAP milestone progress, pilot signals, and investor asks.",
     sourceUrl: "https://mlai.au/founder-tools/drafts",
@@ -2524,7 +2524,7 @@ export async function saveVibeRaisingMonthlyUpdate(
     metrics: Record<string, string>;
     metricSuggestions?: VibeRaisingMetricSuggestion[];
     displayConfig?: VibeRaisingMetricDisplayConfig | null;
-    audienceVisibility?: VibeRaisingAudienceVisibility | null;
+    audienceVisibility?: VibeRaisingAudienceVisibilitySelection | null;
     summary?: string | null;
     sourceUrl?: string | null;
     pitchDeckUrl?: string | null;

--- a/app/routes/vibe-raising-app.company-setup.tsx
+++ b/app/routes/vibe-raising-app.company-setup.tsx
@@ -5,6 +5,7 @@ import VibeMarketingStartupBaselineSetup from "~/components/VibeMarketingStartup
 import { readableBackendError } from "~/lib/backend-error";
 import { getEnv } from "~/lib/env.server";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
+import { normalizeVibeRaisingAudienceVisibility } from "~/lib/vibe-raising-audience-visibility";
 import {
   getVibeMarketingBootstrap,
   startVibeMarketingAutofill,
@@ -23,7 +24,7 @@ import {
 } from "~/lib/vibe-raising";
 import type { VibeMarketingBootstrap } from "~/types/vibe-marketing";
 import type {
-  VibeRaisingAudienceVisibility,
+  VibeRaisingAudienceVisibilitySelection,
   VibeRaisingCompany,
   VibeRaisingProfile,
 } from "~/types/vibe-raising";
@@ -39,11 +40,8 @@ function stringFromForm(formData: FormData, key: string) {
   return String(formData.get(key) ?? "").trim();
 }
 
-function audienceVisibilityFromForm(formData: FormData): VibeRaisingAudienceVisibility {
-  const value = stringFromForm(formData, "audienceVisibility").toLowerCase();
-  if (value === "community") return "community";
-  if (value === "investors") return "investors";
-  return "just_me";
+function audienceVisibilityFromForm(formData: FormData): VibeRaisingAudienceVisibilitySelection {
+  return normalizeVibeRaisingAudienceVisibility(formData.getAll("audienceVisibility"));
 }
 
 const COMPANY_SETUP_FIELD_LABELS: Record<string, string> = {
@@ -198,7 +196,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   return {
     bootstrap,
-    audienceVisibility: activeCompany?.audienceVisibility ?? "just_me",
+    audienceVisibility: activeCompany?.audienceVisibility ?? ["just_me"],
     isAddingNew,
     isEditingExisting: Boolean(activeCompany && !isAddingNew && activeCompany.registered),
   };

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -24,6 +24,7 @@ import {
     resolveActiveCompanyId,
 } from "~/lib/vibe-raising";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
+import { normalizeVibeRaisingAudienceVisibility } from "~/lib/vibe-raising-audience-visibility";
 import {
     VIBE_METRIC_KEYS,
     VIBE_METRIC_OPTIONS,
@@ -71,7 +72,7 @@ import type {
     VibeRaisingFounderProfile,
     VibeRaisingInputSourceSummary,
     VibeRaisingManualDocument,
-    VibeRaisingAudienceVisibility,
+    VibeRaisingAudienceVisibilitySelection,
     VibeRaisingMetricDisplayConfig,
     VibeRaisingMetricSuggestion,
     VibeRaisingMetricVisibility,
@@ -440,11 +441,8 @@ function buildExistingUpdateFormData(update: VibeRaisingMonthlyUpdate) {
     };
 }
 
-function normalizeAudienceVisibilityValue(value: unknown): VibeRaisingAudienceVisibility {
-    const text = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
-    if (text === "community") return "community";
-    if (text === "investors" || text === "investor") return "investors";
-    return "just_me";
+function normalizeAudienceVisibilityValue(value: unknown): VibeRaisingAudienceVisibilitySelection {
+    return normalizeVibeRaisingAudienceVisibility(value);
 }
 
 export async function loader({ request, context }: Route.LoaderArgs) {
@@ -512,7 +510,7 @@ function buildMonthlyUpdateSavePayload(formData: FormData) {
         .filter(Boolean);
 
     return {
-        audienceVisibility: normalizeAudienceVisibilityValue(formData.get("audienceVisibility")),
+        audienceVisibility: normalizeAudienceVisibilityValue(formData.getAll("audienceVisibility")),
         month: String(formData.get("month") || "").trim(),
         year: Number(formData.get("year") || 0),
         summary: String(formData.get("summary") || "").trim() || null,
@@ -579,8 +577,11 @@ export async function action({ request, context }: Route.ActionArgs) {
     const activeCompanyId = resolveActiveCompanyId(appUser);
     const formData = await request.formData();
     const intent = formData.get("intent");
-    const updates = Object.fromEntries(formData);
     const savePayload = buildMonthlyUpdateSavePayload(formData);
+    const updates: Record<string, unknown> = {
+        ...Object.fromEntries(formData),
+        audienceVisibility: savePayload.audienceVisibility,
+    };
 
     if (intent === "publish") {
         const draftId = String(formData.get("draftId") || "").trim();
@@ -2887,7 +2888,7 @@ export default function CreateUpdate() {
         const defaultDocuments = Array.isArray(defaultData?.manualDocuments) ? defaultData.manualDocuments : [];
         return defaultDocuments.length > 0 ? defaultDocuments : storedManualMaterials.documents;
     });
-    const [audienceVisibility, setAudienceVisibility] = useState<VibeRaisingAudienceVisibility>(
+    const [audienceVisibility, setAudienceVisibility] = useState<VibeRaisingAudienceVisibilitySelection>(
         () => normalizeAudienceVisibilityValue(defaultData?.audienceVisibility || user.audienceVisibility),
     );
     const [summary, setSummary] = useState<string>(() => defaultData?.summary || storedManualMaterials.summary || "");
@@ -5522,7 +5523,9 @@ export default function CreateUpdate() {
                 <Form id={PUBLISH_REVIEW_FORM_ID} method="POST" className="hidden">
                     <input type="hidden" name="intent" value="publish" />
                     {reviewDraftId ? <input type="hidden" name="draftId" value={reviewDraftId} /> : null}
-                    <input type="hidden" name="audienceVisibility" value={reviewAudienceVisibility} />
+                    {reviewAudienceVisibility.map((audience) => (
+                        <input key={audience} type="hidden" name="audienceVisibility" value={audience} />
+                    ))}
                     <input type="hidden" name="month" value={reviewMonth} />
                     <input type="hidden" name="year" value={reviewYear} />
                 </Form>
@@ -6416,7 +6419,9 @@ export default function CreateUpdate() {
                                     <input type="hidden" name="intent" value="review" />
                                     <input type="hidden" name="metricKeys" value={formMetricKeys.join(",")} />
                                     <input type="hidden" name="displayConfig" value={displayConfigFormValue} />
-                                    <input type="hidden" name="audienceVisibility" value={audienceVisibility} />
+                                    {audienceVisibility.map((audience) => (
+                                        <input key={audience} type="hidden" name="audienceVisibility" value={audience} />
+                                    ))}
                                     <input type="hidden" name="summary" value={summary} />
                                     <input type="hidden" name="sourceUrl" value={sourceUrl} />
                                     <input type="hidden" name="pitchDeckUrl" value={pitchDeckUrl} />

--- a/app/types/vibe-raising.ts
+++ b/app/types/vibe-raising.ts
@@ -2,6 +2,7 @@ import type { User } from "~/types/user";
 
 export type VibeRaisingRole = "founder" | "investor";
 export type VibeRaisingAudienceVisibility = "just_me" | "community" | "investors";
+export type VibeRaisingAudienceVisibilitySelection = VibeRaisingAudienceVisibility[];
 
 export interface VibeRaisingFounderProfile {
   name: string;
@@ -24,7 +25,7 @@ export interface VibeRaisingCompany {
   stage?: string | null;
   organizationKind?: string | null;
   hasRevenue?: string | null;
-  audienceVisibility?: VibeRaisingAudienceVisibility | null;
+  audienceVisibility?: VibeRaisingAudienceVisibilitySelection | null;
   registered: boolean;
   monthlyUpdatesEnabled?: boolean;
 }
@@ -54,7 +55,7 @@ export interface VibeRaisingAppUser {
   stage?: string | null;
   organizationKind?: string | null;
   hasRevenue?: string | null;
-  audienceVisibility?: VibeRaisingAudienceVisibility | null;
+  audienceVisibility?: VibeRaisingAudienceVisibilitySelection | null;
   companyRegistered: boolean;
 }
 
@@ -133,7 +134,7 @@ export interface VibeRaisingMonthlyUpdate {
   date: string;
   status?: string | null;
   visibility?: "private" | "published" | string | null;
-  audienceVisibility?: VibeRaisingAudienceVisibility | null;
+  audienceVisibility?: VibeRaisingAudienceVisibilitySelection | null;
   publishedAt?: string | null;
   summary?: string | null;
   sourceUrl?: string | null;

--- a/tests/vibe-raising-audience-visibility.test.ts
+++ b/tests/vibe-raising-audience-visibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizeVibeRaisingAudienceVisibility,
+  parseVibeRaisingAudienceVisibility,
+  toggleVibeRaisingAudienceVisibility,
+} from "../app/lib/vibe-raising-audience-visibility";
+import { normalizeMonthlyUpdate } from "../app/lib/vibe-raising";
+
+describe("Vibe Raising audience visibility", () => {
+  test("preserves both public audiences in canonical order", () => {
+    expect(normalizeVibeRaisingAudienceVisibility(["investor", "community"])).toEqual([
+      "community",
+      "investors",
+    ]);
+  });
+
+  test("continues to accept legacy scalar responses", () => {
+    expect(parseVibeRaisingAudienceVisibility("investor")).toEqual(["investors"]);
+    expect(parseVibeRaisingAudienceVisibility("private")).toEqual(["just_me"]);
+  });
+
+  test("keeps private visibility exclusive while allowing both public audiences", () => {
+    const community = toggleVibeRaisingAudienceVisibility(["just_me"], "community");
+    const both = toggleVibeRaisingAudienceVisibility(community, "investors");
+
+    expect(community).toEqual(["community"]);
+    expect(both).toEqual(["community", "investors"]);
+    expect(toggleVibeRaisingAudienceVisibility(both, "just_me")).toEqual(["just_me"]);
+  });
+
+  test("normalizes numeric backend draft IDs without replacing them with the month", () => {
+    const update = normalizeMonthlyUpdate({
+      id: 517,
+      month: "July 2026",
+      audienceVisibility: ["community", "investors"],
+      metrics: {},
+      highlights: "",
+      challenges: "",
+      asks: "",
+      learnings: "",
+      next30Days: "",
+    });
+
+    expect(update?.id).toBe("517");
+    expect(update?.audienceVisibility).toEqual(["community", "investors"]);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve audience visibility arrays returned by the Vibe Raising backend
- keep `just_me` exclusive while allowing founders to select community, investors, or both
- submit repeated form values so both public audiences survive company setup, draft, review, and publish flows
- normalize numeric backend draft IDs instead of replacing them with a month label
- continue accepting legacy scalar visibility responses

## Dependency

Companion frontend support for [mlai-backend#517](https://github.com/MLAI-AUS-Inc/mlai-backend/pull/517). Merge/deploy this after or together with the backend PR.

## Validation

- [x] `bun test tests/vibe-raising-audience-visibility.test.ts` (4 tests)
- [x] `bun run typecheck`
- [x] `bun run build` (completed; existing sourcemap warnings and IndexNow 403 remain non-fatal)
- [x] `git diff --check`