### PR TITLE
Update Content Factory clone location

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,5 @@
+- [x] Point new-developer Content Factory setup at `drsamdonegan/content-factory`
+
 - [x] Resolve monthly-update reminder links to an explicitly owned Founder Tools company
 - [x] Reject stale or foreign reminder company IDs without mutating active-company state
 - [x] Add focused reminder-link tests and run typecheck/build

--- a/docs/NEW_DEVELOPER_SETUP.md
+++ b/docs/NEW_DEVELOPER_SETUP.md
@@ -89,7 +89,7 @@ gh repo clone MLAI-AUS-Inc/roo
 Optional for content/article flows:
 
 ```bash
-gh repo clone MLAI-AUS-Inc/content-factory
+gh repo clone drsamdonegan/content-factory
 ```
 
 If this fails, ask an admin to confirm the repo name and grant access.


### PR DESCRIPTION
## What changed

- update new-developer setup to clone `drsamdonegan/content-factory`
- record the completed repository-transfer setup task

## Why

The Content Factory repository has permanently moved out of the MLAI organization, so the old clone command now relies on a redirect and no longer documents the canonical owner.

## Verification

- confirmed `drsamdonegan/content-factory` is reachable
- documentation-only change; no runtime code or dependencies changed

Cross-repository migration: https://github.com/drsamdonegan/content-factory/pull/758
