### PR TITLE
Add security response headers to mlai.au

### DIFF
--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,5 +1,6 @@
 import { createRequestHandler } from "react-router";
 import { isWattTheHackEndpointPath } from "~/lib/watt-the-hack-access";
+import { applySecurityHeaders } from "./security-headers";
 import { withSessionRefresh } from "./session-refresh";
 
 declare module "react-router" {
@@ -60,86 +61,101 @@ async function renderWithReactRouter(request: Request, env: Env, ctx: ExecutionC
   );
 }
 
-export default {
-  async fetch(request, env, ctx) {
-    const url = new URL(request.url);
+/**
+ * Core routing/render logic. Split out from `fetch` so that security headers can
+ * be applied once, at the outermost layer, across every return path below
+ * (redirects, the 404, the cached homepage, and normal SSR renders) rather than
+ * being repeated — and inevitably missed — at each individual `return`.
+ */
+async function handleRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  url: URL
+): Promise<Response> {
+  // 1. Redirect www → non-www (301)
+  if (url.hostname === "www.mlai.au") {
+    url.hostname = "mlai.au";
+    return Response.redirect(url.toString(), 301);
+  }
 
-    // 1. Redirect www → non-www (301)
-    if (url.hostname === "www.mlai.au") {
-      url.hostname = "mlai.au";
-      return Response.redirect(url.toString(), 301);
+  // 2. Block disabled Watt The Hack API paths on the website domain.
+  if (isWattTheHackEndpointPath(url.pathname)) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        "X-Robots-Tag": "noindex, nofollow",
+      },
+    });
+  }
+
+  // 3. Redirect legacy paths (301)
+  const legacyTarget = LEGACY_REDIRECTS[url.pathname];
+  if (legacyTarget) {
+    url.pathname = legacyTarget;
+    url.search = "";
+    return Response.redirect(url.toString(), 301);
+  }
+
+  // 4. Strip tracking query parameters (301)
+  let hasTrackingParams = false;
+  for (const param of TRACKING_PARAMS) {
+    if (url.searchParams.has(param)) {
+      url.searchParams.delete(param);
+      hasTrackingParams = true;
     }
+  }
+  if (hasTrackingParams) {
+    return Response.redirect(url.toString(), 301);
+  }
 
