### PR TITLE
Forward Origin for cookie-authenticated mutations

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -171,6 +171,17 @@ export function createApiClient(env: any, request?: Request) {
         if (cookieHeader) {
             headers["Cookie"] = cookieHeader;
         }
+
+        // SSR actions authenticate to the backend with the browser's cookie, so
+        // preserve the browser-controlled Origin as well. The backend validates
+        // this exact value against CSRF_TRUSTED_ORIGINS before allowing unsafe
+        // cookie-authenticated requests. Do not synthesize an Origin when the
+        // incoming request omitted one; missing/untrusted origins must still be
+        // rejected by the backend.
+        const originHeader = request.headers.get("Origin");
+        if (originHeader) {
+            headers["Origin"] = originHeader;
+        }
     }
 
     const client = axios.create({

--- a/tests/api-request-timeout.test.ts
+++ b/tests/api-request-timeout.test.ts
@@ -35,3 +35,35 @@ describe("api client uses the Worker-native fetch adapter", () => {
     expect(client.defaults.adapter).toBe("fetch");
   });
 });
+
+// Cookie-authenticated mutations are made server-side by the Cloudflare Worker.
+// The backend requires the original browser Origin for its CSRF origin check, so
+// the per-request client must preserve that header alongside the cookie.
+describe("api client preserves cookie-authenticated mutation origin", () => {
+  test("forwards the incoming Origin alongside the cookie", () => {
+    const request = new Request("https://mlai.au/founder-tools/marketing/runs/run-1", {
+      method: "POST",
+      headers: {
+        Cookie: "access_token=test-token",
+        Origin: "https://mlai.au",
+      },
+    });
+
+    const client = createApiClient({ BACKEND_BASE_URL: "https://api.mlai.au" }, request);
+
+    expect(client.defaults.headers.Cookie).toBe("access_token=test-token");
+    expect(client.defaults.headers.Origin).toBe("https://mlai.au");
+  });
+
+  test("does not invent an Origin when the incoming request omitted it", () => {
+    const request = new Request("https://mlai.au/founder-tools/marketing/runs/run-1", {
+      method: "POST",
+      headers: { Cookie: "access_token=test-token" },
+    });
+
+    const client = createApiClient({ BACKEND_BASE_URL: "https://api.mlai.au" }, request);
+
+    expect(client.defaults.headers.Cookie).toBe("access_token=test-token");
+    expect(client.defaults.headers.Origin).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

- Forward the incoming browser `Origin` header from Cloudflare Worker SSR actions to the MLAI backend alongside the authentication cookie.
- Preserve missing origins as missing so the backend continues rejecting missing or untrusted origins.
- Add regression coverage for both forwarded and absent Origin headers.

## Root cause

The production backend now validates `Origin` for unsafe cookie-authenticated requests. The frontend Worker copied the browser cookie into its backend request but dropped `Origin`, so approval and other mutation endpoints were rejected with HTTP 403 before their handlers ran.

## Impact

Article approval and other cookie-authenticated mutations can pass the backend's trusted-origin check without weakening CSRF protection.

## Verification

- `bun test tests/api-request-timeout.test.ts tests/vibe-marketing-run-view.test.ts` — 18 passed
- `bun run typecheck` — passed
- Internal article-link check — passed for 132 files
- `bunx react-router build` — passed