### PR TITLE
Refresh the session at the edge so logins survive

### DIFF
--- a/app/lib/session-keepalive.ts
+++ b/app/lib/session-keepalive.ts
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+import { API_URL } from "~/lib/api";
+
+/**
+ * Browser-side companion to the worker's session refresh.
+ *
+ * The worker renews the access cookie on every SSR render and loader request, which
+ * covers navigation. It does not cover a tab that simply sits open: a dashboard left
+ * running overnight keeps polling the backend directly from the browser, and once the
+ * access token expires those calls start 401-ing even though the refresh cookie is
+ * still good. This pings the refresh endpoint on a slow timer and whenever the tab is
+ * brought back to the foreground, so a long-lived tab renews itself in the background.
+ */
+
+const REFRESH_ENDPOINT = "/api/v1/auth/token/refresh/";
+
+/** Well inside the access-token lifetime, and cheap enough to be invisible. */
+const KEEPALIVE_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** Floor between refreshes, so tab-switching can't turn into a request storm. */
+const MIN_REFRESH_GAP_MS = 30 * 60 * 1000;
+
+let lastRefreshAt = 0;
+let inFlight: Promise<boolean> | null = null;
+
+export async function refreshSession(options: { force?: boolean } = {}): Promise<boolean> {
+  if (typeof window === "undefined") return false;
+
+  if (!options.force && Date.now() - lastRefreshAt < MIN_REFRESH_GAP_MS) return false;
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      const response = await fetch(new URL(REFRESH_ENDPOINT, API_URL).toString(), {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      });
+      // A 401 means the refresh token itself is gone; the backend has already sent
+      // clearing cookies, and the next navigation will land on the login screen.
+      // Nothing to do here — deliberately no redirect, so a background ping can
+      // never yank a user out of unsaved work.
+      lastRefreshAt = Date.now();
+      return response.ok;
+    } catch {
+      // Offline or backend hiccup: try again on the next tick.
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/** Keep the signed-in session alive while an app surface stays open. */
+export function useSessionKeepalive(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const timer = window.setInterval(() => {
+      void refreshSession();
+    }, KEEPALIVE_INTERVAL_MS);
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void refreshSession();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [enabled]);
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,6 +14,7 @@ import type { Route } from "./+types/root";
 import "./app.css";
 import SectionMarkers from "./components/SectionMarkers";
 import Sidebar from "./components/sidebar";
+import { useSessionKeepalive } from "~/lib/session-keepalive";
 
 const GA_MEASUREMENT_ID = "G-1645KKLT8B";
 const CLARITY_TAG_ID = "wwfzm7293o";
@@ -100,6 +101,10 @@ export default function Layout() {
     isFounderToolsApp ||
     isValleyApp ||
     isWattTheHackApp;
+
+  // Signed-in surfaces renew their access token in the background, so a tab left open
+  // for days keeps working instead of quietly 401-ing. Public pages never ping.
+  useSessionKeepalive(isAppRoute);
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/tests/session-refresh.test.ts
+++ b/tests/session-refresh.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { needsSessionRefresh, withSessionRefresh } from "../workers/session-refresh";
+
+const ENV = { BACKEND_BASE_URL: "https://api.mlai.au" } as unknown as Env;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/** Build an unsigned JWT-shaped token whose `exp` is `secondsFromNow` away. */
+function tokenExpiringIn(secondsFromNow: number): string {
+  const payload = { exp: Math.floor(Date.now() / 1000) + secondsFromNow };
+  const encoded = btoa(JSON.stringify(payload)).replace(/=+$/, "");
+  return `header.${encoded}.signature`;
+}
+
+function stubRefresh(response: Response | (() => Response), seen: Request[] = []) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    seen.push(new Request(input as never, init));
+    return typeof response === "function" ? response() : response;
+  }) as typeof fetch;
+  return seen;
+}
+
+function refreshedResponse(accessToken = "fresh-access", refreshToken = "fresh-refresh") {
+  const headers = new Headers();
+  headers.append(
+    "Set-Cookie",
+    `access_token=${accessToken}; Path=/; Domain=.mlai.au; Secure; HttpOnly; SameSite=None; Max-Age=86400`,
+  );
+  headers.append(
+    "Set-Cookie",
+    `refresh_token=${refreshToken}; Path=/; Domain=.mlai.au; Secure; HttpOnly; SameSite=None; Max-Age=7776000`,
+  );
+  return new Response(JSON.stringify({ refreshed: true }), { status: 200, headers });
+}
+
+function requestWithCookies(cookie: string | null, url = "https://mlai.au/founder-tools") {
+  return new Request(url, cookie ? { headers: { Cookie: cookie } } : undefined);
+}
+
+describe("needsSessionRefresh", () => {
+  test("ignores anonymous requests entirely", () => {
+    expect(needsSessionRefresh(null)).toBe(false);
+    expect(needsSessionRefresh("theme=dark")).toBe(false);
+  });
+
+  test("refreshes when the refresh cookie outlived the access cookie", () => {
+    expect(needsSessionRefresh("refresh_token=abc")).toBe(true);
+  });
+
+  test("leaves a comfortably valid access token alone", () => {
+    expect(needsSessionRefresh(`refresh_token=abc; access_token=${tokenExpiringIn(86400)}`)).toBe(false);
+  });
+
+  test("renews ahead of expiry rather than at it", () => {
+    // 10 minutes left is inside the skew window: renew now, not after the 401.
+    expect(needsSessionRefresh(`refresh_token=abc; access_token=${tokenExpiringIn(600)}`)).toBe(true);
+  });
+
+  test("treats an unreadable access token as stale", () => {
+    expect(needsSessionRefresh("refresh_token=abc; access_token=garbage")).toBe(true);
+  });
+});
+
+describe("withSessionRefresh", () => {
+  test("renders with the fresh token and relays the new cookies", async () => {
+    stubRefresh(refreshedResponse());
+    let renderedCookie: string | null = null;
+
+    const response = await withSessionRefresh(
+      requestWithCookies(`refresh_token=long-lived; access_token=${tokenExpiringIn(60)}`),
+      ENV,
+      async (request) => {
+        renderedCookie = request.headers.get("Cookie");
+        return new Response("ok", { status: 200 });
+      },
+    );
+
+    // The in-flight render must see the renewed token, or this page still 401s.
+    expect(renderedCookie).toContain("access_token=fresh-access");
+    expect(renderedCookie).toContain("refresh_token=long-lived");
+
+    const relayed = response.headers.getSetCookie();
+    expect(relayed.some((cookie) => cookie.startsWith("access_token=fresh-access"))).toBe(true);
+    expect(relayed.some((cookie) => cookie.startsWith("refresh_token=fresh-refresh"))).toBe(true);
+    expect(await response.text()).toBe("ok");
+  });
+
+  test("posts to the backend refresh endpoint with the browser cookies", async () => {
+    const seen = stubRefresh(refreshedResponse());
+
+    await withSessionRefresh(
+      requestWithCookies("refresh_token=long-lived"),
+      ENV,
+      async () => new Response("ok"),
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].url).toBe("https://api.mlai.au/api/v1/auth/token/refresh/");
+    expect(seen[0].method).toBe("POST");
+    expect(seen[0].headers.get("Cookie")).toBe("refresh_token=long-lived");
+  });
+
+  test("drops dead session cookies so the render sees an anonymous user", async () => {
+    const headers = new Headers();
+    headers.append("Set-Cookie", "access_token=; Path=/; Max-Age=0");
+    headers.append("Set-Cookie", "refresh_token=; Path=/; Max-Age=0");
+    stubRefresh(new Response("{}", { status: 401, headers }));
+
+    let renderedCookie: string | null = "unset";
+    const response = await withSessionRefresh(
+      requestWithCookies("refresh_token=expired; theme=dark"),
+      ENV,
+      async (request) => {
+        renderedCookie = request.headers.get("Cookie");
+        return new Response("login", { status: 200 });
+      },
+    );
+
+    expect(renderedCookie).toBe("theme=dark");
+    expect(response.headers.getSetCookie()).toHaveLength(2);
+  });
+
+  test("renders normally when the backend refresh is unreachable", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+
+    const cookie = "refresh_token=long-lived";
+    let renderedCookie: string | null = null;
+    const response = await withSessionRefresh(requestWithCookies(cookie), ENV, async (request) => {
+      renderedCookie = request.headers.get("Cookie");
+      return new Response("ok", { status: 200 });
+    });
+
+    expect(renderedCookie).toBe(cookie);
+    expect(response.headers.getSetCookie()).toHaveLength(0);
+  });
+
+  test("never touches routes that manage the cookies themselves", async () => {
+    const seen = stubRefresh(refreshedResponse());
+
+    for (const path of ["/verify-email?token=abc", "/platform/logout", "/founder-tools/logout"]) {
+      const response = await withSessionRefresh(
+        requestWithCookies("refresh_token=long-lived", `https://mlai.au${path}`),
+        ENV,
+        async () => new Response("ok"),
+      );
+      expect(response.headers.getSetCookie()).toHaveLength(0);
+    }
+
+    expect(seen).toHaveLength(0);
+  });
+
+  test("strips Secure/Domain for localhost so dev browsers accept the cookies", async () => {
+    stubRefresh(refreshedResponse());
+
+    const response = await withSessionRefresh(
+      requestWithCookies("refresh_token=long-lived", "http://localhost:5173/founder-tools"),
+      ENV,
+      async () => new Response("ok"),
+    );
+
+    const relayed = response.headers.getSetCookie();
+    expect(relayed.join("\n")).not.toContain("Domain=");
+    expect(relayed.join("\n")).not.toContain("Secure");
+    expect(relayed.join("\n")).toContain("SameSite=Lax");
+  });
+});

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,5 +1,6 @@
 import { createRequestHandler } from "react-router";
 import { isWattTheHackEndpointPath } from "~/lib/watt-the-hack-access";