-    // 2. Block disabled Watt The Hack API paths on the website domain.
-    if (isWattTheHackEndpointPath(url.pathname)) {
-      return new Response("Not Found", {
-        status: 404,
-        headers: {
-          "X-Robots-Tag": "noindex, nofollow",
-        },
+  // 5. Let React Router handle /__manifest (needed for client-side navigation)
+  //    but add noindex header to keep it out of search engines
+  if (url.pathname === "/__manifest") {
+    const response = await renderWithReactRouter(request, env, ctx);
+    response.headers.set("X-Robots-Tag", "noindex, nofollow");
+    return response;
+  }
+
+  if (isAnonymousHomepageRequest(request, url)) {
+    const cache = defaultCache();
+    const cacheKey = new Request(`${url.origin}/`, { method: "GET" });
+    const cached = await cache.match(cacheKey);
+
+    if (cached) {
+      const headers = new Headers(cached.headers);
+      headers.set("X-MLAI-Homepage-Cache", "HIT");
+      return new Response(request.method === "HEAD" ? null : cached.body, {
+        headers,
+        status: cached.status,
+        statusText: cached.statusText,
       });
     }
 
-    // 3. Redirect legacy paths (301)
-    const legacyTarget = LEGACY_REDIRECTS[url.pathname];
-    if (legacyTarget) {
-      url.pathname = legacyTarget;
-      url.search = "";
-      return Response.redirect(url.toString(), 301);
+    const response = await renderWithReactRouter(request, env, ctx);
+    if (request.method === "GET" && isCacheableHomepageResponse(response)) {
+      const headers = new Headers(response.headers);
+      headers.set("Cache-Control", HOMEPAGE_CACHE_CONTROL);
+      headers.set("X-MLAI-Homepage-Cache", "MISS");
+      const cacheableResponse = new Response(response.body, {
+        headers,
+        status: response.status,
+        statusText: response.statusText,
+      });
+      ctx.waitUntil(cache.put(cacheKey, cacheableResponse.clone()));
+      return cacheableResponse;
     }
 
-    // 4. Strip tracking query parameters (301)
-    let hasTrackingParams = false;
-    for (const param of TRACKING_PARAMS) {
-      if (url.searchParams.has(param)) {
-        url.searchParams.delete(param);
-        hasTrackingParams = true;
-      }
-    }
-    if (hasTrackingParams) {
-      return Response.redirect(url.toString(), 301);
-    }
+    return response;
+  }
 
-    // 5. Let React Router handle /__manifest (needed for client-side navigation)
-    //    but add noindex header to keep it out of search engines
-    if (url.pathname === "/__manifest") {
-      const response = await renderWithReactRouter(request, env, ctx);
-      response.headers.set("X-Robots-Tag", "noindex, nofollow");
-      return response;
-    }
+  return renderWithReactRouter(request, env, ctx);
+}
 
-    if (isAnonymousHomepageRequest(request, url)) {
-      const cache = defaultCache();
-      const cacheKey = new Request(`${url.origin}/`, { method: "GET" });
-      const cached = await cache.match(cacheKey);
-
-      if (cached) {
-        const headers = new Headers(cached.headers);
-        headers.set("X-MLAI-Homepage-Cache", "HIT");
-        return new Response(request.method === "HEAD" ? null : cached.body, {
-          headers,
-          status: cached.status,
-          statusText: cached.statusText,
-        });
-      }
-
-      const response = await renderWithReactRouter(request, env, ctx);
-      if (request.method === "GET" && isCacheableHomepageResponse(response)) {
-        const headers = new Headers(response.headers);
-        headers.set("Cache-Control", HOMEPAGE_CACHE_CONTROL);
-        headers.set("X-MLAI-Homepage-Cache", "MISS");
-        const cacheableResponse = new Response(response.body, {
-          headers,
-          status: response.status,
-          statusText: response.statusText,
-        });
-        ctx.waitUntil(cache.put(cacheKey, cacheableResponse.clone()));
-        return cacheableResponse;
-      }
-
-      return response;
-    }
-
-    return renderWithReactRouter(request, env, ctx);
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const response = await handleRequest(request, env, ctx, url);
+    return applySecurityHeaders(response, url);
   },
 } satisfies ExportedHandler<Env>;

--- a/workers/security-headers.ts
+++ b/workers/security-headers.ts
@@ -1,0 +1,123 @@
+/**
+ * Security response headers for mlai.au.
+ *
+ * The apex site previously served no security headers at all (the API origin,
+ * api.mlai.au, already sets its own via Django's SecurityMiddleware). These are
+ * applied at the worker's outermost layer so every response path — SSR renders,
+ * 301 redirects, the cached homepage, and 404s — is covered uniformly.
+ *
+ * Applying them outside the homepage cache is deliberate: cached entries store
+ * the un-decorated response, and headers are re-applied fresh on each cache HIT.
+ * That way changing a header here takes effect immediately rather than being
+ * frozen into cached entries for the life of their TTL.
+ */
+
+/** Statuses that must not carry a response body (per the fetch spec). */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
+/**
+ * Always-safe headers. None of these change what the site is allowed to load,
+ * so they carry no breakage risk for the existing page set.
+ */
+const BASE_SECURITY_HEADERS: Record<string, string> = {
+  // Stop MIME sniffing (e.g. a user-supplied file being reinterpreted as script).
+  "X-Content-Type-Options": "nosniff",
+  // Clickjacking protection for legacy browsers. SAMEORIGIN rather than DENY so
+  // any first-party embed keeps working; CSP frame-ancestors below is the modern
+  // equivalent and supersedes this where supported.
+  "X-Frame-Options": "SAMEORIGIN",
+  // Send the full URL same-origin, origin-only cross-origin, nothing on downgrade.
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  // Drop ambient access to powerful APIs the site does not use. `payment=()` is
+  // safe here: the site links to stripe.com but never loads Stripe.js.
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
+};
+
+/**
+ * HSTS.
+ *
+ * NOTE (read before merging): `includeSubDomains` applies to EVERY *.mlai.au
+ * subdomain — api, chat, roo, and anything internal. Confirm they are all
+ * HTTPS-only first. If any subdomain still needs plain HTTP, drop the
+ * `; includeSubDomains` portion below.
+ *
+ * `preload` is intentionally omitted. Submitting to the browser preload list is
+ * slow and painful to reverse, so it should be a separate, deliberate decision
+ * once this has been running cleanly.
+ */
+const HSTS_VALUE = "max-age=31536000; includeSubDomains";
+
+/**
+ * Content-Security-Policy — REPORT-ONLY for now.
+ *
+ * This is deliberately not enforced yet. The site relies on inline scripts
+ * (Google Tag Manager, Microsoft Clarity, the Facebook pixel) and React Router's
+ * SSR hydration payload, so an enforcing policy without nonces would break
+ * rendering and analytics on day one. Report-Only surfaces violations without
+ * user impact; once the reports are clean (or the inline scripts are moved to
+ * nonces), flip the header name to `Content-Security-Policy`.
+ *
+ * Origins below reflect what the app actually loads today:
+ *   scripts  — GTM/GA, Ahrefs, Facebook pixel, Microsoft Clarity
+ *   styles   — Google Fonts stylesheets
+ *   fonts    — Google Fonts files
+ *   images   — Firebase Storage, Unsplash, analytics tracking pixels
+ *   frames   — YouTube, Loom, Google Docs embeds in articles
+ *   connect  — the backend API plus analytics beacons
+ */
+const CSP_REPORT_ONLY = [
+  "default-src 'self'",
+  // 'unsafe-inline' + 'unsafe-eval' are required by GTM and the SSR hydration
+  // payload. Replacing them with per-request nonces is the follow-up hardening
+  // step, not something to change blind.
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://analytics.ahrefs.com https://connect.facebook.net https://www.clarity.ms",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  "img-src 'self' data: blob: https:",
+  "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.loom.com https://docs.google.com",
+  "connect-src 'self' https://api.mlai.au https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://www.clarity.ms https://connect.facebook.net",
+  "frame-ancestors 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join("; ");
+
+function isHtmlResponse(response: Response): boolean {
+  return (response.headers.get("Content-Type") || "")
+    .toLowerCase()
+    .includes("text/html");
+}
+
+/**
+ * Returns a copy of `response` with security headers applied.
+ *
+ * Rebuilding the Response is necessary rather than mutating in place: responses
+ * produced by `Response.redirect()` have immutable headers and would throw.
+ * Streaming bodies are passed straight through, so this does not buffer.
+ */
+export function applySecurityHeaders(response: Response, url: URL): Response {
+  const headers = new Headers(response.headers);
+
+  for (const [name, value] of Object.entries(BASE_SECURITY_HEADERS)) {
+    headers.set(name, value);
+  }
+
+  // HSTS is only meaningful over TLS; browsers ignore it on plain HTTP.
+  if (url.protocol === "https:") {
+    headers.set("Strict-Transport-Security", HSTS_VALUE);
+  }
+
+  // Only send CSP on actual documents. Attaching it to JSON/asset responses adds
+  // bytes and report noise without protecting anything.
+  if (isHtmlResponse(response)) {
+    headers.set("Content-Security-Policy-Report-Only", CSP_REPORT_ONLY);
+  }
+
+  const body = NULL_BODY_STATUSES.has(response.status) ? null : response.body;
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}


### PR DESCRIPTION
Closes the "mlai.au serves no security headers" finding. The API origin (`api.mlai.au`) already sets its own via Django's `SecurityMiddleware`; the apex site sent none.

## Enforced headers
None of these change what the site is allowed to load, so they carry no breakage risk for the existing page set:

| Header | Value |
|---|---|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (HTTPS requests only) |

`payment=()` is safe: the site links to stripe.com but never loads Stripe.js (verified).

## CSP ships Report-Only, deliberately
The site relies on inline scripts (Google Tag Manager, Microsoft Clarity, the Facebook pixel) plus React Router's SSR hydration payload, so an **enforcing** policy without nonces would break rendering and analytics on day one. This ships `Content-Security-Policy-Report-Only` so violations surface with zero user impact. Once reports are clean — or the inline scripts move to per-request nonces — flip the header name to `Content-Security-Policy`.

The policy's allowlist reflects what the app actually loads today: GTM/GA, Ahrefs, Facebook, Clarity (scripts); Google Fonts (styles/fonts); Firebase Storage + Unsplash (images, via `https:`); YouTube/Loom/Google Docs (article iframe embeds); `api.mlai.au` + analytics beacons (connect).

## Implementation note
`workers/app.ts` routing logic moves into `handleRequest()`, and `fetch()` applies headers to its result. This covers **all** return paths — redirects, the 404, cached-homepage HIT/MISS, and normal SSR — rather than repeating (and eventually missing) headers at each `return`. Headers are applied *outside* the homepage cache so changing one takes effect immediately instead of being frozen into cached entries for their TTL.

The response is rebuilt rather than mutated because `Response.redirect()` produces immutable headers; null-body statuses (204/304/etc.) are handled, and streaming SSR bodies pass straight through without buffering.

## Verification
Built and ran locally under wrangler, checking every path:
- Homepage SSR (`MISS`) → 200, all headers + CSP
- Homepage repeat (`HIT`) → 200, headers re-applied fresh from the cache
- `/codeofconduct` → 301 with headers (confirms the immutable-redirect rebuild works)
- Watt-The-Hack path → 404 with headers
- Content pages render normally (29.9 KB), streaming intact
- `bun run typecheck` and `bun run build` pass

> In local dev the CSP shows `api.localhost:8799` — that's wrangler's local host rewriting. The built worker contains the correct `https://api.mlai.au` (verified in `build/server/assets/`).

## Before merging — please confirm
**`includeSubDomains` in HSTS applies to every `*.mlai.au` subdomain** (api, chat, roo, and anything internal). Please confirm they're all HTTPS-only; if any still needs plain HTTP, drop `; includeSubDomains` from `HSTS_VALUE` in `workers/security-headers.ts` (one-line change).

`preload` is intentionally omitted — it's slow and painful to reverse, so it should be a separate deliberate decision after this has run cleanly.

## Suggested follow-ups
1. Watch Report-Only violations, then enforce the CSP.
2. Move inline GTM/Clarity/pixel scripts to per-request nonces so `'unsafe-inline'`/`'unsafe-eval'` can be dropped.
3. Optionally add a `report-to` endpoint to aggregate violations rather than relying on browser consoles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)