### PR TITLE
Handle monthly update reminder links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Run type check
         run: bun run typecheck
 
+      - name: Test monthly-update reminder links
+        run: bun test tests/monthly-update-reminder-link.test.ts
+
       - name: Build project
         run: bun run build

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,7 @@
+- [x] Resolve monthly-update reminder links to an explicitly owned Founder Tools company
+- [x] Reject stale or foreign reminder company IDs without mutating active-company state
+- [x] Add focused reminder-link tests and run typecheck/build
+
 - [x] Preserve multi-audience visibility arrays from the Vibe Raising backend
 - [x] Make community and investor visibility independently selectable
 - [x] Preserve numeric backend draft IDs during frontend normalization

--- a/app/lib/monthly-update-reminder-link.ts
+++ b/app/lib/monthly-update-reminder-link.ts
@@ -1,0 +1,37 @@
+import type { VibeRaisingAppUser, VibeRaisingCompany } from "~/types/vibe-raising";
+
+export type MonthlyUpdateReminderCompanyResolution =
+  | { status: "none" }
+  | { status: "invalid" }
+  | { status: "valid"; company: VibeRaisingCompany; needsSwitch: boolean };
+
+/**
+ * Treat the emailed company id as untrusted input. Only companies returned in
+ * the signed-in founder's profile may change active-company state.
+ */
+export function resolveMonthlyUpdateReminderCompany(
+  user: Pick<VibeRaisingAppUser, "companies" | "activeCompanyId">,
+  requestedCompanyId: string | null,
+): MonthlyUpdateReminderCompanyResolution {
+  const companyId = (requestedCompanyId || "").trim();
+  if (!companyId) return { status: "none" };
+
+  const company = user.companies.find((candidate) => candidate.id === companyId);
+  if (!company) return { status: "invalid" };
+
+  return {
+    status: "valid",
+    company,
+    needsSwitch: user.activeCompanyId !== company.id,
+  };
+}
+
+export function getMonthlyUpdateReminderCompanyId(url: URL): string | null {
+  if (url.searchParams.get("source") !== "monthly-update-reminder") return null;
+  return url.searchParams.get("companyId");
+}
+
+export function removeReminderCompanySelector(url: URL): string {
+  url.searchParams.delete("companyId");
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/app/routes/vibe-raising-app.create-update.tsx
+++ b/app/routes/vibe-raising-app.create-update.tsx
@@ -22,7 +22,13 @@ import {
     uploadVibeRaisingPitchDeck,
     uploadVibeRaisingUpdateVideo,
     resolveActiveCompanyId,
+    setVibeRaisingActiveCompany,
 } from "~/lib/vibe-raising";
+import {
+    getMonthlyUpdateReminderCompanyId,
+    removeReminderCompanySelector,
+    resolveMonthlyUpdateReminderCompany,
+} from "~/lib/monthly-update-reminder-link";
 import { parseFounderProfilesFormValue } from "~/lib/founder-profiles";
 import { normalizeVibeRaisingAudienceVisibility } from "~/lib/vibe-raising-audience-visibility";
 import {
@@ -448,6 +454,23 @@ function normalizeAudienceVisibilityValue(value: unknown): VibeRaisingAudienceVi
 export async function loader({ request, context }: Route.LoaderArgs) {
     const env = getEnv(context);
     const { appUser: user } = await requireVibeRaisingFounder(env, request);
+    const url = new URL(request.url);
+    const reminderCompany = resolveMonthlyUpdateReminderCompany(
+        user,
+        getMonthlyUpdateReminderCompanyId(url),
+    );
+
+    if (reminderCompany.status === "invalid") {
+        throw redirect("/founder-tools/companies?error=invalid-reminder-company");
+    }
+    if (reminderCompany.status === "valid") {
+        if (reminderCompany.needsSwitch) {
+            await setVibeRaisingActiveCompany(env, request, reminderCompany.company.id);
+        }
+        // Strip the one-use selector so refreshes and copied URLs do not keep
+        // mutating the user's active-company preference. Attribution remains.
+        throw redirect(removeReminderCompanySelector(url));
+    }
 
     // Require company registration before creating updates
     if (!user.companyRegistered) {
@@ -455,7 +478,6 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     }
 
     // Check for edit mode
-    const url = new URL(request.url);
     const editId = url.searchParams.get("edit");
     const resumeEmailDrafting =
         url.searchParams.get("email_draft") === "1" ||

--- a/tests/monthly-update-reminder-link.test.ts
+++ b/tests/monthly-update-reminder-link.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getMonthlyUpdateReminderCompanyId,
+  removeReminderCompanySelector,
+  resolveMonthlyUpdateReminderCompany,
+} from "../app/lib/monthly-update-reminder-link";
+
+const user = {
+  activeCompanyId: "company-a",
+  companies: [
+    { id: "company-a", name: "Alpha", registered: true },
+    { id: "company-b", name: "Beta", registered: true },
+  ],
+};
+
+describe("monthly-update reminder company links", () => {
+  test("allows an owned company and reports whether it needs switching", () => {
+    expect(resolveMonthlyUpdateReminderCompany(user, "company-b")).toEqual({
+      status: "valid",
+      company: user.companies[1],
+      needsSwitch: true,
+    });
+    expect(resolveMonthlyUpdateReminderCompany(user, "company-a")).toEqual({
+      status: "valid",
+      company: user.companies[0],
+      needsSwitch: false,
+    });
+  });
+
+  test("rejects a company the signed-in founder does not own", () => {
+    expect(resolveMonthlyUpdateReminderCompany(user, "someone-elses-company")).toEqual({
+      status: "invalid",
+    });
+  });
+
+  test("removes only the one-use company selector after resolution", () => {
+    const url = new URL(
+      "https://mlai.au/founder-tools/updates/create?companyId=company-b&source=monthly-update-reminder&reminder=seven_day",
+    );
+
+    expect(removeReminderCompanySelector(url)).toBe(
+      "/founder-tools/updates/create?source=monthly-update-reminder&reminder=seven_day",
+    );
+  });
+
+  test("only treats companyId as a selector on a reminder link", () => {
+    expect(
+      getMonthlyUpdateReminderCompanyId(
+        new URL("https://mlai.au/founder-tools/updates/create?companyId=company-b"),
+      ),
+    ).toBeNull();
+    expect(
+      getMonthlyUpdateReminderCompanyId(
+        new URL(
+          "https://mlai.au/founder-tools/updates/create?companyId=company-b&source=monthly-update-reminder",
+        ),
+      ),
+    ).toBe("company-b");
+  });
+});


### PR DESCRIPTION
Adds a company-aware Founder Tools reminder link that validates ownership, safely switches the active company, preserves attribution, removes the one-use selector, and includes focused tests in CI.