+import { withSessionRefresh } from "./session-refresh";
 
 declare module "react-router" {
   export interface AppLoadContext {
@@ -48,9 +49,15 @@ function isCacheableHomepageResponse(response: Response): boolean {
 }
 
 async function renderWithReactRouter(request: Request, env: Env, ctx: ExecutionContext) {
-  return requestHandler(request, {
-    cloudflare: { env, ctx },
-  });
+  // Every render goes through the session refresher: it renews an expiring access
+  // token from the long-lived refresh cookie and relays the new cookies to the
+  // browser, so a returning user is never bounced to the magic-link screen while
+  // their refresh token is still valid. Anonymous requests pass straight through.
+  return withSessionRefresh(request, env, (refreshedRequest) =>
+    requestHandler(refreshedRequest, {
+      cloudflare: { env, ctx },
+    }),
+  );
 }
 
 export default {

--- a/workers/session-refresh.ts
+++ b/workers/session-refresh.ts
@@ -1,0 +1,236 @@
+/**
+ * Silent session refresh at the worker edge.
+ *
+ * The backend issues two cookies: a short-lived `access_token` that every API call
+ * carries, and a long-lived `refresh_token` (90 days) that can mint new access
+ * tokens. SSR loaders forward the browser's cookies to the backend but have no way
+ * to hand a *new* cookie back to the browser — so before this existed, the moment
+ * the access token expired the user was bounced to the magic-link screen even
+ * though a perfectly good refresh token was sitting in their browser.
+ *
+ * This middleware closes that loop. On any request that carries a refresh cookie
+ * and a stale (or missing) access cookie it:
+ *   1. POSTs the cookies to the backend refresh endpoint,
+ *   2. rewrites the inbound request's Cookie header with the fresh access token so
+ *      this render's loaders authenticate normally, and
+ *   3. relays the backend's Set-Cookie headers to the browser.
+ *
+ * With refresh-token rotation on the backend, every visit slides the window
+ * forward: keep using the site and you stay logged in indefinitely.
+ */
+
+const ACCESS_COOKIE = "access_token";
+const REFRESH_COOKIE = "refresh_token";
+const REFRESH_PATH = "/api/v1/auth/token/refresh/";
+const DEFAULT_BACKEND_BASE_URL = "https://api.mlai.au";
+
+/**
+ * Refresh this long before the access token actually expires, so a page rendered
+ * near the boundary can't lose the race between our check and its own API calls.
+ */
+const REFRESH_SKEW_SECONDS = 30 * 60;
+
+/** Never let a slow backend hold up a page render. */
+const REFRESH_TIMEOUT_MS = 4000;
+
+/**
+ * Routes that manage the auth cookies themselves. Refreshing here would either be
+ * pointless (verify-email is *creating* the session) or actively wrong (a Set-Cookie
+ * appended after logout's clearing cookies would resurrect the session).
+ */
+function ownsItsOwnCookies(pathname: string): boolean {
+  return pathname.startsWith("/verify-email") || pathname.endsWith("/logout");
+}
+
+function readCookie(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const raw = part.trim();
+    const eq = raw.indexOf("=");
+    if (eq === -1) continue;
+    if (raw.slice(0, eq).trim() === name) {
+      return raw.slice(eq + 1).trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Read `exp` out of a JWT without verifying it. The signature is the backend's
+ * problem — here we only need to know whether it is worth asking for a new token.
+ */
+function readJwtExpiry(token: string): number | null {
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payload.padEnd(payload.length + ((4 - (payload.length % 4)) % 4), "=");
+    const decoded = JSON.parse(atob(padded)) as { exp?: unknown };
+    return typeof decoded.exp === "number" ? decoded.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Cookie name of the first `Set-Cookie` entry, e.g. `access_token=abc; Path=/` → value `abc`. */
+function valueFromSetCookie(setCookie: string, name: string): string | null {
+  const [pair] = setCookie.split(";");
+  const eq = pair.indexOf("=");
+  if (eq === -1) return null;
+  if (pair.slice(0, eq).trim() !== name) return null;
+  const value = pair.slice(eq + 1).trim();
+  return value || null;
+}
+
+/** Replace (or append) one cookie in a `Cookie` request header. */
+function withCookie(cookieHeader: string | null, name: string, value: string): string {
+  const kept = (cookieHeader || "")
+    .split(";")
+    .map((part) => part.trim())
+    .filter((part) => part && !part.startsWith(`${name}=`));
+  kept.push(`${name}=${value}`);
+  return kept.join("; ");
+}
+
+/** Drop cookies entirely — used when the backend tells us the session is dead. */
+function withoutCookies(cookieHeader: string | null, names: string[]): string {
+  return (cookieHeader || "")
+    .split(";")
+    .map((part) => part.trim())
+    .filter((part) => part && !names.some((name) => part.startsWith(`${name}=`)))
+    .join("; ");
+}
+
+function isLocalhostRequest(url: URL): boolean {
+  const { hostname } = url;
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".localhost")
+  );
+}
+
+/**
+ * Production cookies are `Secure; Domain=.mlai.au; SameSite=None`, none of which a
+ * plain-HTTP localhost browser will accept. Mirrors the same fix in the
+ * verify-email route.
+ */
+function sanitizeCookieForLocalhost(cookie: string): string {
+  return cookie
+    .split(";")
+    .map((part) => part.trim())
+    .filter((part) => {
+      const lower = part.toLowerCase();
+      return lower !== "secure" && !lower.startsWith("domain=");
+    })
+    .map((part) => (part.toLowerCase().startsWith("samesite=") ? "SameSite=Lax" : part))
+    .join("; ");
+}
+
+/** True when the request carries a refresh cookie whose access cookie needs renewing. */
+export function needsSessionRefresh(cookieHeader: string | null): boolean {
+  if (!readCookie(cookieHeader, REFRESH_COOKIE)) return false;
+
+  const access = readCookie(cookieHeader, ACCESS_COOKIE);
+  if (!access) return true;
+
+  const expiry = readJwtExpiry(access);
+  // An unreadable access token is treated as stale: worst case we spend one
+  // refresh call and get a token we can read.
+  if (expiry === null) return true;
+
+  return expiry - REFRESH_SKEW_SECONDS <= Math.floor(Date.now() / 1000);
+}
+
+type RefreshOutcome =
+  | { status: "refreshed"; setCookies: string[]; accessToken: string | null }
+  | { status: "expired"; setCookies: string[] }
+  | { status: "unavailable" };
+
+async function requestRefresh(cookieHeader: string, env: Env): Promise<RefreshOutcome> {
+  const baseUrl = String(env.BACKEND_BASE_URL || DEFAULT_BACKEND_BASE_URL);
+  let response: Response;
+  try {
+    response = await fetch(new URL(REFRESH_PATH, baseUrl).toString(), {
+      method: "POST",
+      headers: {
+        Cookie: cookieHeader,
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // Backend down or slow — render with whatever session the request already has.
+    console.warn("[session-refresh] refresh request failed:", (error as Error).message);
+    return { status: "unavailable" };
+  }
+
+  const setCookies = response.headers.getSetCookie();
+
+  if (response.status === 401) {
+    // The refresh token is expired or revoked; the backend replies with clearing
+    // cookies so the browser stops retrying on every page load.
+    return { status: "expired", setCookies };
+  }
+
+  if (!response.ok) {
+    console.warn(`[session-refresh] unexpected refresh status ${response.status}`);
+    return { status: "unavailable" };
+  }
+
+  const accessToken =
+    setCookies.map((cookie) => valueFromSetCookie(cookie, ACCESS_COOKIE)).find(Boolean) || null;
+  return { status: "refreshed", setCookies, accessToken };
+}
+
+function withExtraSetCookies(response: Response, setCookies: string[], sanitize: boolean): Response {
+  if (setCookies.length === 0) return response;
+  const headers = new Headers(response.headers);
+  for (const cookie of setCookies) {
+    headers.append("Set-Cookie", sanitize ? sanitizeCookieForLocalhost(cookie) : cookie);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * Wrap a render with silent session refresh. Requests without a refresh cookie —
+ * i.e. all anonymous traffic — pass straight through with zero added latency.
+ */
+export async function withSessionRefresh(
+  request: Request,
+  env: Env,
+  render: (request: Request) => Promise<Response>,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const cookieHeader = request.headers.get("Cookie");
+
+  if (ownsItsOwnCookies(url.pathname) || !needsSessionRefresh(cookieHeader)) {
+    return render(request);
+  }
+
+  const outcome = await requestRefresh(cookieHeader as string, env);
+  if (outcome.status === "unavailable") {
+    return render(request);
+  }
+
+  const headers = new Headers(request.headers);
+  if (outcome.status === "refreshed" && outcome.accessToken) {
+    // Render with the fresh token so this page's loaders authenticate on the first try.
+    headers.set("Cookie", withCookie(cookieHeader, ACCESS_COOKIE, outcome.accessToken));
+  } else if (outcome.status === "expired") {
+    const remaining = withoutCookies(cookieHeader, [ACCESS_COOKIE, REFRESH_COOKIE]);
+    if (remaining) {
+      headers.set("Cookie", remaining);
+    } else {
+      headers.delete("Cookie");
+    }
+  }
+
+  const response = await render(new Request(request, { headers }));
+  return withExtraSetCookies(response, outcome.setCookies, isLocalhostRequest(url));
+}


### PR DESCRIPTION
## Why

The backend has always issued a refresh token capable of minting new access tokens with no user interaction — but nothing in this repo ever called `/api/v1/auth/token/refresh/`. The moment the access cookie expired, loaders got a 401 and bounced the user to the magic-link screen with a perfectly good refresh token still sitting in their browser. That is the daily-re-login complaint.

SSR is where this has to be fixed. Loaders forward the browser's cookies to the backend but have no way to hand a *new* cookie back, so a refresh performed inside a loader would be invisible to the browser.

## What changed

**`workers/session-refresh.ts`** (new), wrapping every render in `workers/app.ts`. The worker entry is the one place that can do both halves: rewrite the inbound `Cookie` header (so this render's loaders authenticate on the first try) and relay the backend's `Set-Cookie` headers out to the browser.

- Decodes the access token's `exp` locally and only calls the backend inside a 30-minute skew window, so anonymous traffic and freshly-authenticated requests cost nothing.
- Leaves `/verify-email` and logout routes alone — those manage the auth cookies themselves, and a `Set-Cookie` appended after logout's clearing cookies would resurrect the session.
- On a 401 it strips the dead cookies from the forwarded request and relays the backend's clearing cookies, so an expired session lands on the login screen instead of retrying forever.
- Backend down or slow (4s timeout) renders unchanged rather than blocking the page.

**`app/lib/session-keepalive.ts`** (new) covers what SSR cannot: a tab left open overnight keeps polling the backend directly from the browser and never re-enters the worker. A 6-hourly ping plus a refresh on tab-focus keeps those sessions alive. Signed-in surfaces only — public pages never ping. A failed ping deliberately does not redirect, so a background call can't yank anyone out of unsaved work.

## Depends on

MLAI-AUS-Inc/mlai-backend#627 — 90-day rotating refresh tokens, and a refresh endpoint that returns both cookies with real lifetimes. **Deploy the backend first.**

## Testing

`tests/session-refresh.test.ts` (11 new tests) covers the refresh decision (anonymous, missing/valid/near-expiry/unreadable access token), the cookie rewrite and relay, the expired-session path, backend-unavailable, the skipped routes, and localhost cookie sanitising. Full suite: 183 pass. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)