### PR TITLE
Read IndexNow key from env instead of hardcoding

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -19,3 +19,7 @@ VITE_ENABLE_FOUNDER_TOOLS_DISCOVER=false
 PRIVATE_HUMANITIX_API_KEY=
 PUBLIC_HUMANITIX_API_KEY=
 LUMA_API_KEY=
+# IndexNow ownership key used by the postbuild submit step. Public by design
+# (served at https://mlai.au/<key>.txt). Set in the build env; leave blank to
+# skip IndexNow submission.
+INDEXNOW_KEY=

--- a/scripts/submit-indexnow.ts
+++ b/scripts/submit-indexnow.ts
@@ -1,11 +1,20 @@
 import { readFile } from "fs/promises";
 import path from "path";
 
-const SITE_URL = "https://mlai.au";
-const API_KEY = "ba9667289a340eef21f8adbd892cfa24";
+const SITE_URL = process.env.SITE_URL ?? "https://mlai.au";
+// The IndexNow key is public by design (it is served at `keyLocation` as the
+// ownership proof), so this is config hygiene rather than a secret: it lets us
+// rotate the key without a code edit. Set INDEXNOW_KEY in the build env. To
+// rotate, also publish the matching `public/<key>.txt` verification file.
+const API_KEY = process.env.INDEXNOW_KEY ?? "";
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
 
 async function submitToIndexNow() {
+  if (!API_KEY) {
+    console.log("IndexNow: INDEXNOW_KEY not set, skipping submission.");
+    return;
+  }
+
   const sitemapPath = path.join(process.cwd(), "public", "sitemap.xml");
   const sitemapContent = await readFile(sitemapPath, "utf-8");
 


### PR DESCRIPTION
Moves the IndexNow key in `scripts/submit-indexnow.ts` out of a hardcoded literal and into `process.env.INDEXNOW_KEY`.

## Context
The IndexNow key is **public by design** — it is served at `https://mlai.au/<key>.txt` as the site-ownership proof — so this is **config hygiene, not a secret fix**. Two benefits:
- The key can be rotated via the build env without a code change.
- The literal won't silently break the postbuild step if git history is ever rewritten to scrub old secrets.

> Note for the history-purge work: **do not** include this IndexNow key in the git-history scrub. It's public by design, and scrubbing it would corrupt the `public/<key>.txt` verification file's history for no security gain.

## Changes
- `scripts/submit-indexnow.ts`: read `INDEXNOW_KEY` (and `SITE_URL`) from `process.env`; skip submission with a clear log line when `INDEXNOW_KEY` is unset (mirrors the existing empty-sitemap skip).
- `.dev.vars.example`: document `INDEXNOW_KEY`.

## Verification
Ran the postbuild script both ways:
- `INDEXNOW_KEY` unset → `IndexNow: INDEXNOW_KEY not set, skipping submission.` (exit 0)
- `INDEXNOW_KEY` set with a sitemap present → `IndexNow: Submitted 1 URLs (status 202)` (exit 0)

## Follow-up (out of band)
Set `INDEXNOW_KEY` in the Cloudflare Pages build environment so IndexNow submission keeps running after this merges. To rotate the key later, set the new value there and publish the matching `public/<newkey>.txt` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)