### PR TITLE
Clarify configuration service recovery guidance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,7 @@
+- [x] Show retry guidance when the Content Factory configuration service is unavailable
+- [x] Keep genuine missing-configuration guidance distinct from upstream transport failures
+- [x] Add focused failure-guidance tests and run typecheck/build
+
 - [x] Point new-developer Content Factory setup at `drsamdonegan/content-factory`
 
 - [x] Resolve monthly-update reminder links to an explicitly owned Founder Tools company

--- a/app/lib/vibe-marketing-run-failures.ts
+++ b/app/lib/vibe-marketing-run-failures.ts
@@ -84,6 +84,15 @@ function nextStepForFailure(code: string, reason: string, run: VibeMarketingRunS
     return "Retry the scan, or cancel it and start again.";
   }
   if (
+    normalizedCode.includes("CONFIG_SERVICE_UNAVAILABLE") ||
+    normalizedCode.includes("UPSTREAM_PROTOCOL_ERROR")
+  ) {
+    return "Retry or resume this run shortly. Your saved competitors and seed keywords have not changed.";
+  }
+  if (normalizedCode.includes("MISSING_CONFIG")) {
+    return "Open company setup and add at least one competitor or seed keyword, then retry topic research.";
+  }
+  if (
     normalizedCode.includes("UNSUPPORTED_RUNTIME") ||
     reasonText.includes("build script") ||
     reasonText.includes("build or preview command")
@@ -92,6 +101,9 @@ function nextStepForFailure(code: string, reason: string, run: VibeMarketingRunS
   }
   if (normalizedCode.includes("ROUTE") || normalizedCode.includes("SURFACE") || normalizedCode.includes("HINT")) {
     return "Paste the public articles/blogs route manually in the setup flow, or add a conventional route and re-scan.";
+  }
+  if (!["repo_scan", "content_factory_scan"].includes(run.workflow)) {
+    return "Review the failed step, then retry or resume this run when ready.";
   }
   return "Review the failed step, then re-scan. If you already know the public articles/blogs route, paste it manually in the setup flow.";
 }

--- a/tests/vibe-marketing-run-failures.test.ts
+++ b/tests/vibe-marketing-run-failures.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { runFailureGuidance } from "../app/lib/vibe-marketing-run-failures";
+import type { VibeMarketingRunSummary } from "../app/types/vibe-marketing";
+
+function failedRun(overrides: Partial<VibeMarketingRunSummary> = {}): VibeMarketingRunSummary {
+  return {
+    runId: "discovery-run-1",
+    workflow: "auto_discovery",
+    domain: "mlai.au",
+    status: "blocked",
+    currentStep: "load_context",
+    approvalState: null,
+    stepOrder: [],
+    steps: [],
+    warnings: [],
+    errors: [],
+    artifacts: [],
+    diagnostics: {},
+    ...overrides,
+  } as VibeMarketingRunSummary;
+}
+
+describe("vibe marketing run failure guidance", () => {
+  test("tells users to retry a configuration service outage without changing setup", () => {
+    const guidance = runFailureGuidance(
+      failedRun({
+        errorCode: "CONFIG_SERVICE_UNAVAILABLE",
+        errors: ["The organization configuration service is temporarily unavailable for mlai.au."],
+        resumeAvailable: true,
+      }),
+    );
+
+    expect(guidance.nextStep).toBe(
+      "Retry or resume this run shortly. Your saved competitors and seed keywords have not changed.",
+    );
+    expect(guidance.nextStep).not.toContain("re-scan");
+    expect(guidance.nextStep).not.toContain("articles/blogs route");
+  });
+
+  test("keeps genuine missing configuration guidance distinct", () => {
+    const guidance = runFailureGuidance(
+      failedRun({
+        status: "failed",
+        errorCode: "MISSING_CONFIG",
+        errors: ["No configuration found for domain mlai.au."],
+      }),
+    );
+
+    expect(guidance.nextStep).toBe(
+      "Open company setup and add at least one competitor or seed keyword, then retry topic research.",
+    );
+  });
+
+  test("does not give repository scan advice to an unknown discovery failure", () => {
+    const guidance = runFailureGuidance(
+      failedRun({
+        status: "failed",
+        errorCode: "INTERNAL_ERROR",
+        errors: ["Research provider failed."],
+      }),
+    );
+
+    expect(guidance.nextStep).toBe("Review the failed step, then retry or resume this run when ready.");
+    expect(guidance.nextStep).not.toContain("articles/blogs route");
+  });
+});


### PR DESCRIPTION
## Summary
- show retry/resume guidance for configuration-service outages
- keep real missing setup guidance distinct
- avoid repository scan/public-route advice for unrelated discovery failures

## Validation
- 20 related Bun tests
- TypeScript typecheck
- internal-link validation (132 files)
- production React Router build